### PR TITLE
Phase 0: setup

### DIFF
--- a/CREDITS.txt
+++ b/CREDITS.txt
@@ -1,0 +1,54 @@
+CREDITS
+=======
+
+Original Data Dealer
+--------------------
+
+Data Dealer (datadealer.com) was created by Cuteacute Media OG.
+The original team behind the game and its source repositories
+(dd_js, dd_rules, dd_app, dd_auth, dd_cms) included:
+
+  - Ivan Averintsev
+  - Wolfie Christl
+  - Pascale Osterwalder
+  - Tobi Schäfer
+  - Ralf Traunsteiner
+
+Original copyright: Copyright (c) 2011-2014, Cuteacute Media OG.
+
+Upstream repositories used as the basis of this fork:
+
+  - https://github.com/datadealer/dd_js     (frontend)
+  - https://github.com/datadealer/dd_rules  (game data)
+  - https://github.com/datadealer/dd_app    (Python backend)
+
+Third-party fonts shipped under font/ retain their own notices and
+licenses (SIL Open Font License). See font/LICENSE/ for details:
+
+  - Bowlby One SC — Copyright (c) 2011 by vernon adams
+  - Skranji      — Copyright (c) 2012, Font Diner
+  - Source       — Copyright 2010, 2012 Adobe Systems Incorporated
+  - Voltaire     — Copyright (c) 2011 by Sorkin Type Co
+
+Modifications in this fork
+--------------------------
+
+This repository is a work-in-progress port of Data Dealer into a
+webxdc mini-app (see README.md, "About this fork"). Modifications are
+made by the Data Dealer webxdc contributors and include, among other
+things:
+
+  - Vendoring game data from dd_rules into data/ (see data/UPSTREAM.txt).
+  - Reorganising license documentation: the original LICENSE.txt is
+    retained for historical reference; LICENSE-CODE.txt and
+    LICENSE-ASSETS.txt now state the licensing of source code and
+    non-code material respectively.
+  - Forthcoming work (tracked in separate threads/PRs): porting dd_app
+    behaviour into in-browser JavaScript, replacing networked state
+    with window.webxdc.sendUpdate, and removing or stubbing
+    server-only integrations.
+
+Planning for the port was done with Claude (https://www.anthropic.com/claude).
+
+This file is licensed under CC BY-SA 3.0 AT, the same terms as the
+other non-code material in this repository (see LICENSE-ASSETS.txt).

--- a/LICENSE-ASSETS.txt
+++ b/LICENSE-ASSETS.txt
@@ -1,0 +1,39 @@
+Asset & data license — Creative Commons Attribution-ShareAlike 3.0 Austria
+==========================================================================
+
+This file applies to the non-code material in this repository, including:
+
+  - data/                  Game data vendored from datadealer/dd_rules
+                           (default_game.json, ruleset_3.de.json,
+                           ruleset_3.en.json). See data/UPSTREAM.txt for
+                           the source commit SHA.
+  - img/                   Sprite sheets and other game artwork inherited
+                           from dd_js.
+  - i18n/                  Translation catalogues inherited from dd_js.
+  - font/ (game fonts)     The CC-BY-SA portions only. The third-party
+                           webfonts shipped under font/ (Bowlby One SC,
+                           Skranji, Source, Voltaire) remain under the
+                           SIL Open Font License — see font/LICENSE/ for
+                           their original notices.
+
+These works are licensed under the Creative Commons
+Attribution-ShareAlike 3.0 Austria license (CC BY-SA 3.0 AT).
+
+  License deed:        https://creativecommons.org/licenses/by-sa/3.0/at/
+  Full legal code:     https://creativecommons.org/licenses/by-sa/3.0/at/legalcode
+
+Original authors (see CREDITS.txt for full credits):
+  Ivan Averintsev, Wolfie Christl, Pascale Osterwalder, Tobi Schäfer,
+  Ralf Traunsteiner.
+
+Under CC BY-SA 3.0 AT you are free to share and adapt these works for
+any purpose, including commercially, provided that you:
+
+  - give appropriate credit to the original authors,
+  - indicate if changes were made, and
+  - distribute your contributions under the same license as the
+    original.
+
+Modifications made in this fork (e.g. any reformatting of dd_rules data
+for the webxdc build, or adapted artwork) are also released under
+CC BY-SA 3.0 AT.

--- a/LICENSE-CODE.txt
+++ b/LICENSE-CODE.txt
@@ -1,0 +1,224 @@
+Source code license — Artistic License 2.0
+==========================================
+
+Original code:
+  Copyright (c) 2012-2014 Cuteacute Media OG (dd_js, dd_app, and related
+  Data Dealer source repositories).
+
+Modifications for the webxdc port (this fork):
+  Copyright (c) 2026 the Data Dealer webxdc contributors.
+
+This file applies to the source code in this repository, including the
+dd_js fork that this repository started from and any code ported from
+dd_app into in-browser JavaScript as part of the webxdc port.
+
+Game data (the contents of data/, vendored from dd_rules) and creative
+assets (img/, i18n/, fonts) are licensed separately — see
+LICENSE-ASSETS.txt and CREDITS.txt.
+
+If not stated otherwise, the source code is released under the Artistic
+License 2.0. The text of the License follows:
+
+------------------------------------------------------------------------------
+
+               The Artistic License 2.0
+
+           Copyright (c) 2000-2006, The Perl Foundation.
+
+     Everyone is permitted to copy and distribute verbatim copies
+      of this license document, but changing it is not allowed.
+
+Preamble
+
+This license establishes the terms under which a given free software
+Package may be copied, modified, distributed, and/or redistributed.
+The intent is that the Copyright Holder maintains some artistic
+control over the development of that Package while still keeping the
+Package available as open source and free software.
+
+You are always permitted to make arrangements wholly outside of this
+license directly with the Copyright Holder of a given Package.  If the
+terms of this license do not permit the full use that you propose to
+make of the Package, you should contact the Copyright Holder and seek
+a different licensing arrangement.
+
+Definitions
+
+    "Copyright Holder" means the individual(s) or organization(s)
+    named in the copyright notice for the entire Package.
+
+    "Contributor" means any party that has contributed code or other
+    material to the Package, in accordance with the Copyright Holder's
+    procedures.
+
+    "You" and "your" means any person who would like to copy,
+    distribute, or modify the Package.
+
+    "Package" means the collection of files distributed by the
+    Copyright Holder, and derivatives of that collection and/or of
+    those files. A given Package may consist of either the Standard
+    Version, or a Modified Version.
+
+    "Distribute" means providing a copy of the Package or making it
+    accessible to anyone else, or in the case of a company or
+    organization, to others outside of your company or organization.
+
+    "Distributor Fee" means any fee that you charge for Distributing
+    this Package or providing support for this Package to another
+    party.  It does not mean licensing fees.
+
+    "Standard Version" refers to the Package if it has not been
+    modified, or has been modified only in ways explicitly requested
+    by the Copyright Holder.
+
+    "Modified Version" means the Package, if it has been changed, and
+    such changes were not explicitly requested by the Copyright
+    Holder.
+
+    "Original License" means this Artistic License as Distributed with
+    the Standard Version of the Package, in its current version or as
+    it may be modified by The Perl Foundation in the future.
+
+    "Source" form means the source code, documentation source, and
+    configuration files for the Package.
+
+    "Compiled" form means the compiled bytecode, object code, binary,
+    or any other form resulting from mechanical transformation or
+    translation of the Source form.
+
+
+Permission for Use and Modification Without Distribution
+
+(1)  You are permitted to use the Standard Version and create and use
+Modified Versions for any purpose without restriction, provided that
+you do not Distribute the Modified Version.
+
+
+Permissions for Redistribution of the Standard Version
+
+(2)  You may Distribute verbatim copies of the Source form of the
+Standard Version of this Package in any medium without restriction,
+either gratis or for a Distributor Fee, provided that you duplicate
+all of the original copyright notices and associated disclaimers.  At
+your discretion, such verbatim copies may or may not include a
+Compiled form of the Package.
+
+(3)  You may apply any bug fixes, portability changes, and other
+modifications made available from the Copyright Holder.  The resulting
+Package will still be considered the Standard Version, and as such
+will be subject to the Original License.
+
+
+Distribution of Modified Versions of the Package as Source
+
+(4)  You may Distribute your Modified Version as Source (either gratis
+or for a Distributor Fee, and with or without a Compiled form of the
+Modified Version) provided that you clearly document how it differs
+from the Standard Version, including, but not limited to, documenting
+any non-standard features, executables, or modules, and provided that
+you do at least ONE of the following:
+
+    (a)  make the Modified Version available to the Copyright Holder
+    of the Standard Version, under the Original License, so that the
+    Copyright Holder may include your modifications in the Standard
+    Version.
+
+    (b)  ensure that installation of your Modified Version does not
+    prevent the user installing or running the Standard Version. In
+    addition, the Modified Version must bear a name that is different
+    from the name of the Standard Version.
+
+    (c)  allow anyone who receives a copy of the Modified Version to
+    make the Source form of the Modified Version available to others
+    under
+
+    (i)  the Original License or
+
+    (ii)  a license that permits the licensee to freely copy,
+    modify and redistribute the Modified Version using the same
+    licensing terms that apply to the copy that the licensee
+    received, and requires that the Source form of the Modified
+    Version, and of any works derived from it, be made freely
+    available in that license fees are prohibited but Distributor
+    Fees are allowed.
+
+
+Distribution of Compiled Forms of the Standard Version
+or Modified Versions without the Source
+
+(5)  You may Distribute Compiled forms of the Standard Version without
+the Source, provided that you include complete instructions on how to
+get the Source of the Standard Version.  Such instructions must be
+valid at the time of your distribution.  If these instructions, at any
+time while you are carrying out such distribution, become invalid, you
+must provide new instructions on demand or cease further distribution.
+If you provide valid instructions or cease distribution within thirty
+days after you become aware that the instructions are invalid, then
+you do not forfeit any of your rights under this license.
+
+(6)  You may Distribute a Modified Version in Compiled form without
+the Source, provided that you comply with Section 4 with respect to
+the Source of the Modified Version.
+
+
+Aggregating or Linking the Package
+
+(7)  You may aggregate the Package (either the Standard Version or
+Modified Version) with other packages and Distribute the resulting
+aggregation provided that you do not charge a licensing fee for the
+Package.  Distributor Fees are permitted, and licensing fees for other
+components in the aggregation are permitted. The terms of this license
+apply to the use and Distribution of the Standard or Modified Versions
+as included in the aggregation.
+
+(8) You are permitted to link Modified and Standard Versions with
+other works, to embed the Package in a larger work of your own, or to
+build stand-alone binary or bytecode versions of applications that
+include the Package, and Distribute the result without restriction,
+provided the result does not expose a direct interface to the Package.
+
+
+Items That are Not Considered Part of a Modified Version
+
+(9) Works (including, but not limited to, modules and scripts) that
+merely extend or make use of the Package, do not, by themselves, cause
+the Package to be a Modified Version.  In addition, such works are not
+considered parts of the Package itself, and are not subject to the
+terms of this license.
+
+
+General Provisions
+
+(10)  Any use, modification, and distribution of the Standard or
+Modified Versions is governed by this Artistic License. By using,
+modifying or distributing the Package, you accept this license. Do not
+use, modify, or distribute the Package, if you do not accept this
+license.
+
+(11)  If your Modified Version has been derived from a Modified
+Version made by someone other than you, you are nevertheless required
+to ensure that your Modified Version complies with the requirements of
+this license.
+
+(12)  This license does not grant you the right to use any trademark,
+service mark, tradename, or logo of the Copyright Holder.
+
+(13)  This license includes the non-exclusive, worldwide,
+free-of-charge patent license to make, have made, use, offer to sell,
+sell, import and otherwise transfer the Package with respect to any
+patent claims licensable by the Copyright Holder that are necessarily
+infringed by the Package. If you institute patent litigation
+(including a cross-claim or counterclaim) against any party alleging
+that the Package constitutes direct or contributory patent
+infringement, then this Artistic License to you shall terminate on the
+date that such litigation is filed.
+
+(14)  Disclaimer of Warranty:
+THE PACKAGE IS PROVIDED BY THE COPYRIGHT HOLDER AND CONTRIBUTORS "AS
+IS' AND WITHOUT ANY EXPRESS OR IMPLIED WARRANTIES. THE IMPLIED
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, OR
+NON-INFRINGEMENT ARE DISCLAIMED TO THE EXTENT PERMITTED BY YOUR LOCAL
+LAW. UNLESS REQUIRED BY LAW, NO COPYRIGHT HOLDER OR CONTRIBUTOR WILL
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES ARISING IN ANY WAY OUT OF THE USE OF THE PACKAGE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,27 @@
+# Data Dealer (webxdc port) #
+
+## About this fork
+
+This repository is a work-in-progress port of the [Data Dealer](http://datadealer.com) browser game into a [webxdc](https://webxdc.org) mini-app — a self-contained, offline-capable application that runs inside a Delta Chat group. The aim is a full-game port (not a demo), fusing three of the original repositories:
+
+- [`datadealer/dd_js`](https://github.com/datadealer/dd_js) — the original frontend (this fork's starting point).
+- [`datadealer/dd_rules`](https://github.com/datadealer/dd_rules) — game data (rulesets, default game state). Vendored under [`data/`](./data/).
+- [`datadealer/dd_app`](https://github.com/datadealer/dd_app) — the original Python backend, to be ported into in-browser JavaScript so the game runs without a server.
+
+State that was previously synchronised through the backend will instead be exchanged between players using `window.webxdc.sendUpdate`, so each chat group becomes its own isolated game instance.
+
+> webxdc's per-chat sandbox model is almost a better fit for what Data Dealer was trying to be than what they actually built. Their planned multiplayer needed a server, social login, friend graphs — all of which evaporated when the company stopped paying hosting bills. webxdc gives you "every chat group is a game lobby" essentially for free, and there's no service to keep alive. The original architecture is the reason it died; webxdc's architecture is the reason a successor wouldn't.
+
+Planning for this port was done with [Claude](https://www.anthropic.com/claude).
+
+### Licensing & credits
+
+See [`LICENSE-CODE.txt`](./LICENSE-CODE.txt) (Artistic License 2.0, covering the dd_js fork and the ported dd_app code), [`LICENSE-ASSETS.txt`](./LICENSE-ASSETS.txt) (CC-BY-SA 3.0 Austria, covering dd_rules data, `img/`, `i18n/`, and fonts), and [`CREDITS.txt`](./CREDITS.txt) for the original team and modification notes.
+
+---
+
+The remainder of this README is the original `dd_js` documentation, retained for reference while the port is in progress. It does not yet describe the webxdc build.
+
 # dd_js #
 
 Application serving the frontend API for [Data Dealer](http://datadealer.com)

--- a/data/UPSTREAM.txt
+++ b/data/UPSTREAM.txt
@@ -1,0 +1,12 @@
+Source repository: https://github.com/datadealer/dd_rules
+Source commit SHA: 9290ab97a9ab7623d85290541cb44173b7a908d9
+
+Files vendored from this commit (unmodified):
+- default_game.json
+- ruleset_3.de.json
+- ruleset_3.en.json
+
+To diff against future upstream changes:
+  git clone https://github.com/datadealer/dd_rules.git
+  cd dd_rules
+  git diff 9290ab97a9ab7623d85290541cb44173b7a908d9 -- default_game.json ruleset_3.de.json ruleset_3.en.json

--- a/data/default_game.json
+++ b/data/default_game.json
@@ -1,0 +1,27 @@
+{
+  "Database": {
+    "children": [], 
+    "instance_data": {}
+  }, 
+  "Imperium": {
+    "children": [
+      {
+        "full_type": "DatabasePerp:database001", 
+        "instance_data": {
+          "x": 1024, 
+          "y": 800
+        }
+      }
+    ], 
+    "instance_data": {}
+  }, 
+  "game_values": {
+    "ap_snapshot": 6, 
+    "cash_value": 300, 
+    "karma_value": 50, 
+    "profiles_max": 1, 
+    "profiles_value": 0, 
+    "xp_level": 1, 
+    "xp_value": 1
+  }
+}

--- a/data/ruleset_3.de.json
+++ b/data/ruleset_3.de.json
@@ -1,0 +1,18186 @@
+{
+  "karmalauters": [
+    {
+      "game_type": "Karmalauter", 
+      "type_data": {
+        "description": "Manche Blogs sind heute wichtiger als Fernsehen und Zeitung zusammen. Organisiere eine Veranstaltung, zu der du prominente Blogger einl\u00e4dst. Wichtig: Coole, aber exklusive Location. Extravagantes Buffet, angesagter DJ. Und behaupte, du m\u00f6chtest offen mit ihnen diskutieren. Sie werden es lieben!", 
+        "gestalt": "karma004", 
+        "karma_points": 20, 
+        "label": "Blogger Event organisieren", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-025.png"
+        }, 
+        "price": 1300, 
+        "required_level": 7, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 680, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "title": "Blogger Event organisieren"
+      }
+    }, 
+    {
+      "game_type": "Karmalauter", 
+      "type_data": {
+        "description": "CSR, das bedeutet \"Corporate Social Responsibility\". Es geht also um deine \"gesellschaftliche Verantwortung\". Klingt gut, oder? Das ist einfach: Du spendest ein wenig Geld f\u00fcr kranke Kinder oder den Hunger in der dritten Welt. Ergebnis: Die Eliten in Politik und Medien werden in Zukunft zweimal \u00fcberlegen, bevor sie dich kritisieren!", 
+        "gestalt": "karma005", 
+        "karma_points": 50, 
+        "label": "CSR-Aktion", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-024.png"
+        }, 
+        "price": 4000, 
+        "required_level": 10, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 680, 
+              "y": 300
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "title": "CSR-Aktion"
+      }
+    }, 
+    {
+      "game_type": "Karmalauter", 
+      "type_data": {
+        "description": "Engagiere eine ganz besonderen Mann, um endlich mal aufzur\u00e4umen mit deinem schlechten Image. Er ist m\u00e4chtig, zynisch und durchtrieben. Er liebt Kommandozentralen, die aussehen wie die Br\u00fccke vom Raumschiff Enterprise. Und er kennt die wirklich wichtigen Leute und wei\u00df genau, wie er das zu deinem Vorteil nutzen kann.", 
+        "gestalt": "karma019", 
+        "karma_points": 70, 
+        "label": "Ex-Geheimdienstchef", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-025.png"
+        }, 
+        "price": 6000, 
+        "required_level": 10, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 580, 
+              "y": 200
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "title": "Ex-Geheimdienstchef"
+      }
+    }, 
+    {
+      "game_type": "Karmalauter", 
+      "type_data": {
+        "description": "Organisiere eine wissenschaftliche Konferenz und lade renommierte Elite-ProfessorInnen dazu ein, Vortr\u00e4ge zu halten. Das ist nicht ganz einfach. Am besten sagst du den einen, dass die anderen schon zugesagt h\u00e4tten - und umgekehrt. Am Ende k\u00f6nnen sich alle im Glanz deiner Konferenz sonnen und du hast alle auf deiner Seite.", 
+        "gestalt": "karma007", 
+        "karma_points": 25, 
+        "label": "Konferenz organisieren", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-024.png"
+        }, 
+        "price": 1700, 
+        "required_level": 9, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 680, 
+              "y": 100
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "title": "Konferenz organisieren"
+      }
+    }, 
+    {
+      "game_type": "Karmalauter", 
+      "type_data": {
+        "description": "Lobbying ist die K\u00f6nigsdisziplin, wenn es um die Beeinflussung der \u00f6ffentlichen Meinung geht. Daf\u00fcr gibt es Profis, die ganz genau wissen, wie sie deine Interessen an den richtigen Stellen unterbringen. Ob es um Gesetze geht, die dir ganz schlecht passen oder ob dir gar Strafverfolgung droht - mit gut gemachtem Lobbying kannst du viele Probleme l\u00f6sen.", 
+        "gestalt": "karma006", 
+        "karma_points": 14, 
+        "label": "Lobbying", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-024.png"
+        }, 
+        "price": 900, 
+        "required_level": 7, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 680, 
+              "y": 200
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "title": "Lobbying"
+      }
+    }, 
+    {
+      "game_type": "Karmalauter", 
+      "type_data": {
+        "description": "Die wichtigste Grundlage f\u00fcr ein gutes Image ist eine gewissenhafte Pflege deines Netzwerks. Besuche vielversprechende Veranstaltungen, sei nett zu den richtigen Leuten und tu ihnen immer wieder kleine Gefallen. Das k\u00f6nnte dir eines Tages sehr n\u00fctzlich werden.", 
+        "gestalt": "karma001", 
+        "karma_points": 5, 
+        "label": "Netzwerk pflegen", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-025.png"
+        }, 
+        "price": 250, 
+        "required_level": 5, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 100, 
+              "y": 660
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "title": "Netzwerk pflegen"
+      }
+    }, 
+    {
+      "game_type": "Karmalauter", 
+      "type_data": {
+        "description": "Das beste Mittel gegen negative Medienberichterstattung ist, ihr etwas Positives entgegenzusetzen! Lade die Presse auf Reisen ein, zahle ihnen Drinks und lass ihnen kleine Aufmerksamkeiten zukommen. Menschen m\u00f6gen Geschenke und dann m\u00f6gen sie vielleicht auch dich.", 
+        "gestalt": "karma008", 
+        "karma_points": 10, 
+        "label": "Presse einladen", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-024.png"
+        }, 
+        "price": 600, 
+        "required_level": 5, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 680, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "title": "Presse einladen"
+      }
+    }, 
+    {
+      "game_type": "Karmalauter", 
+      "type_data": {
+        "description": "Die Wissenschaft braucht immer Geld. Verschaffe dir Kontakte an der Universit\u00e4t und finanziere eine fette Studie. Nat\u00fcrlich zahlst du nur f\u00fcr Forschung, die dir prinzipiell wohlgesonnen ist. Ein ganz klein wenig Kritik darf schon sein, dann wirkt das Ganze glaubw\u00fcrdiger. Aber nicht zuviel, denn dann suchst du dir andere, die dein Geld mehr zu sch\u00e4tzen wissen.", 
+        "gestalt": "karma003", 
+        "karma_points": 40, 
+        "label": "Studie finanzieren", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-024.png"
+        }, 
+        "price": 3000, 
+        "required_level": 9, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 680, 
+              "y": 500
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "title": "Studie finanzieren"
+      }
+    }, 
+    {
+      "game_type": "Karmalauter", 
+      "type_data": {
+        "description": "Eine gro\u00df angelegte Kampagne zur F\u00f6rderung deines Images kostet dich zwar ein paar M\u00e4use. Du kommst aber kaum daran vorbei, schlie\u00dflich willst du nicht hinter Gittern landen. Am besten beauftragst du eine renommierte Werbeagentur. Die wissen genau, wie sie deine Botschaft gezielt unter die Leute bringen!", 
+        "gestalt": "karma009", 
+        "karma_points": 100, 
+        "label": "Umfassende Imagekampagne", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-024.png"
+        }, 
+        "price": 9000, 
+        "required_level": 11, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 500, 
+              "y": 560
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "title": "Umfassende Imagekampagne"
+      }
+    }, 
+    {
+      "game_type": "Karmalauter", 
+      "type_data": {
+        "description": "Einige dieser Wikipedia-Artikel \u00fcber deine Machenschaften k\u00f6nnten dir in Zukunft sehr schaden. Da glauben ein paar Schlaumeier immer alles besser zu wissen. Auch wenn sie vielleicht recht haben: So, wie du es formulierst, klingt es doch gleich viel besser! Dabei solltest du aber unauff\u00e4llig vorgehen.", 
+        "gestalt": "karma002", 
+        "karma_points": 7, 
+        "label": "Wikipedia manipulieren", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-024.png"
+        }, 
+        "price": 400, 
+        "required_level": 5, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 0, 
+              "y": 660
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "title": "Wikipedia manipulieren"
+      }
+    }
+  ], 
+  "karmalizers": [
+    {
+      "game_type": "Karmalizer", 
+      "type_data": {
+        "description": "Heikle interne Infos \u00fcber deine Pl\u00e4ne sind an die \u00d6ffentlichkeit gelangt. Ooops. Jetzt hat es dich also auch erwischt. \u00dcblicherweise profitierst du ja davon, dass heute an allen Ecken und Enden Millionen von digitalen Daten gesammelt werden, ohne dass sich viel darum gek\u00fcmmert wird, wer denn eigentlich Zugriff darauf hat. Zu dumm!", 
+        "gestalt": "karma013", 
+        "karma_points": -3, 
+        "label": "Datenleck", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-025.png"
+        }, 
+        "price": 0, 
+        "required_level": 5, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 100, 
+              "y": 560
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "title": "Datenleck"
+      }
+    }, 
+    {
+      "game_type": "Karmalizer", 
+      "type_data": {
+        "description": "Du hast ein kleines Problem. Eine Gruppe von unverbesserlichen Datensch\u00fctzerInnen hat die Bev\u00f6lkerung erfolgreich gegen dich aufgehetzt. Du bist wohl etwas leichtsinnig geworden und warst gar zu riskant unterwegs in letzter Zeit. Wahrscheinlich hast du bei deinen Projekten zu wenig in Werbung investiert.", 
+        "gestalt": "karma014", 
+        "karma_points": -4, 
+        "label": "Datenschutzproteste", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-025.png"
+        }, 
+        "price": 0, 
+        "required_level": 5, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 0, 
+              "y": 560
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "title": "Datenschutzproteste"
+      }
+    }, 
+    {
+      "game_type": "Karmalizer", 
+      "type_data": {
+        "description": "Ein paar Scherzkekse verbreiten halblustige Bildchen im Internet, auf denen du wirklich nicht gut wegkommst. Da stehen schlimme Unwahrheiten drauf, die dir gar nicht passen. Bl\u00f6d nur, dass die sich so schnell verbreiten! Zeit, was dagegen zu unternehmen.", 
+        "gestalt": "karma016", 
+        "karma_points": -6, 
+        "label": "Gemeines Meme", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-024.png"
+        }, 
+        "price": 0, 
+        "required_level": 6, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 580, 
+              "y": 300
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "title": "Gemeines Meme"
+      }
+    }, 
+    {
+      "game_type": "Karmalizer", 
+      "type_data": {
+        "description": "Da gibt es diesen seltsamen Typ, der dir schon die l\u00e4ngste Zeit auf die Nerven geht. Scheint so als h\u00e4tte er sich irgendwie an dir festgebissen. Diese Klette kritisiert deine glorreichen Gesch\u00e4fte nun schon zum hundersten Mal, hat der kein Leben? Allerh\u00f6chste Zeit, den mal zum Schweigen zu bringen.", 
+        "gestalt": "karma018", 
+        "karma_points": -2, 
+        "label": "L\u00e4stiger Datenschutztyp", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-025.png"
+        }, 
+        "price": 0, 
+        "required_level": 5, 
+        "slot_sprite": [], 
+        "title": "L\u00e4stiger Datenschutztyp"
+      }
+    }, 
+    {
+      "game_type": "Karmalizer", 
+      "type_data": {
+        "description": "Du hast es wohl zu bunt getrieben, das hast du nun davon! Parlament und Medien diskutieren neue Datenschutzgesetze, die b\u00f6se Auswirkungen auf dein Business haben k\u00f6nnten. Du solltest dringend etwas unternehmen und darauf hinarbeiten, dass das Gesetz etwas mehr in deinem Sinne formuliert wird!", 
+        "gestalt": "karma010", 
+        "karma_points": -5, 
+        "label": "Neue Datenschutzgesetze", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-024.png"
+        }, 
+        "price": 0, 
+        "required_level": 5, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 400, 
+              "y": 560
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "title": "Neue Datenschutzgesetze"
+      }
+    }, 
+    {
+      "game_type": "Karmalizer", 
+      "type_data": {
+        "description": "Verdammt! Die Medien stecken ihre Nase immer in Dinge, die sie so gar nichts angehen. Und dann auch noch auf Seite 1. Was das wieder kostet! Hoffentlich passiert irgendein Ungl\u00fcck, damit dieses Thema bald wieder aus den Medien verschwindet.", 
+        "gestalt": "karma011", 
+        "karma_points": -8, 
+        "label": "Schlechte Presse", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-025.png"
+        }, 
+        "price": 0, 
+        "required_level": 8, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 300, 
+              "y": 560
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "title": "Schlechte Presse"
+      }
+    }, 
+    {
+      "game_type": "Karmalizer", 
+      "type_data": {
+        "description": "Heilige Schei\u00dfe! Wohl nicht fr\u00fch genug reagiert. Das Internet ist voll von falschen Anschuldigungen gegen dich, tausende entr\u00fcstete Postings haben zu einem Sturm der Emp\u00f6rung gef\u00fchrt. Jetzt kannst du nur hoffen, dass das bald wieder ein Ende hat!", 
+        "gestalt": "karma015", 
+        "karma_points": -10, 
+        "label": "Shitstorm", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-024.png"
+        }, 
+        "price": 0, 
+        "required_level": 10, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 580, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "title": "Shitstorm"
+      }
+    }, 
+    {
+      "game_type": "Karmalizer", 
+      "type_data": {
+        "description": "Shit. Einer deiner ehemaligen Mitarbeiter hat sich alle dreckigen Details \u00fcber deine Machenschaften runterkopiert und verbreitet das jetzt \u00fcber die Medien! Du solltest alles versuchen, ihn fertigzumachen. Und zwar schnell. Zieh alle Register, droh ihm mit Strafverfolgung und stell ihn als unglaubw\u00fcrdigen Verr\u00e4ter hin. Du machst das schon!", 
+        "gestalt": "karma017", 
+        "karma_points": -15, 
+        "label": "Whistleblower", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-024.png"
+        }, 
+        "price": 0, 
+        "required_level": 12, 
+        "slot_sprite": [], 
+        "title": "Whistleblower"
+      }
+    }, 
+    {
+      "game_type": "Karmalizer", 
+      "type_data": {
+        "description": "W\u00fctende UserInnen beschweren sich online \u00fcber dich. Grrr! Was soll die ganze Aufregung um nichts und wieder nichts? Die sollen dich einfach in Ruhe deine florierenden Gesch\u00e4fte weiterbetreiben lassen. Trotzdem solltest du das ernst nehmen, bevor sich die Sache zu einem ausgewachsenen Shitstorm aufbl\u00e4st.", 
+        "gestalt": "karma012", 
+        "karma_points": -8, 
+        "label": "W\u00fctende UserInnen", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-025.png"
+        }, 
+        "price": 0, 
+        "required_level": 7, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 200, 
+              "y": 560
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "title": "W\u00fctende UserInnen"
+      }
+    }
+  ], 
+  "levels": [
+    {
+      "ap_inc_interval": 120000, 
+      "ap_inc_value": 1, 
+      "ap_max": 6, 
+      "number": 1, 
+      "xp_max": 10, 
+      "xp_min": 0
+    }, 
+    {
+      "ap_inc_interval": 120000, 
+      "ap_inc_value": 1, 
+      "ap_max": 8, 
+      "number": 2, 
+      "xp_max": 30, 
+      "xp_min": 11
+    }, 
+    {
+      "ap_inc_interval": 120000, 
+      "ap_inc_value": 1, 
+      "ap_max": 12, 
+      "number": 3, 
+      "xp_max": 54, 
+      "xp_min": 31
+    }, 
+    {
+      "ap_inc_interval": 120000, 
+      "ap_inc_value": 1, 
+      "ap_max": 14, 
+      "number": 4, 
+      "xp_max": 80, 
+      "xp_min": 55
+    }, 
+    {
+      "ap_inc_interval": 120000, 
+      "ap_inc_value": 1, 
+      "ap_max": 18, 
+      "number": 5, 
+      "xp_max": 111, 
+      "xp_min": 81
+    }, 
+    {
+      "ap_inc_interval": 120000, 
+      "ap_inc_value": 1, 
+      "ap_max": 20, 
+      "number": 6, 
+      "xp_max": 152, 
+      "xp_min": 112
+    }, 
+    {
+      "ap_inc_interval": 120000, 
+      "ap_inc_value": 1, 
+      "ap_max": 24, 
+      "number": 7, 
+      "xp_max": 213, 
+      "xp_min": 153
+    }, 
+    {
+      "ap_inc_interval": 120000, 
+      "ap_inc_value": 1, 
+      "ap_max": 28, 
+      "number": 8, 
+      "xp_max": 290, 
+      "xp_min": 214
+    }, 
+    {
+      "ap_inc_interval": 120000, 
+      "ap_inc_value": 1, 
+      "ap_max": 30, 
+      "number": 9, 
+      "xp_max": 381, 
+      "xp_min": 291
+    }, 
+    {
+      "ap_inc_interval": 120000, 
+      "ap_inc_value": 1, 
+      "ap_max": 32, 
+      "number": 10, 
+      "xp_max": 522, 
+      "xp_min": 382
+    }, 
+    {
+      "ap_inc_interval": 120000, 
+      "ap_inc_value": 1, 
+      "ap_max": 34, 
+      "number": 11, 
+      "xp_max": 664, 
+      "xp_min": 523
+    }, 
+    {
+      "ap_inc_interval": 120000, 
+      "ap_inc_value": 1, 
+      "ap_max": 36, 
+      "number": 12, 
+      "xp_max": 877, 
+      "xp_min": 665
+    }, 
+    {
+      "ap_inc_interval": 120000, 
+      "ap_inc_value": 1, 
+      "ap_max": 38, 
+      "number": 13, 
+      "xp_max": 1171, 
+      "xp_min": 878
+    }, 
+    {
+      "ap_inc_interval": 120000, 
+      "ap_inc_value": 1, 
+      "ap_max": 40, 
+      "number": 14, 
+      "xp_max": 1483, 
+      "xp_min": 1172
+    }, 
+    {
+      "ap_inc_interval": 120000, 
+      "ap_inc_value": 1, 
+      "ap_max": 42, 
+      "number": 15, 
+      "xp_max": 1909, 
+      "xp_min": 1484
+    }, 
+    {
+      "ap_inc_interval": 120000, 
+      "ap_inc_value": 1, 
+      "ap_max": 46, 
+      "number": 16, 
+      "xp_max": 2684, 
+      "xp_min": 1910
+    }, 
+    {
+      "ap_inc_interval": 120000, 
+      "ap_inc_value": 1, 
+      "ap_max": 48, 
+      "number": 17, 
+      "xp_max": 3871, 
+      "xp_min": 2685
+    }, 
+    {
+      "ap_inc_interval": 120000, 
+      "ap_inc_value": 1, 
+      "ap_max": 50, 
+      "number": 18, 
+      "xp_max": 5426, 
+      "xp_min": 3872
+    }, 
+    {
+      "ap_inc_interval": 120000, 
+      "ap_inc_value": 1, 
+      "ap_max": 54, 
+      "number": 19, 
+      "xp_max": 6981, 
+      "xp_min": 5427
+    }, 
+    {
+      "ap_inc_interval": 120000, 
+      "ap_inc_value": 1, 
+      "ap_max": 56, 
+      "number": 20, 
+      "xp_max": 66673647, 
+      "xp_min": 6982
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 36, 
+      "number": 21, 
+      "xp_max": 733340313, 
+      "xp_min": 66673648
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 40, 
+      "number": 22, 
+      "xp_max": 733340475, 
+      "xp_min": 733340314
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 45, 
+      "number": 23, 
+      "xp_max": 733340656, 
+      "xp_min": 733340476
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 51, 
+      "number": 24, 
+      "xp_max": 733340859, 
+      "xp_min": 733340657
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 57, 
+      "number": 25, 
+      "xp_max": 733341086, 
+      "xp_min": 733340860
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 57, 
+      "number": 26, 
+      "xp_max": 733341341, 
+      "xp_min": 733341087
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 71, 
+      "number": 27, 
+      "xp_max": 733341626, 
+      "xp_min": 733341342
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 80, 
+      "number": 28, 
+      "xp_max": 733341946, 
+      "xp_min": 733341627
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 90, 
+      "number": 29, 
+      "xp_max": 733342304, 
+      "xp_min": 733341947
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 100, 
+      "number": 30, 
+      "xp_max": 733342704, 
+      "xp_min": 733342305
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 149, 
+      "number": 31, 
+      "xp_max": 733343304, 
+      "xp_min": 733342705
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 167, 
+      "number": 32, 
+      "xp_max": 733344004, 
+      "xp_min": 733343305
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 187, 
+      "number": 33, 
+      "xp_max": 733344754, 
+      "xp_min": 733344005
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 210, 
+      "number": 34, 
+      "xp_max": 733345604, 
+      "xp_min": 733344755
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 234, 
+      "number": 35, 
+      "xp_max": 733346554, 
+      "xp_min": 733345605
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 263, 
+      "number": 36, 
+      "xp_max": 733347554, 
+      "xp_min": 733346555
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 295, 
+      "number": 37, 
+      "xp_max": 733348704, 
+      "xp_min": 733347555
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 331, 
+      "number": 38, 
+      "xp_max": 733350004, 
+      "xp_min": 733348705
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 370, 
+      "number": 39, 
+      "xp_max": 733351504, 
+      "xp_min": 733350005
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 415, 
+      "number": 40, 
+      "xp_max": 733353154, 
+      "xp_min": 733351505
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 436, 
+      "number": 41, 
+      "xp_max": 733355054, 
+      "xp_min": 733353155
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 446, 
+      "number": 42, 
+      "xp_max": 733357154, 
+      "xp_min": 733355055
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 466, 
+      "number": 43, 
+      "xp_max": 733359454, 
+      "xp_min": 733357155
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 522, 
+      "number": 44, 
+      "xp_max": 733362054, 
+      "xp_min": 733359455
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 585, 
+      "number": 45, 
+      "xp_max": 733364954, 
+      "xp_min": 733362055
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 655, 
+      "number": 46, 
+      "xp_max": 733368254, 
+      "xp_min": 733364955
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 734, 
+      "number": 47, 
+      "xp_max": 733371954, 
+      "xp_min": 733368255
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 822, 
+      "number": 48, 
+      "xp_max": 733376054, 
+      "xp_min": 733371955
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 921, 
+      "number": 49, 
+      "xp_max": 733380654, 
+      "xp_min": 733376055
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 1032, 
+      "number": 50, 
+      "xp_max": 733385854, 
+      "xp_min": 733380655
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 1156, 
+      "number": 51, 
+      "xp_max": 733391654, 
+      "xp_min": 733385855
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 1294, 
+      "number": 52, 
+      "xp_max": 733398154, 
+      "xp_min": 733391655
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 1450, 
+      "number": 53, 
+      "xp_max": 733405354, 
+      "xp_min": 733398155
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 1624, 
+      "number": 54, 
+      "xp_max": 733413454, 
+      "xp_min": 733405355
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 1819, 
+      "number": 55, 
+      "xp_max": 733422454, 
+      "xp_min": 733413455
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 2037, 
+      "number": 56, 
+      "xp_max": 733432554, 
+      "xp_min": 733422455
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 2281, 
+      "number": 57, 
+      "xp_max": 733443954, 
+      "xp_min": 733432555
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 2555, 
+      "number": 58, 
+      "xp_max": 733456754, 
+      "xp_min": 733443955
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 2862, 
+      "number": 59, 
+      "xp_max": 733471054, 
+      "xp_min": 733456755
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 3205, 
+      "number": 60, 
+      "xp_max": 734471053, 
+      "xp_min": 733471055
+    }
+  ], 
+  "missions": [
+    {
+      "game_type": "Mission", 
+      "type_data": {
+        "branch": "trunk", 
+        "description": "Deine erste Mission! Klick auf Jessica, f\u00fcttere sie mit ein wenig Cash und hol dir nach kurzer Zeit deine ersten Profile ab. Lecker!", 
+        "gestalt": "mission001", 
+        "goals": [
+          {
+            "amount": 900, 
+            "position": 2, 
+            "project": null, 
+            "target": "contact035", 
+            "workflow": "collect_profiles"
+          }
+        ], 
+        "price": 0, 
+        "required_level": 0, 
+        "rewards": [
+          {
+            "amount": 2, 
+            "target": "xp_value"
+          }
+        ], 
+        "title": "Mission 1", 
+        "tutorial": [
+          {
+            "delay": 0, 
+            "description": "Hey. Willkommen! Ich bin Marko, dein pers\u00f6nlicher Berater. Bist du bereit?", 
+            "name": "tut01: willkommen", 
+            "viewmap": "empire001", 
+            "viewmapPos": {
+              "x": 1024, 
+              "y": 1
+            }
+          }, 
+          {
+            "delay": 0, 
+            "description": "Ich begleite dich auf deinem Weg zum m\u00e4chtigen Daten-Tycoon! Lass mich wie ein <i>grosser Bruder</i> f\u00fcr dich sein.", 
+            "name": "tut02: willkommen 2", 
+            "viewmap": "empire001", 
+            "viewmapPos": {
+              "x": 1024, 
+              "y": 1
+            }
+          }, 
+          {
+            "delay": 0, 
+            "description": "Das ist deine Datenbank. Bereit f\u00fcr Millionen hochwertige Pers\u00f6nlichkeitsprofile.", 
+            "name": "tut03: datenbank perp", 
+            "viewmap": "empire001", 
+            "viewmapPos": {
+              "x": 1024, 
+              "y": 840
+            }
+          }, 
+          {
+            "buyParent": "database001", 
+            "buyPerp": "city002", 
+            "buyPerpPos": {
+              "x": 805, 
+              "y": 865
+            }, 
+            "delay": 0, 
+            "description": "Dein Daten-Imperium braucht ein Hauptquartier: Little Rock City ist perfekt! Warum? Dazu sp\u00e4ter.", 
+            "name": "tut04: first city", 
+            "viewmap": "empire001"
+          }, 
+          {
+            "delay": 0, 
+            "description": "Lass uns zuerst mal einen Blick in deine Datenbank werfen.", 
+            "name": "tut05: first city 2", 
+            "viewmap": "empire001"
+          }, 
+          {
+            "delay": 0, 
+            "description": "So sieht deine Datenbank von innen aus.\r\nNoch ziemlich leer!", 
+            "name": "tut06: datenbank leer", 
+            "viewmap": "database001", 
+            "viewmapPos": {
+              "x": 1024, 
+              "y": 800
+            }
+          }, 
+          {
+            "delay": 0, 
+            "description": "Darum hab ich als Starthilfe eine DVD mit leckeren Telefonbuch-Daten f\u00fcr dich. Schau mal, wie die reinkugeln.", 
+            "name": "tut07: telefonbuch integrieren", 
+            "viewmap": "database001"
+          }, 
+          {
+            "delay": 0, 
+            "description": "Na bitte, sieht doch schon besser aus. Schau mal nach links oben: Ganze 100.000 Profile!\r\nEine gute Basis.", 
+            "integrateProfileSet": "city002", 
+            "name": "tut08: telefonbuch integrieren 2", 
+            "viewmap": "database001"
+          }, 
+          {
+            "delay": 0, 
+            "description": "Zur\u00fcck in dein zuk\u00fcnftiges Imperium. 100.000 Namen, Adressen und Telefonnummern sind zwar nett. Aber du brauchst delikatere Infos.\t", 
+            "name": "tut09: back in imperium", 
+            "viewmap": "empire001"
+          }, 
+          {
+            "buyParent": "city002", 
+            "buyPerp": "agent002", 
+            "buyPerpPos": {
+              "x": 625, 
+              "y": 900
+            }, 
+            "delay": 0, 
+            "description": "Darf ich vorstellen: Manny Mayer, Privat- detektiv und alter Freund. Vor Jahren war er mal ganz erfolgreich, doch die fetten Jahre sind vorbei.", 
+            "name": "tut10: manny 1", 
+            "viewmap": "empire001"
+          }, 
+          {
+            "delay": 0, 
+            "description": "Unterbezahlt, gelangweilt und frustriert, ist Manny inzwischen ein grosser Experte im Aufst\u00f6bern von kleinen Angestellten...", 
+            "name": "tut11: manny 2", 
+            "viewmap": "empire001"
+          }, 
+          {
+            "delay": 0, 
+            "description": "...die mit ganz sch\u00f6n pers\u00f6nlichen Daten zu tun haben! Zum Beispiel Jessica Seno. Die arbeitet in einem grossen Casino.", 
+            "name": "tut12: manny kennt jessica", 
+            "viewmap": "empire001"
+          }, 
+          {
+            "buyParent": "agent002", 
+            "buyPerp": "contact035", 
+            "buyPerpPos": {
+              "x": 485, 
+              "y": 840
+            }, 
+            "delay": 0, 
+            "description": "Sie ist mindestens genauso unterbezahlt, gelangweilt & frustriert. Und hat zuf\u00e4llig Zugriff auf den Casino-Zentralcomputer! Deine Chance.", 
+            "name": "tut13: jessica 1", 
+            "viewmap": "empire001"
+          }, 
+          {
+            "delay": 0, 
+            "description": "Wenn du sie mit ein wenig Cash f\u00fctterst, liefert sie dir interessante Infos \u00fcber die Leute, die im Casino regelm\u00e4ssig ihr Hab und Gut verspielen.", 
+            "name": "tut14: jessica 2", 
+            "viewmap": "empire001"
+          }
+        ]
+      }
+    }, 
+    {
+      "game_type": "Mission", 
+      "type_data": {
+        "branch": "trunk", 
+        "description": "Neue Mission! Geh in die Datenbank und importiere die neuen Profile, die Jessica geliefert hat. Tipp: Schau auf das F\u00f6rderband unten links.", 
+        "gestalt": "mission002", 
+        "goals": [
+          {
+            "amount": 900, 
+            "position": 1, 
+            "project": null, 
+            "target": "token008", 
+            "workflow": "integrate_profiles"
+          }
+        ], 
+        "price": 0, 
+        "required_level": 0, 
+        "required_mission": "mission001", 
+        "rewards": [
+          {
+            "amount": 100, 
+            "target": "cash_value"
+          }, 
+          {
+            "amount": 1, 
+            "target": "xp_value"
+          }
+        ], 
+        "title": "Ab in die Datenbank!"
+      }
+    }, 
+    {
+      "game_type": "Mission", 
+      "type_data": {
+        "branch": "trunk", 
+        "description": "Neue Mission! Verkauf deine Daten. Klick dazu auf den Autoh\u00e4ndler und mach deinen ersten Deal.", 
+        "gestalt": "mission003", 
+        "goals": [
+          {
+            "amount": null, 
+            "position": 1, 
+            "project": null, 
+            "target": "client007", 
+            "workflow": "charge_perp"
+          }
+        ], 
+        "price": 0, 
+        "required_level": 0, 
+        "required_mission": "mission002", 
+        "rewards": [
+          {
+            "amount": 600, 
+            "target": "cash_value"
+          }, 
+          {
+            "amount": 1, 
+            "target": "xp_value"
+          }
+        ], 
+        "title": "Strassendealer", 
+        "tutorial": [
+          {
+            "delay": 0, 
+            "description": "Du weisst jetzt schon 8 unterschiedliche Dinge von \u00fcber 100.000 Leuten! Nicht schlecht.", 
+            "name": "Vor Mission 3 (1): Datenbank", 
+            "viewmap": "database001"
+          }, 
+          {
+            "delay": 0, 
+            "description": "Zur\u00fcck ins Imperium. Deine Daten sind Gold wert. Du solltest sie verkaufen! Nur: An wen?", 
+            "name": "Vor Mission 3 (2): Verkaufen", 
+            "viewmap": "empire001"
+          }, 
+          {
+            "buyParent": "city002", 
+            "buyPerp": "pusher004", 
+            "buyPerpPos": {
+              "x": 920, 
+              "y": 980
+            }, 
+            "delay": 0, 
+            "description": "Das ist Denise. Sie ist ein Profi & findet immer neue Kundschaft, die sich brennend f\u00fcr deinen Daten-Schatz interessiert!", 
+            "name": "Vor Mission 3 (3): Denise", 
+            "viewmap": "empire001"
+          }, 
+          {
+            "buyParent": "pusher004", 
+            "buyPerp": "client007", 
+            "buyPerpPos": {
+              "x": 1055, 
+              "y": 1070
+            }, 
+            "delay": 0, 
+            "description": "Zum Beispiel diese Auto-Firma. Die h\u00e4tten gern die Namen und Adressen von besonders naiven und leichtgl\u00e4ubigen Leuten...", 
+            "name": "Vor Mission 3 (4): Autoh\u00e4ndler", 
+            "viewmap": "empire001"
+          }, 
+          {
+            "delay": 0, 
+            "description": "...die gut auf ihre superbilligen Angebote im Hochglanz-Werbeprospekt reinfallen. Die sind n\u00e4mlich genauer betrachtet gar nicht so billig.", 
+            "name": "Vor Mission 3 (4): Autoh\u00e4ndler 2", 
+            "viewmap": "empire001"
+          }
+        ]
+      }
+    }, 
+    {
+      "game_type": "Mission", 
+      "type_data": {
+        "branch": "trunk", 
+        "description": "Neue Mission! Mit einem Gewinnspiel lassen sich gut Profile scheffeln. Klick auf die Briefkasten- firma und starte ein Gewinnspiel!", 
+        "gestalt": "mission004", 
+        "goals": [
+          {
+            "amount": null, 
+            "position": 1, 
+            "project": null, 
+            "target": "project001", 
+            "workflow": "buy_perp"
+          }, 
+          {
+            "amount": null, 
+            "position": 2, 
+            "project": null, 
+            "target": "project001", 
+            "workflow": "charge_perp"
+          }
+        ], 
+        "price": 0, 
+        "required_level": 0, 
+        "required_mission": "mission003", 
+        "rewards": [
+          {
+            "amount": 100, 
+            "target": "cash_value"
+          }, 
+          {
+            "amount": 5, 
+            "target": "xp_value"
+          }
+        ], 
+        "title": "Gewinner-Typ", 
+        "tutorial": [
+          {
+            "delay": 0, 
+            "description": "Nun. Du ben\u00f6tigst weitere attraktive Daten-Quellen. Werd aktiv und betreib eigene Firmen und Online-Projekte!", 
+            "name": "Vor Mission 4 (1): Intro", 
+            "viewmap": "empire001"
+          }, 
+          {
+            "buyParent": "city002", 
+            "buyPerp": "proxy001", 
+            "buyPerpPos": {
+              "x": 680, 
+              "y": 680
+            }, 
+            "delay": 0, 
+            "description": "Deine Gesch\u00e4fte sind nicht ganz unheikel. Darum brauchst du erstmal eine Briefkastenfirma. Benutze immer eine Scheinfirma, zur Tarnung!", 
+            "name": "Vor Mission 4 (2): Briefkastenfirma", 
+            "viewmap": "empire001"
+          }
+        ]
+      }
+    }, 
+    {
+      "game_type": "Mission", 
+      "type_data": {
+        "branch": "trunk", 
+        "description": "Neue Mission! Dein erster Deal ist unter Dach und Fach? Kassiere vom Autoh\u00e4ndler mindestens $500 f\u00fcr die verkauften Daten.", 
+        "gestalt": "a388da08d87dc9fd6d543977a2047262000", 
+        "goals": [
+          {
+            "amount": 500, 
+            "position": 1, 
+            "project": null, 
+            "target": "client007", 
+            "workflow": "collect_cash"
+          }
+        ], 
+        "price": 0, 
+        "required_level": 0, 
+        "required_mission": "mission004", 
+        "rewards": [
+          {
+            "amount": 200, 
+            "target": "cash_value"
+          }, 
+          {
+            "amount": 1, 
+            "target": "xp_value"
+          }
+        ], 
+        "title": "Abkassieren!"
+      }
+    }, 
+    {
+      "game_type": "Mission", 
+      "type_data": {
+        "branch": "trunk", 
+        "description": "Neue Mission! Bau dein Gewinnspiel aus, mach Werbung und erweitere dein Team! So sammelst du mehr Profile in der gleichen Zeit.", 
+        "gestalt": "mission006", 
+        "goals": [
+          {
+            "amount": null, 
+            "position": 1, 
+            "project": "project001", 
+            "target": "upgrade001", 
+            "workflow": "buy_powerup"
+          }, 
+          {
+            "amount": null, 
+            "position": 2, 
+            "project": "project001", 
+            "target": "ad002", 
+            "workflow": "buy_powerup"
+          }, 
+          {
+            "amount": null, 
+            "position": 3, 
+            "project": "project001", 
+            "target": "teammember020", 
+            "workflow": "buy_powerup"
+          }
+        ], 
+        "price": 0, 
+        "required_level": 0, 
+        "required_mission": "a388da08d87dc9fd6d543977a2047262000", 
+        "rewards": [
+          {
+            "amount": 800, 
+            "target": "cash_value"
+          }, 
+          {
+            "amount": 3, 
+            "target": "xp_value"
+          }
+        ], 
+        "title": "Gewinnspiel erweitern"
+      }
+    }, 
+    {
+      "game_type": "Mission", 
+      "type_data": {
+        "branch": "trunk", 
+        "description": "Neue Mission! Wirb Schwester Elfriede an und bring sie dazu, dir 3.000 Krankenakten f\u00fcr deine Datenbank zu \u00fcberlassen.", 
+        "gestalt": "mission007", 
+        "goals": [
+          {
+            "amount": null, 
+            "position": 1, 
+            "project": null, 
+            "target": "contact001", 
+            "workflow": "buy_perp"
+          }, 
+          {
+            "amount": 3000, 
+            "position": 2, 
+            "project": null, 
+            "target": "contact001", 
+            "workflow": "collect_profiles"
+          }, 
+          {
+            "amount": 3000, 
+            "position": 3, 
+            "project": null, 
+            "target": "token017", 
+            "workflow": "integrate_profiles"
+          }
+        ], 
+        "price": 0, 
+        "required_level": 0, 
+        "required_mission": "mission006", 
+        "rewards": [
+          {
+            "amount": 10, 
+            "target": "xp_value"
+          }
+        ], 
+        "title": "Schwester Elfriede"
+      }
+    }, 
+    {
+      "game_type": "Mission", 
+      "type_data": {
+        "branch": "trunk", 
+        "description": "Neue Mission! Klick auf Geschlecht und berechne aus deinen Vornamen das Geschlecht von Profilen, bei denen du es noch gar nicht kennst.", 
+        "gestalt": "e59302bed28769c3c76761c14516e764000", 
+        "goals": [
+          {
+            "amount": null, 
+            "position": 1, 
+            "project": null, 
+            "target": "token007", 
+            "workflow": "upgrade_token"
+          }
+        ], 
+        "price": 0, 
+        "required_level": 0, 
+        "required_mission": "mission007", 
+        "rewards": [
+          {
+            "amount": 1000, 
+            "target": "cash_value"
+          }, 
+          {
+            "amount": 5, 
+            "target": "xp_value"
+          }
+        ], 
+        "title": "Datenbank-Maschine", 
+        "tutorial": [
+          {
+            "delay": 0, 
+            "description": "Kleiner Tipp: Eigenschaften mit einem Zahnrad an der rechten oberen Ecke bieten dir ganz besondere M\u00f6glichkeiten.", 
+            "name": "Vor Mission 8 Geschlecht (1)", 
+            "viewmap": "database001"
+          }, 
+          {
+            "delay": 0, 
+            "description": "Zum Beispiel beim Geschlecht: Du kannst deine gesammelten Vornamen analysieren und daraus das Geschlecht berechnen.", 
+            "name": "Vor Mission 8 Geschlecht (2)", 
+            "viewmap": "database001"
+          }
+        ]
+      }
+    }, 
+    {
+      "game_type": "Mission", 
+      "type_data": {
+        "branch": "trunk", 
+        "description": "Neue Mission! Klick auf Denise & mach einen Deal mit der Versicherung. Du brauchst das Geld! Und frag Manny nach Alexa.", 
+        "gestalt": "mission008", 
+        "goals": [
+          {
+            "amount": null, 
+            "position": 1, 
+            "project": null, 
+            "target": "client002", 
+            "workflow": "buy_perp"
+          }, 
+          {
+            "amount": null, 
+            "position": 2, 
+            "project": null, 
+            "target": "client002", 
+            "workflow": "charge_perp"
+          }, 
+          {
+            "amount": null, 
+            "position": 3, 
+            "project": null, 
+            "target": "contact019", 
+            "workflow": "buy_perp"
+          }
+        ], 
+        "price": 0, 
+        "required_level": 0, 
+        "required_mission": "e59302bed28769c3c76761c14516e764000", 
+        "rewards": [
+          {
+            "amount": 500, 
+            "target": "cash_value"
+          }, 
+          {
+            "amount": 10, 
+            "target": "xp_value"
+          }
+        ], 
+        "title": "Kranke Welt"
+      }
+    }, 
+    {
+      "game_type": "Mission", 
+      "type_data": {
+        "branch": "trunk", 
+        "description": "Neue Mission: Finde von mindestens 10.000 Leuten raus, wie naiv und blau\u00e4ugig sie sind & verkauf diese Info an den Autoh\u00e4ndler.", 
+        "gestalt": "mission005", 
+        "goals": [
+          {
+            "amount": 10000, 
+            "position": 1, 
+            "project": null, 
+            "target": "token084", 
+            "workflow": "integrate_profiles"
+          }, 
+          {
+            "amount": 500, 
+            "position": 2, 
+            "project": null, 
+            "target": "client007", 
+            "workflow": "collect_cash"
+          }
+        ], 
+        "price": 0, 
+        "required_level": 0, 
+        "required_mission": "mission008", 
+        "rewards": [
+          {
+            "amount": 1000, 
+            "target": "cash_value"
+          }, 
+          {
+            "amount": 5, 
+            "target": "xp_value"
+          }
+        ], 
+        "title": "Voll naiv"
+      }
+    }, 
+    {
+      "game_type": "Mission", 
+      "type_data": {
+        "branch": "trunk", 
+        "description": "Neue Mission! Klick auf die Briefkasten- firma, check dir den Psychotest & bau darin gleich das Upgrade \"Wie treu bin ich?\" aus.", 
+        "gestalt": "e33a3ef9d70038e0a9c6d088f37d02cb000", 
+        "goals": [
+          {
+            "amount": null, 
+            "position": 1, 
+            "project": null, 
+            "target": "project003", 
+            "workflow": "buy_perp"
+          }, 
+          {
+            "amount": null, 
+            "position": 2, 
+            "project": "project003", 
+            "target": "upgrade015", 
+            "workflow": "buy_powerup"
+          }, 
+          {
+            "amount": null, 
+            "position": 3, 
+            "project": null, 
+            "target": "project003", 
+            "workflow": "charge_perp"
+          }
+        ], 
+        "price": 0, 
+        "required_level": 0, 
+        "required_mission": "mission005", 
+        "rewards": [
+          {
+            "amount": 20, 
+            "target": "xp_value"
+          }, 
+          {
+            "amount": 2000, 
+            "target": "cash_value"
+          }
+        ], 
+        "title": "Psycho"
+      }
+    }, 
+    {
+      "game_type": "Mission", 
+      "type_data": {
+        "branch": "trunk", 
+        "description": "Neue Mission! Finde von 6.000 Leuten raus, wie lahm sie unterwegs sind & verkauf das an die Krankenversicherung.", 
+        "gestalt": "af1149c315321ef4f477893fcc1807e1000", 
+        "goals": [
+          {
+            "amount": 6000, 
+            "position": 1, 
+            "project": null, 
+            "target": "contact019", 
+            "workflow": "collect_profiles"
+          }, 
+          {
+            "amount": 6000, 
+            "position": 2, 
+            "project": null, 
+            "target": "token088", 
+            "workflow": "integrate_profiles"
+          }, 
+          {
+            "amount": 500, 
+            "position": 3, 
+            "project": null, 
+            "target": "client002", 
+            "workflow": "collect_cash"
+          }
+        ], 
+        "price": 0, 
+        "required_level": 0, 
+        "required_mission": "e33a3ef9d70038e0a9c6d088f37d02cb000", 
+        "rewards": [
+          {
+            "amount": 10000, 
+            "target": "cash_value"
+          }, 
+          {
+            "amount": 1, 
+            "target": "xp_value"
+          }
+        ], 
+        "title": "Lahmer Arsch"
+      }
+    }, 
+    {
+      "game_type": "Mission", 
+      "type_data": {
+        "branch": "trunk", 
+        "description": "Neue Mission! Klick auf Denise, check dir neue Kundschaft & kassiere mindestens $ 2000.", 
+        "gestalt": "b638f35b5ec6b0558981378c9037c3d3000", 
+        "goals": [
+          {
+            "amount": null, 
+            "position": 1, 
+            "project": null, 
+            "target": "client006", 
+            "workflow": "buy_perp"
+          }, 
+          {
+            "amount": 2000, 
+            "position": 2, 
+            "project": null, 
+            "target": "client006", 
+            "workflow": "collect_cash"
+          }
+        ], 
+        "price": 0, 
+        "required_level": 0, 
+        "required_mission": "af1149c315321ef4f477893fcc1807e1000", 
+        "rewards": [
+          {
+            "amount": 5000, 
+            "target": "cash_value"
+          }, 
+          {
+            "amount": 1, 
+            "target": "xp_value"
+          }
+        ], 
+        "title": "Personal\u00fcberwachung"
+      }
+    }, 
+    {
+      "game_type": "Mission", 
+      "type_data": {
+        "branch": "trunk", 
+        "description": "Neue Mission! Profile sammeln ist riskant. Mach Werbung f\u00fcr den Psychotest und stell eine Anw\u00e4ltin ein, um dein Risiko zu senken.", 
+        "gestalt": "9f5735d01587f640cc862e0a82280d3f000", 
+        "goals": [
+          {
+            "amount": null, 
+            "position": 1, 
+            "project": "project003", 
+            "target": "teammember043", 
+            "workflow": "buy_powerup"
+          }, 
+          {
+            "amount": null, 
+            "position": 2, 
+            "project": "project003", 
+            "target": "ad006", 
+            "workflow": "buy_powerup"
+          }
+        ], 
+        "price": 0, 
+        "required_level": 0, 
+        "required_mission": "b638f35b5ec6b0558981378c9037c3d3000", 
+        "rewards": [
+          {
+            "amount": 2000, 
+            "target": "cash_value"
+          }, 
+          {
+            "amount": 1, 
+            "target": "xp_value"
+          }
+        ], 
+        "title": "Image polieren"
+      }
+    }, 
+    {
+      "game_type": "Mission", 
+      "type_data": {
+        "branch": "trunk", 
+        "description": "Neue Mission! Klick auf Little Rock und wirb Heidrun Klump an. Nicht ganz billig, aber sie hat gute Kontakte. Und check dir Elly!", 
+        "gestalt": "16f302f84b84498a734dfdbe1a7794b9000", 
+        "goals": [
+          {
+            "amount": null, 
+            "position": 1, 
+            "project": null, 
+            "target": "agent004", 
+            "workflow": "buy_perp"
+          }, 
+          {
+            "amount": null, 
+            "position": 2, 
+            "project": null, 
+            "target": "contact026", 
+            "workflow": "buy_perp"
+          }
+        ], 
+        "price": 0, 
+        "required_level": 0, 
+        "required_mission": "9f5735d01587f640cc862e0a82280d3f000", 
+        "rewards": [
+          {
+            "amount": 2000, 
+            "target": "cash_value"
+          }, 
+          {
+            "amount": 1, 
+            "target": "xp_value"
+          }
+        ], 
+        "title": "Informelle Mitarbeit"
+      }
+    }, 
+    {
+      "game_type": "Mission", 
+      "type_data": {
+        "branch": "trunk", 
+        "description": "Neue Mission! Klick auf Little Rock und wirb Alfonso an. Er treibt garantiert lukrative Kundschaft f\u00fcr deine Daten auf.", 
+        "gestalt": "dc481d7863ceb18575c50d36e2c5ecfe000", 
+        "goals": [
+          {
+            "amount": null, 
+            "position": 1, 
+            "project": null, 
+            "target": "pusher003", 
+            "workflow": "buy_perp"
+          }
+        ], 
+        "price": 0, 
+        "required_level": 0, 
+        "required_mission": "16f302f84b84498a734dfdbe1a7794b9000", 
+        "rewards": [
+          {
+            "amount": 5000, 
+            "target": "cash_value"
+          }, 
+          {
+            "amount": 1, 
+            "target": "xp_value"
+          }
+        ], 
+        "title": "Alfonso"
+      }
+    }, 
+    {
+      "game_type": "Mission", 
+      "type_data": {
+        "branch": "trunk", 
+        "description": "Neue Mission! Erreiche Level 9, klick auf Little Rock & check dir eine zweite Briefkastenfirma, damit du weitere Projekte starten kannst.", 
+        "gestalt": "3cb9492322191121ebf7a10aafd0fc4a000", 
+        "goals": [
+          {
+            "amount": null, 
+            "position": 1, 
+            "project": null, 
+            "target": "proxy004", 
+            "workflow": "buy_perp"
+          }
+        ], 
+        "price": 0, 
+        "required_level": 0, 
+        "required_mission": "dc481d7863ceb18575c50d36e2c5ecfe000", 
+        "rewards": [
+          {
+            "amount": 2000, 
+            "target": "cash_value"
+          }, 
+          {
+            "amount": 1, 
+            "target": "xp_value"
+          }
+        ], 
+        "title": "Scheinfirmen-Geflecht"
+      }
+    }, 
+    {
+      "game_type": "Mission", 
+      "type_data": {
+        "branch": "trunk", 
+        "description": "Neue Mission! Geh in die Datenbank, kauf die Erweiterung Body Mass Index und starte die Berechnung.", 
+        "gestalt": "1da63b8adf60878f693dfb9d9f73690f000", 
+        "goals": [
+          {
+            "amount": null, 
+            "position": 1, 
+            "project": null, 
+            "target": "token055", 
+            "workflow": "buy_perp"
+          }, 
+          {
+            "amount": null, 
+            "position": 2, 
+            "project": null, 
+            "target": "token055", 
+            "workflow": "upgrade_token"
+          }
+        ], 
+        "price": 0, 
+        "required_level": 0, 
+        "required_mission": "3cb9492322191121ebf7a10aafd0fc4a000", 
+        "rewards": [
+          {
+            "amount": 2000, 
+            "target": "cash_value"
+          }, 
+          {
+            "amount": 1, 
+            "target": "xp_value"
+          }
+        ], 
+        "title": "Kleines 1x1"
+      }
+    }, 
+    {
+      "game_type": "Mission", 
+      "type_data": {
+        "branch": "trunk", 
+        "description": "Neue Mission! Erreiche Level 11, klick auf Little Rock und expandiere nach New York City. Damit kannst du deine Zielgruppe verzehnfachen!", 
+        "gestalt": "2f59d10a67ca7ee9006dfe5db31a4c5f000", 
+        "goals": [
+          {
+            "amount": null, 
+            "position": 1, 
+            "project": null, 
+            "target": "city004", 
+            "workflow": "buy_perp"
+          }
+        ], 
+        "price": 0, 
+        "required_level": 0, 
+        "required_mission": "1da63b8adf60878f693dfb9d9f73690f000", 
+        "rewards": [
+          {
+            "amount": 10000, 
+            "target": "cash_value"
+          }, 
+          {
+            "amount": 1, 
+            "target": "xp_value"
+          }
+        ], 
+        "title": "Big Apple, Big Data!"
+      }
+    }
+  ], 
+  "perps": {
+    "13fee24f6edc8f796903e5b1fad001d3000": {
+      "game_type": "StoryPerp", 
+      "type_data": {
+        "perp_sprite": [], 
+        "popup_sprite": [], 
+        "price": 0, 
+        "required_level": 0, 
+        "text": "Neue Kundschaft, perfekt! Tipp: Schau rein, f\u00fcr welche Daten sich der Schulverband genau interessiert & sammle mehr davon."
+      }
+    }, 
+    "48f7fea778e2ceb1d209a8ba4f2eb4a3000": {
+      "game_type": "StoryPerp", 
+      "type_data": {
+        "perp_sprite": [], 
+        "popup_sprite": [], 
+        "price": 0, 
+        "required_level": 0, 
+        "text": "Neue Kundschaft, perfekt! Klick am besten gleich rein und mach einen Deal. Du brauchst Kohle f\u00fcr dein Imperium!"
+      }
+    }, 
+    "4f74159de0af2bb6b1806091abe8fd7d000": {
+      "game_type": "StoryPerp", 
+      "type_data": {
+        "perp_sprite": [], 
+        "popup_sprite": [], 
+        "price": 0, 
+        "required_level": 0, 
+        "text": "Yeah, dein B\u00fcro in New York City steht. Klick gleich mal rein und check dir neue Scheinfirmen, Agenten & Vertreter f\u00fcr dein Imperium!"
+      }
+    }, 
+    "8ae826a6f66442819cb913f7507dae2b000": {
+      "game_type": "StoryPerp", 
+      "type_data": {
+        "perp_sprite": [], 
+        "popup_sprite": [], 
+        "price": 0, 
+        "required_level": 0, 
+        "text": "Nur so nebenbei: Deine Kundschaft zahlt dir umso mehr, je mehr du von den gew\u00fcnschten Infos auf Lager hast."
+      }
+    }, 
+    "a867c7ac1fffeaec009c8be4baa6f375000": {
+      "game_type": "StoryPerp", 
+      "type_data": {
+        "perp_sprite": [], 
+        "popup_sprite": [], 
+        "price": 0, 
+        "required_level": 0, 
+        "text": "Ich sag dir: Alfonso ist der Superhit. Klick rein und schau, ob er eine lukrative Daten-Quelle f\u00fcr dich aufgetrieben hat!"
+      }
+    }, 
+    "agent002": {
+      "game_type": "AgentPerp", 
+      "type_data": {
+        "description": "Vor Jahren war er mal ganz erfolgreich, doch die fetten Jahre sind vorbei. Schlecht bezahlt, gelangweilt und frustriert, ist Manny inzwischen ein gro\u00dfer Experte im Aufst\u00f6bern von kleinen Angestellten, die mit ganz sch\u00f6n pers\u00f6nlichen Daten zu tun haben. Gegen ein wenig Cash liefern sie dir st\u00fcckchenweise leckere Happen f\u00fcr deine Datenbank.", 
+        "label": "Manny Mayer", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 780, 
+              "y": 200
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "price": 0, 
+        "provided_perps": [
+          "contact035", 
+          "contact001", 
+          "contact019", 
+          "contact022"
+        ], 
+        "required_level": 1, 
+        "subtitle": "ist Privatdetektiv und ein alter Freund", 
+        "title": "Manny Mayer"
+      }
+    }, 
+    "agent003": {
+      "game_type": "AgentPerp", 
+      "type_data": {
+        "description": "Du hast sie noch nie pers\u00f6nlich getroffen. Wenn \u00fcberhaupt, dann meldet sie sich. Mara Loft ist ein Phantom, und doch eine wertvolle Bekanntschaft. Sie kennt dubiose Kreise, in denen gro\u00dfe Pakete echt delikater Daten zu Spottpreisen verkauft werden. Auch gro\u00dfe Firmen sind betroffen: Irgendjemand hackt sich immer rein und zweigt was ab.", 
+        "label": "Mara Loft", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 780, 
+              "y": 100
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "price": 2500, 
+        "provided_perps": [
+          "contact003"
+        ], 
+        "required_level": 19, 
+        "subtitle": "ist eine grosse Nummer in der Hacker-Szene", 
+        "title": "Mara Loft"
+      }
+    }, 
+    "agent004": {
+      "game_type": "AgentPerp", 
+      "type_data": {
+        "description": "Bekannt und beliebt aus Funk und Fernsehen, das war einmal. Seit sie in ihrer TV-Show vor laufender Kamera eine 12j\u00e4hrige Kandidatin verpr\u00fcgelt hat, ist sie leider weg vom Fenster. Sie kennt aber immer noch viele Leute, darunter auch welche mit Geldbedarf und Zugang zu delikaten Datenbanken. Gern stellt sie ein paar Kontakte f\u00fcr dich her.", 
+        "label": "Heidrun Klump", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 780, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-019.png"
+        }, 
+        "price": 800, 
+        "provided_perps": [
+          "contact007", 
+          "contact026", 
+          "contact008", 
+          "contact033"
+        ], 
+        "required_level": 6, 
+        "subtitle": "hat viel mit Medien zu tun", 
+        "title": "Heidrun Klump"
+      }
+    }, 
+    "agent008": {
+      "game_type": "AgentPerp", 
+      "type_data": {
+        "description": "Ob Politiker oder Beamte, ob in Ministerien, Beh\u00f6rden oder bei der Polizei: Barnie kennt sie alle. Zumindest indirekt. Immerhin war er viele Jahre ein wichtiger Mann. Das ist zwar vorbei, trotzdem kann er immer noch jede Menge interessante Kontakte zu Leuten herstellen, die Zugriff auf ganz besonders attraktive Daten haben.", 
+        "label": "Barnie Maddog", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 300, 
+              "y": 660
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 179, 
+              "width": 180, 
+              "x": 720, 
+              "y": 537
+            }
+          }, 
+          "frameSrc": "sprite-019.png"
+        }, 
+        "price": 1700, 
+        "provided_perps": [
+          "contact005", 
+          "contact004"
+        ], 
+        "required_level": 11, 
+        "subtitle": "kennt die wichtigen Leute im Staat", 
+        "title": "Barnie Maddog"
+      }
+    }, 
+    "city002": {
+      "game_type": "CityPerp", 
+      "type_data": {
+        "description": "Little Rock ist nicht gerade der Mittelpunkt der Welt, aber trotzdem das perfekte Hauptquartier f\u00fcr dich. Denn hier hat schon einmal eine bekannte Datensammel-Firma ihren gl\u00e4nzenden Aufstieg begonnen. Von hier aus erweiterst du dein Imperium, steuerst deine Briefkastenfirmen und bleibst mit deinem Netzwerk in Verbindung.", 
+        "label": "Little Rock City", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 150, 
+              "width": 120, 
+              "x": 0, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-001.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "price": 0, 
+        "profiles_max": 2915918, 
+        "profileset_size": 100000, 
+        "provided_perps": [
+          "agent002", 
+          "agent004", 
+          "pusher004", 
+          "pusher003", 
+          "proxy001", 
+          "proxy004"
+        ], 
+        "required_level": 1, 
+        "title": "Little Rock City", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token005", 
+            "gestalt": "token005"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin001", 
+            "gestalt": "origin001"
+          }
+        ]
+      }
+    }, 
+    "city004": {
+      "game_type": "CityPerp", 
+      "type_data": {
+        "description": "New York ist nicht gerade billig, aber trotzdem die perfekte Stadt f\u00fcr dein zweites B\u00fcro! Denn hier laufen viele F\u00e4den zusammen. Durch die Expansion nach New York erweitert sich dein Einzugsgebiet auf 40 Millionen, das bedeutet: Viel mehr Profile! Von hier aus steuerst du deine Briefkastenfirmen und bleibst mit deinem Netzwerk in Verbindung.", 
+        "label": "New York City", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 150, 
+              "width": 120, 
+              "x": 360, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "price": 15000, 
+        "profiles_max": 19378102, 
+        "profileset_size": 1000000, 
+        "provided_perps": [
+          "agent008", 
+          "agent003", 
+          "pusher001", 
+          "proxy002", 
+          "proxy003"
+        ], 
+        "required_level": 11, 
+        "story": {
+          "text": "Yeah, dein B\u00fcro in New York City steht. Klick gleich mal rein und check dir neue Scheinfirmen, Agenten & Vertreter f\u00fcr dein Imperium!", 
+          "trigger": "buy"
+        }, 
+        "title": "New York City", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token005", 
+            "gestalt": "token005"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin014", 
+            "gestalt": "origin014"
+          }
+        ]
+      }
+    }, 
+    "client002": {
+      "game_type": "ClientPerp", 
+      "type_data": {
+        "charge_time": 180000, 
+        "consumed_tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token053", 
+            "gestalt": "token053", 
+            "is_query": false
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token055", 
+            "gestalt": "token055", 
+            "is_query": false
+          }, 
+          {
+            "amount": 70, 
+            "full_type": "TokenPerp:token018", 
+            "gestalt": "token018", 
+            "is_query": false
+          }, 
+          {
+            "amount": 40, 
+            "full_type": "TokenPerp:token125", 
+            "gestalt": "token125", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token006", 
+            "gestalt": "token006", 
+            "is_query": true
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token007", 
+            "gestalt": "token007", 
+            "is_query": true
+          }, 
+          {
+            "amount": 70, 
+            "full_type": "TokenPerp:token017", 
+            "gestalt": "token017", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002", 
+            "is_query": true
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token054", 
+            "gestalt": "token054", 
+            "is_query": false
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token114", 
+            "gestalt": "token114", 
+            "is_query": false
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token092", 
+            "gestalt": "token092", 
+            "is_query": false
+          }, 
+          {
+            "amount": 30, 
+            "full_type": "TokenPerp:token103", 
+            "gestalt": "token103", 
+            "is_query": false
+          }, 
+          {
+            "amount": 30, 
+            "full_type": "TokenPerp:token088", 
+            "gestalt": "token088", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001", 
+            "is_query": true
+          }
+        ], 
+        "description": "Unsere Krankenversicherung wollen viele. Ist schon n\u00fctzlich im Fall der F\u00e4lle, nicht nur f\u00fcr die \u00c4lteren. Aber manche Krankheiten kommen uns wirklich teuer! Bevor wir jemanden neu aufnehmen, brauchen wir unbedingt Infos \u00fcber Vorerkrankungen und Risikofaktoren. Erst dann k\u00f6nnen wir entscheiden, wie teuer die Pr\u00e4mie wird und ob wir jemand \u00fcberhaupt nehmen.", 
+        "income_base": 1050, 
+        "income_factor": 143, 
+        "label": "Krankenkasse", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 820, 
+              "y": 300
+            }
+          }, 
+          "frameSrc": "sprite-024.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-019.png"
+        }, 
+        "price": 200, 
+        "provided_tokens": [
+          "token006", 
+          "token007", 
+          "token002", 
+          "token001"
+        ], 
+        "required_level": 1, 
+        "required_providers": [
+          "contact001"
+        ], 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "story": {
+          "text": "Neue Kundschaft, perfekt! Klick am besten gleich rein und mach einen Deal. Du brauchst Kohle f\u00fcr dein Imperium!", 
+          "trigger": "buy"
+        }, 
+        "title": "Krankenkasse", 
+        "xp_inc": 1
+      }
+    }, 
+    "client005": {
+      "game_type": "ClientPerp", 
+      "type_data": {
+        "charge_time": 1800000, 
+        "consumed_tokens": [
+          {
+            "amount": 30, 
+            "full_type": "TokenPerp:token053", 
+            "gestalt": "token053", 
+            "is_query": false
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token115", 
+            "gestalt": "token115", 
+            "is_query": true
+          }, 
+          {
+            "amount": 70, 
+            "full_type": "TokenPerp:token120", 
+            "gestalt": "token120", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token006", 
+            "gestalt": "token006", 
+            "is_query": true
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token067", 
+            "gestalt": "token067", 
+            "is_query": false
+          }, 
+          {
+            "amount": 20, 
+            "full_type": "TokenPerp:token102", 
+            "gestalt": "token102", 
+            "is_query": false
+          }, 
+          {
+            "amount": 30, 
+            "full_type": "TokenPerp:token089", 
+            "gestalt": "token089", 
+            "is_query": false
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token128", 
+            "gestalt": "token128", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002", 
+            "is_query": true
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token030", 
+            "gestalt": "token030", 
+            "is_query": false
+          }, 
+          {
+            "amount": 60, 
+            "full_type": "TokenPerp:token092", 
+            "gestalt": "token092", 
+            "is_query": false
+          }, 
+          {
+            "amount": 20, 
+            "full_type": "TokenPerp:token098", 
+            "gestalt": "token098", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001", 
+            "is_query": true
+          }
+        ], 
+        "description": "Beschaulich, ruhig und geordnet - so ist das Leben bei uns. Und das soll auch so bleiben! Darum hei\u00dft es, m\u00f6glichst fr\u00fch zu handeln, bevor irgendwelche asozialen Rowdies, Punks oder andere Wahnsinnige beginnen, ihr Unwesen in unserer sch\u00f6nen Stadt treiben. Auch vor diesen politischen und religi\u00f6sen FanatikerInnen an jeder Ecke f\u00fcrchten wir uns total. Die sollten wir genau beobachten, besser zu viel als zu wenig!", 
+        "income_base": 4550, 
+        "income_factor": 129, 
+        "label": "Gemeindeamt", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 820, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-024.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-018.png"
+        }, 
+        "price": 1500, 
+        "provided_tokens": [
+          "token006", 
+          "token002", 
+          "token001"
+        ], 
+        "required_level": 1, 
+        "required_providers": [
+          "contact026"
+        ], 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "story": {
+          "text": "Neue Kundschaft, perfekt! Tipp: Du solltest immer einen Deal laufen haben, damit die Kasse klingelt.", 
+          "trigger": "buy"
+        }, 
+        "title": "Gemeindeamt", 
+        "xp_inc": 3
+      }
+    }, 
+    "client006": {
+      "game_type": "ClientPerp", 
+      "type_data": {
+        "charge_time": 180000, 
+        "consumed_tokens": [
+          {
+            "amount": 30, 
+            "full_type": "TokenPerp:token083", 
+            "gestalt": "token083", 
+            "is_query": false
+          }, 
+          {
+            "amount": 30, 
+            "full_type": "TokenPerp:token081", 
+            "gestalt": "token081", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token006", 
+            "gestalt": "token006", 
+            "is_query": true
+          }, 
+          {
+            "amount": 30, 
+            "full_type": "TokenPerp:token047", 
+            "gestalt": "token047", 
+            "is_query": false
+          }, 
+          {
+            "amount": 30, 
+            "full_type": "TokenPerp:token026", 
+            "gestalt": "token026", 
+            "is_query": false
+          }, 
+          {
+            "amount": 20, 
+            "full_type": "TokenPerp:token065", 
+            "gestalt": "token065", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002", 
+            "is_query": true
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token023", 
+            "gestalt": "token023", 
+            "is_query": false
+          }, 
+          {
+            "amount": 30, 
+            "full_type": "TokenPerp:token030", 
+            "gestalt": "token030", 
+            "is_query": false
+          }, 
+          {
+            "amount": 20, 
+            "full_type": "TokenPerp:token090", 
+            "gestalt": "token090", 
+            "is_query": false
+          }, 
+          {
+            "amount": 25, 
+            "full_type": "TokenPerp:token085", 
+            "gestalt": "token085", 
+            "is_query": false
+          }, 
+          {
+            "amount": 30, 
+            "full_type": "TokenPerp:token024", 
+            "gestalt": "token024", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001", 
+            "is_query": true
+          }
+        ], 
+        "description": "Mit fast 50.000 Angestellten sind wir einer der gr\u00f6\u00dften Arbeitgeber des Landes. Au\u00dferdem muss unsere Personalabteilung jedes Jahr viele Tausend Bewerbungen abarbeiten - vom Lehrling bis zum Abteilungsleiter. Wir brauchen ein paar Background-Infos \u00fcber unsere aktuellen und zuk\u00fcnftigen Angestellten, damit wir die schwarzen Schafe schnell aussortieren k\u00f6nnen.", 
+        "income_base": 1120, 
+        "income_factor": 172, 
+        "label": "Waldi", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 700, 
+              "y": 640
+            }
+          }, 
+          "frameSrc": "sprite-024.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-019.png"
+        }, 
+        "price": 400, 
+        "provided_tokens": [
+          "token006", 
+          "token002", 
+          "token001"
+        ], 
+        "required_level": 1, 
+        "required_providers": [
+          "project003"
+        ], 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "story": {
+          "text": "Nur so nebenbei: Deine Kundschaft zahlt dir umso mehr, je mehr du von den gew\u00fcnschten Infos auf Lager hast.", 
+          "trigger": "buy"
+        }, 
+        "title": "Waldi", 
+        "xp_inc": 1
+      }
+    }, 
+    "client007": {
+      "game_type": "ClientPerp", 
+      "type_data": {
+        "charge_time": 60000, 
+        "consumed_tokens": [
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003", 
+            "is_query": false
+          }, 
+          {
+            "amount": 20, 
+            "full_type": "TokenPerp:token012", 
+            "gestalt": "token012", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002", 
+            "is_query": false
+          }, 
+          {
+            "amount": 40, 
+            "full_type": "TokenPerp:token084", 
+            "gestalt": "token084", 
+            "is_query": true
+          }, 
+          {
+            "amount": 40, 
+            "full_type": "TokenPerp:token132", 
+            "gestalt": "token132", 
+            "is_query": true
+          }, 
+          {
+            "amount": 25, 
+            "full_type": "TokenPerp:token099", 
+            "gestalt": "token099", 
+            "is_query": true
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004", 
+            "is_query": false
+          }
+        ], 
+        "description": "Auto-Leasing, ein super Gesch\u00e4ft! Wir werben mit voll billigen Angeboten, scheinbar kostet so ein Auto bei uns fast nichts. Gl\u00fccklicherweise liest niemand das Kleingedruckte, erst da steht der wahre Preis. Wir brauchen Namen und Adressen von besonders leichtgl\u00e4ubigen Menschen, die gut auf unser Angebot reinfallen werden. Denen schicken wir dann unsere gl\u00e4nzenden Brosch\u00fcren und hoffen, dass sie anbei\u00dfen!", 
+        "income_base": 584, 
+        "income_factor": 358, 
+        "label": "Autoh\u00e4ndler", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 600, 
+              "y": 640
+            }
+          }, 
+          "frameSrc": "sprite-024.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-019.png"
+        }, 
+        "price": 30, 
+        "provided_tokens": [
+          "token084", 
+          "token132", 
+          "token099"
+        ], 
+        "required_level": 1, 
+        "required_providers": [
+          "contact035"
+        ], 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Autoh\u00e4ndler", 
+        "xp_inc": 1
+      }
+    }, 
+    "client008": {
+      "game_type": "ClientPerp", 
+      "type_data": {
+        "charge_time": 3600000, 
+        "consumed_tokens": [
+          {
+            "amount": 30, 
+            "full_type": "TokenPerp:token053", 
+            "gestalt": "token053", 
+            "is_query": false
+          }, 
+          {
+            "amount": 30, 
+            "full_type": "TokenPerp:token020", 
+            "gestalt": "token020", 
+            "is_query": false
+          }, 
+          {
+            "amount": 20, 
+            "full_type": "TokenPerp:token032", 
+            "gestalt": "token032", 
+            "is_query": false
+          }, 
+          {
+            "amount": 20, 
+            "full_type": "TokenPerp:token022", 
+            "gestalt": "token022", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token006", 
+            "gestalt": "token006", 
+            "is_query": true
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002", 
+            "is_query": true
+          }, 
+          {
+            "amount": 30, 
+            "full_type": "TokenPerp:token040", 
+            "gestalt": "token040", 
+            "is_query": false
+          }, 
+          {
+            "amount": 20, 
+            "full_type": "TokenPerp:token054", 
+            "gestalt": "token054", 
+            "is_query": false
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token023", 
+            "gestalt": "token023", 
+            "is_query": false
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token030", 
+            "gestalt": "token030", 
+            "is_query": false
+          }, 
+          {
+            "amount": 60, 
+            "full_type": "TokenPerp:token092", 
+            "gestalt": "token092", 
+            "is_query": false
+          }, 
+          {
+            "amount": 20, 
+            "full_type": "TokenPerp:token021", 
+            "gestalt": "token021", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001", 
+            "is_query": true
+          }
+        ], 
+        "description": "Erstens wollen wir nicht jeden an unseren Schulen und zweitens kann ein bisschen Info dar\u00fcber, was unsere Kids so treiben nie schaden. Hat psychische Probleme, raucht, oder h\u00e4ngt die ganze Nacht vor dem Ego-Shooter? Raus mit ihm! Oder zumindest: Gut zu wissen. Postet Frechheiten im Internet, kriegt aber sonst ihren Arsch nicht hoch? Nicht bei uns! Unsere Schulen haben schlie\u00dflich einen Ruf zu verlieren.", 
+        "income_base": 6300, 
+        "income_factor": 122, 
+        "label": "Schulverband", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 500, 
+              "y": 640
+            }
+          }, 
+          "frameSrc": "sprite-024.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-018.png"
+        }, 
+        "price": 2100, 
+        "provided_tokens": [
+          "token006", 
+          "token002", 
+          "token001"
+        ], 
+        "required_level": 1, 
+        "required_providers": [
+          "contact008"
+        ], 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "story": {
+          "text": "Neue Kundschaft, perfekt! Tipp: Schau rein, f\u00fcr welche Daten sich der Schulverband genau interessiert & sammle mehr davon.", 
+          "trigger": "buy"
+        }, 
+        "title": "Schulverband", 
+        "xp_inc": 4
+      }
+    }, 
+    "client010": {
+      "game_type": "ClientPerp", 
+      "type_data": {
+        "charge_time": 7200000, 
+        "consumed_tokens": [
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003", 
+            "is_query": false
+          }, 
+          {
+            "amount": 20, 
+            "full_type": "TokenPerp:token064", 
+            "gestalt": "token064", 
+            "is_query": false
+          }, 
+          {
+            "amount": 20, 
+            "full_type": "TokenPerp:token012", 
+            "gestalt": "token012", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token007", 
+            "gestalt": "token007", 
+            "is_query": false
+          }, 
+          {
+            "amount": 20, 
+            "full_type": "TokenPerp:token065", 
+            "gestalt": "token065", 
+            "is_query": true
+          }, 
+          {
+            "amount": 20, 
+            "full_type": "TokenPerp:token113", 
+            "gestalt": "token113", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002", 
+            "is_query": false
+          }, 
+          {
+            "amount": 20, 
+            "full_type": "TokenPerp:token084", 
+            "gestalt": "token084", 
+            "is_query": false
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token132", 
+            "gestalt": "token132", 
+            "is_query": false
+          }, 
+          {
+            "amount": 4, 
+            "full_type": "TokenPerp:token005", 
+            "gestalt": "token005", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004", 
+            "is_query": false
+          }
+        ], 
+        "description": "Wir verkaufen Spielzeug. Alle m\u00f6glichen Arten von Spielzeug. Vom Baby bis zum Teenager. Und wir brauchen die Adressen von Eltern. Oder von zuk\u00fcnftigen Eltern. Am besten von Eltern, die nur das Beste f\u00fcr ihre Kinder wollen. Und was ist das Beste f\u00fcr deren Kinder? Unsere Produkte! Es w\u00e4re gut, wenn das Eltern w\u00e4ren, die unsere Werbung nicht gleich in den M\u00fcll werfen. Sondern welche, die kaufen!", 
+        "income_base": 8050, 
+        "income_factor": 64, 
+        "label": "Toys\u00b4r\u00b4 Nice", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 300, 
+              "y": 640
+            }
+          }, 
+          "frameSrc": "sprite-024.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-019.png"
+        }, 
+        "price": 2400, 
+        "provided_tokens": [
+          "token064", 
+          "token065"
+        ], 
+        "required_level": 1, 
+        "required_providers": [
+          "project002"
+        ], 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Toys\u00b4r\u00b4 Nice", 
+        "xp_inc": 6
+      }
+    }, 
+    "client011": {
+      "game_type": "ClientPerp", 
+      "type_data": {
+        "charge_time": 14400000, 
+        "consumed_tokens": [
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003", 
+            "is_query": false
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token029", 
+            "gestalt": "token029", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002", 
+            "is_query": false
+          }, 
+          {
+            "amount": 30, 
+            "full_type": "TokenPerp:token040", 
+            "gestalt": "token040", 
+            "is_query": false
+          }, 
+          {
+            "amount": 70, 
+            "full_type": "TokenPerp:token123", 
+            "gestalt": "token123", 
+            "is_query": true
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004", 
+            "is_query": false
+          }
+        ], 
+        "description": "Fr\u00fcher haben wir jedes Jahr nach Schema F einen neuen Superstar erfunden, ein paar Hits produziert und damit Milliarden verdient. Seit es diese MP3s gibt, ist alles Scheisse. Niemand kauft mehr unsere teuren CDs! Im Gegenteil. In jedem Kinderzimmer wird runtergeladen Ende nie. Wenn wir diese Copyright-Verbrecher ausforschen k\u00f6nnten, verklagen wir sie einfach und quetschen so ein paar M\u00e4use aus denen raus.", 
+        "income_base": 11200, 
+        "income_factor": 3, 
+        "label": "Major Label", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 200, 
+              "y": 640
+            }
+          }, 
+          "frameSrc": "sprite-024.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-018.png"
+        }, 
+        "price": 3700, 
+        "provided_tokens": [
+          "token123"
+        ], 
+        "required_level": 1, 
+        "required_providers": [
+          "project007"
+        ], 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Major Label", 
+        "xp_inc": 9
+      }
+    }, 
+    "client014": {
+      "game_type": "ClientPerp", 
+      "type_data": {
+        "charge_time": 7200000, 
+        "consumed_tokens": [
+          {
+            "amount": 20, 
+            "full_type": "TokenPerp:token064", 
+            "gestalt": "token064", 
+            "is_query": false
+          }, 
+          {
+            "amount": 20, 
+            "full_type": "TokenPerp:token032", 
+            "gestalt": "token032", 
+            "is_query": false
+          }, 
+          {
+            "amount": 80, 
+            "full_type": "TokenPerp:token018", 
+            "gestalt": "token018", 
+            "is_query": false
+          }, 
+          {
+            "amount": 70, 
+            "full_type": "TokenPerp:token120", 
+            "gestalt": "token120", 
+            "is_query": false
+          }, 
+          {
+            "amount": 20, 
+            "full_type": "TokenPerp:token012", 
+            "gestalt": "token012", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token006", 
+            "gestalt": "token006", 
+            "is_query": true
+          }, 
+          {
+            "amount": 20, 
+            "full_type": "TokenPerp:token102", 
+            "gestalt": "token102", 
+            "is_query": false
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:supertoken014", 
+            "gestalt": "supertoken014", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002", 
+            "is_query": true
+          }, 
+          {
+            "amount": 70, 
+            "full_type": "TokenPerp:token013", 
+            "gestalt": "token013", 
+            "is_query": false
+          }, 
+          {
+            "amount": 30, 
+            "full_type": "TokenPerp:token024", 
+            "gestalt": "token024", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001", 
+            "is_query": true
+          }
+        ], 
+        "description": "Ein Konto bei uns bekommt nicht jeder. Und einen Kredit schon gar nicht. Und falls doch stellt sich die Frage, wie teuer der Kredit f\u00fcr wen wird. Dazu ben\u00f6tigen wir JEDE Info, die uns dabei hilft, unsere aktuellen und zuk\u00fcnftigen KundInnen besser einzusch\u00e4tzen. Dabei gehts nicht darum, dass diese Prognosen in jedem einzelnen Fall stimmen. Hauptsache, es bringt uns was in Summe!", 
+        "income_base": 8400, 
+        "income_factor": 43, 
+        "label": "Bank", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 720, 
+              "y": 500
+            }
+          }, 
+          "frameSrc": "sprite-024.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-019.png"
+        }, 
+        "price": 2800, 
+        "provided_tokens": [
+          "token006", 
+          "token002", 
+          "token001"
+        ], 
+        "required_level": 1, 
+        "required_providers": [
+          "contact004"
+        ], 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Bank", 
+        "xp_inc": 6
+      }
+    }, 
+    "client016": {
+      "game_type": "ClientPerp", 
+      "type_data": {
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "label": "Unternehmen", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 720, 
+              "y": 300
+            }
+          }, 
+          "frameSrc": "sprite-024.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-019.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Unternehmen"
+      }
+    }, 
+    "client019": {
+      "game_type": "ClientPerp", 
+      "type_data": {
+        "charge_time": 28800000, 
+        "consumed_tokens": [
+          {
+            "amount": 20, 
+            "full_type": "TokenPerp:token064", 
+            "gestalt": "token064", 
+            "is_query": false
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token066", 
+            "gestalt": "token066", 
+            "is_query": false
+          }, 
+          {
+            "amount": 20, 
+            "full_type": "TokenPerp:token032", 
+            "gestalt": "token032", 
+            "is_query": false
+          }, 
+          {
+            "amount": 20, 
+            "full_type": "TokenPerp:token022", 
+            "gestalt": "token022", 
+            "is_query": false
+          }, 
+          {
+            "amount": 70, 
+            "full_type": "TokenPerp:token120", 
+            "gestalt": "token120", 
+            "is_query": false
+          }, 
+          {
+            "amount": 20, 
+            "full_type": "TokenPerp:token012", 
+            "gestalt": "token012", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token006", 
+            "gestalt": "token006", 
+            "is_query": true
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token129", 
+            "gestalt": "token129", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002", 
+            "is_query": true
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token030", 
+            "gestalt": "token030", 
+            "is_query": false
+          }, 
+          {
+            "amount": 70, 
+            "full_type": "TokenPerp:token013", 
+            "gestalt": "token013", 
+            "is_query": false
+          }, 
+          {
+            "amount": 20, 
+            "full_type": "TokenPerp:token021", 
+            "gestalt": "token021", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001", 
+            "is_query": true
+          }
+        ], 
+        "description": "Unsere Mitglieder besitzen jede Menge Wohnungen und H\u00e4user. Sie w\u00fcrden ihre neuen Mieter und Mieterinnen echt gern ein wenig besser \"kennen lernen\", bevor die einziehen. Wer nicht genug verdient oder gar Schulden hat, kommt sowieso nicht in Frage. Und manche wollen ausschlie\u00dflich langweilige P\u00e4rchen, bitte Hetero und ohne Haustiere, Kinder oder Drogen. Alle anderen sollen sich bitte verpissen!", 
+        "income_base": 15750, 
+        "income_factor": 1, 
+        "label": "Vermieterverband", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 720, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-024.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-018.png"
+        }, 
+        "price": 5300, 
+        "provided_tokens": [
+          "token006", 
+          "token002", 
+          "token001"
+        ], 
+        "required_level": 1, 
+        "required_providers": [
+          "project006"
+        ], 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Vermieterverband", 
+        "xp_inc": 12
+      }
+    }, 
+    "contact001": {
+      "game_type": "ContactPerp", 
+      "type_data": {
+        "charge_cost": 190, 
+        "charge_time": 120000, 
+        "collect_amount": 3300, 
+        "collect_risk": 1, 
+        "description": "Schwester Elfriede arbeitet im gr\u00f6\u00dften Krankenhaus des Landes. Seit 20 Jahren opfert sie sich in der Pflegestation auf. Jetzt wurde ihre Arbeitszeit verl\u00e4ngert und ihr Lohn gek\u00fcrzt. Das findet sie gar nicht ok. Zuf\u00e4llig hat sie vollen Zugriff auf den Krankenhaus-Zentralcomputer, braucht das Geld und w\u00e4re bereit, uns zuverl\u00e4ssige Daten \u00fcber den Gesundheitszustand ihrer PatientInnen zu besorgen.", 
+        "label": "Schwester\r\nElfriede", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 900, 
+              "y": 240
+            }
+          }, 
+          "frameSrc": "sprite-010.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 900
+            }
+          }, 
+          "frameSrc": "sprite-017.png"
+        }, 
+        "price": 400, 
+        "required_level": 3, 
+        "title": "Schwester Elfriede", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token006", 
+            "gestalt": "token006"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token007", 
+            "gestalt": "token007"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token005", 
+            "gestalt": "token005"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token014", 
+            "gestalt": "token014"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token015", 
+            "gestalt": "token015"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token017", 
+            "gestalt": "token017"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token018", 
+            "gestalt": "token018"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin012", 
+            "gestalt": "origin012"
+          }
+        ], 
+        "xp_inc": 1
+      }
+    }, 
+    "contact003": {
+      "game_type": "ContactPerp", 
+      "type_data": {
+        "charge_cost": 1620, 
+        "charge_time": 3600000, 
+        "collect_amount": 25900, 
+        "collect_risk": 2, 
+        "description": "Er nennt sich Onkel Enzo und behauptet, sich in das Online-Netzwerk eines globalen Spielkonsolen-Anbieters gehackt zu haben. Angeblich war das ziemlich easy. Er bietet uns nicht nur Namen und Adressen, sondern auch Passw\u00f6rter, Kreditkartennummern und Game-Listen. Insgesamt hat er fast eine Million Datens\u00e4tze allein aus unserem Land, da m\u00fcssen wir unbedingt ran!", 
+        "label": "Onkel Enzo", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 900, 
+              "y": 160
+            }
+          }, 
+          "frameSrc": "sprite-010.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-016.png"
+        }, 
+        "price": 4900, 
+        "required_level": 19, 
+        "title": "Onkel Enzo", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token006", 
+            "gestalt": "token006"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token007", 
+            "gestalt": "token007"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token005", 
+            "gestalt": "token005"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token008", 
+            "gestalt": "token008"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token029", 
+            "gestalt": "token029"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token027", 
+            "gestalt": "token027"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token028", 
+            "gestalt": "token028"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token032", 
+            "gestalt": "token032"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin022", 
+            "gestalt": "origin022"
+          }
+        ], 
+        "xp_inc": 9
+      }
+    }, 
+    "contact004": {
+      "game_type": "ContactPerp", 
+      "type_data": {
+        "charge_cost": 1320, 
+        "charge_time": 1800000, 
+        "collect_amount": 22600, 
+        "collect_risk": 3, 
+        "description": "Franz Sauerzapf ist Gerichtsvollzieher und hat es schon lange satt, jeden Tag diese schwer verschuldeten armen Schweine zu besuchen und denen auch noch Fernseher, Computer oder Auto wegzunehmen. Er ist irgendwie zynisch geworden, nennt man das Burnout? Wenn du ein paar Kr\u00f6ten r\u00fcberwachsen l\u00e4sst, schickt er dir gerne regelm\u00e4ssig die Daten seiner \u201eKunden\u201c - und die von ein paar Kollegen gleich dazu.", 
+        "label": "Franz Sauerzapf", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 900, 
+              "y": 80
+            }
+          }, 
+          "frameSrc": "sprite-010.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 900
+            }
+          }, 
+          "frameSrc": "sprite-017.png"
+        }, 
+        "price": 4000, 
+        "required_level": 11, 
+        "title": "Franz Sauerzapf", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token006", 
+            "gestalt": "token006"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token007", 
+            "gestalt": "token007"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token013", 
+            "gestalt": "token013"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin020", 
+            "gestalt": "origin020"
+          }
+        ], 
+        "xp_inc": 5
+      }
+    }, 
+    "contact005": {
+      "game_type": "ContactPerp", 
+      "type_data": {
+        "charge_cost": 970, 
+        "charge_time": 1800000, 
+        "collect_amount": 4850, 
+        "collect_risk": 1, 
+        "description": "Sieglinde Bayer-Wurz ist Abteilungsleiterin im Bildungsministerium und hat mit dieser neu eingef\u00fchrten zentralen Sch\u00fclerInnendatenbank zu tun, in der seit kurzem zur \u201eVereinfachung der Verwaltung\u201c jede Schul- und Universit\u00e4ts-Laufbahn mit allen Einzelheiten abgespeichert wird. Sie verdient zwar nicht schlecht, aber mit dieser Innenstadt-Dachgeschosswohnung hat sie sich vielleicht doch etwas \u00fcbernommen.", 
+        "label": "Sieglinde\r\nBayer-Wurz", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 900, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-010.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-016.png"
+        }, 
+        "price": 2900, 
+        "required_level": 16, 
+        "title": "Sieglinde Bayer-Wurz", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token006", 
+            "gestalt": "token006"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token007", 
+            "gestalt": "token007"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token011", 
+            "gestalt": "token011"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token048", 
+            "gestalt": "token048"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token130", 
+            "gestalt": "token130"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin021", 
+            "gestalt": "origin021"
+          }
+        ], 
+        "xp_inc": 6
+      }
+    }, 
+    "contact007": {
+      "game_type": "ContactPerp", 
+      "type_data": {
+        "charge_cost": 240, 
+        "charge_time": 240000, 
+        "collect_amount": 5400, 
+        "collect_risk": 1, 
+        "description": "Sadik besucht mindestens 10 Events pro Abend und nimmt dabei selten den Finger vom Ausl\u00f6ser. Au\u00dferdem vergi\u00dft er nie, seine oft schon recht gl\u00fcckseligen fotografischen Objekte nach ihrer Email-Adresse zu fragen. Damit er ihnen die Fotos schicken kann! In der Nacht stellt er das Zeug auf ein gro\u00dfes Partyfoto-Portal. Die zahlen leider wirklich nicht gut. Daf\u00fcr kommt er problemlos an die ganzen anderen Fotos dort ran.", 
+        "label": "Sadik Konetschnig", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 720, 
+              "y": 800
+            }
+          }, 
+          "frameSrc": "sprite-010.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-016.png"
+        }, 
+        "price": 700, 
+        "required_level": 6, 
+        "title": "Sadik Konetschnig", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token007", 
+            "gestalt": "token007"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token008", 
+            "gestalt": "token008"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token023", 
+            "gestalt": "token023"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token036", 
+            "gestalt": "token036"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin009", 
+            "gestalt": "origin009"
+          }
+        ], 
+        "xp_inc": 2
+      }
+    }, 
+    "contact008": {
+      "game_type": "ContactPerp", 
+      "type_data": {
+        "charge_cost": 460, 
+        "charge_time": 300000, 
+        "collect_amount": 7100, 
+        "collect_risk": 1, 
+        "description": "Lennon arbeitet seit vielen Jahren im Jugendzentrum. Begonnen hat er enthusiastisch und schlecht bezahlt, mittlerweile ist er nur noch schlecht bezahlt. Er benutzt jetzt ein Programm, das in vielen Jugendzentren verwendet wird. Da werden alle m\u00f6glichen Infos \u00fcber die Jugendlichen gespeichert, die vorbei schauen. Also, ob sie schon mal eine Anzeige hatten, ob sie rauchen, oder sonstige Probleme haben. Wie praktisch!", 
+        "label": "Lennon Che\r\nWurlitschek", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 640, 
+              "y": 800
+            }
+          }, 
+          "frameSrc": "sprite-010.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-016.png"
+        }, 
+        "price": 1400, 
+        "required_level": 8, 
+        "title": "Lennon Che Wurlitschek", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token006", 
+            "gestalt": "token006"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token085", 
+            "gestalt": "token085"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token088", 
+            "gestalt": "token088"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token089", 
+            "gestalt": "token089"
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token092", 
+            "gestalt": "token092"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token120", 
+            "gestalt": "token120"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token054", 
+            "gestalt": "token054"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token053", 
+            "gestalt": "token053"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin008", 
+            "gestalt": "origin008"
+          }
+        ], 
+        "xp_inc": 2
+      }
+    }, 
+    "contact019": {
+      "game_type": "ContactPerp", 
+      "type_data": {
+        "charge_cost": 210, 
+        "charge_time": 180000, 
+        "collect_amount": 4000, 
+        "collect_risk": 1, 
+        "description": "Alexa C. Tivia ist Trainerin in einem Mittelklasse-Fitnesscenter mit Filialen im ganzen Land. Vor 15 Jahren war sie gutbezahlter Superstar in einem beliebten Aerobic-Video, aber das ist vorbei. Gegen kleine Gef\u00e4lligkeiten liefert sie dir gern ein paar Fakten \u00fcber ihre schwitzenden K\u00fcken. Im Computer steht alles drin, auch die Infos aus der Wellness- und Ern\u00e4hrungsberatung. Mit ihrem Passwort kommt sie \u00fcberall ran. Cool!", 
+        "label": "Alexa C. Tivia", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 80, 
+              "y": 800
+            }
+          }, 
+          "frameSrc": "sprite-010.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-016.png"
+        }, 
+        "price": 500, 
+        "required_level": 4, 
+        "title": "Alexa C. Tivia", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token006", 
+            "gestalt": "token006"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token005", 
+            "gestalt": "token005"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token014", 
+            "gestalt": "token014"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token015", 
+            "gestalt": "token015"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token088", 
+            "gestalt": "token088"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token083", 
+            "gestalt": "token083"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token125", 
+            "gestalt": "token125"
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token065", 
+            "gestalt": "token065"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin010", 
+            "gestalt": "origin010"
+          }
+        ], 
+        "xp_inc": 1
+      }
+    }, 
+    "contact022": {
+      "game_type": "ContactPerp", 
+      "type_data": {
+        "charge_cost": 320, 
+        "charge_time": 240000, 
+        "collect_amount": 5700, 
+        "collect_risk": 1, 
+        "description": "Ulli ist Zustellerin bei einem ganz sch\u00f6n gro\u00dfen Pizza-Service. Stressig. Inzwischen weiss sie aber schon genau, an welcher Adresse was gefragt ist. Jeden Tag vier Bier und eine Quattro Formaggi mit extra K\u00e4se? Oder doch eher die Salatpizza in Kombination mit stillem Wasser? Seit kurzem bekommt sie die Bestellungen sogar direkt aufs Smartphone. Und kann jederzeit nachsehen, was sie an der n\u00e4chsten Adresse so erwartet.", 
+        "label": "Ulli Stenzer", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 720, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-010.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-016.png"
+        }, 
+        "price": 1000, 
+        "required_level": 6, 
+        "title": "Ulli Stenzer", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token005", 
+            "gestalt": "token005"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token008", 
+            "gestalt": "token008"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token125", 
+            "gestalt": "token125"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token132", 
+            "gestalt": "token132"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin013", 
+            "gestalt": "origin013"
+          }
+        ], 
+        "xp_inc": 2
+      }
+    }, 
+    "contact026": {
+      "game_type": "ContactPerp", 
+      "type_data": {
+        "charge_cost": 400, 
+        "charge_time": 300000, 
+        "collect_amount": 6800, 
+        "collect_risk": 1, 
+        "description": "Elly DeTelly arbeitet in einer st\u00e4dtischen Bibliothek, die Mitglied eines landesweiten Verbands ist. Seit kurzem werden im Computersystem alle ausgeliehenen B\u00fccher ganz genau gespeichert. Sie kann nicht nur danach suchen, wer welche B\u00fccher wie lang ausgeliehen hat, sondern sich tats\u00e4chlich auch ganze Listen davon ausgeben lassen. Wenn das mal nicht geil ist.", 
+        "label": "Elly DeTelly ", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 400, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-010.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-016.png"
+        }, 
+        "price": 1200, 
+        "required_level": 7, 
+        "title": "Elly DeTelly ", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token006", 
+            "gestalt": "token006"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token007", 
+            "gestalt": "token007"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token005", 
+            "gestalt": "token005"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token008", 
+            "gestalt": "token008"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token115", 
+            "gestalt": "token115"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin006", 
+            "gestalt": "origin006"
+          }
+        ], 
+        "xp_inc": 2
+      }
+    }, 
+    "contact033": {
+      "game_type": "ContactPerp", 
+      "type_data": {
+        "charge_cost": 1130, 
+        "charge_time": 1800000, 
+        "collect_amount": 18900, 
+        "collect_risk": 1, 
+        "description": "Hana arbeitet in einem gro\u00dfen Verlag, der hunderte von Zeitungen und Magazinen herausgibt. Echt gro\u00df, der Verlag. Sie hat Zugang zu ausf\u00fchrlichen Listen von AbonnentInnen - vom Anzeiger f\u00fcr notleidende Singles \u00fcber das Magazin f\u00fcr gl\u00fcckliche Meerschweinchen bis zum Blatt f\u00fcr ungl\u00fcckliche Wirtschaftsbosse. Damit l\u00e4sst sich durchaus was machen! Diese Goldquelle solltest du dir keinesfalls entgehen lassen.", 
+        "label": "Hana Blum", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 720, 
+              "y": 620
+            }
+          }, 
+          "frameSrc": "sprite-010.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-017.png"
+        }, 
+        "price": 3400, 
+        "required_level": 16, 
+        "title": "Hana Blum", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token006", 
+            "gestalt": "token006"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token007", 
+            "gestalt": "token007"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token005", 
+            "gestalt": "token005"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token008", 
+            "gestalt": "token008"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token128", 
+            "gestalt": "token128"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token132", 
+            "gestalt": "token132"
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token028", 
+            "gestalt": "token028"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin007", 
+            "gestalt": "origin007"
+          }
+        ], 
+        "xp_inc": 3
+      }
+    }, 
+    "contact035": {
+      "game_type": "ContactPerp", 
+      "type_data": {
+        "charge_cost": 60, 
+        "charge_time": 30000, 
+        "collect_amount": 1100, 
+        "collect_risk": 1, 
+        "description": "Jessica Seno arbeitet im Casino und das ist kein Spa\u00df. Wenn die Leute mal angefangen haben mit Roulette, Poker oder Automaten, gibts oft kein Ende. Bis das letzte Hemd verspielt ist. Die Sicherheit steht aber an erster Stelle! Wer reingeht, wird von Jessica genau erfasst. Wenn du sie mit ein wenig Cash f\u00fctterst, liefert sie dir leckere Infos \u00fcber die Leute, die dort regelm\u00e4\u00dfig ihr Hab und Gut verspielen. Denn ihr Lohn ist mies.", 
+        "label": "Jessica Seno", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 720, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-010.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-016.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Jessica Seno", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token005", 
+            "gestalt": "token005"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token008", 
+            "gestalt": "token008"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token084", 
+            "gestalt": "token084"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token102", 
+            "gestalt": "token102"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin011", 
+            "gestalt": "origin011"
+          }
+        ], 
+        "xp_inc": 1
+      }
+    }, 
+    "database001": {
+      "game_type": "DatabasePerp", 
+      "type_data": {
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "label": "Datenbank", 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Datenbank"
+      }
+    }, 
+    "ddd374508122aa3ca8c1bc8e72b9bcf4000": {
+      "game_type": "StoryPerp", 
+      "type_data": {
+        "perp_sprite": [], 
+        "popup_sprite": [], 
+        "price": 0, 
+        "required_level": 0, 
+        "text": "Neue Kundschaft, perfekt! Tipp: Du solltest immer einen Deal laufen haben, damit die Kasse klingelt."
+      }
+    }, 
+    "project001": {
+      "game_type": "ProjectPerp", 
+      "type_data": {
+        "ad_slots": 3, 
+        "charge_cost": 190, 
+        "charge_time": 300000, 
+        "collect_amount": 3600, 
+        "collect_risk": 2, 
+        "description": "Setz den Leuten eine dicke, fette Karotte vor die Nase und sie wissen nicht mehr, was sie tun. Mit attraktiven Gewinnspiel-Postkarten lassen sich gut Profile scheffeln. Je geiler der Gewinn, desto mehr sind dabei!", 
+        "label": "Gewinnspiel", 
+        "max_ad_slots": 7, 
+        "max_teammember_slots": 14, 
+        "max_upgrade_slots": 10, 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 300, 
+              "y": 700
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "price": 300, 
+        "provided_ads": [
+          {
+            "charge_cost_modifier": 35, 
+            "collect_amount_modifier": 160, 
+            "collect_risk_modifier": 0, 
+            "full_type": "AdPowerup:ad002", 
+            "gestalt": "ad002", 
+            "notification": false, 
+            "price": 90, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 55, 
+            "collect_amount_modifier": 390, 
+            "collect_risk_modifier": 0, 
+            "full_type": "AdPowerup:ad003", 
+            "gestalt": "ad003", 
+            "notification": false, 
+            "price": 130, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 80, 
+            "collect_amount_modifier": 870, 
+            "collect_risk_modifier": 0, 
+            "full_type": "AdPowerup:ad001", 
+            "gestalt": "ad001", 
+            "notification": false, 
+            "price": 180, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 111, 
+            "collect_amount_modifier": 1340, 
+            "collect_risk_modifier": 0, 
+            "full_type": "AdPowerup:ad004", 
+            "gestalt": "ad004", 
+            "notification": false, 
+            "price": 240, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 139, 
+            "collect_amount_modifier": 1580, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad010", 
+            "gestalt": "ad010", 
+            "notification": false, 
+            "price": 420, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 150, 
+            "collect_amount_modifier": 1730, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad012", 
+            "gestalt": "ad012", 
+            "notification": true, 
+            "price": 450, 
+            "required_level": 14
+          }
+        ], 
+        "provided_teammembers": [
+          {
+            "charge_cost_modifier": 41, 
+            "collect_amount_modifier": 160, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember020", 
+            "gestalt": "teammember020", 
+            "notification": false, 
+            "price": 110, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 35, 
+            "collect_amount_modifier": 180, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember021", 
+            "gestalt": "teammember021", 
+            "notification": false, 
+            "price": 100, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 47, 
+            "collect_amount_modifier": 240, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember014", 
+            "gestalt": "teammember014", 
+            "notification": false, 
+            "price": 130, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 41, 
+            "collect_amount_modifier": 270, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember015", 
+            "gestalt": "teammember015", 
+            "notification": false, 
+            "price": 110, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 56, 
+            "collect_amount_modifier": 360, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember001", 
+            "gestalt": "teammember001", 
+            "notification": true, 
+            "price": 150, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 50, 
+            "collect_amount_modifier": 410, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember023", 
+            "gestalt": "teammember023", 
+            "notification": false, 
+            "price": 130, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 50, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -2, 
+            "full_type": "TeamMemberPowerup:teammember044", 
+            "gestalt": "teammember044", 
+            "notification": false, 
+            "price": 150, 
+            "required_level": 6
+          }, 
+          {
+            "charge_cost_modifier": 45, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -2, 
+            "full_type": "TeamMemberPowerup:teammember043", 
+            "gestalt": "teammember043", 
+            "notification": true, 
+            "price": 140, 
+            "required_level": 6
+          }, 
+          {
+            "charge_cost_modifier": 67, 
+            "collect_amount_modifier": 500, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember026", 
+            "gestalt": "teammember026", 
+            "notification": false, 
+            "price": 170, 
+            "required_level": 10
+          }, 
+          {
+            "charge_cost_modifier": 60, 
+            "collect_amount_modifier": 570, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember042", 
+            "gestalt": "teammember042", 
+            "notification": true, 
+            "price": 150, 
+            "required_level": 10
+          }, 
+          {
+            "charge_cost_modifier": 67, 
+            "collect_amount_modifier": 500, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember005", 
+            "gestalt": "teammember005", 
+            "notification": true, 
+            "price": 170, 
+            "required_level": 13
+          }, 
+          {
+            "charge_cost_modifier": 60, 
+            "collect_amount_modifier": 570, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember006", 
+            "gestalt": "teammember006", 
+            "notification": false, 
+            "price": 150, 
+            "required_level": 13
+          }, 
+          {
+            "charge_cost_modifier": 71, 
+            "collect_amount_modifier": 790, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember012", 
+            "gestalt": "teammember012", 
+            "notification": false, 
+            "price": 180, 
+            "required_level": 15
+          }, 
+          {
+            "charge_cost_modifier": 64, 
+            "collect_amount_modifier": 890, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember036", 
+            "gestalt": "teammember036", 
+            "notification": true, 
+            "price": 160, 
+            "required_level": 15
+          }
+        ], 
+        "provided_upgrades": [
+          {
+            "charge_cost_modifier": 41, 
+            "collect_amount_modifier": 320, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade001", 
+            "gestalt": "upgrade001", 
+            "notification": false, 
+            "price": 160, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 53, 
+            "collect_amount_modifier": 790, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade002", 
+            "gestalt": "upgrade002", 
+            "notification": false, 
+            "price": 230, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 119, 
+            "collect_amount_modifier": 1580, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade004", 
+            "gestalt": "upgrade004", 
+            "notification": false, 
+            "price": 540, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 101, 
+            "collect_amount_modifier": 1260, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade003", 
+            "gestalt": "upgrade003", 
+            "notification": false, 
+            "price": 450, 
+            "required_level": 10
+          }, 
+          {
+            "charge_cost_modifier": 45, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -2, 
+            "full_type": "UpgradePowerup:upgrade008", 
+            "gestalt": "upgrade008", 
+            "notification": true, 
+            "price": 140, 
+            "required_level": 9
+          }, 
+          {
+            "charge_cost_modifier": 32, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 2, 
+            "full_type": "UpgradePowerup:upgrade006", 
+            "gestalt": "upgrade006", 
+            "notification": false, 
+            "price": 100, 
+            "required_level": 8
+          }, 
+          {
+            "charge_cost_modifier": 63, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 2, 
+            "full_type": "UpgradePowerup:upgrade007", 
+            "gestalt": "upgrade007", 
+            "notification": false, 
+            "price": 190, 
+            "required_level": 8
+          }, 
+          {
+            "charge_cost_modifier": 51, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 2, 
+            "full_type": "UpgradePowerup:upgrade005", 
+            "gestalt": "upgrade005", 
+            "notification": true, 
+            "price": 150, 
+            "required_level": 8
+          }, 
+          {
+            "charge_cost_modifier": 24, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade112", 
+            "gestalt": "upgrade112", 
+            "notification": true, 
+            "price": 70, 
+            "required_level": 10
+          }, 
+          {
+            "charge_cost_modifier": 49, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade146", 
+            "gestalt": "upgrade146", 
+            "notification": true, 
+            "price": 150, 
+            "required_level": 10
+          }
+        ], 
+        "rename_ads_tab": false, 
+        "required_level": 2, 
+        "slot_cost": 10, 
+        "slot_cost_modifier": 1, 
+        "story": {
+          "text": "Dein erstes Projekt, yeah! Tipp: Damit dein Gewinnspiel brav Daten sammelt, musst du das Ding mit Cash aufladen.", 
+          "trigger": "buy"
+        }, 
+        "teammember_slots": 3, 
+        "title": "Gewinnspiel", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004"
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token006", 
+            "gestalt": "token006"
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token005", 
+            "gestalt": "token005"
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token008", 
+            "gestalt": "token008"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token084", 
+            "gestalt": "token084"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token102", 
+            "gestalt": "token102"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token132", 
+            "gestalt": "token132"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token012", 
+            "gestalt": "token012"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token129", 
+            "gestalt": "token129"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token064", 
+            "gestalt": "token064"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token065", 
+            "gestalt": "token065"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token011", 
+            "gestalt": "token011"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token130", 
+            "gestalt": "token130"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin001", 
+            "gestalt": "origin001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin002", 
+            "gestalt": "origin002"
+          }
+        ], 
+        "upgrade_slots": 3, 
+        "xp_inc": 2
+      }
+    }, 
+    "project002": {
+      "game_type": "ProjectPerp", 
+      "type_data": {
+        "ad_slots": 3, 
+        "charge_cost": 1330, 
+        "charge_time": 7200000, 
+        "collect_amount": 25900, 
+        "collect_risk": 3, 
+        "description": "F\u00fcr die Aussicht auf dem Traumpartner sch\u00fctten dir einsame Seelen gerne ihr Herz aus und verraten dir ihre intimsten Geheimnisse. Wenn du die Email-Adressen und Pseudonyme den richtigen Namen zuordnen kannst, wird das so richtig interessant.", 
+        "label": "Partnerb\u00f6rse", 
+        "max_ad_slots": 10, 
+        "max_teammember_slots": 18, 
+        "max_upgrade_slots": 10, 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 200, 
+              "y": 700
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-005.png"
+        }, 
+        "price": 4000, 
+        "provided_ads": [
+          {
+            "charge_cost_modifier": 138, 
+            "collect_amount_modifier": 520, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad006", 
+            "gestalt": "ad006", 
+            "notification": false, 
+            "price": 390, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 176, 
+            "collect_amount_modifier": 1030, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad007", 
+            "gestalt": "ad007", 
+            "notification": true, 
+            "price": 530, 
+            "required_level": 12
+          }, 
+          {
+            "charge_cost_modifier": 282, 
+            "collect_amount_modifier": 2930, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad005", 
+            "gestalt": "ad005", 
+            "notification": true, 
+            "price": 700, 
+            "required_level": 12
+          }, 
+          {
+            "charge_cost_modifier": 269, 
+            "collect_amount_modifier": 3100, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad012", 
+            "gestalt": "ad012", 
+            "notification": true, 
+            "price": 660, 
+            "required_level": 14
+          }, 
+          {
+            "charge_cost_modifier": 181, 
+            "collect_amount_modifier": 1380, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad013", 
+            "gestalt": "ad013", 
+            "notification": false, 
+            "price": 490, 
+            "required_level": 9
+          }, 
+          {
+            "charge_cost_modifier": 231, 
+            "collect_amount_modifier": 2410, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad014", 
+            "gestalt": "ad014", 
+            "notification": false, 
+            "price": 690, 
+            "required_level": 9
+          }, 
+          {
+            "charge_cost_modifier": 252, 
+            "collect_amount_modifier": 2760, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad015", 
+            "gestalt": "ad015", 
+            "notification": false, 
+            "price": 970, 
+            "required_level": 9
+          }, 
+          {
+            "charge_cost_modifier": 293, 
+            "collect_amount_modifier": 3450, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad009", 
+            "gestalt": "ad009", 
+            "notification": false, 
+            "price": 880, 
+            "required_level": 9
+          }, 
+          {
+            "charge_cost_modifier": 233, 
+            "collect_amount_modifier": 2070, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad025", 
+            "gestalt": "ad025", 
+            "notification": true, 
+            "price": 700, 
+            "required_level": 18
+          }
+        ], 
+        "provided_teammembers": [
+          {
+            "charge_cost_modifier": 127, 
+            "collect_amount_modifier": 690, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember020", 
+            "gestalt": "teammember020", 
+            "notification": false, 
+            "price": 360, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 109, 
+            "collect_amount_modifier": 780, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember021", 
+            "gestalt": "teammember021", 
+            "notification": false, 
+            "price": 300, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 144, 
+            "collect_amount_modifier": 1030, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember014", 
+            "gestalt": "teammember014", 
+            "notification": false, 
+            "price": 400, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 126, 
+            "collect_amount_modifier": 1160, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember015", 
+            "gestalt": "teammember015", 
+            "notification": false, 
+            "price": 340, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 162, 
+            "collect_amount_modifier": 1380, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember001", 
+            "gestalt": "teammember001", 
+            "notification": true, 
+            "price": 430, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 142, 
+            "collect_amount_modifier": 1550, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember023", 
+            "gestalt": "teammember023", 
+            "notification": false, 
+            "price": 380, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 151, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -1, 
+            "full_type": "TeamMemberPowerup:teammember044", 
+            "gestalt": "teammember044", 
+            "notification": false, 
+            "price": 450, 
+            "required_level": 6
+          }, 
+          {
+            "charge_cost_modifier": 136, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -1, 
+            "full_type": "TeamMemberPowerup:teammember043", 
+            "gestalt": "teammember043", 
+            "notification": true, 
+            "price": 410, 
+            "required_level": 6
+          }, 
+          {
+            "charge_cost_modifier": 196, 
+            "collect_amount_modifier": 2070, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember026", 
+            "gestalt": "teammember026", 
+            "notification": false, 
+            "price": 510, 
+            "required_level": 10
+          }, 
+          {
+            "charge_cost_modifier": 174, 
+            "collect_amount_modifier": 2330, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember042", 
+            "gestalt": "teammember042", 
+            "notification": true, 
+            "price": 450, 
+            "required_level": 10
+          }, 
+          {
+            "charge_cost_modifier": 213, 
+            "collect_amount_modifier": 2410, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember005", 
+            "gestalt": "teammember005", 
+            "notification": true, 
+            "price": 550, 
+            "required_level": 13
+          }, 
+          {
+            "charge_cost_modifier": 190, 
+            "collect_amount_modifier": 2720, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember006", 
+            "gestalt": "teammember006", 
+            "notification": false, 
+            "price": 490, 
+            "required_level": 13
+          }, 
+          {
+            "charge_cost_modifier": 176, 
+            "collect_amount_modifier": 2550, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember012", 
+            "gestalt": "teammember012", 
+            "notification": false, 
+            "price": 450, 
+            "required_level": 15
+          }, 
+          {
+            "charge_cost_modifier": 157, 
+            "collect_amount_modifier": 2870, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember036", 
+            "gestalt": "teammember036", 
+            "notification": true, 
+            "price": 400, 
+            "required_level": 15
+          }, 
+          {
+            "charge_cost_modifier": 231, 
+            "collect_amount_modifier": 2760, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember035", 
+            "gestalt": "teammember035", 
+            "notification": true, 
+            "price": 590, 
+            "required_level": 19
+          }, 
+          {
+            "charge_cost_modifier": 207, 
+            "collect_amount_modifier": 3100, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember049", 
+            "gestalt": "teammember049", 
+            "notification": false, 
+            "price": 530, 
+            "required_level": 19
+          }
+        ], 
+        "provided_upgrades": [
+          {
+            "charge_cost_modifier": 123, 
+            "collect_amount_modifier": 1380, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade001", 
+            "gestalt": "upgrade001", 
+            "notification": false, 
+            "price": 310, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 136, 
+            "collect_amount_modifier": 1720, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade009", 
+            "gestalt": "upgrade009", 
+            "notification": false, 
+            "price": 340, 
+            "required_level": 9
+          }, 
+          {
+            "charge_cost_modifier": 114, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 4, 
+            "full_type": "UpgradePowerup:upgrade012", 
+            "gestalt": "upgrade012", 
+            "notification": true, 
+            "price": 340, 
+            "required_level": 14
+          }, 
+          {
+            "charge_cost_modifier": 194, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -2, 
+            "full_type": "UpgradePowerup:upgrade008", 
+            "gestalt": "upgrade008", 
+            "notification": true, 
+            "price": 580, 
+            "required_level": 9
+          }, 
+          {
+            "charge_cost_modifier": 404, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 2, 
+            "full_type": "UpgradePowerup:upgrade114", 
+            "gestalt": "upgrade114", 
+            "notification": false, 
+            "price": 1210, 
+            "required_level": 9
+          }, 
+          {
+            "charge_cost_modifier": 298, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 3, 
+            "full_type": "UpgradePowerup:upgrade113", 
+            "gestalt": "upgrade113", 
+            "notification": true, 
+            "price": 890, 
+            "required_level": 14
+          }, 
+          {
+            "charge_cost_modifier": 188, 
+            "collect_amount_modifier": 3100, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade013", 
+            "gestalt": "upgrade013", 
+            "notification": false, 
+            "price": 780, 
+            "required_level": 12
+          }, 
+          {
+            "charge_cost_modifier": 234, 
+            "collect_amount_modifier": 3790, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade010", 
+            "gestalt": "upgrade010", 
+            "notification": true, 
+            "price": 1000, 
+            "required_level": 12
+          }, 
+          {
+            "charge_cost_modifier": 233, 
+            "collect_amount_modifier": 4830, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade109", 
+            "gestalt": "upgrade109", 
+            "notification": true, 
+            "price": 830, 
+            "required_level": 20
+          }
+        ], 
+        "rename_ads_tab": false, 
+        "required_level": 9, 
+        "slot_cost": 30, 
+        "slot_cost_modifier": 0, 
+        "teammember_slots": 3, 
+        "title": "Partnerb\u00f6rse", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token006", 
+            "gestalt": "token006"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token007", 
+            "gestalt": "token007"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token008", 
+            "gestalt": "token008"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token036", 
+            "gestalt": "token036"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token015", 
+            "gestalt": "token015"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token014", 
+            "gestalt": "token014"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token033", 
+            "gestalt": "token033"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token034", 
+            "gestalt": "token034"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token022", 
+            "gestalt": "token022"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token021", 
+            "gestalt": "token021"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token040", 
+            "gestalt": "token040"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token029", 
+            "gestalt": "token029"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token086", 
+            "gestalt": "token086"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token081", 
+            "gestalt": "token081"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token129", 
+            "gestalt": "token129"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token097", 
+            "gestalt": "token097"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token030", 
+            "gestalt": "token030"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token020", 
+            "gestalt": "token020"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token066", 
+            "gestalt": "token066"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token024", 
+            "gestalt": "token024"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token025", 
+            "gestalt": "token025"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin001", 
+            "gestalt": "origin001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin005", 
+            "gestalt": "origin005"
+          }
+        ], 
+        "upgrade_slots": 3, 
+        "xp_inc": 11
+      }
+    }, 
+    "project003": {
+      "game_type": "ProjectPerp", 
+      "type_data": {
+        "ad_slots": 3, 
+        "charge_cost": 360, 
+        "charge_time": 1800000, 
+        "collect_amount": 11000, 
+        "collect_risk": 2, 
+        "description": "Auf Online-Psychotests stehen sie alle. Damit lassen sich detaillierte Charakterprofile erstellen. Die ausf\u00fchrliche Premium-Auswertung f\u00fcr den m\u00fchsam aufgef\u00fcllten Test gibts am Ende nat\u00fcrlich nur gegen Angabe von ein paar Eckdaten zur Person.", 
+        "label": "Psychotest", 
+        "max_ad_slots": 8, 
+        "max_teammember_slots": 18, 
+        "max_upgrade_slots": 13, 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 300, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-024.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-005.png"
+        }, 
+        "price": 1100, 
+        "provided_ads": [
+          {
+            "charge_cost_modifier": 376, 
+            "collect_amount_modifier": 730, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad006", 
+            "gestalt": "ad006", 
+            "notification": false, 
+            "price": 1130, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 392, 
+            "collect_amount_modifier": 1280, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad007", 
+            "gestalt": "ad007", 
+            "notification": true, 
+            "price": 1130, 
+            "required_level": 12
+          }, 
+          {
+            "charge_cost_modifier": 482, 
+            "collect_amount_modifier": 1460, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad005", 
+            "gestalt": "ad005", 
+            "notification": true, 
+            "price": 1820, 
+            "required_level": 12
+          }, 
+          {
+            "charge_cost_modifier": 554, 
+            "collect_amount_modifier": 1820, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad010", 
+            "gestalt": "ad010", 
+            "notification": false, 
+            "price": 1660, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 505, 
+            "collect_amount_modifier": 2190, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad023", 
+            "gestalt": "ad023", 
+            "notification": true, 
+            "price": 1250, 
+            "required_level": 18
+          }, 
+          {
+            "charge_cost_modifier": 546, 
+            "collect_amount_modifier": 2550, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad024", 
+            "gestalt": "ad024", 
+            "notification": true, 
+            "price": 1330, 
+            "required_level": 18
+          }, 
+          {
+            "charge_cost_modifier": 534, 
+            "collect_amount_modifier": 2910, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad025", 
+            "gestalt": "ad025", 
+            "notification": true, 
+            "price": 1290, 
+            "required_level": 18
+          }
+        ], 
+        "provided_teammembers": [
+          {
+            "charge_cost_modifier": 209, 
+            "collect_amount_modifier": 360, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember020", 
+            "gestalt": "teammember020", 
+            "notification": false, 
+            "price": 580, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 180, 
+            "collect_amount_modifier": 410, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember021", 
+            "gestalt": "teammember021", 
+            "notification": false, 
+            "price": 500, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 239, 
+            "collect_amount_modifier": 550, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember014", 
+            "gestalt": "teammember014", 
+            "notification": false, 
+            "price": 650, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 208, 
+            "collect_amount_modifier": 610, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember015", 
+            "gestalt": "teammember015", 
+            "notification": false, 
+            "price": 560, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 287, 
+            "collect_amount_modifier": 840, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember001", 
+            "gestalt": "teammember001", 
+            "notification": true, 
+            "price": 760, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 254, 
+            "collect_amount_modifier": 940, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember023", 
+            "gestalt": "teammember023", 
+            "notification": false, 
+            "price": 670, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 463, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -2, 
+            "full_type": "TeamMemberPowerup:teammember044", 
+            "gestalt": "teammember044", 
+            "notification": false, 
+            "price": 1390, 
+            "required_level": 6
+          }, 
+          {
+            "charge_cost_modifier": 438, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -2, 
+            "full_type": "TeamMemberPowerup:teammember043", 
+            "gestalt": "teammember043", 
+            "notification": true, 
+            "price": 1310, 
+            "required_level": 6
+          }, 
+          {
+            "charge_cost_modifier": 341, 
+            "collect_amount_modifier": 1170, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember026", 
+            "gestalt": "teammember026", 
+            "notification": false, 
+            "price": 880, 
+            "required_level": 10
+          }, 
+          {
+            "charge_cost_modifier": 304, 
+            "collect_amount_modifier": 1310, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember042", 
+            "gestalt": "teammember042", 
+            "notification": true, 
+            "price": 780, 
+            "required_level": 10
+          }, 
+          {
+            "charge_cost_modifier": 341, 
+            "collect_amount_modifier": 1170, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember005", 
+            "gestalt": "teammember005", 
+            "notification": true, 
+            "price": 880, 
+            "required_level": 13
+          }, 
+          {
+            "charge_cost_modifier": 304, 
+            "collect_amount_modifier": 1310, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember006", 
+            "gestalt": "teammember006", 
+            "notification": false, 
+            "price": 780, 
+            "required_level": 13
+          }, 
+          {
+            "charge_cost_modifier": 287, 
+            "collect_amount_modifier": 1280, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember012", 
+            "gestalt": "teammember012", 
+            "notification": false, 
+            "price": 740, 
+            "required_level": 15
+          }, 
+          {
+            "charge_cost_modifier": 257, 
+            "collect_amount_modifier": 1430, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember036", 
+            "gestalt": "teammember036", 
+            "notification": true, 
+            "price": 660, 
+            "required_level": 15
+          }, 
+          {
+            "charge_cost_modifier": 329, 
+            "collect_amount_modifier": 1090, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember035", 
+            "gestalt": "teammember035", 
+            "notification": true, 
+            "price": 860, 
+            "required_level": 19
+          }, 
+          {
+            "charge_cost_modifier": 293, 
+            "collect_amount_modifier": 1230, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember049", 
+            "gestalt": "teammember049", 
+            "notification": false, 
+            "price": 760, 
+            "required_level": 19
+          }
+        ], 
+        "provided_upgrades": [
+          {
+            "charge_cost_modifier": 210, 
+            "collect_amount_modifier": 730, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade001", 
+            "gestalt": "upgrade001", 
+            "notification": false, 
+            "price": 800, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 752, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -4, 
+            "full_type": "UpgradePowerup:upgrade008", 
+            "gestalt": "upgrade008", 
+            "notification": true, 
+            "price": 2260, 
+            "required_level": 9
+          }, 
+          {
+            "charge_cost_modifier": 277, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 2, 
+            "full_type": "UpgradePowerup:upgrade017", 
+            "gestalt": "upgrade017", 
+            "notification": false, 
+            "price": 830, 
+            "required_level": 12
+          }, 
+          {
+            "charge_cost_modifier": 305, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 4, 
+            "full_type": "UpgradePowerup:upgrade018", 
+            "gestalt": "upgrade018", 
+            "notification": true, 
+            "price": 920, 
+            "required_level": 12
+          }, 
+          {
+            "charge_cost_modifier": 293, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade015", 
+            "gestalt": "upgrade015", 
+            "notification": false, 
+            "price": 880, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 417, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade120", 
+            "gestalt": "upgrade120", 
+            "notification": false, 
+            "price": 1250, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 293, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade117", 
+            "gestalt": "upgrade117", 
+            "notification": false, 
+            "price": 880, 
+            "required_level": 8
+          }, 
+          {
+            "charge_cost_modifier": 231, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade119", 
+            "gestalt": "upgrade119", 
+            "notification": true, 
+            "price": 690, 
+            "required_level": 8
+          }, 
+          {
+            "charge_cost_modifier": 417, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade118", 
+            "gestalt": "upgrade118", 
+            "notification": false, 
+            "price": 1250, 
+            "required_level": 8
+          }, 
+          {
+            "charge_cost_modifier": 215, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 2, 
+            "full_type": "UpgradePowerup:upgrade116", 
+            "gestalt": "upgrade116", 
+            "notification": false, 
+            "price": 640, 
+            "required_level": 12
+          }, 
+          {
+            "charge_cost_modifier": 727, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade016", 
+            "gestalt": "upgrade016", 
+            "notification": false, 
+            "price": 2180, 
+            "required_level": 12
+          }, 
+          {
+            "charge_cost_modifier": 397, 
+            "collect_amount_modifier": 2550, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade109", 
+            "gestalt": "upgrade109", 
+            "notification": true, 
+            "price": 1410, 
+            "required_level": 20
+          }
+        ], 
+        "rename_ads_tab": false, 
+        "required_level": 5, 
+        "slot_cost": 80, 
+        "slot_cost_modifier": 0, 
+        "story": {
+          "text": "Guter Job! Tipp: Wenn du Psychotest und Gewinnspiel ausbaust, werfen sie mehr Profile ab oder liefern gar neue Eigenschaften.", 
+          "trigger": "buy"
+        }, 
+        "teammember_slots": 3, 
+        "title": "Psychotest", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token026", 
+            "gestalt": "token026"
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token007", 
+            "gestalt": "token007"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token006", 
+            "gestalt": "token006"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token029", 
+            "gestalt": "token029"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token053", 
+            "gestalt": "token053"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token120", 
+            "gestalt": "token120"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token025", 
+            "gestalt": "token025"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token081", 
+            "gestalt": "token081"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token012", 
+            "gestalt": "token012"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token008", 
+            "gestalt": "token008"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token084", 
+            "gestalt": "token084"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token132", 
+            "gestalt": "token132"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token117", 
+            "gestalt": "token117"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token022", 
+            "gestalt": "token022"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token065", 
+            "gestalt": "token065"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token085", 
+            "gestalt": "token085"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token089", 
+            "gestalt": "token089"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token103", 
+            "gestalt": "token103"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token092", 
+            "gestalt": "token092"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token090", 
+            "gestalt": "token090"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token066", 
+            "gestalt": "token066"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token021", 
+            "gestalt": "token021"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token024", 
+            "gestalt": "token024"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token083", 
+            "gestalt": "token083"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin001", 
+            "gestalt": "origin001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin003", 
+            "gestalt": "origin003"
+          }
+        ], 
+        "upgrade_slots": 3, 
+        "xp_inc": 4
+      }
+    }, 
+    "project004": {
+      "game_type": "ProjectPerp", 
+      "type_data": {
+        "ad_slots": 3, 
+        "charge_cost": 1790, 
+        "charge_time": 7200000, 
+        "collect_amount": 25900, 
+        "collect_risk": 3, 
+        "description": "Sag mir, was du kaufst, und ich sage dir, wer du bist. Betreib ein Kundenkarten-System f\u00fcr Superm\u00e4rkte, Tankstellen, M\u00f6belh\u00e4user oder Fitness-Studios. Die Leute fliegen auf die Sonderangebote im Vorteilsclub und du erf\u00e4hrst alle Details \u00fcber deren Eink\u00e4ufe.", 
+        "label": "Vorteilsclub", 
+        "max_ad_slots": 7, 
+        "max_teammember_slots": 18, 
+        "max_upgrade_slots": 9, 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 100, 
+              "y": 700
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "price": 5400, 
+        "provided_ads": [
+          {
+            "charge_cost_modifier": 233, 
+            "collect_amount_modifier": 1380, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad008", 
+            "gestalt": "ad008", 
+            "notification": false, 
+            "price": 620, 
+            "required_level": 12
+          }, 
+          {
+            "charge_cost_modifier": 315, 
+            "collect_amount_modifier": 2070, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad005", 
+            "gestalt": "ad005", 
+            "notification": true, 
+            "price": 790, 
+            "required_level": 12
+          }, 
+          {
+            "charge_cost_modifier": 321, 
+            "collect_amount_modifier": 2760, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad010", 
+            "gestalt": "ad010", 
+            "notification": false, 
+            "price": 960, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 324, 
+            "collect_amount_modifier": 2410, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad012", 
+            "gestalt": "ad012", 
+            "notification": true, 
+            "price": 970, 
+            "required_level": 14
+          }, 
+          {
+            "charge_cost_modifier": 349, 
+            "collect_amount_modifier": 3790, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad013", 
+            "gestalt": "ad013", 
+            "notification": false, 
+            "price": 1050, 
+            "required_level": 9
+          }, 
+          {
+            "charge_cost_modifier": 368, 
+            "collect_amount_modifier": 3450, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad016", 
+            "gestalt": "ad016", 
+            "notification": true, 
+            "price": 1490, 
+            "required_level": 20
+          }
+        ], 
+        "provided_teammembers": [
+          {
+            "charge_cost_modifier": 160, 
+            "collect_amount_modifier": 690, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember020", 
+            "gestalt": "teammember020", 
+            "notification": false, 
+            "price": 440, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 138, 
+            "collect_amount_modifier": 780, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember021", 
+            "gestalt": "teammember021", 
+            "notification": false, 
+            "price": 380, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 184, 
+            "collect_amount_modifier": 1030, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember014", 
+            "gestalt": "teammember014", 
+            "notification": false, 
+            "price": 500, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 161, 
+            "collect_amount_modifier": 1160, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember015", 
+            "gestalt": "teammember015", 
+            "notification": false, 
+            "price": 430, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 234, 
+            "collect_amount_modifier": 1720, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember001", 
+            "gestalt": "teammember001", 
+            "notification": true, 
+            "price": 610, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 208, 
+            "collect_amount_modifier": 1940, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember023", 
+            "gestalt": "teammember023", 
+            "notification": false, 
+            "price": 540, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 184, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -1, 
+            "full_type": "TeamMemberPowerup:teammember044", 
+            "gestalt": "teammember044", 
+            "notification": false, 
+            "price": 550, 
+            "required_level": 6
+          }, 
+          {
+            "charge_cost_modifier": 165, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -1, 
+            "full_type": "TeamMemberPowerup:teammember043", 
+            "gestalt": "teammember043", 
+            "notification": true, 
+            "price": 500, 
+            "required_level": 6
+          }, 
+          {
+            "charge_cost_modifier": 406, 
+            "collect_amount_modifier": 3100, 
+            "collect_risk_modifier": -1, 
+            "full_type": "TeamMemberPowerup:teammember026", 
+            "gestalt": "teammember026", 
+            "notification": false, 
+            "price": 1060, 
+            "required_level": 10
+          }, 
+          {
+            "charge_cost_modifier": 300, 
+            "collect_amount_modifier": 3490, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember042", 
+            "gestalt": "teammember042", 
+            "notification": true, 
+            "price": 750, 
+            "required_level": 10
+          }, 
+          {
+            "charge_cost_modifier": 308, 
+            "collect_amount_modifier": 2760, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember005", 
+            "gestalt": "teammember005", 
+            "notification": true, 
+            "price": 780, 
+            "required_level": 13
+          }, 
+          {
+            "charge_cost_modifier": 277, 
+            "collect_amount_modifier": 3100, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember006", 
+            "gestalt": "teammember006", 
+            "notification": false, 
+            "price": 700, 
+            "required_level": 13
+          }, 
+          {
+            "charge_cost_modifier": 266, 
+            "collect_amount_modifier": 3100, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember012", 
+            "gestalt": "teammember012", 
+            "notification": false, 
+            "price": 670, 
+            "required_level": 15
+          }, 
+          {
+            "charge_cost_modifier": 240, 
+            "collect_amount_modifier": 3490, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember036", 
+            "gestalt": "teammember036", 
+            "notification": true, 
+            "price": 600, 
+            "required_level": 15
+          }
+        ], 
+        "provided_upgrades": [
+          {
+            "charge_cost_modifier": 198, 
+            "collect_amount_modifier": 2070, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade001", 
+            "gestalt": "upgrade001", 
+            "notification": false, 
+            "price": 470, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 248, 
+            "collect_amount_modifier": 2760, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade024", 
+            "gestalt": "upgrade024", 
+            "notification": false, 
+            "price": 740, 
+            "required_level": 11
+          }, 
+          {
+            "charge_cost_modifier": 202, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade146", 
+            "gestalt": "upgrade146", 
+            "notification": true, 
+            "price": 610, 
+            "required_level": 10
+          }, 
+          {
+            "charge_cost_modifier": 239, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -2, 
+            "full_type": "UpgradePowerup:upgrade008", 
+            "gestalt": "upgrade008", 
+            "notification": true, 
+            "price": 720, 
+            "required_level": 9
+          }, 
+          {
+            "charge_cost_modifier": 387, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 2, 
+            "full_type": "UpgradePowerup:upgrade021", 
+            "gestalt": "upgrade021", 
+            "notification": false, 
+            "price": 1160, 
+            "required_level": 11
+          }, 
+          {
+            "charge_cost_modifier": 295, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 2, 
+            "full_type": "UpgradePowerup:upgrade022", 
+            "gestalt": "upgrade022", 
+            "notification": false, 
+            "price": 880, 
+            "required_level": 11
+          }, 
+          {
+            "charge_cost_modifier": 272, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 2, 
+            "full_type": "UpgradePowerup:upgrade023", 
+            "gestalt": "upgrade023", 
+            "notification": false, 
+            "price": 810, 
+            "required_level": 17
+          }, 
+          {
+            "charge_cost_modifier": 180, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 2, 
+            "full_type": "UpgradePowerup:upgrade020", 
+            "gestalt": "upgrade020", 
+            "notification": true, 
+            "price": 540, 
+            "required_level": 17
+          }, 
+          {
+            "charge_cost_modifier": 262, 
+            "collect_amount_modifier": 3450, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade038", 
+            "gestalt": "upgrade038", 
+            "notification": false, 
+            "price": 720, 
+            "required_level": 11
+          }
+        ], 
+        "rename_ads_tab": false, 
+        "required_level": 11, 
+        "slot_cost": 60, 
+        "slot_cost_modifier": 0, 
+        "teammember_slots": 3, 
+        "title": "Vorteilsclub", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token006", 
+            "gestalt": "token006"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token007", 
+            "gestalt": "token007"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token005", 
+            "gestalt": "token005"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token008", 
+            "gestalt": "token008"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token099", 
+            "gestalt": "token099"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token125", 
+            "gestalt": "token125"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token067", 
+            "gestalt": "token067"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token030", 
+            "gestalt": "token030"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token083", 
+            "gestalt": "token083"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token014", 
+            "gestalt": "token014"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token015", 
+            "gestalt": "token015"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token088", 
+            "gestalt": "token088"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token012", 
+            "gestalt": "token012"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token070", 
+            "gestalt": "token070"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token113", 
+            "gestalt": "token113"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token069", 
+            "gestalt": "token069"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token132", 
+            "gestalt": "token132"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin014", 
+            "gestalt": "origin014"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin015", 
+            "gestalt": "origin015"
+          }
+        ], 
+        "upgrade_slots": 3, 
+        "xp_inc": 13
+      }
+    }, 
+    "project005": {
+      "game_type": "ProjectPerp", 
+      "type_data": {
+        "ad_slots": 0, 
+        "charge_cost": 990, 
+        "charge_time": 3600000, 
+        "collect_amount": 16900, 
+        "collect_risk": 3, 
+        "description": "Warum kompliziert, wenns auch einfach geht? Ruf die Leute einfach an und frag sie direkt nach all den lukrativen Details. Am Telefon tarnst du dich als seri\u00f6ses Marktforschungsinstitut und m\u00f6chtest nur ein paar ganz diskrete Fragen stellen. Je gezielter und \u00fcberzeugender deine Anrufe, desto besser wird diese Art von Telefonterror funktionieren.", 
+        "label": "Telefon-\r\numfrage", 
+        "max_ad_slots": 0, 
+        "max_teammember_slots": 18, 
+        "max_upgrade_slots": 15, 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 200, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-024.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-005.png"
+        }, 
+        "price": 3000, 
+        "provided_ads": [], 
+        "provided_teammembers": [
+          {
+            "charge_cost_modifier": 162, 
+            "collect_amount_modifier": 500, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember020", 
+            "gestalt": "teammember020", 
+            "notification": false, 
+            "price": 450, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 140, 
+            "collect_amount_modifier": 560, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember021", 
+            "gestalt": "teammember021", 
+            "notification": false, 
+            "price": 390, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 186, 
+            "collect_amount_modifier": 750, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember014", 
+            "gestalt": "teammember014", 
+            "notification": false, 
+            "price": 510, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 162, 
+            "collect_amount_modifier": 850, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember015", 
+            "gestalt": "teammember015", 
+            "notification": false, 
+            "price": 440, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 224, 
+            "collect_amount_modifier": 1150, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember001", 
+            "gestalt": "teammember001", 
+            "notification": true, 
+            "price": 590, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 198, 
+            "collect_amount_modifier": 1300, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember023", 
+            "gestalt": "teammember023", 
+            "notification": false, 
+            "price": 520, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 327, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -3, 
+            "full_type": "TeamMemberPowerup:teammember044", 
+            "gestalt": "teammember044", 
+            "notification": false, 
+            "price": 980, 
+            "required_level": 6
+          }, 
+          {
+            "charge_cost_modifier": 307, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -3, 
+            "full_type": "TeamMemberPowerup:teammember043", 
+            "gestalt": "teammember043", 
+            "notification": true, 
+            "price": 920, 
+            "required_level": 6
+          }, 
+          {
+            "charge_cost_modifier": 314, 
+            "collect_amount_modifier": 2010, 
+            "collect_risk_modifier": -1, 
+            "full_type": "TeamMemberPowerup:teammember012", 
+            "gestalt": "teammember012", 
+            "notification": false, 
+            "price": 830, 
+            "required_level": 15
+          }, 
+          {
+            "charge_cost_modifier": 289, 
+            "collect_amount_modifier": 2260, 
+            "collect_risk_modifier": -1, 
+            "full_type": "TeamMemberPowerup:teammember036", 
+            "gestalt": "teammember036", 
+            "notification": true, 
+            "price": 760, 
+            "required_level": 15
+          }, 
+          {
+            "charge_cost_modifier": 281, 
+            "collect_amount_modifier": 1760, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember016", 
+            "gestalt": "teammember016", 
+            "notification": false, 
+            "price": 720, 
+            "required_level": 17
+          }, 
+          {
+            "charge_cost_modifier": 251, 
+            "collect_amount_modifier": 1980, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember017", 
+            "gestalt": "teammember017", 
+            "notification": true, 
+            "price": 640, 
+            "required_level": 17
+          }
+        ], 
+        "provided_upgrades": [
+          {
+            "charge_cost_modifier": 214, 
+            "collect_amount_modifier": 1510, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade029", 
+            "gestalt": "upgrade029", 
+            "notification": false, 
+            "price": 560, 
+            "required_level": 7
+          }, 
+          {
+            "charge_cost_modifier": 307, 
+            "collect_amount_modifier": 3010, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade028", 
+            "gestalt": "upgrade028", 
+            "notification": false, 
+            "price": 680, 
+            "required_level": 7
+          }, 
+          {
+            "charge_cost_modifier": 459, 
+            "collect_amount_modifier": 4520, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade026", 
+            "gestalt": "upgrade026", 
+            "notification": true, 
+            "price": 1650, 
+            "required_level": 13
+          }, 
+          {
+            "charge_cost_modifier": 483, 
+            "collect_amount_modifier": 5020, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade025", 
+            "gestalt": "upgrade025", 
+            "notification": false, 
+            "price": 2040, 
+            "required_level": 13
+          }, 
+          {
+            "charge_cost_modifier": 643, 
+            "collect_amount_modifier": 7530, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade027", 
+            "gestalt": "upgrade027", 
+            "notification": false, 
+            "price": 2140, 
+            "required_level": 13
+          }, 
+          {
+            "charge_cost_modifier": 378, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -4, 
+            "full_type": "UpgradePowerup:upgrade008", 
+            "gestalt": "upgrade008", 
+            "notification": true, 
+            "price": 1130, 
+            "required_level": 9
+          }, 
+          {
+            "charge_cost_modifier": 204, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade030", 
+            "gestalt": "upgrade030", 
+            "notification": false, 
+            "price": 610, 
+            "required_level": 7
+          }, 
+          {
+            "charge_cost_modifier": 252, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade033", 
+            "gestalt": "upgrade033", 
+            "notification": false, 
+            "price": 760, 
+            "required_level": 7
+          }, 
+          {
+            "charge_cost_modifier": 156, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade032", 
+            "gestalt": "upgrade032", 
+            "notification": true, 
+            "price": 470, 
+            "required_level": 13
+          }, 
+          {
+            "charge_cost_modifier": 108, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade037", 
+            "gestalt": "upgrade037", 
+            "notification": false, 
+            "price": 330, 
+            "required_level": 7
+          }, 
+          {
+            "charge_cost_modifier": 61, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade110", 
+            "gestalt": "upgrade110", 
+            "notification": false, 
+            "price": 180, 
+            "required_level": 7
+          }, 
+          {
+            "charge_cost_modifier": 204, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade031", 
+            "gestalt": "upgrade031", 
+            "notification": true, 
+            "price": 610, 
+            "required_level": 13
+          }, 
+          {
+            "charge_cost_modifier": 156, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade034", 
+            "gestalt": "upgrade034", 
+            "notification": false, 
+            "price": 470, 
+            "required_level": 13
+          }, 
+          {
+            "charge_cost_modifier": 84, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade036", 
+            "gestalt": "upgrade036", 
+            "notification": false, 
+            "price": 250, 
+            "required_level": 13
+          }
+        ], 
+        "rename_ads_tab": false, 
+        "required_level": 7, 
+        "slot_cost": 70, 
+        "slot_cost_modifier": 100, 
+        "story": {
+          "text": "Das Telefonieren dauert \u00fcbrigens seine Zeit. Daf\u00fcr gibt's nach jedem Aufladen \u00fcber 10.000 Profile, gut ausgebaut um vieles mehr!", 
+          "trigger": "buy"
+        }, 
+        "teammember_slots": 3, 
+        "title": "Telefonumfrage", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token006", 
+            "gestalt": "token006"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token007", 
+            "gestalt": "token007"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token005", 
+            "gestalt": "token005"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token008", 
+            "gestalt": "token008"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token114", 
+            "gestalt": "token114"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token012", 
+            "gestalt": "token012"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token125", 
+            "gestalt": "token125"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token047", 
+            "gestalt": "token047"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token094", 
+            "gestalt": "token094"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token064", 
+            "gestalt": "token064"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token065", 
+            "gestalt": "token065"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token030", 
+            "gestalt": "token030"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token093", 
+            "gestalt": "token093"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token098", 
+            "gestalt": "token098"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token103", 
+            "gestalt": "token103"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin001", 
+            "gestalt": "origin001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin004", 
+            "gestalt": "origin004"
+          }
+        ], 
+        "upgrade_slots": 3, 
+        "xp_inc": 7
+      }
+    }, 
+    "project006": {
+      "game_type": "ProjectPerp", 
+      "type_data": {
+        "ad_slots": 0, 
+        "charge_cost": 3440, 
+        "charge_time": 28800000, 
+        "collect_amount": 61400, 
+        "collect_risk": 5, 
+        "description": "Vor allem bei teureren Produkten werden immer diese eleganten Karten beigelegt, zum Beispiel bei Druckern. Viele Leute f\u00fcllen die ganz brav aus und denken wohl, sie bek\u00e4men dadurch eine Sonderbehandlung, wenn etwas kaputt geht. Dabei gehen die Karten gar nicht an den Hersteller, sondern direkt an dich. Daf\u00fcr \u00fcbernimmst du die Auswertung.", 
+        "label": "Garantiekarten", 
+        "max_ad_slots": 0, 
+        "max_teammember_slots": 18, 
+        "max_upgrade_slots": 12, 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 0, 
+              "y": 700
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "price": 10300, 
+        "provided_ads": [], 
+        "provided_teammembers": [
+          {
+            "charge_cost_modifier": 400, 
+            "collect_amount_modifier": 1930, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember014", 
+            "gestalt": "teammember014", 
+            "notification": false, 
+            "price": 1130, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 343, 
+            "collect_amount_modifier": 2170, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember015", 
+            "gestalt": "teammember015", 
+            "notification": false, 
+            "price": 970, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 369, 
+            "collect_amount_modifier": 1280, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember020", 
+            "gestalt": "teammember020", 
+            "notification": false, 
+            "price": 1060, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 314, 
+            "collect_amount_modifier": 1440, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember021", 
+            "gestalt": "teammember021", 
+            "notification": false, 
+            "price": 900, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 461, 
+            "collect_amount_modifier": 3210, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember001", 
+            "gestalt": "teammember001", 
+            "notification": true, 
+            "price": 1270, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 400, 
+            "collect_amount_modifier": 3610, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember023", 
+            "gestalt": "teammember023", 
+            "notification": false, 
+            "price": 1090, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 682, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -4, 
+            "full_type": "TeamMemberPowerup:teammember044", 
+            "gestalt": "teammember044", 
+            "notification": false, 
+            "price": 2050, 
+            "required_level": 6
+          }, 
+          {
+            "charge_cost_modifier": 631, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -4, 
+            "full_type": "TeamMemberPowerup:teammember043", 
+            "gestalt": "teammember043", 
+            "notification": true, 
+            "price": 1890, 
+            "required_level": 6
+          }, 
+          {
+            "charge_cost_modifier": 491, 
+            "collect_amount_modifier": 3850, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember005", 
+            "gestalt": "teammember005", 
+            "notification": true, 
+            "price": 1340, 
+            "required_level": 13
+          }, 
+          {
+            "charge_cost_modifier": 428, 
+            "collect_amount_modifier": 4330, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember006", 
+            "gestalt": "teammember006", 
+            "notification": false, 
+            "price": 1160, 
+            "required_level": 13
+          }, 
+          {
+            "charge_cost_modifier": 442, 
+            "collect_amount_modifier": 5130, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember012", 
+            "gestalt": "teammember012", 
+            "notification": false, 
+            "price": 1180, 
+            "required_level": 15
+          }, 
+          {
+            "charge_cost_modifier": 388, 
+            "collect_amount_modifier": 5780, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember036", 
+            "gestalt": "teammember036", 
+            "notification": true, 
+            "price": 1030, 
+            "required_level": 15
+          }
+        ], 
+        "provided_upgrades": [
+          {
+            "charge_cost_modifier": 278, 
+            "collect_amount_modifier": 1280, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade001", 
+            "gestalt": "upgrade001", 
+            "notification": false, 
+            "price": 780, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 429, 
+            "collect_amount_modifier": 1930, 
+            "collect_risk_modifier": -1, 
+            "full_type": "UpgradePowerup:upgrade038", 
+            "gestalt": "upgrade038", 
+            "notification": false, 
+            "price": 1200, 
+            "required_level": 11
+          }, 
+          {
+            "charge_cost_modifier": 441, 
+            "collect_amount_modifier": 3850, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade040", 
+            "gestalt": "upgrade040", 
+            "notification": false, 
+            "price": 1320, 
+            "required_level": 18
+          }, 
+          {
+            "charge_cost_modifier": 348, 
+            "collect_amount_modifier": 3850, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade029", 
+            "gestalt": "upgrade029", 
+            "notification": false, 
+            "price": 1280, 
+            "required_level": 7
+          }, 
+          {
+            "charge_cost_modifier": 450, 
+            "collect_amount_modifier": 6420, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade039", 
+            "gestalt": "upgrade039", 
+            "notification": false, 
+            "price": 630, 
+            "required_level": 20
+          }, 
+          {
+            "charge_cost_modifier": 631, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -4, 
+            "full_type": "UpgradePowerup:upgrade008", 
+            "gestalt": "upgrade008", 
+            "notification": true, 
+            "price": 1890, 
+            "required_level": 9
+          }, 
+          {
+            "charge_cost_modifier": 421, 
+            "collect_amount_modifier": 6420, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade044", 
+            "gestalt": "upgrade044", 
+            "notification": false, 
+            "price": 1010, 
+            "required_level": 18
+          }, 
+          {
+            "charge_cost_modifier": 473, 
+            "collect_amount_modifier": 6420, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade045", 
+            "gestalt": "upgrade045", 
+            "notification": false, 
+            "price": 1130, 
+            "required_level": 18
+          }, 
+          {
+            "charge_cost_modifier": 615, 
+            "collect_amount_modifier": 8980, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade147", 
+            "gestalt": "upgrade147", 
+            "notification": false, 
+            "price": 1710, 
+            "required_level": 18
+          }, 
+          {
+            "charge_cost_modifier": 258, 
+            "collect_amount_modifier": 1280, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade041", 
+            "gestalt": "upgrade041", 
+            "notification": false, 
+            "price": 630, 
+            "required_level": 20
+          }, 
+          {
+            "charge_cost_modifier": 258, 
+            "collect_amount_modifier": 1280, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade042", 
+            "gestalt": "upgrade042", 
+            "notification": false, 
+            "price": 630, 
+            "required_level": 20
+          }, 
+          {
+            "charge_cost_modifier": 214, 
+            "collect_amount_modifier": 130, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade043", 
+            "gestalt": "upgrade043", 
+            "notification": true, 
+            "price": 630, 
+            "required_level": 20
+          }
+        ], 
+        "rename_ads_tab": false, 
+        "required_level": 18, 
+        "slot_cost": 90, 
+        "slot_cost_modifier": 0, 
+        "teammember_slots": 3, 
+        "title": "Garantiekarten", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token006", 
+            "gestalt": "token006"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token007", 
+            "gestalt": "token007"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token005", 
+            "gestalt": "token005"
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token008", 
+            "gestalt": "token008"
+          }, 
+          {
+            "amount": 25, 
+            "full_type": "TokenPerp:supertoken014", 
+            "gestalt": "supertoken014"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token132", 
+            "gestalt": "token132"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token084", 
+            "gestalt": "token084"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token029", 
+            "gestalt": "token029"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token012", 
+            "gestalt": "token012"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin014", 
+            "gestalt": "origin014"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin018", 
+            "gestalt": "origin018"
+          }
+        ], 
+        "upgrade_slots": 3, 
+        "xp_inc": 31
+      }
+    }, 
+    "project007": {
+      "game_type": "ProjectPerp", 
+      "type_data": {
+        "ad_slots": 0, 
+        "charge_cost": 2480, 
+        "charge_time": 14400000, 
+        "collect_amount": 42300, 
+        "collect_risk": 4, 
+        "description": "Wer kauft noch die neuen Hits auf CD, wenn das MP3 nur einen Klick entfernt ist? Gut, dass die Musikindustrie eine bessere Methode zum Geldverdienen entdeckt hat: Raubkopierer verklagen! Wenn du dich in diese Filesharing-Netzwerke wie eine Spinne reinh\u00e4ngst, kannst du rausfinden, wer was runtersaugt. Und diese Info teuer verkaufen!", 
+        "label": "Raubkopierer\r\nSpinne", 
+        "max_ad_slots": 0, 
+        "max_teammember_slots": 18, 
+        "max_upgrade_slots": 7, 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 700, 
+              "y": 600
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "price": 7400, 
+        "provided_ads": [], 
+        "provided_teammembers": [
+          {
+            "charge_cost_modifier": 157, 
+            "collect_amount_modifier": 1970, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember020", 
+            "gestalt": "teammember020", 
+            "notification": false, 
+            "price": 440, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 136, 
+            "collect_amount_modifier": 2210, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember021", 
+            "gestalt": "teammember021", 
+            "notification": false, 
+            "price": 380, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 168, 
+            "collect_amount_modifier": 2460, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember014", 
+            "gestalt": "teammember014", 
+            "notification": false, 
+            "price": 460, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 146, 
+            "collect_amount_modifier": 2770, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember015", 
+            "gestalt": "teammember015", 
+            "notification": false, 
+            "price": 400, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 203, 
+            "collect_amount_modifier": 3940, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember001", 
+            "gestalt": "teammember001", 
+            "notification": true, 
+            "price": 540, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 179, 
+            "collect_amount_modifier": 4430, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember023", 
+            "gestalt": "teammember023", 
+            "notification": false, 
+            "price": 470, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 134, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -1, 
+            "full_type": "TeamMemberPowerup:teammember044", 
+            "gestalt": "teammember044", 
+            "notification": false, 
+            "price": 400, 
+            "required_level": 6
+          }, 
+          {
+            "charge_cost_modifier": 115, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -1, 
+            "full_type": "TeamMemberPowerup:teammember043", 
+            "gestalt": "teammember043", 
+            "notification": true, 
+            "price": 350, 
+            "required_level": 6
+          }, 
+          {
+            "charge_cost_modifier": 192, 
+            "collect_amount_modifier": 3440, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember016", 
+            "gestalt": "teammember016", 
+            "notification": false, 
+            "price": 520, 
+            "required_level": 17
+          }, 
+          {
+            "charge_cost_modifier": 168, 
+            "collect_amount_modifier": 3870, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember017", 
+            "gestalt": "teammember017", 
+            "notification": true, 
+            "price": 450, 
+            "required_level": 17
+          }, 
+          {
+            "charge_cost_modifier": 215, 
+            "collect_amount_modifier": 4430, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember035", 
+            "gestalt": "teammember035", 
+            "notification": true, 
+            "price": 570, 
+            "required_level": 19
+          }, 
+          {
+            "charge_cost_modifier": 190, 
+            "collect_amount_modifier": 4980, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember049", 
+            "gestalt": "teammember049", 
+            "notification": false, 
+            "price": 500, 
+            "required_level": 19
+          }
+        ], 
+        "provided_upgrades": [
+          {
+            "charge_cost_modifier": 173, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade069", 
+            "gestalt": "upgrade069", 
+            "notification": false, 
+            "price": 520, 
+            "required_level": 15
+          }, 
+          {
+            "charge_cost_modifier": 219, 
+            "collect_amount_modifier": 6400, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade049", 
+            "gestalt": "upgrade049", 
+            "notification": false, 
+            "price": 890, 
+            "required_level": 15
+          }, 
+          {
+            "charge_cost_modifier": 198, 
+            "collect_amount_modifier": 6890, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade064", 
+            "gestalt": "upgrade064", 
+            "notification": false, 
+            "price": 590, 
+            "required_level": 15
+          }, 
+          {
+            "charge_cost_modifier": 252, 
+            "collect_amount_modifier": 7870, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade057", 
+            "gestalt": "upgrade057", 
+            "notification": false, 
+            "price": 580, 
+            "required_level": 15
+          }
+        ], 
+        "rename_ads_tab": false, 
+        "required_level": 15, 
+        "slot_cost": 60, 
+        "slot_cost_modifier": 0, 
+        "teammember_slots": 3, 
+        "title": "Raubkopierer-Spinne", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token029", 
+            "gestalt": "token029"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token040", 
+            "gestalt": "token040"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token123", 
+            "gestalt": "token123"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token097", 
+            "gestalt": "token097"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token087", 
+            "gestalt": "token087"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token078", 
+            "gestalt": "token078"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token124", 
+            "gestalt": "token124"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token032", 
+            "gestalt": "token032"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token122", 
+            "gestalt": "token122"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin014", 
+            "gestalt": "origin014"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin016", 
+            "gestalt": "origin016"
+          }
+        ], 
+        "upgrade_slots": 3, 
+        "xp_inc": 20
+      }
+    }, 
+    "project009": {
+      "game_type": "ProjectPerp", 
+      "type_data": {
+        "ad_slots": 3, 
+        "charge_cost": 2100, 
+        "charge_time": 14400000, 
+        "collect_amount": 39900, 
+        "collect_risk": 4, 
+        "description": "Du willst ja nur das Beste f\u00fcr die Menschen. Biete eine kostenlose Vorsorgeuntersuchung an und sammle umfassende Daten \u00fcber den Gesundheitszustand deiner PatientInnen. Mit ein paar zus\u00e4tzlichen Fragen zum Lifestyle erf\u00e4hrst du dann auch das, was sich nicht so einfach messen l\u00e4sst. Nat\u00fcrlich alles total vertraulich und nur zur Vorsorge!", 
+        "label": "Vorsorge-\r\nUntersuchung", 
+        "max_ad_slots": 8, 
+        "max_teammember_slots": 18, 
+        "max_upgrade_slots": 11, 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 700, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "price": 6300, 
+        "provided_ads": [
+          {
+            "charge_cost_modifier": 250, 
+            "collect_amount_modifier": 1180, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad006", 
+            "gestalt": "ad006", 
+            "notification": false, 
+            "price": 730, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 281, 
+            "collect_amount_modifier": 1890, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad008", 
+            "gestalt": "ad008", 
+            "notification": false, 
+            "price": 760, 
+            "required_level": 12
+          }, 
+          {
+            "charge_cost_modifier": 294, 
+            "collect_amount_modifier": 2360, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad027", 
+            "gestalt": "ad027", 
+            "notification": true, 
+            "price": 850, 
+            "required_level": 15
+          }, 
+          {
+            "charge_cost_modifier": 312, 
+            "collect_amount_modifier": 2830, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad007", 
+            "gestalt": "ad007", 
+            "notification": true, 
+            "price": 900, 
+            "required_level": 12
+          }, 
+          {
+            "charge_cost_modifier": 405, 
+            "collect_amount_modifier": 3770, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad005", 
+            "gestalt": "ad005", 
+            "notification": true, 
+            "price": 1150, 
+            "required_level": 12
+          }, 
+          {
+            "charge_cost_modifier": 312, 
+            "collect_amount_modifier": 1890, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad012", 
+            "gestalt": "ad012", 
+            "notification": true, 
+            "price": 1000, 
+            "required_level": 14
+          }, 
+          {
+            "charge_cost_modifier": 429, 
+            "collect_amount_modifier": 5180, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad010", 
+            "gestalt": "ad010", 
+            "notification": false, 
+            "price": 1290, 
+            "required_level": 2
+          }
+        ], 
+        "provided_teammembers": [
+          {
+            "charge_cost_modifier": 203, 
+            "collect_amount_modifier": 940, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember020", 
+            "gestalt": "teammember020", 
+            "notification": false, 
+            "price": 570, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 174, 
+            "collect_amount_modifier": 1060, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember021", 
+            "gestalt": "teammember021", 
+            "notification": false, 
+            "price": 490, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 227, 
+            "collect_amount_modifier": 1410, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember014", 
+            "gestalt": "teammember014", 
+            "notification": false, 
+            "price": 630, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 197, 
+            "collect_amount_modifier": 1590, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember015", 
+            "gestalt": "teammember015", 
+            "notification": false, 
+            "price": 540, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 281, 
+            "collect_amount_modifier": 2450, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember001", 
+            "gestalt": "teammember001", 
+            "notification": true, 
+            "price": 750, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 242, 
+            "collect_amount_modifier": 2650, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember023", 
+            "gestalt": "teammember023", 
+            "notification": false, 
+            "price": 640, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 335, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -2, 
+            "full_type": "TeamMemberPowerup:teammember044", 
+            "gestalt": "teammember044", 
+            "notification": false, 
+            "price": 1000, 
+            "required_level": 6
+          }, 
+          {
+            "charge_cost_modifier": 309, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -2, 
+            "full_type": "TeamMemberPowerup:teammember043", 
+            "gestalt": "teammember043", 
+            "notification": true, 
+            "price": 930, 
+            "required_level": 6
+          }, 
+          {
+            "charge_cost_modifier": 300, 
+            "collect_amount_modifier": 2830, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember005", 
+            "gestalt": "teammember005", 
+            "notification": true, 
+            "price": 790, 
+            "required_level": 13
+          }, 
+          {
+            "charge_cost_modifier": 265, 
+            "collect_amount_modifier": 3180, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember006", 
+            "gestalt": "teammember006", 
+            "notification": false, 
+            "price": 700, 
+            "required_level": 13
+          }
+        ], 
+        "provided_upgrades": [
+          {
+            "charge_cost_modifier": 117, 
+            "collect_amount_modifier": 940, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade001", 
+            "gestalt": "upgrade001", 
+            "notification": false, 
+            "price": 350, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 130, 
+            "collect_amount_modifier": 1410, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade038", 
+            "gestalt": "upgrade038", 
+            "notification": false, 
+            "price": 390, 
+            "required_level": 11
+          }, 
+          {
+            "charge_cost_modifier": 221, 
+            "collect_amount_modifier": 3770, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade049", 
+            "gestalt": "upgrade049", 
+            "notification": false, 
+            "price": 500, 
+            "required_level": 15
+          }, 
+          {
+            "charge_cost_modifier": 309, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -2, 
+            "full_type": "UpgradePowerup:upgrade008", 
+            "gestalt": "upgrade008", 
+            "notification": true, 
+            "price": 930, 
+            "required_level": 9
+          }, 
+          {
+            "charge_cost_modifier": 325, 
+            "collect_amount_modifier": 5660, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade053", 
+            "gestalt": "upgrade053", 
+            "notification": false, 
+            "price": 1430, 
+            "required_level": 15
+          }, 
+          {
+            "charge_cost_modifier": 276, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade073", 
+            "gestalt": "upgrade073", 
+            "notification": false, 
+            "price": 830, 
+            "required_level": 15
+          }, 
+          {
+            "charge_cost_modifier": 167, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 2, 
+            "full_type": "UpgradePowerup:upgrade074", 
+            "gestalt": "upgrade074", 
+            "notification": false, 
+            "price": 500, 
+            "required_level": 15
+          }, 
+          {
+            "charge_cost_modifier": 263, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 2, 
+            "full_type": "UpgradePowerup:upgrade070", 
+            "gestalt": "upgrade070", 
+            "notification": false, 
+            "price": 790, 
+            "required_level": 15
+          }, 
+          {
+            "charge_cost_modifier": 376, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 2, 
+            "full_type": "UpgradePowerup:upgrade071", 
+            "gestalt": "upgrade071", 
+            "notification": false, 
+            "price": 1130, 
+            "required_level": 15
+          }
+        ], 
+        "rename_ads_tab": false, 
+        "required_level": 15, 
+        "slot_cost": 60, 
+        "slot_cost_modifier": 10, 
+        "teammember_slots": 3, 
+        "title": "Vorsorgeuntersuchung", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token006", 
+            "gestalt": "token006"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token007", 
+            "gestalt": "token007"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token005", 
+            "gestalt": "token005"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token041", 
+            "gestalt": "token041"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token015", 
+            "gestalt": "token015"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token014", 
+            "gestalt": "token014"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token017", 
+            "gestalt": "token017"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token022", 
+            "gestalt": "token022"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token098", 
+            "gestalt": "token098"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token021", 
+            "gestalt": "token021"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token058", 
+            "gestalt": "token058"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token053", 
+            "gestalt": "token053"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token018", 
+            "gestalt": "token018"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token125", 
+            "gestalt": "token125"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token109", 
+            "gestalt": "token109"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token105", 
+            "gestalt": "token105"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token114", 
+            "gestalt": "token114"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token120", 
+            "gestalt": "token120"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token054", 
+            "gestalt": "token054"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin014", 
+            "gestalt": "origin014"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin017", 
+            "gestalt": "origin017"
+          }
+        ], 
+        "upgrade_slots": 3, 
+        "xp_inc": 20
+      }
+    }, 
+    "project011": {
+      "game_type": "ProjectPerp", 
+      "type_data": {
+        "ad_slots": 3, 
+        "charge_cost": 3220, 
+        "charge_time": 28800000, 
+        "collect_amount": 61400, 
+        "collect_risk": 5, 
+        "description": "Jahrelang gemeinsam von der Schulbank erdr\u00fcckt und sich danach gleich komplett aus den Augen verloren? Passiert gar nicht so selten. Und irgendwann werden sie dann ganz r\u00fchrselig und w\u00fcrden alles geben, um die alten Zeiten aufleben zu lassen. Auf einer Website zum Wiederfinden alter SchulkollegInnen geben sie gern ein paar Dinge von sich preis.", 
+        "label": "Virtuelles Klassentreffen", 
+        "max_ad_slots": 12, 
+        "max_teammember_slots": 22, 
+        "max_upgrade_slots": 12, 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 700, 
+              "y": 200
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "price": 9700, 
+        "provided_ads": [
+          {
+            "charge_cost_modifier": 206, 
+            "collect_amount_modifier": 320, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad006", 
+            "gestalt": "ad006", 
+            "notification": false, 
+            "price": 610, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 217, 
+            "collect_amount_modifier": 640, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad007", 
+            "gestalt": "ad007", 
+            "notification": true, 
+            "price": 630, 
+            "required_level": 12
+          }, 
+          {
+            "charge_cost_modifier": 247, 
+            "collect_amount_modifier": 1600, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad005", 
+            "gestalt": "ad005", 
+            "notification": true, 
+            "price": 720, 
+            "required_level": 12
+          }, 
+          {
+            "charge_cost_modifier": 229, 
+            "collect_amount_modifier": 640, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad033", 
+            "gestalt": "ad033", 
+            "notification": true, 
+            "price": 690, 
+            "required_level": 18
+          }, 
+          {
+            "charge_cost_modifier": 240, 
+            "collect_amount_modifier": 960, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad013", 
+            "gestalt": "ad013", 
+            "notification": false, 
+            "price": 720, 
+            "required_level": 9
+          }, 
+          {
+            "charge_cost_modifier": 247, 
+            "collect_amount_modifier": 1280, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad014", 
+            "gestalt": "ad014", 
+            "notification": false, 
+            "price": 820, 
+            "required_level": 9
+          }, 
+          {
+            "charge_cost_modifier": 274, 
+            "collect_amount_modifier": 1930, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad029", 
+            "gestalt": "ad029", 
+            "notification": true, 
+            "price": 820, 
+            "required_level": 18
+          }, 
+          {
+            "charge_cost_modifier": 267, 
+            "collect_amount_modifier": 1280, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad023", 
+            "gestalt": "ad023", 
+            "notification": true, 
+            "price": 800, 
+            "required_level": 18
+          }, 
+          {
+            "charge_cost_modifier": 280, 
+            "collect_amount_modifier": 1600, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad024", 
+            "gestalt": "ad024", 
+            "notification": true, 
+            "price": 840, 
+            "required_level": 18
+          }, 
+          {
+            "charge_cost_modifier": 353, 
+            "collect_amount_modifier": 3850, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad032", 
+            "gestalt": "ad032", 
+            "notification": true, 
+            "price": 1330, 
+            "required_level": 20
+          }
+        ], 
+        "provided_teammembers": [
+          {
+            "charge_cost_modifier": 194, 
+            "collect_amount_modifier": 1280, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember020", 
+            "gestalt": "teammember020", 
+            "notification": false, 
+            "price": 540, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 168, 
+            "collect_amount_modifier": 1440, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember021", 
+            "gestalt": "teammember021", 
+            "notification": false, 
+            "price": 460, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 223, 
+            "collect_amount_modifier": 1930, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember014", 
+            "gestalt": "teammember014", 
+            "notification": false, 
+            "price": 600, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 195, 
+            "collect_amount_modifier": 2170, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember015", 
+            "gestalt": "teammember015", 
+            "notification": false, 
+            "price": 520, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 281, 
+            "collect_amount_modifier": 3210, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember001", 
+            "gestalt": "teammember001", 
+            "notification": true, 
+            "price": 740, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 249, 
+            "collect_amount_modifier": 3610, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember023", 
+            "gestalt": "teammember023", 
+            "notification": false, 
+            "price": 650, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 229, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -1, 
+            "full_type": "TeamMemberPowerup:teammember044", 
+            "gestalt": "teammember044", 
+            "notification": false, 
+            "price": 690, 
+            "required_level": 6
+          }, 
+          {
+            "charge_cost_modifier": 206, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -1, 
+            "full_type": "TeamMemberPowerup:teammember043", 
+            "gestalt": "teammember043", 
+            "notification": true, 
+            "price": 620, 
+            "required_level": 6
+          }, 
+          {
+            "charge_cost_modifier": 402, 
+            "collect_amount_modifier": 3850, 
+            "collect_risk_modifier": -1, 
+            "full_type": "TeamMemberPowerup:teammember026", 
+            "gestalt": "teammember026", 
+            "notification": false, 
+            "price": 1080, 
+            "required_level": 10
+          }, 
+          {
+            "charge_cost_modifier": 369, 
+            "collect_amount_modifier": 4330, 
+            "collect_risk_modifier": -1, 
+            "full_type": "TeamMemberPowerup:teammember042", 
+            "gestalt": "teammember042", 
+            "notification": true, 
+            "price": 990, 
+            "required_level": 10
+          }, 
+          {
+            "charge_cost_modifier": 338, 
+            "collect_amount_modifier": 4490, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember005", 
+            "gestalt": "teammember005", 
+            "notification": true, 
+            "price": 870, 
+            "required_level": 13
+          }, 
+          {
+            "charge_cost_modifier": 303, 
+            "collect_amount_modifier": 5050, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember006", 
+            "gestalt": "teammember006", 
+            "notification": false, 
+            "price": 770, 
+            "required_level": 13
+          }, 
+          {
+            "charge_cost_modifier": 271, 
+            "collect_amount_modifier": 4490, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember012", 
+            "gestalt": "teammember012", 
+            "notification": false, 
+            "price": 690, 
+            "required_level": 15
+          }, 
+          {
+            "charge_cost_modifier": 242, 
+            "collect_amount_modifier": 5050, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember036", 
+            "gestalt": "teammember036", 
+            "notification": true, 
+            "price": 620, 
+            "required_level": 15
+          }, 
+          {
+            "charge_cost_modifier": 321, 
+            "collect_amount_modifier": 4110, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember016", 
+            "gestalt": "teammember016", 
+            "notification": false, 
+            "price": 830, 
+            "required_level": 17
+          }, 
+          {
+            "charge_cost_modifier": 287, 
+            "collect_amount_modifier": 4620, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember017", 
+            "gestalt": "teammember017", 
+            "notification": true, 
+            "price": 730, 
+            "required_level": 17
+          }, 
+          {
+            "charge_cost_modifier": 367, 
+            "collect_amount_modifier": 5130, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember035", 
+            "gestalt": "teammember035", 
+            "notification": true, 
+            "price": 930, 
+            "required_level": 19
+          }, 
+          {
+            "charge_cost_modifier": 330, 
+            "collect_amount_modifier": 5780, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember049", 
+            "gestalt": "teammember049", 
+            "notification": false, 
+            "price": 830, 
+            "required_level": 19
+          }
+        ], 
+        "provided_upgrades": [
+          {
+            "charge_cost_modifier": 147, 
+            "collect_amount_modifier": 1280, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade001", 
+            "gestalt": "upgrade001", 
+            "notification": false, 
+            "price": 390, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 216, 
+            "collect_amount_modifier": 1930, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade038", 
+            "gestalt": "upgrade038", 
+            "notification": false, 
+            "price": 680, 
+            "required_level": 11
+          }, 
+          {
+            "charge_cost_modifier": 192, 
+            "collect_amount_modifier": 2570, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade057", 
+            "gestalt": "upgrade057", 
+            "notification": false, 
+            "price": 480, 
+            "required_level": 15
+          }, 
+          {
+            "charge_cost_modifier": 200, 
+            "collect_amount_modifier": 3210, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade049", 
+            "gestalt": "upgrade049", 
+            "notification": false, 
+            "price": 680, 
+            "required_level": 15
+          }, 
+          {
+            "charge_cost_modifier": 206, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -1, 
+            "full_type": "UpgradePowerup:upgrade008", 
+            "gestalt": "upgrade008", 
+            "notification": true, 
+            "price": 620, 
+            "required_level": 9
+          }, 
+          {
+            "charge_cost_modifier": 213, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 2, 
+            "full_type": "UpgradePowerup:upgrade103", 
+            "gestalt": "upgrade103", 
+            "notification": false, 
+            "price": 640, 
+            "required_level": 18
+          }, 
+          {
+            "charge_cost_modifier": 250, 
+            "collect_amount_modifier": 3850, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade104", 
+            "gestalt": "upgrade104", 
+            "notification": false, 
+            "price": 750, 
+            "required_level": 18
+          }, 
+          {
+            "charge_cost_modifier": 31, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 3, 
+            "full_type": "UpgradePowerup:upgrade105", 
+            "gestalt": "upgrade105", 
+            "notification": false, 
+            "price": 90, 
+            "required_level": 18
+          }, 
+          {
+            "charge_cost_modifier": 427, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 3, 
+            "full_type": "UpgradePowerup:upgrade107", 
+            "gestalt": "upgrade107", 
+            "notification": false, 
+            "price": 1280, 
+            "required_level": 18
+          }, 
+          {
+            "charge_cost_modifier": 312, 
+            "collect_amount_modifier": 5130, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade109", 
+            "gestalt": "upgrade109", 
+            "notification": true, 
+            "price": 1160, 
+            "required_level": 20
+          }, 
+          {
+            "charge_cost_modifier": 300, 
+            "collect_amount_modifier": 4490, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade108", 
+            "gestalt": "upgrade108", 
+            "notification": false, 
+            "price": 900, 
+            "required_level": 20
+          }
+        ], 
+        "rename_ads_tab": false, 
+        "required_level": 18, 
+        "slot_cost": 40, 
+        "slot_cost_modifier": 0, 
+        "teammember_slots": 3, 
+        "title": "Virtuelles Klassentreffen", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token006", 
+            "gestalt": "token006"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token007", 
+            "gestalt": "token007"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token008", 
+            "gestalt": "token008"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token011", 
+            "gestalt": "token011"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token061", 
+            "gestalt": "token061"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token005", 
+            "gestalt": "token005"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token064", 
+            "gestalt": "token064"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token045", 
+            "gestalt": "token045"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token036", 
+            "gestalt": "token036"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin014", 
+            "gestalt": "origin014"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin019", 
+            "gestalt": "origin019"
+          }
+        ], 
+        "upgrade_slots": 3, 
+        "xp_inc": 31
+      }
+    }, 
+    "proxy001": {
+      "game_type": "ProxyPerp", 
+      "type_data": {
+        "description": "Du betreibst Gewinnspiele, Partnerb\u00f6rsen und schlie\u00dflich dein eigenes Smoogle & Tracebook? Und schiebst die gesammelten Daten allesamt in deine Datenbank rein? Das ist nicht unheikel. Es w\u00e4r besser, diese Projekte und Firmen geh\u00f6ren offiziell gar nicht DIR, sondern einer Briefkastenfirma. Wem die geh\u00f6rt, muss ja niemand wissen.", 
+        "label": "Scheinfirma", 
+        "max_instances": 1, 
+        "max_slots": 3, 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 320, 
+              "y": 760
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "price": 100, 
+        "provided_perps": [
+          "project001", 
+          "project003", 
+          "project005", 
+          "project002"
+        ], 
+        "required_level": 2, 
+        "title": "Scheinfirma"
+      }
+    }, 
+    "proxy002": {
+      "game_type": "ProxyPerp", 
+      "type_data": {
+        "description": "Du betreibst Gewinnspiele, Partnerb\u00f6rsen und schlie\u00dflich dein eigenes Smoogle & Tracebook? Und schiebst die gesammelten Daten allesamt in deine Datenbank rein? Das ist nicht unheikel. Es w\u00e4r besser, diese Projekte und Firmen geh\u00f6ren offiziell gar nicht DIR, sondern einer Briefkastenfirma. Wem die geh\u00f6rt, muss ja niemand wissen.", 
+        "label": "Scheinfirma", 
+        "max_instances": 1, 
+        "max_slots": 3, 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 240, 
+              "y": 760
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "price": 2000, 
+        "provided_perps": [
+          "project004", 
+          "project009", 
+          "project007", 
+          "project011", 
+          "project006"
+        ], 
+        "required_level": 11, 
+        "title": "Scheinfirma"
+      }
+    }, 
+    "proxy003": {
+      "game_type": "ProxyPerp", 
+      "type_data": {
+        "description": "Du betreibst Gewinnspiele, Partnerb\u00f6rsen und schlie\u00dflich dein eigenes Smoogle & Tracebook? Und schiebst die gesammelten Daten allesamt in deine Datenbank rein? Das ist nicht unheikel. Es w\u00e4r besser, diese Projekte und Firmen geh\u00f6ren offiziell gar nicht DIR, sondern einer Briefkastenfirma. Wem die geh\u00f6rt, muss ja niemand wissen.", 
+        "label": "Scheinfirma", 
+        "max_instances": 1, 
+        "max_slots": 5, 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 160, 
+              "y": 760
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "price": 10000, 
+        "provided_perps": [
+          "project004", 
+          "project009", 
+          "project007", 
+          "project011", 
+          "project006"
+        ], 
+        "required_level": 18, 
+        "title": "Scheinfirma"
+      }
+    }, 
+    "proxy004": {
+      "game_type": "ProxyPerp", 
+      "type_data": {
+        "description": "Du betreibst Gewinnspiele, Partnerb\u00f6rsen und schlie\u00dflich dein eigenes Smoogle & Tracebook? Und schiebst die gesammelten Daten allesamt in deine Datenbank rein? Das ist nicht unheikel. Es w\u00e4r besser, diese Projekte und Firmen geh\u00f6ren offiziell gar nicht DIR, sondern einer Briefkastenfirma. Wem die geh\u00f6rt, muss ja niemand wissen.", 
+        "label": "Scheinfirma", 
+        "max_instances": 1, 
+        "max_slots": 4, 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 80, 
+              "y": 760
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "price": 4000, 
+        "provided_perps": [
+          "project001", 
+          "project003", 
+          "project005", 
+          "project002"
+        ], 
+        "required_level": 9, 
+        "story": {
+          "text": "Top! Mit einer Scheinfirma machst du es Medien und Beh\u00f6rden schwerer, einen \u00dcberblick \u00fcber dein Imperium zu gewinnen. Klick gleich mal rein!", 
+          "trigger": "buy"
+        }, 
+        "title": "Scheinfirma"
+      }
+    }, 
+    "pusher001": {
+      "game_type": "PusherPerp", 
+      "type_data": {
+        "description": "Scotty war mal oberster Chef einer gro\u00dfen Datensammel-Firma und weiss daher genau, an wen du die Infos in deiner Datenbank profitabel verkaufen kannst. Ein alter Hase im Gesch\u00e4ft! Er findet ganz spezielle Kundschaft f\u00fcr dich und das ist gut so. Schlie\u00dflich brauchst du die Kohle f\u00fcr den weiteren Ausbau deines Imperiums!", 
+        "label": "Scotty", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 0, 
+              "y": 760
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-001.png"
+        }, 
+        "price": 1800, 
+        "provided_perps": [
+          "client014", 
+          "client011", 
+          "client019"
+        ], 
+        "required_level": 1, 
+        "required_providers": [
+          "project007", 
+          "contact004", 
+          "project006"
+        ], 
+        "subtitle": "treibt neue Kundschaft f\u00fcr dich auf", 
+        "title": "Scotty"
+      }
+    }, 
+    "pusher003": {
+      "game_type": "PusherPerp", 
+      "type_data": {
+        "description": "Alfonso ist jung, motiviert, dynamisch und ein Vollblut-Verk\u00e4ufer. Gib ihm 10 Minuten und er wird dir mit seinen Tricks alles andrehen, wovon du vor 11 Minuten noch nicht mal gewusst hast, dass du es brauchst. Gemeinde\u00e4mter, Schulen und staatliche Beh\u00f6rden sind seine Spezialit\u00e4t, alles lukrative Kundschaft f\u00fcr deinen umfangreichen Datenschatz!", 
+        "label": "Alfonso", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 600, 
+              "y": 560
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-001.png"
+        }, 
+        "price": 900, 
+        "provided_perps": [
+          "client005", 
+          "client008"
+        ], 
+        "required_level": 1, 
+        "required_providers": [
+          "contact026", 
+          "contact008"
+        ], 
+        "story": {
+          "text": "Ich sag dir: Alfonso ist der Superhit. Klick rein und schau, ob er eine lukrative Daten-Quelle f\u00fcr dich aufgetrieben hat!", 
+          "trigger": "buy"
+        }, 
+        "subtitle": "treibt neue Kundschaft f\u00fcr dich auf", 
+        "title": "Alfonso"
+      }
+    }, 
+    "pusher004": {
+      "game_type": "PusherPerp", 
+      "type_data": {
+        "description": "Denise ist ein Profi und bahnt seit Jahren die wirklich fetten Gesch\u00e4fte an. Ob Autoh\u00e4ndler, Superm\u00e4rkte oder Versicherungen - sie findet immer neue Kundschaft, die sich brennend f\u00fcr deinen Datenschatz interessiert. Und gut daf\u00fcr bezahlt! Sie arbeitet nicht gratis. Aber es zahlt sich sicher f\u00fcr dich aus, wenn sie wieder neue Kundschaft aufgetrieben hat.", 
+        "label": "Denise", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 500, 
+              "y": 460
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-001.png"
+        }, 
+        "price": 50, 
+        "provided_perps": [
+          "client007", 
+          "client002", 
+          "client006", 
+          "client010"
+        ], 
+        "required_level": 1, 
+        "required_providers": [
+          "project002", 
+          "contact035", 
+          "project003", 
+          "contact001"
+        ], 
+        "subtitle": "treibt neue Kundschaft f\u00fcr dich auf", 
+        "title": "Denise"
+      }
+    }
+  }, 
+  "powerups": {
+    "ad001": {
+      "game_type": "AdPowerup", 
+      "type_data": {
+        "description": "Engagiere ein paar h\u00fcbsche, lustige und redegewandte Verkaufstalente und lass sie vor die U-Bahn-Stationen der Stadt ausschw\u00e4rmen.", 
+        "label": "Verteilen an U-Bahn-Stationen", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-027.png"
+        }, 
+        "required_level": 2, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 760, 
+              "y": 600
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "title": "Verteilen an U-Bahn-Stationen", 
+        "tokens": []
+      }
+    }, 
+    "ad002": {
+      "game_type": "AdPowerup", 
+      "type_data": {
+        "description": "Engagiere ein paar h\u00fcbsche, lustige und redegewandte Verkaufstalente und schick sie in die gro\u00dfen Shopping Center des Landes.", 
+        "label": "Verteilen in Einkaufszentren", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-025.png"
+        }, 
+        "required_level": 2, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 760, 
+              "y": 500
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "title": "Verteilen in Einkaufszentren", 
+        "tokens": []
+      }
+    }, 
+    "ad003": {
+      "game_type": "AdPowerup", 
+      "type_data": {
+        "description": "Engagiere ein paar h\u00fcbsche, charmante und redegewandte Verkaufstalente und lass sie auf die Restaurants der Stadt los.", 
+        "label": "Verteilen in Restaurants", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-025.png"
+        }, 
+        "required_level": 2, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 760, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "title": "Verteilen in Restaurants", 
+        "tokens": []
+      }
+    }, 
+    "ad004": {
+      "game_type": "AdPowerup", 
+      "type_data": {
+        "description": "Erstelle ein kleines, buntes Heftchen mit drei lustigen Geschichten, zehn niedlichen Fotos und nat\u00fcrlich massig Werbung f\u00fcr dich und lege es einer auflagenstarken Zeitung bei.", 
+        "label": "Zeitungsbeilage", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-025.png"
+        }, 
+        "required_level": 2, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 760, 
+              "y": 300
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "title": "Zeitungsbeilage", 
+        "tokens": []
+      }
+    }, 
+    "ad005": {
+      "game_type": "AdPowerup", 
+      "type_data": {
+        "description": "Werbespots f\u00fcrs Fernsehen sind nicht ganz billig zu drehen, daf\u00fcr umso effektiver. Eine richtig schlechte Pointe ist dabei genauso wichtig wie eine besonders hohe Lautst\u00e4rke.", 
+        "label": "TV Spot", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-025.png"
+        }, 
+        "required_level": 12, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 760, 
+              "y": 200
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "title": "TV Spot", 
+        "tokens": []
+      }
+    }, 
+    "ad006": {
+      "game_type": "AdPowerup", 
+      "type_data": {
+        "description": "Viel genutzt und oft erprobt ist eine Zeitungsanzeige immer noch ein gutes Mittel, dein Projekt zu bewerben. Ein fetziges Bild und ein halblustiger Slogan: Fertig!", 
+        "label": "Zeitungsanzeige", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-026.png"
+        }, 
+        "required_level": 5, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 760, 
+              "y": 100
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "title": "Zeitungsanzeige", 
+        "tokens": []
+      }
+    }, 
+    "ad007": {
+      "game_type": "AdPowerup", 
+      "type_data": {
+        "description": "Mit Hilfe eines guten alten Radio-Spots kannst du deine Werbung zielgruppengerecht steuern: Volksmusik oder Klassik, Disco oder Reportage. Angst, die Leute h\u00f6ren dir nicht zu? Mach den Spot noch lauter und ihre Aufmerksamkeit ist dir sicher!", 
+        "label": "Radio-Spot", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-026.png"
+        }, 
+        "required_level": 12, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 760, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "title": "Radio-Spot", 
+        "tokens": []
+      }
+    }, 
+    "ad008": {
+      "game_type": "AdPowerup", 
+      "type_data": {
+        "description": "Lass dir ein \u00fcberzeugendes Plakat designen und pflastere die Stra\u00dfen damit voll. Ein wenig provokant muss es schon sein, damit auch wirklich was h\u00e4ngen bleibt!", 
+        "label": "Plakatwerbung", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-026.png"
+        }, 
+        "required_level": 12, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 600, 
+              "y": 658
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "title": "Plakatwerbung", 
+        "tokens": []
+      }
+    }, 
+    "ad009": {
+      "game_type": "AdPowerup", 
+      "type_data": {
+        "description": "Stell einen scheinbar unabh\u00e4ngigen Produkt-Vergleichstest ins Netz. Du bist dabei nat\u00fcrlich Sieger, wenn auch nur knapp.", 
+        "label": "Vergleichstest", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-026.png"
+        }, 
+        "required_level": 9, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 500, 
+              "y": 658
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "title": "Vergleichstest", 
+        "tokens": []
+      }
+    }, 
+    "ad010": {
+      "game_type": "AdPowerup", 
+      "type_data": {
+        "description": "Kauf dir einen Promi und lass ihn f\u00fcr dich werben. Ex-SportlerInnen sind auf jeden Fall beliebter als Ex-PolitikerInnen und als Lieblinge der Nation besonders gut f\u00fcr deine Zwecke geeignet.", 
+        "label": "Ex-Sportler", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-025.png"
+        }, 
+        "required_level": 2, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 400, 
+              "y": 658
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "title": "Ex-Sportler", 
+        "tokens": []
+      }
+    }, 
+    "ad012": {
+      "game_type": "AdPowerup", 
+      "type_data": {
+        "description": "Kauf dir einen Promi und lass ihn f\u00fcr dich werben. TV-ModeratorInnen stehen auf der Beliebtheitsskala ganz oben und sind sehr gut f\u00fcr deinen Zweck geeignet.", 
+        "label": "TV-Moderator", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-025.png"
+        }, 
+        "required_level": 14, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 200, 
+              "y": 658
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "title": "TV-Moderator", 
+        "tokens": []
+      }
+    }, 
+    "ad013": {
+      "game_type": "AdPowerup", 
+      "type_data": {
+        "description": "Massen-Maturareisen nach Griechenland sind kein Kindergeburtstag und darum das optimale Umfeld, um ein paar Tausend Delirium-Profile abzuschleppen.", 
+        "label": "Maturareise", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-025.png"
+        }, 
+        "required_level": 9, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 100, 
+              "y": 658
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "title": "Maturareise", 
+        "tokens": []
+      }
+    }, 
+    "ad014": {
+      "game_type": "AdPowerup", 
+      "type_data": {
+        "description": "Regelm\u00e4\u00dfige Single Parties geben deinen Usern die gewisse soziale W\u00e4rme und geh\u00f6ren zum absoluten Pflichtprogramm f\u00fcr deine Partnerb\u00f6rse.", 
+        "label": "Single Party", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-026.png"
+        }, 
+        "required_level": 9, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 0, 
+              "y": 658
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "title": "Single Party", 
+        "tokens": []
+      }
+    }, 
+    "ad015": {
+      "game_type": "AdPowerup", 
+      "type_data": {
+        "description": "Werd zum Hauptsponsor eines dieser Mega-Rockfestivals! 100.000 Leute, die total auf Entertainment aus sind. Und dein Logo gross und breit auf der Hauptb\u00fchne. Rockt!", 
+        "label": "Rockfestival", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-025.png"
+        }, 
+        "required_level": 9, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 660, 
+              "y": 500
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "title": "Rockfestival", 
+        "tokens": []
+      }
+    }, 
+    "ad016": {
+      "game_type": "AdPowerup", 
+      "type_data": {
+        "description": "Als Hauptsponsor beim Skispringen wirst du schnell bekannt und die sportlichen Couch-Profile werden dir nur so zufliegen.", 
+        "label": "Skispringen", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-025.png"
+        }, 
+        "required_level": 20, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 660, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "title": "Skispringen", 
+        "tokens": []
+      }
+    }, 
+    "ad023": {
+      "game_type": "AdPowerup", 
+      "type_data": {
+        "description": "Wenn dich die Leute nicht von selber liken, muss da eben nachgeholfen werden! Bezahl ein paar Studis oder andere billige Arbeitskr\u00e4fte daf\u00fcr, dass man dich im Netz ein wenig mehr mag.", 
+        "label": "Bezahlte Likes", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-026.png"
+        }, 
+        "required_level": 18, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 300, 
+              "y": 558
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "title": "Bezahlte Likes", 
+        "tokens": []
+      }
+    }, 
+    "ad024": {
+      "game_type": "AdPowerup", 
+      "type_data": {
+        "description": "Wenn die Leute nicht von selber anfangen, \u00fcber dich zu posten, muss eben nachgeholfen werden! Bezahl ein paar Studis oder andere billige Arbeitskr\u00e4fte daf\u00fcr, dass sie im Netz unauff\u00e4llig Werbung f\u00fcr dich machen.", 
+        "label": "Bezahlte Online Postings", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-026.png"
+        }, 
+        "required_level": 18, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 200, 
+              "y": 558
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "title": "Bezahlte Online Postings", 
+        "tokens": []
+      }
+    }, 
+    "ad025": {
+      "game_type": "AdPowerup", 
+      "type_data": {
+        "description": "Stell eine dilettantisch gemachte Hobby-Website online, die sich mit deinem Angebot besch\u00e4ftigt. So was wird gut von Suchmaschinen gefunden und kommt ziemlich glaubw\u00fcrdig r\u00fcber.", 
+        "label": "Hobby Website", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-026.png"
+        }, 
+        "required_level": 18, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 100, 
+              "y": 558
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "title": "Hobby Website", 
+        "tokens": []
+      }
+    }, 
+    "ad027": {
+      "game_type": "AdPowerup", 
+      "type_data": {
+        "description": "Mach eine Brosch\u00fcre und verstopfe die Briefk\u00e4sten der Stadt damit! Irgendwer wird sich den Mist schon anschauen. Verwende all die \u00fcblichen Tricks, schreib zehnmal \"Sonderangebot\" und \"billiger\" hinein und die Profile werden nur so reinflattern.", 
+        "label": "Postwurf-M\u00fcll", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-026.png"
+        }, 
+        "required_level": 15, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 560, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "title": "Postwurf-M\u00fcll", 
+        "tokens": []
+      }
+    }, 
+    "ad029": {
+      "game_type": "AdPowerup", 
+      "type_data": {
+        "description": "Bring ein paar besonders \u00fcberzeugte Fans dazu, ihre Bekannten zu sich nach Hause einzuladen und f\u00fcr dich Werbung zu machen. Ein paar von diesen Bekannten wiederrum laden dann ihre eigenen Bekannten ein...und so weiter. Genial!", 
+        "label": "Tupper-Partys", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-026.png"
+        }, 
+        "required_level": 18, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 560, 
+              "y": 200
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "title": "Tupper-Partys", 
+        "tokens": []
+      }
+    }, 
+    "ad032": {
+      "game_type": "AdPowerup", 
+      "type_data": {
+        "description": "Filme ein paar Leute, die auf einem belebten Platz oder in einer Bahnhofshalle pl\u00f6tzlich alle die gleichen Bewegungen machen und stell das Video ins Netz. Sowas verbreitet sich oft wie ein Virus! Ganz wichtig: Die Verwunderung der Umstehenden \u00fcber das Geschehen muss m\u00f6glichst oft ins Bild.", 
+        "label": "Flashmob Video", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-025.png"
+        }, 
+        "required_level": 20, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 400, 
+              "y": 458
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "title": "Flashmob Video", 
+        "tokens": []
+      }
+    }, 
+    "ad033": {
+      "game_type": "AdPowerup", 
+      "type_data": {
+        "description": "Kauf dir einen Promi und lass ihn f\u00fcr dich werben. Superbekannte Immobilien-Haie mit regelm\u00e4\u00dfiger TV-Pr\u00e4senz sind dabei eine besondere Spezialit\u00e4t. Achtung: nicht f\u00fcr jeden Zweck geeignet!", 
+        "label": "Immobilien-Hai", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-026.png"
+        }, 
+        "required_level": 18, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 300, 
+              "y": 458
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "title": "Immobilien-Hai", 
+        "tokens": []
+      }
+    }, 
+    "teammember001": {
+      "game_type": "TeamMemberPowerup", 
+      "type_data": {
+        "description": "Auf Dauer kannst du nicht alles selber machen. Stell einen Manager ein, der sich um alles k\u00fcmmert und deinem Team in den Arsch tritt.", 
+        "label": "Manager", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-017.png"
+        }, 
+        "required_level": 5, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 840, 
+              "y": 600
+            }
+          }, 
+          "frameSrc": "sprite-001.png"
+        }, 
+        "title": "Manager", 
+        "tokens": []
+      }
+    }, 
+    "teammember005": {
+      "game_type": "TeamMemberPowerup", 
+      "type_data": {
+        "description": "Dein Projekt muss von vorne bis hinten durchgestylt sein, dann ist der Erfolg sicher. Daf\u00fcr ben\u00f6tigst du GrafikerInnen, die wissen, was die Leute sehen wollen.", 
+        "label": "Grafiker", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-017.png"
+        }, 
+        "required_level": 13, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 840, 
+              "y": 200
+            }
+          }, 
+          "frameSrc": "sprite-001.png"
+        }, 
+        "title": "Grafiker", 
+        "tokens": []
+      }
+    }, 
+    "teammember006": {
+      "game_type": "TeamMemberPowerup", 
+      "type_data": {
+        "description": "Dein Projekt muss von vorne bis hinten durchgestylt sein, dann ist der Erfolg sicher. Daf\u00fcr ben\u00f6tigst du GrafikerInnen, die wissen, was die Leute sehen wollen.", 
+        "label": "Grafikerin", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-018.png"
+        }, 
+        "required_level": 13, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 840, 
+              "y": 100
+            }
+          }, 
+          "frameSrc": "sprite-001.png"
+        }, 
+        "title": "Grafikerin", 
+        "tokens": []
+      }
+    }, 
+    "teammember012": {
+      "game_type": "TeamMemberPowerup", 
+      "type_data": {
+        "description": "Nicht alle Menschen geben ihre Daten ganz freiwillig her. Erkenntnisse aus der Verhaltensforschung sind hier sehr n\u00fctzlich, ein wenig Manipulation schadet nie.", 
+        "label": "Psychologe", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-018.png"
+        }, 
+        "required_level": 15, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 300, 
+              "y": 710
+            }
+          }, 
+          "frameSrc": "sprite-001.png"
+        }, 
+        "title": "Psychologe", 
+        "tokens": []
+      }
+    }, 
+    "teammember014": {
+      "game_type": "TeamMemberPowerup", 
+      "type_data": {
+        "description": "Studis sind oft hoch qualifiziert, aber billig und willig. Sie lassen sich in vielen Bereichen einsetzen und verbessern deine Gesamt-Performance.", 
+        "label": "Student", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-017.png"
+        }, 
+        "required_level": 2, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 100, 
+              "y": 710
+            }
+          }, 
+          "frameSrc": "sprite-001.png"
+        }, 
+        "title": "Student", 
+        "tokens": []
+      }
+    }, 
+    "teammember015": {
+      "game_type": "TeamMemberPowerup", 
+      "type_data": {
+        "description": "Studis sind oft hoch qualifiziert, aber billig und willig. Sie lassen sich in vielen Bereichen einsetzen und verbessern deine Gesamt-Performance.", 
+        "label": "Studentin", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-018.png"
+        }, 
+        "required_level": 2, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 0, 
+              "y": 710
+            }
+          }, 
+          "frameSrc": "sprite-001.png"
+        }, 
+        "title": "Studentin", 
+        "tokens": []
+      }
+    }, 
+    "teammember016": {
+      "game_type": "TeamMemberPowerup", 
+      "type_data": {
+        "description": "Wenn wo eine Schraube locker ist oder sonst etwas nicht so funktioniert wie es soll - der Techniker hilft dir aus der Patsche. In jeder Hinsicht n\u00fctzlich!", 
+        "label": "Techniker", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-017.png"
+        }, 
+        "required_level": 17, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 740, 
+              "y": 600
+            }
+          }, 
+          "frameSrc": "sprite-001.png"
+        }, 
+        "title": "Techniker", 
+        "tokens": []
+      }
+    }, 
+    "teammember017": {
+      "game_type": "TeamMemberPowerup", 
+      "type_data": {
+        "description": "Wenn wo eine Schraube locker ist oder sonst etwas nicht so funktioniert wie es soll - die Technikerin hilft dir aus der Patsche. In jeder Hinsicht n\u00fctzlich!", 
+        "label": "Technikerin", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-018.png"
+        }, 
+        "required_level": 17, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 740, 
+              "y": 500
+            }
+          }, 
+          "frameSrc": "sprite-001.png"
+        }, 
+        "title": "Technikerin", 
+        "tokens": []
+      }
+    }, 
+    "teammember020": {
+      "game_type": "TeamMemberPowerup", 
+      "type_data": {
+        "description": "PraktikantInnen sind meistens nicht so fit wie Studis, haben aber einen gro\u00dfen Vorteil: Sie machen jeden Schei\u00df f\u00fcr dich.", 
+        "label": "Praktikant", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-017.png"
+        }, 
+        "required_level": 2, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 740, 
+              "y": 200
+            }
+          }, 
+          "frameSrc": "sprite-001.png"
+        }, 
+        "title": "Praktikant", 
+        "tokens": []
+      }
+    }, 
+    "teammember021": {
+      "game_type": "TeamMemberPowerup", 
+      "type_data": {
+        "description": "PraktikantInnen sind meistens nicht so fit wie Studis, haben aber einen gro\u00dfen Vorteil: Sie machen jeden Schei\u00df f\u00fcr dich.", 
+        "label": "Praktikantin", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-018.png"
+        }, 
+        "required_level": 2, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 740, 
+              "y": 100
+            }
+          }, 
+          "frameSrc": "sprite-001.png"
+        }, 
+        "title": "Praktikantin", 
+        "tokens": []
+      }
+    }, 
+    "teammember023": {
+      "game_type": "TeamMemberPowerup", 
+      "type_data": {
+        "description": "Auf Dauer kannst du nicht alles selber machen. Mit einer Frau in der F\u00fchrungsetage l\u00e4uft dein Team erst so richtig wie geschmiert.", 
+        "label": "Managerin", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-017.png"
+        }, 
+        "required_level": 5, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 600, 
+              "y": 610
+            }
+          }, 
+          "frameSrc": "sprite-001.png"
+        }, 
+        "title": "Managerin", 
+        "tokens": []
+      }
+    }, 
+    "teammember026": {
+      "game_type": "TeamMemberPowerup", 
+      "type_data": {
+        "description": "Werbung ist alles in deinem Business. Daf\u00fcr brauchst du absolute Profis, die den Leuten das Hirn weich machen, ohne dass sie es merken.", 
+        "label": "Werbe-Fuzzi", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-018.png"
+        }, 
+        "required_level": 10, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 300, 
+              "y": 610
+            }
+          }, 
+          "frameSrc": "sprite-001.png"
+        }, 
+        "title": "Werbe-Fuzzi", 
+        "tokens": []
+      }
+    }, 
+    "teammember035": {
+      "game_type": "TeamMemberPowerup", 
+      "type_data": {
+        "description": "Die Technik ist entscheidend im Datensammel-Business. Damit alles funktioniert und dir kein Profil verloren geht, brauchst du einen Programmierer, die die Maschine am Laufen h\u00e4lt.", 
+        "label": "Programmierer", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-018.png"
+        }, 
+        "required_level": 19, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 640, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-001.png"
+        }, 
+        "title": "Programmierer", 
+        "tokens": []
+      }
+    }, 
+    "teammember036": {
+      "game_type": "TeamMemberPowerup", 
+      "type_data": {
+        "description": "Nicht alle Menschen geben ihre Daten ganz freiwillig her. Erkenntnisse aus der Verhaltensforschung sind hier sehr n\u00fctzlich, ein wenig Manipulation schadet nie.", 
+        "label": "Psychologin", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-018.png"
+        }, 
+        "required_level": 15, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 500, 
+              "y": 510
+            }
+          }, 
+          "frameSrc": "sprite-001.png"
+        }, 
+        "title": "Psychologin", 
+        "tokens": []
+      }
+    }, 
+    "teammember042": {
+      "game_type": "TeamMemberPowerup", 
+      "type_data": {
+        "description": "Werbung ist alles in deinem Business. Daf\u00fcr brauchst du absolute Profis, die den Leuten das Hirn weich machen, ohne dass sie es merken.", 
+        "label": "Werbe-Fuzzi", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-017.png"
+        }, 
+        "required_level": 10, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 540, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-001.png"
+        }, 
+        "title": "Werbe-Fuzzi", 
+        "tokens": []
+      }
+    }, 
+    "teammember043": {
+      "game_type": "TeamMemberPowerup", 
+      "type_data": {
+        "description": "Damit du bei deiner Profil-Sammelei auf der sicheren Seite bist, brauchst du eine gute Juristin, die deine trickreichen Formulierungen auf Herz und Nieren \u00fcberpr\u00fcft und kritische Stimmen in Grund und Boden klagt.", 
+        "label": "Anw\u00e4ltin", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-017.png"
+        }, 
+        "required_level": 6, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 540, 
+              "y": 300
+            }
+          }, 
+          "frameSrc": "sprite-001.png"
+        }, 
+        "title": "Anw\u00e4ltin", 
+        "tokens": []
+      }
+    }, 
+    "teammember044": {
+      "game_type": "TeamMemberPowerup", 
+      "type_data": {
+        "description": "Damit du bei deiner Profil-Sammelei auf der sicheren Seite bist, brauchst du einen guten Juristen, der deine trickreichen Formulierungen auf Herz und Nieren \u00fcberpr\u00fcft und kritische Stimmen in Grund und Boden klagt.", 
+        "label": "Anwalt", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-018.png"
+        }, 
+        "required_level": 6, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 540, 
+              "y": 200
+            }
+          }, 
+          "frameSrc": "sprite-001.png"
+        }, 
+        "title": "Anwalt", 
+        "tokens": []
+      }
+    }, 
+    "teammember049": {
+      "game_type": "TeamMemberPowerup", 
+      "type_data": {
+        "description": "Die Technik ist entscheidend im Datensammel-Business. Damit alles funktioniert und dir kein Profil verloren geht, brauchst du eine Programmiererin, die die Maschine am Laufen h\u00e4lt.", 
+        "label": "Programmiererin", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-017.png"
+        }, 
+        "required_level": 19, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 240, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-001.png"
+        }, 
+        "title": "Programmiererin", 
+        "tokens": []
+      }
+    }, 
+    "upgrade001": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Die Oberfl\u00e4che muss gl\u00e4nzen! Dein Projekt muss von vorne bis hinten durchgestylt sein, dann ist der Erfolg sicher. Je cooler die Gestaltung deines Firmen-Outfits, desto mehr Kunden kannst du ihre Daten abluchsen.", 
+        "label": "Logo & Design", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-015.png"
+        }, 
+        "required_level": 2, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 600, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "title": "Logo & Design", 
+        "tokens": []
+      }
+    }, 
+    "upgrade002": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Verlose mehrere schicke Eier Potts unter den TeilnehmerInnen. Sp\u00e4ter kannst du dir vielleicht \u00fcberzeugendere Gewinne leisten, aber f\u00fcr den Anfang reicht das auch.", 
+        "label": "Gewinn Eier Pott", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-014.png"
+        }, 
+        "required_level": 2, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 500, 
+              "y": 700
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "Gewinn Eier Pott", 
+        "tokens": []
+      }
+    }, 
+    "upgrade003": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Verlose drei tolle \u00dcberraschungsreisen unter den TeilnehmerInnen. Welche Art der \u00dcberraschung sie erwartet, musst du ja nicht dazu sagen. Deswegen hei\u00dft es ja: \u00dcberraschung!", 
+        "label": "Gewinn \u00dcberraschungsreise", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-015.png"
+        }, 
+        "required_level": 10, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 600, 
+              "y": 300
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "title": "Gewinn \u00dcberraschungsreise", 
+        "tokens": []
+      }
+    }, 
+    "upgrade004": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Verlose einen schicken Sportwagen unter den TeilnehmerInnen. Autos gehen immer gut, protzige umso besser!", 
+        "label": "Gewinn Sportwagen", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-015.png"
+        }, 
+        "required_level": 2, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 600, 
+              "y": 200
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "title": "Gewinn Sportwagen", 
+        "tokens": []
+      }
+    }, 
+    "upgrade005": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Bau in deine Postkarte geschickt die Frage nach dem Haushaltseinkommen ein. Das Feld ist selbstverst\u00e4ndlich verpflichtend auszuf\u00fcllen!", 
+        "label": "Zusatzfrage Einkommen", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-011.png"
+        }, 
+        "required_level": 8, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 860, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "Zusatzfrage Einkommen", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token012", 
+            "gestalt": "token012"
+          }
+        ]
+      }
+    }, 
+    "upgrade006": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Bau in deine Postkarte geschickt eine Frage \u00fcber die Schulbildung ein. Das Feld ist selbstverst\u00e4ndlich verpflichtend auszuf\u00fcllen!", 
+        "label": "Zusatzfrage Schulabschluss", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-014.png"
+        }, 
+        "required_level": 8, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 600, 
+              "y": 100
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "title": "Zusatzfrage Schulabschluss", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token130", 
+            "gestalt": "token130"
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token011", 
+            "gestalt": "token011"
+          }
+        ]
+      }
+    }, 
+    "upgrade007": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Bau in deine Postkarte geschickt eine Frage \u00fcber Kinder ein. Das Feld ist selbstverst\u00e4ndlich verpflichtend auszuf\u00fcllen!", 
+        "label": "Zusatzfrage Kinder", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-012.png"
+        }, 
+        "required_level": 8, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 400, 
+              "y": 700
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "Zusatzfrage Kinder", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token064", 
+            "gestalt": "token064"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token065", 
+            "gestalt": "token065"
+          }
+        ]
+      }
+    }, 
+    "upgrade008": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Je l\u00e4nger, unverst\u00e4ndlicher und vertrauenserweckender deine \u201eErkl\u00e4rung zur Privatsph\u00e4re\u201c formuliert ist, desto bedenkenloser \u00f6ffnen dir die Leute ihr Herz.", 
+        "label": "Privacy Policy", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-015.png"
+        }, 
+        "required_level": 9, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 600, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "title": "Privacy Policy", 
+        "tokens": []
+      }
+    }, 
+    "upgrade009": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Damit sich deine User nicht langweilen, braucht es ein paar v\u00f6llig neue Ideen und technische Spielereien.", 
+        "label": "Technik", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-013.png"
+        }, 
+        "required_level": 9, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 300, 
+              "y": 700
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "Technik", 
+        "tokens": []
+      }
+    }, 
+    "upgrade010": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Online-Dating ist vor allem dann superattraktiv, wenn sich dort viele superattraktive Menschen tummeln. Am besten so superattraktiv wie die Photoshop-Models in der Werbung. Leider sieht das in der Realit\u00e4t oft anders aus. Vielleicht solltest du da etwas nachhelfen?", 
+        "label": "Fake Profile", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-015.png"
+        }, 
+        "required_level": 12, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 500, 
+              "y": 500
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "title": "Fake Profile", 
+        "tokens": []
+      }
+    }, 
+    "upgrade012": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Wenn du gen\u00fcgend Profile gesammelt hast, kannst du beginnen, mit Mitgliedsbeitr\u00e4gen abzucashen. Au\u00dferdem kommst du durch die Zahlung zu absolut zuverl\u00e4ssigen Namen und Adressen.", 
+        "label": "Premium Mitgliedschaft", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-013.png"
+        }, 
+        "required_level": 14, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 200, 
+              "y": 700
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "Premium Mitgliedschaft", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004"
+          }
+        ]
+      }
+    }, 
+    "upgrade013": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Wozu alles selber machen? Da drau\u00dfen gibts gen\u00fcgend engagierte Menschen, die dir gern ein wenig Arbeit abnehmen, wenn sie daf\u00fcr den honorigen Titel \"Moderator\" bekommen. Die k\u00fcmmern sich dann Tag und Nacht um deine Community, r\u00e4umen alle Schwierigkeiten aus dem Weg und machen dein Ding noch attraktiver.", 
+        "label": "Community Moderators", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-014.png"
+        }, 
+        "required_level": 12, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 400, 
+              "y": 500
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "title": "Community Moderators", 
+        "tokens": []
+      }
+    }, 
+    "upgrade015": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Mit diesem Test kannst du die Vertrauensw\u00fcrdigkeit, Zuverl\u00e4ssigkeit und Loyalit\u00e4t deiner User untersuchen. Die Ergebnisse gelten nat\u00fcrlich nicht nur f\u00fcr Beziehungskisten.", 
+        "label": "Wie treu bist du?", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-011.png"
+        }, 
+        "required_level": 5, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 600, 
+              "y": 760
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "Wie treu bist du?", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token024", 
+            "gestalt": "token024"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token066", 
+            "gestalt": "token066"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token021", 
+            "gestalt": "token021"
+          }
+        ]
+      }
+    }, 
+    "upgrade016": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Gl\u00fccklich und zufrieden oder doch eher frustriert bis depressiv? Echte Depression ist zwar kein Spass, aber f\u00fcr die Ergebnisse dieses Tests findest du sicher Abnehmer.", 
+        "label": "Bin ich depressiv?", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-010.png"
+        }, 
+        "required_level": 12, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 500, 
+              "y": 760
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "Bin ich depressiv?", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token025", 
+            "gestalt": "token025"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token053", 
+            "gestalt": "token053"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token120", 
+            "gestalt": "token120"
+          }
+        ]
+      }
+    }, 
+    "upgrade017": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Die Tests sind nat\u00fcrlich v\u00f6llig anonym! Die ausf\u00fchrliche, super-seri\u00f6se Premium-Auswertung bekommen die Teilnehmer aber gerne per Email zugeschickt. Dazu erfragst du ihre Email-Adresse.", 
+        "label": "Ergebnis per Email", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-013.png"
+        }, 
+        "required_level": 12, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 0, 
+              "y": 700
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "Ergebnis per Email", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token008", 
+            "gestalt": "token008"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token132", 
+            "gestalt": "token132"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token084", 
+            "gestalt": "token084"
+          }
+        ]
+      }
+    }, 
+    "upgrade018": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Die Tests sind nat\u00fcrlich v\u00f6llig anonym! Die ausf\u00fchrliche, super-seri\u00f6se Premium-Auswertung bekommen die Teilnehmer aber gerne per Post zugeschickt. Dazu erfragst du Namen und Adresse.", 
+        "label": "Ergebnis per Post", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-012.png"
+        }, 
+        "required_level": 12, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 400, 
+              "y": 760
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "Ergebnis per Post", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004"
+          }
+        ]
+      }
+    }, 
+    "upgrade020": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Erh\u00f6he deine Reichweite durch eine Partnerschaft mit einer M\u00f6belhaus-Kette. Die schicke Familien-Clubkarte ist bei jedem Einkauf dabei, durch die Analyse des Kaufverhaltens \u00fcber einen l\u00e4ngeren Zeitraum kannst du auf das Einkommen r\u00fcckschlie\u00dfen.", 
+        "label": "Partnerschaft mit M\u00f6belhaus-Kette", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-011.png"
+        }, 
+        "required_level": 17, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 300, 
+              "y": 760
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "Partnerschaft mit M\u00f6belhaus-Kette", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token069", 
+            "gestalt": "token069"
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token012", 
+            "gestalt": "token012"
+          }
+        ]
+      }
+    }, 
+    "upgrade021": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Erh\u00f6he deine Reichweite durch eine Partnerschaft mit einer Buchhandels-Kette. Durch eine Analyse des Kaufverhaltens \u00fcber einen l\u00e4ngeren Zeitraum kannst du auf die politische Einstellung r\u00fcckschlie\u00dfen.", 
+        "label": "Partnerschaft mit Buchhandels-Kette", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-013.png"
+        }, 
+        "required_level": 11, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 700, 
+              "y": 600
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "Partnerschaft mit Buchhandels-Kette", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token067", 
+            "gestalt": "token067"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token030", 
+            "gestalt": "token030"
+          }
+        ]
+      }
+    }, 
+    "upgrade022": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Erh\u00f6he deine Reichweite durch eine Partnerschaft mit einer Fitnessstudio-Kette. Damit gewinnst du einiges an zus\u00e4tzlichen Infos \u00fcber diejenigen, die dort regelm\u00e4ssig brav trainieren!", 
+        "label": "Partnerschaft mit Fitnessstudio-Kette", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-012.png"
+        }, 
+        "required_level": 11, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 200, 
+              "y": 760
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "Partnerschaft mit Fitnessstudio-Kette", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token088", 
+            "gestalt": "token088"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token015", 
+            "gestalt": "token015"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token014", 
+            "gestalt": "token014"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token083", 
+            "gestalt": "token083"
+          }
+        ]
+      }
+    }, 
+    "upgrade023": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Erh\u00f6he deine Reichweite durch eine Partnerschaft mit einer Mode-Kette. Die schicke Clubkarte ist bei jedem Einkauf dabei, durch die Analyse des Kaufverhaltens \u00fcber einen l\u00e4ngeren Zeitraum kannst du auf das Einkommen und Markenfetischismus r\u00fcckschlie\u00dfen.", 
+        "label": "Partnerschaft mit Mode-Kette", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-011.png"
+        }, 
+        "required_level": 17, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 100, 
+              "y": 760
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "Partnerschaft mit Mode-Kette", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token070", 
+            "gestalt": "token070"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token113", 
+            "gestalt": "token113"
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token012", 
+            "gestalt": "token012"
+          }
+        ]
+      }
+    }, 
+    "upgrade024": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Die Kunden und Kundinnen bekommen leckere Bonus-Angebote, wenn sie einen kleinen Fragebogen ausf\u00fcllen. Die Antworten dienen nat\u00fcrlich ausschlie\u00dflich zur Verbesserung des Service!", 
+        "label": "Bonus Programm", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-013.png"
+        }, 
+        "required_level": 11, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 700, 
+              "y": 500
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "Bonus Programm", 
+        "tokens": []
+      }
+    }, 
+    "upgrade025": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Ein Callcenter ist effizient, billig und platzsparend. Kaum zu glauben, wieviele MitarbeiterInnen da auf engstem Raum Platz haben. Und das mit der Kontrolle \u00fcbernehmen sie auch noch untereinander, sehr praktisch. Hopp hopp & n\u00e4chster Anruf! Und wenn es irgendwann trotzdem zu teuer wird, verpflanzt du das Ding einfach dorthin, wo die L\u00f6hne noch billiger sind.", 
+        "label": "Callcenter", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-015.png"
+        }, 
+        "required_level": 13, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 200, 
+              "y": 500
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "title": "Callcenter", 
+        "tokens": []
+      }
+    }, 
+    "upgrade026": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Du hast das unbestimmte Gef\u00fchl, dein Team arbeitet nicht effizient genug? Surfen im Internet, ausgedehnte Kaffeepausen - vielleicht hast du recht! Vertrauen ist gut, Kontrolle ist besser. Auch wenn du gar keine Zeit hast, dir das Material anzusehen, eine paar kleine Kameras wirken oft Wunder!", 
+        "label": "Mitarbeiter\u00fcberwachung", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-010.png"
+        }, 
+        "required_level": 13, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 0, 
+              "y": 760
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "Mitarbeiter\u00fcberwachung", 
+        "tokens": []
+      }
+    }, 
+    "upgrade027": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Lass dein Team von zu Hause aus arbeiten. F\u00fcr dich hat das viele Vorteile: Dein B\u00fcro kommt dir billiger, du zahlst deinen Angestellten weniger und es besteht auch weniger die Gefahr, dass sie sich gegen dich zusammentun. Dank der heutigen technischen M\u00f6glichkeiten kontrollierst du nat\u00fcrlich ihre Arbeit aus der Ferne. Alles in allem: Mehr Profile f\u00fcrs gleiche Geld!", 
+        "label": "Heimarbeit", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-010.png"
+        }, 
+        "required_level": 13, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 760, 
+              "y": 600
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "Heimarbeit", 
+        "tokens": []
+      }
+    }, 
+    "upgrade028": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Die wichtigste Basis beim Telefonterror ist der sogenannte Gespr\u00e4chsleitfaden, auch genannt: DAS Handbuch. Da steht zum Beispiel genau drin, wie dein Team am Telefon reagieren soll, wenn ihr Gegen\u00fcber auflegen will. Und mit welchen Tricks sie das verhindern k\u00f6nnen.", 
+        "label": "Gespr\u00e4chsleitfaden", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-012.png"
+        }, 
+        "required_level": 7, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 760, 
+              "y": 500
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "Gespr\u00e4chsleitfaden", 
+        "tokens": []
+      }
+    }, 
+    "upgrade029": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Mit besseren statistischen Auswertungsmethoden kannst du noch mehr n\u00fctzliche Daten rausziehen und die Menge an unbrauchbaren oder falschen Infos minimieren. Das bedeutet schlicht und einfach: Mehr Profile!", 
+        "label": "Verbesserte Auswertung", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-011.png"
+        }, 
+        "required_level": 7, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 760, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "Verbesserte Auswertung", 
+        "tokens": []
+      }
+    }, 
+    "upgrade030": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Wenn du sie schon mal am Telefon hast, warum nicht gleich noch mehr fragen? Entwickle einen Fragebogen zum Thema Einkommen. Mit ein wenig Psychologie und sogenannten Kontrollfragen kannst du sicher gehen, dass du auch wirklich die Wahrheit erf\u00e4hrst.", 
+        "label": "Fragebogen: Einkommen", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-014.png"
+        }, 
+        "required_level": 7, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 100, 
+              "y": 500
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "title": "Fragebogen: Einkommen", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token012", 
+            "gestalt": "token012"
+          }
+        ]
+      }
+    }, 
+    "upgrade031": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Wenn du sie schon mal am Telefon hast, warum nicht gleich noch mehr fragen? Entwickle einen Fragebogen zur politischen Einstellung. Mit ein wenig Psychologie und sogenannten Kontrollfragen kannst du sicher gehen, dass du auch wirklich die Wahrheit erf\u00e4hrst.", 
+        "label": "Fragebogen: Politik", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-013.png"
+        }, 
+        "required_level": 13, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 700, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "Fragebogen: Politik", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token030", 
+            "gestalt": "token030"
+          }
+        ]
+      }
+    }, 
+    "upgrade032": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Wenn du sie schon mal am Telefon hast, warum nicht gleich noch mehr fragen? Entwickle einen Fragebogen zum Thema Ern\u00e4hrung. Mit ein wenig Psychologie und sogenannten Kontrollfragen kannst du sicher gehen, dass du auch wirklich die Wahrheit erf\u00e4hrst.", 
+        "label": "Fragebogen: Ern\u00e4hrung", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-014.png"
+        }, 
+        "required_level": 13, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 0, 
+              "y": 500
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "title": "Fragebogen: Ern\u00e4hrung", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token125", 
+            "gestalt": "token125"
+          }
+        ]
+      }
+    }, 
+    "upgrade033": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Wenn du sie schon mal am Telefon hast, warum nicht gleich noch mehr fragen? Entwickle einen Fragebogen zu den Themen Kinder & Kinderwunsch. Mit ein wenig Psychologie und sogenannten Kontrollfragen kannst du sicher gehen, dass du auch wirklich die Wahrheit erf\u00e4hrst.", 
+        "label": "Fragebogen: Kinder", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-013.png"
+        }, 
+        "required_level": 7, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 700, 
+              "y": 300
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "Fragebogen: Kinder", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token064", 
+            "gestalt": "token064"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token065", 
+            "gestalt": "token065"
+          }
+        ]
+      }
+    }, 
+    "upgrade034": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Wenn du sie schon mal am Telefon hast, warum nicht gleich noch mehr fragen? Entwickle einen Fragebogen zum Thema Reisen und Urlaub. Mit ein wenig Psychologie und sogenannten Kontrollfragen kannst du sicher gehen, dass du auch wirklich die Wahrheit erf\u00e4hrst.", 
+        "label": "Fragebogen: Reisen", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-014.png"
+        }, 
+        "required_level": 13, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 500, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "title": "Fragebogen: Reisen", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token093", 
+            "gestalt": "token093"
+          }
+        ]
+      }
+    }, 
+    "upgrade036": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Wenn du sie schon mal am Telefon hast, warum nicht gleich noch mehr fragen? Entwickle einen Fragebogen zum Thema Religion. Mit ein wenig Psychologie und sogenannten Kontrollfragen kannst du sicher gehen, dass du auch wirklich die Wahrheit erf\u00e4hrst.", 
+        "label": "Fragebogen: Religion", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-014.png"
+        }, 
+        "required_level": 13, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 500, 
+              "y": 300
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "title": "Fragebogen: Religion", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token098", 
+            "gestalt": "token098"
+          }
+        ]
+      }
+    }, 
+    "upgrade037": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Wenn du sie schon mal am Telefon hast, warum nicht gleich noch mehr fragen? Entwickle einen Fragebogen zu Risikosportarten. Mit ein wenig Psychologie und sogenannten Kontrollfragen kannst du sicher gehen, dass du auch wirklich die Wahrheit erf\u00e4hrst.", 
+        "label": "Fragebogen: Risikosportarten", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-013.png"
+        }, 
+        "required_level": 7, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 700, 
+              "y": 100
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "Fragebogen: Risikosportarten", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token103", 
+            "gestalt": "token103"
+          }
+        ]
+      }
+    }, 
+    "upgrade038": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Text und Text sind nicht das gleiche. Etwas Fein-Tuning kann hier nicht schaden! Je eleganter, manipulativer und \u00fcberzeugender du deine Texte gestaltest, desto mehr werden dir auf den Leim gehen.", 
+        "label": "\u00dcberzeugender Text", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-011.png"
+        }, 
+        "required_level": 11, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 760, 
+              "y": 300
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "\u00dcberzeugender Text", 
+        "tokens": []
+      }
+    }, 
+    "upgrade039": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Du vertraust immer noch darauf, dass du die Garantiekarten alle per Post geschickt bekommst? Etwas r\u00fcckst\u00e4ndig! H\u00f6chste Zeit f\u00fcr ein Online-Formular. Das Ergebnis: Mehr Profile und jede Menge Email- und IP-Adressen.", 
+        "label": "Online-Formular", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-011.png"
+        }, 
+        "required_level": 20, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 760, 
+              "y": 200
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "Online-Formular", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token008", 
+            "gestalt": "token008"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token029", 
+            "gestalt": "token029"
+          }
+        ]
+      }
+    }, 
+    "upgrade040": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Du willst die Infos auf den Garantiekarten wohl kaum auf ewig h\u00e4ndisch in den Computer tippen? Besorg dir ein intelligentes automatisches Texterkennungs-System samt Scanner, das das f\u00fcr dich \u00fcbernimmt. Beschleunigt die Dinge ungemein!", 
+        "label": "Automatische\r\nTexterkennung", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-013.png"
+        }, 
+        "required_level": 18, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 700, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "Automatische Texterkennung", 
+        "tokens": []
+      }
+    }, 
+    "upgrade041": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Erh\u00f6he deine Reichweite durch eine Partnerschaft mit einem Luxusuhrenhersteller. Wie schnell so eine Protz-Uhr kaputt gehen kann! Darauf solltest du besonders hinweisen. Und gewinnst damit die Daten von wirklich zahlungskr\u00e4ftigen Zielgruppen.", 
+        "label": "Partnerschaft mit\r\nLuxusuhrenhersteller", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-015.png"
+        }, 
+        "required_level": 20, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 500, 
+              "y": 200
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "title": "Partnerschaft mit Luxusuhrenhersteller", 
+        "tokens": [
+          {
+            "amount": 25, 
+            "full_type": "TokenPerp:token012", 
+            "gestalt": "token012"
+          }
+        ]
+      }
+    }, 
+    "upgrade042": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Erh\u00f6he deine Reichweite durch eine Partnerschaft mit einem Autohersteller. SUV-Gel\u00e4ndewagen mit Allradantrieb werden vor allem im Stadtverkehr immer beliebter, sind aber nicht gerade billig. Das bedeutet: Lukrative Daten!", 
+        "label": "Partnerschaft mit\r\nSUV-Autohersteller", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-014.png"
+        }, 
+        "required_level": 20, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 600, 
+              "y": 600
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "Partnerschaft mit SUV-Autohersteller", 
+        "tokens": [
+          {
+            "amount": 25, 
+            "full_type": "TokenPerp:token012", 
+            "gestalt": "token012"
+          }
+        ]
+      }
+    }, 
+    "upgrade043": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Erh\u00f6he deine Reichweite durch eine Partnerschaft mit einem Yachthersteller. Ob nach dem Kauf eines Motorboots oder einer schicken Segelyacht - diese Leute nehmen sich besonders viel Zeit beim Ausf\u00fcllen der Garantiekarte.", 
+        "label": "Partnerschaft mit\r\nYachthersteller", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-011.png"
+        }, 
+        "required_level": 20, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 760, 
+              "y": 100
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "Partnerschaft mit Yachthersteller", 
+        "tokens": [
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token012", 
+            "gestalt": "token012"
+          }
+        ]
+      }
+    }, 
+    "upgrade044": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Erh\u00f6he deine Reichweite durch eine Partnerschaft mit einem Bohrmaschinenhersteller. Diese Heimwerker legen viel Wert auf scheinbar gutes Kundenservice und f\u00fcllen ihre Garantiekarte darum besonders sorgf\u00e4ltig aus.", 
+        "label": "Partnerschaft mit\r\nBohrmaschinenhersteller", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-015.png"
+        }, 
+        "required_level": 18, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 500, 
+              "y": 100
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "title": "Partnerschaft mit Bohrmaschinenhersteller", 
+        "tokens": [
+          {
+            "amount": 25, 
+            "full_type": "TokenPerp:supertoken014", 
+            "gestalt": "supertoken014"
+          }
+        ]
+      }
+    }, 
+    "upgrade045": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Erh\u00f6he deine Reichweite durch eine Partnerschaft mit einem TV-Ger\u00e4tehersteller. Ob Billig-Fernseher oder tonnenschweres Prestige-Ger\u00e4t im Kinoformat, da kommt mit Sicherheit einiges an Garantiekarten rein.", 
+        "label": "Partnerschaft mit\r\nTV-Ger\u00e4tehersteller", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-014.png"
+        }, 
+        "required_level": 18, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 500, 
+              "y": 600
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "Partnerschaft mit TV-Ger\u00e4tehersteller", 
+        "tokens": [
+          {
+            "amount": 25, 
+            "full_type": "TokenPerp:supertoken014", 
+            "gestalt": "supertoken014"
+          }
+        ]
+      }
+    }, 
+    "upgrade049": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Mit besseren statistischen Auswertungsmethoden kannst du noch mehr n\u00fctzliche Daten rausziehen und die Menge an unbrauchbaren oder falschen Infos minimieren. Das bedeutet schlicht und einfach: Mehr Profile!", 
+        "label": "Verbesserte Auswertung", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-010.png"
+        }, 
+        "required_level": 15, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 760, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "Verbesserte Auswertung", 
+        "tokens": []
+      }
+    }, 
+    "upgrade053": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Biete einen Allergietest an. Dazu brauchst du nicht mal medizinisches Personal. Der ist einfach und billig durchzuf\u00fchren und macht dein Angebot attraktiver. Und wer leidet heute nicht unter der einen oder anderen l\u00e4stigen Allergie?", 
+        "label": "Allergietest", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-015.png"
+        }, 
+        "required_level": 15, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 200, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "title": "Allergietest", 
+        "tokens": []
+      }
+    }, 
+    "upgrade057": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Es l\u00e4uft so gut, dass dein Server das gar nicht mehr verkraften kann? Gar nicht gut. Ausf\u00e4lle wegen \u00dcberlastung sind das letzte, was du brauchen kannst. Du solltest ein wenig Geld in die Hand nehmen, damit du f\u00fcr die Zukunft gewappnet bist.", 
+        "label": "Besserer Server", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-013.png"
+        }, 
+        "required_level": 15, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 200, 
+              "y": 600
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "Besserer Server", 
+        "tokens": []
+      }
+    }, 
+    "upgrade064": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Deine Software ist dein wichtigstes Kapital. Wenn die nicht perfekt funktioniert, entgeht dir die H\u00e4lfte der raubkopierenden Massen. BitTorrent ist au\u00dferdem nicht genug. H\u00e4ng dich in noch mehr P2P-Netzwerke rein und verbessere deine Erfolgsrate!", 
+        "label": "Verbesserte Spinne", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-011.png"
+        }, 
+        "required_level": 15, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 0, 
+              "y": 660
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "Verbesserte Spinne", 
+        "tokens": []
+      }
+    }, 
+    "upgrade069": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Du sammelst nur die IP-Adressen deiner ahnungslosen Opfer? H\u00f6chste Zeit, dass du dich mit einem Internet-Provider zusammen tust. Der wei\u00df genau, welche IP-Adresse zu welcher Person geh\u00f6rt. Wenn du erst Namen und Adressen weisst, k\u00f6nnen die Plattenbosse die Raubkopierern noch einfacher verklagen und deine Infos sind gleich viel mehr wert.", 
+        "label": "Partnerschaft mit\r\nInternet-Provider", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-011.png"
+        }, 
+        "required_level": 15, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 660, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "Partnerschaft mit Internet-Provider", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004"
+          }
+        ]
+      }
+    }, 
+    "upgrade070": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Stell einen Fragebogen zu medizinischen Hintergrund-Infos zusammen. Und frag sie aus! Es gibt immer Leute, die glauben, solche Fragen wahrheitsgem\u00e4\u00df zu beantworten sei nur zu ihrem Besten. Versuchs einfach und frag mal einfach direkt nach ihren Wehwehchen und welche Pillen sie in sich reinstopfen.", 
+        "label": "Medizinischer Fragebogen", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-011.png"
+        }, 
+        "required_level": 15, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 660, 
+              "y": 300
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "Medizinischer Fragebogen", 
+        "tokens": [
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token018", 
+            "gestalt": "token018"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token114", 
+            "gestalt": "token114"
+          }
+        ]
+      }
+    }, 
+    "upgrade071": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Stell einen Fragebogen \u00fcber Suchtverhalten & Co zusammen. Es gibt immer Leute, die glauben, solche Fragen genau zu beantworten ist nur zu ihrem Besten. Versuchs einfach und frag nach Drogen wie Nikotin, Alkohol und mehr.", 
+        "label": "Sucht-Fragebogen", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-011.png"
+        }, 
+        "required_level": 15, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 660, 
+              "y": 200
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "Sucht-Fragebogen", 
+        "tokens": [
+          {
+            "amount": 75, 
+            "full_type": "TokenPerp:token053", 
+            "gestalt": "token053"
+          }, 
+          {
+            "amount": 75, 
+            "full_type": "TokenPerp:token054", 
+            "gestalt": "token054"
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token120", 
+            "gestalt": "token120"
+          }
+        ]
+      }
+    }, 
+    "upgrade073": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Biete einen Bluttest samt Auswertung an. Die Leute lieben es, ihr Blut analysieren zu lassen und all die Werte miteinander zu vergleichen. Und du findest nicht nur m\u00f6gliche Krankheiten raus, sondern auch, was die Leute so t\u00e4glich in sich hineinstopfen.", 
+        "label": "Bluttest", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-015.png"
+        }, 
+        "required_level": 15, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 400, 
+              "y": 200
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "title": "Bluttest", 
+        "tokens": [
+          {
+            "amount": 25, 
+            "full_type": "TokenPerp:token018", 
+            "gestalt": "token018"
+          }, 
+          {
+            "amount": 25, 
+            "full_type": "TokenPerp:token053", 
+            "gestalt": "token053"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token125", 
+            "gestalt": "token125"
+          }
+        ]
+      }
+    }, 
+    "upgrade074": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Du solltest dein Angebot um einen Urintest erweitern. Ist beliebter als Blutabnahme, weil tut nicht so weh. Und auch damit lassen sich bestimmte Krankheiten nachweisen - und so mancher Drogenkonsum. Die Auswertung machst du nat\u00fcrlich nicht selbst, daf\u00fcr bezahlst du ein Labor.", 
+        "label": "Urintest", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-012.png"
+        }, 
+        "required_level": 15, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 600, 
+              "y": 200
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "Urintest", 
+        "tokens": [
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token018", 
+            "gestalt": "token018"
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token120", 
+            "gestalt": "token120"
+          }
+        ]
+      }
+    }, 
+    "upgrade103": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Das Alter ist gnadenlos. Die Leute sehen nicht nur \u00e4lter aus, sondern oft auch viel braver. Wie sollen die einander erkennen, wenn du Ihnen keine M\u00f6glichkeit bietest, ihre Fotos raufzuladen? Ohne Fotos geht gar nichts.", 
+        "label": "Fotos Raufladen", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-014.png"
+        }, 
+        "required_level": 18, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 500, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "Fotos Raufladen", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token036", 
+            "gestalt": "token036"
+          }
+        ]
+      }
+    }, 
+    "upgrade104": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Das ist garantiert der Superhit. Biete deinen UserInnen eine Funktion zum Teilen ihrer alten Klassenfotos. Irgendjemand hat die sicher noch und die haben eine fast magische Anziehungskraft auf dein sentimentales Zielpublikum.", 
+        "label": "Klassenfotos", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-010.png"
+        }, 
+        "required_level": 18, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 560, 
+              "y": 100
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "Klassenfotos", 
+        "tokens": []
+      }
+    }, 
+    "upgrade105": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Nur online ist langweilig. Biete deinen Usern Funktionen zur Organisation ihrer ganz realen Klassentreffen. An diesem Punkt empfiehlt es sich, sie ganz vertraulich um die Angabe von  Adresse und Wohnort zu bitten.", 
+        "label": "Klassentreffen\r\norganisieren", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-011.png"
+        }, 
+        "required_level": 18, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 560, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "Klassentreffen organisieren", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004"
+          }
+        ]
+      }
+    }, 
+    "upgrade107": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Jahrzehnte ist das oft schon her: Die Schule. Alles wieder aufw\u00e4rmen, ist das wirklich gut? Mit einer anonymen telefonischen Kontaktm\u00f6glichkeit h\u00e4lt sich das Risiko in Grenzen. Nicht nur im Fall der unsterblichen, aber nie ausgesprochenen, Klassenliebe.", 
+        "label": "Anonymer Telefon-Kontakt", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-012.png"
+        }, 
+        "required_level": 18, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 400, 
+              "y": 460
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "Anonymer Telefon-Kontakt", 
+        "tokens": [
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token005", 
+            "gestalt": "token005"
+          }
+        ]
+      }
+    }, 
+    "upgrade108": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Erweitere deine Zielgruppen durch eine Partnerschaft mit der Online-Version einer reichweitenstarken Tageszeitung. Die bekommen ein sch\u00f6nes Zusatzangebot f\u00fcr ihre Website und du: Mehr Daten!", 
+        "label": "Partnerschaft mit\r\nOnline-Magazin", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-012.png"
+        }, 
+        "required_level": 20, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 300, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "Partnerschaft mit Online-Magazin", 
+        "tokens": []
+      }
+    }, 
+    "upgrade109": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Gib ihnen ein Forum! Da k\u00f6nnen sie diskutieren, sich anfreunden, sich befetzen und vor allem: Sie kommen immer wieder. Mit einem Diskussionsforum wird dein Projekt noch popul\u00e4rer, ohne dass deine teure Redaktion andauernd was Neues bringen muss.", 
+        "label": "Forum", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-012.png"
+        }, 
+        "required_level": 20, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 200, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "Forum", 
+        "tokens": []
+      }
+    }, 
+    "upgrade110": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Wenn du sie schon mal am Telefon hast, warum nicht gleich noch mehr fragen? Entwickle einen Fragebogen zum Thema Gewerkschaft. Mit ein wenig Psychologie und sogenannten Kontrollfragen kannst du sicher gehen, dass du auch wirklich die Wahrheit erf\u00e4hrst.", 
+        "label": "Fragebogen: Gewerkschaft", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-012.png"
+        }, 
+        "required_level": 7, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 300, 
+              "y": 460
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "Fragebogen: Gewerkschaft", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token047", 
+            "gestalt": "token047"
+          }
+        ]
+      }
+    }, 
+    "upgrade112": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Bau in deine Postkarte geschickt die Frage nach Haustieren ein. Das Feld ist selbstverst\u00e4ndlich verpflichtend auszuf\u00fcllen!", 
+        "label": "Zusatzfrage Haustiere", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-013.png"
+        }, 
+        "required_level": 10, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 100, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "Zusatzfrage Haustiere", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token129", 
+            "gestalt": "token129"
+          }
+        ]
+      }
+    }, 
+    "upgrade113": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Bei vielen Online-Partnerb\u00f6rsen sollen die User hundert Fragen zu ihrer Pers\u00f6nlichkeit beantworten. Daraus ergibt sich der sogenannte Match-Faktor. Wer passt zueinander? 90% Match: Da funkt es sicher! Bau einen Matching-Test zum Thema Sex ein.", 
+        "label": "Matching-Test: Sex", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-013.png"
+        }, 
+        "required_level": 14, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 0, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "Matching-Test: Sex", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token066", 
+            "gestalt": "token066"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token020", 
+            "gestalt": "token020"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token024", 
+            "gestalt": "token024"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token025", 
+            "gestalt": "token025"
+          }
+        ]
+      }
+    }, 
+    "upgrade114": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Bei vielen Online-Partnerb\u00f6rsen sollen die User hundert Fragen zu ihrer Pers\u00f6nlichkeit beantworten. Daraus ergibt sich der sogenannte Match-Faktor. Wer passt zueinander? 90% Match: Da funkt es sicher! Bau einen Matching-Test zum Thema Lifestyle ein.", 
+        "label": "Matching-Test:\r\nLifestyle", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-012.png"
+        }, 
+        "required_level": 9, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 400, 
+              "y": 300
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "Matching-Test: Lifestyle", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token097", 
+            "gestalt": "token097"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token030", 
+            "gestalt": "token030"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token129", 
+            "gestalt": "token129"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token081", 
+            "gestalt": "token081"
+          }
+        ]
+      }
+    }, 
+    "upgrade116": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Pulverfass oder Ruhepol? Multitasking-Talent oder steigt bei zwei parallel ge\u00f6ffneten Websites schon die Nervosit\u00e4t? Wie \u00fcberfordert sind deine User? Aus diesem Test lassen sich sicher einige interessante Informationen ziehen.", 
+        "label": "Wird mir alles zuviel?", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-015.png"
+        }, 
+        "required_level": 12, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 300, 
+              "y": 200
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "title": "Wird mir alles zuviel?", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token083", 
+            "gestalt": "token083"
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token092", 
+            "gestalt": "token092"
+          }
+        ]
+      }
+    }, 
+    "upgrade117": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Berechnend und strategisch oder impulsiv und explosiv? Zur\u00fcckhaltend oder rechthaberisch? Aus diesem Test lassen sich sicher einige interessante Informationen ziehen.", 
+        "label": "Welcher Streit-Typ bin ich?", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-015.png"
+        }, 
+        "required_level": 8, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 300, 
+              "y": 100
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "title": "Welcher Streit-Typ bin ich?", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token089", 
+            "gestalt": "token089"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token103", 
+            "gestalt": "token103"
+          }
+        ]
+      }
+    }, 
+    "upgrade118": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Wiesel oder Faultier? Karrieregeil oder lieber ruhig und gem\u00fctlich? David Allen oder Paul Lafargue? Wie ehrgeizig sind deine User? Aus diesem Test lassen sich sicher einige interessante Informationen ziehen.", 
+        "label": "Bin ich zielstrebig genug?", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-015.png"
+        }, 
+        "required_level": 8, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 300, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "title": "Bin ich zielstrebig genug?", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token081", 
+            "gestalt": "token081"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token012", 
+            "gestalt": "token012"
+          }
+        ]
+      }
+    }, 
+    "upgrade119": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Scheues Reh oder Rampensau? Mauerbl\u00fcmchen oder arrogantes Arschloch? Wie selbstbewusst sind deine User? Aus diesem Test lassen sich sicher einige interessante Informationen ziehen.", 
+        "label": "Wie selbstbewusst bin ich?", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-012.png"
+        }, 
+        "required_level": 8, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 400, 
+              "y": 200
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "Wie selbstbewusst bin ich?", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token090", 
+            "gestalt": "token090"
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token092", 
+            "gestalt": "token092"
+          }
+        ]
+      }
+    }, 
+    "upgrade120": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Klammeraffe oder freiheitsliebend? Gro\u00dfer Freundeskreis oder gro\u00dfer Fernseher? Wie gestalten sich die pers\u00f6nlichen Beziehungen deiner UserInnen? Aus den Ergebnissen lassen sich sicher einige interessante Informationen ziehen.", 
+        "label": "Welcher Beziehungs-\r\nTyp bin ich?", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-012.png"
+        }, 
+        "required_level": 5, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 400, 
+              "y": 100
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "Welcher Beziehungstyp bin ich?", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token085", 
+            "gestalt": "token085"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token022", 
+            "gestalt": "token022"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token065", 
+            "gestalt": "token065"
+          }
+        ]
+      }
+    }, 
+    "upgrade146": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Analysiere welche Leute \u00fcberhaupt auf dich reinfallen und wer dir durch die Lappen geht. Das hilft dir nicht nur dabei, dein Projekt in Zukunft noch besser auf deine Zielgruppen abstimmen. Du kannst damit auch herausfinden, wer besonders gut auf deine Werbung reagiert.", 
+        "label": "R\u00fccklauf\r\n\u00dcberwachung", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-012.png"
+        }, 
+        "required_level": 10, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 200, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "R\u00fccklauf-\u00dcberwachung", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token132", 
+            "gestalt": "token132"
+          }
+        ]
+      }
+    }, 
+    "upgrade147": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Erh\u00f6he deine Reichweite durch eine Partnerschaft mit einem Handyhersteller. Ein Bild eines Mobiltelefons mit tausend feinen Rissen am Display wird wahre Wunder wirken, auch wenn die Garantie f\u00fcr Display-Sch\u00e4den im Kleingedruckten nat\u00fcrlich ausgeschlossen wird.", 
+        "label": "Partnerschaft mit\r\nHandyhersteller", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-010.png"
+        }, 
+        "required_level": 18, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 0, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "Partnerschaft mit Handyhersteller", 
+        "tokens": [
+          {
+            "amount": 25, 
+            "full_type": "TokenPerp:supertoken014", 
+            "gestalt": "supertoken014"
+          }
+        ]
+      }
+    }
+  }, 
+  "tokens": {
+    "origin001": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "label": "Little Rock City", 
+        "origin_full_type": "CityPerp:city002", 
+        "origin_gestalt": "city002", 
+        "title": "Little Rock City"
+      }
+    }, 
+    "origin002": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "label": "Gewinnspiel", 
+        "origin_full_type": "ProjectPerp:project001", 
+        "origin_gestalt": "project001", 
+        "title": "Gewinnspiel"
+      }
+    }, 
+    "origin003": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "label": "Psychotest", 
+        "origin_full_type": "ProjectPerp:project003", 
+        "origin_gestalt": "project003", 
+        "title": "Psychotest"
+      }
+    }, 
+    "origin004": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "label": "Telefon-\r\numfrage", 
+        "origin_full_type": "ProjectPerp:project005", 
+        "origin_gestalt": "project005", 
+        "title": "Telefon-\r\numfrage"
+      }
+    }, 
+    "origin005": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "label": "Partnerb\u00f6rse", 
+        "origin_full_type": "ProjectPerp:project002", 
+        "origin_gestalt": "project002", 
+        "title": "Partnerb\u00f6rse"
+      }
+    }, 
+    "origin006": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "label": "Elly DeTelly ", 
+        "origin_full_type": "ContactPerp:contact026", 
+        "origin_gestalt": "contact026", 
+        "title": "Elly DeTelly "
+      }
+    }, 
+    "origin007": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "label": "Hana Blum", 
+        "origin_full_type": "ContactPerp:contact033", 
+        "origin_gestalt": "contact033", 
+        "title": "Hana Blum"
+      }
+    }, 
+    "origin008": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "label": "Lennon Che\r\nWurlitschek", 
+        "origin_full_type": "ContactPerp:contact008", 
+        "origin_gestalt": "contact008", 
+        "title": "Lennon Che\r\nWurlitschek"
+      }
+    }, 
+    "origin009": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "label": "Sadik Konetschnig", 
+        "origin_full_type": "ContactPerp:contact007", 
+        "origin_gestalt": "contact007", 
+        "title": "Sadik Konetschnig"
+      }
+    }, 
+    "origin010": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "label": "Alexa C. Tivia", 
+        "origin_full_type": "ContactPerp:contact019", 
+        "origin_gestalt": "contact019", 
+        "title": "Alexa C. Tivia"
+      }
+    }, 
+    "origin011": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "label": "Jessica Seno", 
+        "origin_full_type": "ContactPerp:contact035", 
+        "origin_gestalt": "contact035", 
+        "title": "Jessica Seno"
+      }
+    }, 
+    "origin012": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "label": "Schwester\r\nElfriede", 
+        "origin_full_type": "ContactPerp:contact001", 
+        "origin_gestalt": "contact001", 
+        "title": "Schwester\r\nElfriede"
+      }
+    }, 
+    "origin013": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "label": "Ulli Stenzer", 
+        "origin_full_type": "ContactPerp:contact022", 
+        "origin_gestalt": "contact022", 
+        "title": "Ulli Stenzer"
+      }
+    }, 
+    "origin014": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "label": "New York City", 
+        "origin_full_type": "CityPerp:city004", 
+        "origin_gestalt": "city004", 
+        "title": "New York City"
+      }
+    }, 
+    "origin015": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "label": "Vorteilsclub", 
+        "origin_full_type": "ProjectPerp:project004", 
+        "origin_gestalt": "project004", 
+        "title": "Vorteilsclub"
+      }
+    }, 
+    "origin016": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "label": "Raubkopierer\r\nSpinne", 
+        "origin_full_type": "ProjectPerp:project007", 
+        "origin_gestalt": "project007", 
+        "title": "Raubkopierer\r\nSpinne"
+      }
+    }, 
+    "origin017": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "label": "Vorsorge-\r\nUntersuchung", 
+        "origin_full_type": "ProjectPerp:project009", 
+        "origin_gestalt": "project009", 
+        "title": "Vorsorge-\r\nUntersuchung"
+      }
+    }, 
+    "origin018": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "label": "Garantiekarten", 
+        "origin_full_type": "ProjectPerp:project006", 
+        "origin_gestalt": "project006", 
+        "title": "Garantiekarten"
+      }
+    }, 
+    "origin019": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "label": "Virtuelles Klassentreffen", 
+        "origin_full_type": "ProjectPerp:project011", 
+        "origin_gestalt": "project011", 
+        "title": "Virtuelles Klassentreffen"
+      }
+    }, 
+    "origin020": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "label": "Franz Sauerzapf", 
+        "origin_full_type": "ContactPerp:contact004", 
+        "origin_gestalt": "contact004", 
+        "title": "Franz Sauerzapf"
+      }
+    }, 
+    "origin021": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "label": "Sieglinde\r\nBayer-Wurz", 
+        "origin_full_type": "ContactPerp:contact005", 
+        "origin_gestalt": "contact005", 
+        "title": "Sieglinde\r\nBayer-Wurz"
+      }
+    }, 
+    "origin022": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "label": "Onkel Enzo", 
+        "origin_full_type": "ContactPerp:contact003", 
+        "origin_gestalt": "contact003", 
+        "title": "Onkel Enzo"
+      }
+    }, 
+    "supertoken002": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 14400000, 
+        "contained_tokens": [
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token125", 
+            "gestalt": "token125", 
+            "is_required": true, 
+            "position": 2
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token018", 
+            "gestalt": "token018", 
+            "is_required": true, 
+            "position": 4
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token092", 
+            "gestalt": "token092", 
+            "is_required": false, 
+            "position": 7
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token088", 
+            "gestalt": "token088", 
+            "is_required": false, 
+            "position": 6
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token114", 
+            "gestalt": "token114", 
+            "is_required": false, 
+            "position": 8
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token120", 
+            "gestalt": "token120", 
+            "is_required": false, 
+            "position": 11
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token103", 
+            "gestalt": "token103", 
+            "is_required": false, 
+            "position": 5
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token054", 
+            "gestalt": "token054", 
+            "is_required": false, 
+            "position": 10
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token055", 
+            "gestalt": "token055", 
+            "is_required": true, 
+            "position": 1
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token017", 
+            "gestalt": "token017", 
+            "is_required": true, 
+            "position": 3
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token053", 
+            "gestalt": "token053", 
+            "is_required": false, 
+            "position": 9
+          }
+        ], 
+        "description": "Wie siehts nun aus mit dem allgemeinen Zustand deiner Profile? Wie ist die Prognose? Voll fit oder baldiger Betreuungsfall? Wirf alle deine Daten auf einen Haufen und berechne daraus f\u00fcr jede einzelne Person einen Wert, der ihre k\u00f6rperlichen und psychischen Risiken zusammenfasst. Deine Kundschaft wird sich darum rei\u00dfen! Hilf ihnen, Entscheidungen zu treffen. Schlechte Prognose? Pech gehabt! Je mehr neue Infos du sammelst, die du f\u00fcr die Berechnung verwenden kannst, desto besser.", 
+        "findings_text": "Du bekommst f\u00fcr %s Personen eine Gesundheits-Prognose.", 
+        "is_buyable": true, 
+        "is_supertoken": true, 
+        "knowledge_text": "Du hast f\u00fcr %s Personen eine Gesundheits-Prognose berechnet.", 
+        "label": "Gesundheits-Prognose", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 580, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-005.png"
+        }, 
+        "price": 5000, 
+        "required_level": 17, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Gesundheits-Prognose", 
+        "xp_inc": 30
+      }
+    }, 
+    "supertoken014": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 7200000, 
+        "contained_tokens": [
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token097", 
+            "gestalt": "token097", 
+            "is_required": false, 
+            "position": 8
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token093", 
+            "gestalt": "token093", 
+            "is_required": false, 
+            "position": 9
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token032", 
+            "gestalt": "token032", 
+            "is_required": false, 
+            "position": 10
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token067", 
+            "gestalt": "token067", 
+            "is_required": false, 
+            "position": 1
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token070", 
+            "gestalt": "token070", 
+            "is_required": false, 
+            "position": 2
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token069", 
+            "gestalt": "token069", 
+            "is_required": false, 
+            "position": 3
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token113", 
+            "gestalt": "token113", 
+            "is_required": false, 
+            "position": 4
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token125", 
+            "gestalt": "token125", 
+            "is_required": false, 
+            "position": 5
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token099", 
+            "gestalt": "token099", 
+            "is_required": false, 
+            "position": 6
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token128", 
+            "gestalt": "token128", 
+            "is_required": false, 
+            "position": 7
+          }
+        ], 
+        "description": "Lebensmittel, Getr\u00e4nke, Kosmetika, Kleidung, Schuhe, Elektroger\u00e4te, Tontr\u00e4ger, Videos, B\u00fccher, Zeitschriften, Autos. Wenn du alle pers\u00f6nlichen Eink\u00e4ufe \u00fcber ein paar Monate genau verfolgst, kennst du diese Person ganz gut. Allein aus den Supermarkt-Eink\u00e4ufen kannst du absch\u00e4tzen: Reich oder arm? Gebildet oder ungebildet? Und vielleicht sogar, ob schwul oder hetero. Je mehr du \u00fcber die Eink\u00e4ufe wei\u00dft, desto besser kannst du das verkaufen - nicht nur f\u00fcr gezielte Werbung.", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du, was sie regelm\u00e4\u00dfig kaufen", 
+        "is_buyable": true, 
+        "is_supertoken": true, 
+        "knowledge_text": "Von %s Personen wei\u00dft du, was sie regelm\u00e4\u00dfig kaufen", 
+        "label": "Konsum-\r\nGewohnheiten", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 100, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-005.png"
+        }, 
+        "price": 2000, 
+        "required_level": 12, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Konsumgewohnheiten", 
+        "xp_inc": 11
+      }
+    }, 
+    "token001": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Ob bescheuert oder cool, kurz oder lang, altmodisch oder hip - der Vorname ist zentral f\u00fcr die eindeutige Identifizierung einer Person und damit eine wichtige Basis-Eigenschaft in deinem Business. Dazu l\u00e4sst sich zumindest im deutschen Sprachraum ziemlich eindeutig vom Vornamen auf das Geschlecht schlie\u00dfen. Mit Hilfe von Listen beliebter Vornamen verschiedener Geburtsjahrg\u00e4nge kannst du sogar ungef\u00e4hr das Alter einer Person einsch\u00e4tzen. Ein Thoralf oder eine Hildegard sind wohl kaum unter 30, ein Kevin oder eine Mandy dagegen selten \u00fcber 50.", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du den Vornamen", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen kennst du den Vornamen", 
+        "label": "Vorname", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 800, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 900
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Vorname", 
+        "xp_inc": 1
+      }
+    }, 
+    "token002": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Der Nachname ist zentral f\u00fcr die Identifizierung einer Person. In Verbindung mit Vorname und Geburtsdatum ist das meistens schon eine ziemlich eindeutige Sache. Zugegebenerma\u00dfen nicht ganz so easy bei M\u00fcllers, Schmidts oder Schneiders.\r\nVor- und Nachname geh\u00f6ren gemeinsam mit dem Geburtsdatum zu den Schl\u00fcssel-Eigenschaften in deiner Datenbank! Wenn du neue Profile bekommst, kann sie deine Datenbank damit m\u00f6glicherweise bereits vorhandenen Profilen zuordnen.", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du den Nachnamen", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen kennst du den Nachnamen", 
+        "label": "Nachname", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 720, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 900
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Nachname", 
+        "xp_inc": 1
+      }
+    }, 
+    "token003": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Die Wohnadresse eignet sich nicht nur hervorragend zum Zum\u00fcllen mit Werbeprospekten, sondern sagt auch sonst einiges \u00fcber die Person aus. Luxusviertel oder Problembezirk? Gro\u00dfstadt-Ratte oder Land-Ei? In Kombination mit anderen Infos sehr wichtig beim professionellen Einordnen und Schubladisieren.", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du Strasse und Hausnummer", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen kennst du Strasse und Hausnummer", 
+        "label": "Adresse", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 640, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 900
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Adresse", 
+        "xp_inc": 1
+      }
+    }, 
+    "token004": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Abgesehen davon, dass der Wohnort dabei hilft, jemand eindeutig zu identifizieren, sagt er auch sonst einiges \u00fcber die Person aus. Luxusviertel oder Problembezirk? Gro\u00dfstadt-Ratte oder Land-Ei? In Kombination mit anderen Infos sehr wichtig beim professionellen Einordnen und Schubladisieren.", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du Wohnort und Postleitzahl", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen kennst du Wohnort und Postleitzahl", 
+        "label": "Wohnort", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 560, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 900
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Wohnort", 
+        "xp_inc": 1
+      }
+    }, 
+    "token005": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Das Telefon ist eines der wichtigsten pers\u00f6nlichen Kommunikations-Tools. Werbeagenturen zahlen gut f\u00fcr Profile mit Telefonnummer.\r\nAu\u00dferdem ballen sich im Zeitalter der Smartphones immer mehr pers\u00f6nliche Informationen in diesem st\u00e4ndigen Begleiter. Hast du Zugriff auf das Mobiltelefon, wei\u00dft du beinahe alles \u00fcber den Besitzer. Aus den darin gespeicherten Daten lassen sich perfekte Pers\u00f6nlichkeitsprofile erstellen. Besonders fiese Datensammler schieben den Leuten lustige Apps unter, die still und heimlich den Smartphone-Speicher anzapfen.", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du ein oder mehrere Telefonnummern", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen kennst du ein oder mehrere Telefonnummern", 
+        "label": "Telefonnummer", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 480, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 900
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Telefonnummer", 
+        "xp_inc": 1
+      }
+    }, 
+    "token006": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Die Kombination aus Name und Geburtsdatum identifiziert eine Person ziemlich eindeutig. Dar\u00fcber hinaus ergibt sich aus dem Geburtsdatum das Alter, und daraus l\u00e4sst sich auf vieles r\u00fcckschlie\u00dfen. Etwa auf Verm\u00f6gen, Einkommen, Interessen, Probleme, Konsumgewohnheiten oder Gesundheitszustand.", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du das Geburtsdatum", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen kennst du das Geburtsdatum", 
+        "label": "Geburtsdatum", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 400, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 900
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Geburtsdatum", 
+        "xp_inc": 1
+      }
+    }, 
+    "token007": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 30000, 
+        "contained_tokens": [
+          {
+            "amount": 75, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001", 
+            "is_required": false, 
+            "position": 1
+          }
+        ], 
+        "description": "Viel Auswahl gibts meistens nicht, wenn irgendwo das Geschlecht angegeben werden muss. Doch auf Basis dieser 2 Schubladen werden gern Vermutungen \u00fcber Lebensl\u00e4ufe oder gesundheitliche Risikofaktoren angestellt. Auch wenn die oft gar nicht stimmen, schlie\u00dfen Firmen daraus zum Beispiel auf Hobbies, Interessen oder Ern\u00e4hrung und passen die Werbung entsprechend an. Tipp: Wenn du gen\u00fcgend neue Vornamen gesammelt hast, kannst du aus denen das Geschlecht von Profilen berechnen, bei denen du das Geschlecht noch gar nicht kennst.", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du, ob m\u00e4nnlich oder weiblich", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen wei\u00dft du, ob m\u00e4nnlich oder weiblich", 
+        "label": "Geschlecht", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 320, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Geschlecht", 
+        "xp_inc": 1
+      }
+    }, 
+    "token008": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Die Email-Adresse ist heute wichtiger als die Postadresse und der Schl\u00fcssel zu vielen Daten-Goldgruben im Internet. Es gibt unz\u00e4hlige Online-Services, bei denen sich Nutzer und Nutzerinnen nicht etwa mit ihrem Namen, sondern einzig mit ihrer Email-Adresse anmelden. Sobald du die Email-Adresse einer Person kennst, kannst du sie immer wieder zielgenau identifizieren - egal unter welchem Nickname oder Pseudonym jemand gerade unterwegs ist. Au\u00dferdem kannst du Email-Adressen nat\u00fcrlich hervorragend f\u00fcr Werbezwecke verkaufen.", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du ein oder mehrere Email-Adressen", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen kennst du ein oder mehrere Email-Adressen", 
+        "label": "Email", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 240, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Email", 
+        "xp_inc": 1
+      }
+    }, 
+    "token009": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Notorisches Zu-Sp\u00e4t-Kommen? Krankfeiern? Dauerndes Rummotzen? Sonstige Verwarnungen? Viele Firmen legen ausf\u00fchrliche Dossiers \u00fcber ihre Mitarbeiter mit all ihren St\u00e4rken, Schw\u00e4chen und Verfehlungen an. Darin werden mehr oder weniger legal ganz sch\u00f6n viele Details gespeichert. Sehr interessant f\u00fcr zuk\u00fcnftige Arbeitgeber.", 
+        "findings_text": "Von %s Personen erh\u00e4ltst du firmeninterne Personalakten", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen hast du unternehmensinterne Personalakten in der Datenbank", 
+        "label": "Personal-\r\nAkten", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 160, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 900
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Personalakten", 
+        "xp_inc": 1
+      }
+    }, 
+    "token011": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Promis protzen manchmal in den Medien mit abgebrochenen Schullaufbahnen und schlechten Noten. F\u00fcr eine Berufslaufbahn als Prominenter ist das wohl auch kein Problem. In der harten Realit\u00e4t sieht das allerdings anders aus. Vor allem bei j\u00fcngeren ist ein l\u00fcckenloser Werdegang in guten Schulen immer noch absolute Voraussetzung f\u00fcr einen Job. Au\u00dferdem wird in Bewerbungsschreiben gern mal geflunkert.", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du, welche Schulen von wann bis wann besucht wurden", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen wei\u00dft du, welche Schulen von wann bis wann besucht wurden", 
+        "label": "Besuchte\r\nSchulen", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 0, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 900
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Besuchte Schulen", 
+        "xp_inc": 1
+      }
+    }, 
+    "token012": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 1800000, 
+        "contained_tokens": [
+          {
+            "amount": 3, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004", 
+            "is_required": true, 
+            "position": 1
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token067", 
+            "gestalt": "token067", 
+            "is_required": true, 
+            "position": 3
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token070", 
+            "gestalt": "token070", 
+            "is_required": false, 
+            "position": 4
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token069", 
+            "gestalt": "token069", 
+            "is_required": false, 
+            "position": 5
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token128", 
+            "gestalt": "token128", 
+            "is_required": false, 
+            "position": 2
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token093", 
+            "gestalt": "token093", 
+            "is_required": false, 
+            "position": 6
+          }
+        ], 
+        "description": "H\u00f6chstverdiener, Mittelklasse oder hart an der Armutsgrenze? Ob das fair ist oder nicht, interessiert uns nicht. Keine Frage: Die Leute verdienen sehr verschieden - das pr\u00e4gt ihr Leben und meistens auch das ihrer Kinder. Ob Unternehmer, Sklavenjob, Arbeitslosengeld oder Pension - f\u00fcr die finanzielle Situation interessieren sich viele. Tipp: Mit Hilfe von Statistiken kannst du das Einkommen allein daraus sch\u00e4tzen, in welcher Gegend sie wohnen. Geo-Scoring! Und du kannst auch andere Eigenschaften dazu verwenden, das Einkommen zu berechnen.", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du, wieviel sie aufs Konto bekommen", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen wei\u00dft du, wieviel sie aufs Konto bekommen", 
+        "label": "Einkommen", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 720, 
+              "y": 640
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Einkommen", 
+        "xp_inc": 3
+      }
+    }, 
+    "token013": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Ob Ratenzahlung f\u00fcr den Protze-Fernseher, Auto-Leasing oder gar der fette H\u00e4uslbauerkredit: Viele Leute sind verschuldet. Besonders heikel, wenn ein Kredit f\u00fcr die R\u00fcckzahlung eines anderen Kredits aufgenommen wurde. Was f\u00fcr Staaten und Konzerne ganz normal ist, geht bei Privatpersonen gar nicht! Sind die Schulden im Verh\u00e4ltnis zu Einkommen und Eink\u00e4ufen zu hoch, werden die Leute erst mal vorgemerkt. Besonders interessant f\u00fcr Banken, Versandh\u00e4user, Online-Shops und etwa Mobilfunk-Anbieter.", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du, ob sie verschuldet sind und wenn ja, wie desastr\u00f6s", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen wei\u00dft du, ob sie verschuldet sind und wenn ja, wie desastr\u00f6s", 
+        "label": "Schulden\r\nund Kredite", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 720, 
+              "y": 560
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 900
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Schulden und Kredite", 
+        "xp_inc": 1
+      }
+    }, 
+    "token014": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Magers\u00fcchtig, voll dick oder eh okay? \u00dcbergewichtige Menschen haben es zwar schwer genug, und an die retuschierten Models aus der Werbung kommt eh niemand ran. Aber sorry, Leute: wer aus der Norm f\u00e4llt, ist halt oft unerw\u00fcnscht. Das Gewicht ist eine lukrative Information f\u00fcr alle, die mit Gesundheit zu tun haben. Und auch f\u00fcr manche Arbeitgeber nicht ganz uninteressant. Ganz zu schweigen von gezielter Produktwerbung f\u00fcr Dicke!", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du das aktuelle K\u00f6rpergewicht", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen kennst du das aktuelle K\u00f6rpergewicht", 
+        "label": "Gewicht", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 720, 
+              "y": 480
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Gewicht", 
+        "xp_inc": 1
+      }
+    }, 
+    "token015": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Haupts\u00e4chlich in Verbindung mit dem K\u00f6rpergewicht interessant. Aus Gr\u00f6\u00dfe und Gewicht l\u00e4sst sich der Body-Mass-Index errechnen, kurz BMI. Der ist um einiges aussagekr\u00e4ftiger als das Gewicht allein und l\u00e4sst sich daher noch viel besser verkaufen. In vielen Jobs haben Fetts\u00e4cke keine Chance und die Krankenversicherungen verzichten gerne auf potenzielle Risikopatienten.", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du die K\u00f6rpergr\u00f6\u00dfe", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen kennst du die K\u00f6rpergr\u00f6\u00dfe", 
+        "label": "K\u00f6rpergr\u00f6\u00dfe", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 720, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "K\u00f6rpergr\u00f6\u00dfe", 
+        "xp_inc": 1
+      }
+    }, 
+    "token017": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Vergangene und aktuelle Krankheiten, Behandlungen und Operationen, Untersuchungsbefunde und deren Zeitpunkte: Krankenakten aus Arztpraxen und Kliniken bieten wertvolle Anhaltspunkte f\u00fcr zuk\u00fcnftige Prognosen. Solche Infos l\u00e4sst sich die Gesundheitsindustrie viel kosten.", 
+        "findings_text": "Von %s Personen bekommst du mehr oder weniger ausf\u00fchrliche Krankenakten", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen hast du mehr oder weniger ausf\u00fchrliche Krankenakten in der Datenbank", 
+        "label": "Krankenakten", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 720, 
+              "y": 240
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Krankenakten", 
+        "xp_inc": 1
+      }
+    }, 
+    "token018": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Asthma, Migr\u00e4ne, Allergien, Neurodermitis oder chronische Bandscheibenprobleme? Suchtkrankheiten, Depressionen, Hepatitis oder gar Multiple Sklerose oder Krebs? Krankenversicherungen interessieren sich brennend daf\u00fcr, und auch so mancher Arbeitgeber sagt nicht Nein zu diesen Infos.", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du, ob und welche chronischen Erkrankungen vorliegen", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen wei\u00dft du, ob und welche chronischen Erkrankungen vorliegen", 
+        "label": "Chronische\r\nKrankheiten", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 80, 
+              "y": 800
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Chronische Krankheiten", 
+        "xp_inc": 1
+      }
+    }, 
+    "token019": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Jede Woche 20 Minuten k\u00fcnstliche Sonne mit der st\u00e4rksten Strahlenkanone der Filiale? Wenn das der Hautarzt w\u00fcsste! Auf Dauer tut das wohl nicht so gut, irgendwann machen sich vielleicht irgendwelche Muttermale selbstst\u00e4ndig und wachsen sich zu so ganz und gar nicht geilen Melanomen aus. Das werden die Betroffenen schon noch merken, es gibt aber auch noch andere, die sich f\u00fcr den legeren Umgang mit der UV-Strahlung interessieren. Denn f\u00fcr die Gesundheitsindustrie besteht die Welt haupts\u00e4chlich aus Risikofaktoren.", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du, wie viel UV-Strahlung sie abbekommen haben", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen wei\u00dft du, wie viel UV-Strahlung sie abbekommen haben", 
+        "label": "Solarien-\r\nBesuche", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 0, 
+              "y": 800
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Solarien-Besuche", 
+        "xp_inc": 1
+      }
+    }, 
+    "token020": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Na, das ist ja mal ein pikantes kleines Detail. Und doch f\u00fcr dein Pers\u00f6nlichkeitsprofil verwertbar. Zu fr\u00fch die Unschuld verloren? Neigt wohl zu un\u00fcberlegtem, riskantem Verhalten und ist leicht beeinflussbar! Viel zu sp\u00e4t? Seltsamer Typ! Im \u201egro\u00dfen psychologischen Matching-Test\u201c bei der Online-Partnerb\u00f6rse erf\u00e4hrst du nat\u00fcrlich noch viel mehr als das. Sch\u00f6n, dass die Leute nie die langen \u201eErkl\u00e4rungen zur Privatsph\u00e4re\u201c lesen.", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du, mit welchem Alter sie das erste Mal gefickt haben", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen wei\u00dft du, mit welchem Alter sie das erste Mal gefickt haben", 
+        "label": "Alter beim\r\n\u201eersten Mal\u201c", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 720, 
+              "y": 160
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Alter beim \"ersten Mal\"", 
+        "xp_inc": 1
+      }
+    }, 
+    "token021": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Nicht-Heteros haben es zwar nicht mehr ganz so schwer wie fr\u00fcher mal. Trotzdem gibts immer noch jede Menge Steinzeit-Menschen, die ein Problem mit bestimmten sexuellen Orientierungen haben. Darum halten manche ihre Neigungen vor Eltern oder Arbeitgebern geheim. Aber nicht vor dir! Die sexuelle Orientierung l\u00e4sst sich gut f\u00fcr zielgruppenspezifische Werbung einsetzen, ist aber auch dar\u00fcber hinaus f\u00fcr ein vollst\u00e4ndiges Pers\u00f6nlichkeitsprofil unerl\u00e4sslich.", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du, ob hetero, schwul, lesbisch oder sonstwas", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen wei\u00dft du, ob hetero, schwul, lesbisch oder sonstwas", 
+        "label": "Sexuelle\r\nOrientierung", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 720, 
+              "y": 80
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Sexuelle Orientierung", 
+        "xp_inc": 1
+      }
+    }, 
+    "token022": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Single, liiert oder gar verheiratet, geschieden, verwitwet? Singles sind oft flexibler, P\u00e4rchen daf\u00fcr stabiler. Das kann sich heute zwar schnell \u00e4ndern, l\u00e4sst sich aber trotzdem gut einsetzen - egal ob f\u00fcr Werbung oder ganz allgemein zur Erstellung umfassender Pers\u00f6nlichkeitsprofile.", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du, wie kompliziert es ist", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen wei\u00dft du, wie kompliziert es ist", 
+        "label": "Beziehungs-\r\nstatus", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 800, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Beziehungsstatus", 
+        "xp_inc": 1
+      }
+    }, 
+    "token023": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Die Leute sind ja so s\u00fc\u00df. Vor allem die Teenies. Wie die es lieben, auch noch die seltsamsten Fotos m\u00f6glichst \u00f6ffentlich zu machen! Jedes lustige Handyfoto wird gleich mal online gestellt und wenn man das nicht selber macht, wird das von den gesch\u00e4tzten Freunde oder von einem Fotograf des Partyfoto-Portals erledigt. Wobei hier schon betont werden soll: Nicht jeder Arbeitgeber st\u00f6rt sich an dem Foto mit dem halb nackten, gr\u00f6lenden Alkohol-Zombie von der Party vom letzten Monat! Aber er will es zumindest gesehen haben.", 
+        "findings_text": "Von %s Personen bekommst du lustige Party-Fotos", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen hast du lustige Party-Fotos in der Datenbank", 
+        "label": "Party-Fotos", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 720, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Party-Fotos", 
+        "xp_inc": 1
+      }
+    }, 
+    "token024": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Kann man sich auf jemanden verlassen oder handelt es sich etwa um so ein echt unzuverl\u00e4ssiges Arschloch? Vertrauensw\u00fcrdig oder unzuverl\u00e4ssig? Loyal oder illoyal? Das fragen sich zum Beispiel viele Arbeitgeber beim Bewerbungsgespr\u00e4ch. So ein Gespr\u00e4ch ist kurz, eigentlich w\u00e4r hier eine zuverl\u00e4ssige Einsch\u00e4tzung gefragt. Durch kleine Tricks wie etwa einem Online-Psychotest kannst du hier Abhilfe schaffen. Eine gewisse Fehlerrate ist unvermeidlich, aber besser als nichts! Und diese Info l\u00e4sst sich sicherlich auch anders verwerten.", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du, wie loyal und zuverl\u00e4ssig sie sind", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen wei\u00dft du, wie loyal und zuverl\u00e4ssig sie sind", 
+        "label": "Vertrauensw\u00fcrdig/\r\nUnzuverl\u00e4ssig?", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 800, 
+              "y": 640
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Vertrauensw\u00fcrdig/Unzuverl\u00e4ssig?", 
+        "xp_inc": 1
+      }
+    }, 
+    "token025": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Im Gro\u00dfen und Ganzen gl\u00fccklich? Oder doch ziemlich unzufrieden und frustriert? Es gibt verschiedene Methoden, Menschen psychologisch zu scannen. Wenn du mit der T\u00fcr ins Haus f\u00e4llst, wirst du kaum was erfahren. Wenn du es aber geschickt und trickreich anstellst, verraten dir die Leute mit Begeisterung ihre intimen seelischen Zust\u00e4nde. Charakterliche Einsch\u00e4tzungen wie diese bilden eine wertvolle Basis f\u00fcr die fundierte Analyse einer Person.", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du, ob sie eher zufrieden oder frustriert sind", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen wei\u00dft du, ob sie eher zufrieden oder frustriert sind", 
+        "label": "Zufrieden/\r\nFrustriert?", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 640, 
+              "y": 640
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Zufrieden oder Frustriert?", 
+        "xp_inc": 1
+      }
+    }, 
+    "token026": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Ob der IQ wirklich dazu geeignet ist, die Intelligenz zu messen, dar\u00fcber streitet die Psychologie seit Jahrzehnten. Nichtsdestotrotz stehen die Leute unglaublich auf IQ-Tests und kein Arbeitgeber w\u00fcrde wohl ein derartiges Testergebnis ablehnen. Einfach so als Hintergrund-Information.", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du den sogenannten Intelligenzquotienten", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen kennst du den sogenannten Intelligenzquotienten", 
+        "label": "IQ", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 800, 
+              "y": 560
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "IQ", 
+        "xp_inc": 1
+      }
+    }, 
+    "token027": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Fremde Passw\u00f6rter in deiner Datenbank? Ganz sch\u00f6n heikel. Aber wer wei\u00df, vielleicht kannst du sp\u00e4ter mal was damit anfangen. Zur \u201eSicherheit\u201c einfach mal abspeichern! Eventuell kannst du damit User irgendwelcher Online-Portale wiedererkennen, obwohl sie Pseudonyme und anonyme Email-Adressen verwenden.\r\nUnd falls du mal so richtig in Cash-N\u00f6ten bist, gibts finstere Gegenden am Daten-Markt, die auch an heiklen Angelegenheiten interessiert sind.", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du ein oder mehrere Passw\u00f6rter", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen kennst du ein oder mehrere Passw\u00f6rter", 
+        "label": "Passw\u00f6rter", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 560, 
+              "y": 640
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Passw\u00f6rter", 
+        "xp_inc": 1
+      }
+    }, 
+    "token028": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Kreditkarten sind super. Sobald dieses beliebte Online-Zahlungsmittel ins Spiel kommt, hast du gewonnen. Denn in diesem Fall kannst du sicher sein, dass du ziemlich zuverl\u00e4ssige Angaben zur Person geliefert bekommst. Ganz abgesehen davon, dass der illegale Handel mit Kreditkartennummern floriert. Ob du dich darauf einl\u00e4sst, solltest du dir drei Mal \u00fcberlegen.", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du die Kreditkartennummer", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen kennst du die Kreditkartennummer", 
+        "label": "Kreditkarten-\r\nnummer", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 480, 
+              "y": 640
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Kreditkartennummer", 
+        "xp_inc": 1
+      }
+    }, 
+    "token029": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Ob Computer, Spielkonsole oder Smartphone mit Internet-Zugang - jedes Ger\u00e4t, das mit dem Netz verbunden ist, besitzt eine eigene IP-Adresse. Die UserInnen hinterlassen damit auch dann ihre Spuren beim Surfen, wenn sie ohne jede Registrierung herumsurfen.\r\nZwar teilen sich manchmal mehrere Personen eines Haushalts eine gemeinsame IP-Adresse. Trotzdem ist eine gro\u00dfe Sammlung von IP-Adressen eine wichtige Basis f\u00fcr deine Datenbank, die damit intelligent Zusammenh\u00e4nge und Querverbindung zwischen den Datens\u00e4tzen herstellen kann.", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du eine oder mehrere IP-Adressen", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen kennst du eine oder mehrere IP-Adressen", 
+        "label": "IP-Adresse", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 400, 
+              "y": 640
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "IP-Adresse", 
+        "xp_inc": 1
+      }
+    }, 
+    "token030": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Liberal oder konservativ? Links oder rechts? Desinteressiert oder engagiert? Die politische Einstellung ist f\u00fcr viele Menschen pr\u00e4gend und darum ein unverzichtbarer Bestandteil eines ausgewogenen Pers\u00f6nlichkeitsprofils.\r\nUnd auch wenn staatlicher Spitzel-Terror \u00e1 la Gestapo oder Stasi in unseren Breiten eher der Vergangenheit angeh\u00f6rt - f\u00fcr eine Liste unbequemer, kritischer oder gar \u201eradikaler\u201c Namen werden dir die Sicherheitsorgane dankbar sein!", 
+        "findings_text": "Von %s Personen erfahren wir Hinweise auf ihre politische Einstellung", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen haben wir Hinweise auf ihre politische Einstellung", 
+        "label": "Politische\r\nEinstellung", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 800, 
+              "y": 480
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Politische Einstellung", 
+        "xp_inc": 1
+      }
+    }, 
+    "token032": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Casual-Games, Strategie, Online-Rollenspiele oder blutr\u00fcnstige Ego-Shooter? Manche behaupten ja, von den bevorzugten Computer-Games lie\u00dfe sich auf den Charakter r\u00fcckschlie\u00dfen. Das ist zwar umstritten, den Glauben wollen wir ihnen aber auf keinen Fall nehmen und geben ihnen, was sie wollen. F\u00fcr Cash!", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du, welche Art von Computer-Games sie bevorzugen", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen wei\u00dft du, welche Art von Computer-Games sie bevorzugen", 
+        "label": "Bevorzugte\r\nComputer-Games", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 240, 
+              "y": 640
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Bevorzugte Computer-Games", 
+        "xp_inc": 1
+      }
+    }, 
+    "token033": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Wasserstoffblond, br\u00fcnett, r\u00f6tlich oder so richtig sch\u00f6n dunkel? Ob es sich dabei wirklich um die originale Haarfarbe handelt, l\u00e4sst sich oft schwer sagen. Bei gr\u00fcn, blau oder pink liegt das schon eher auf der Hand. Im Endeffekt ist die Haarfarbe nicht unbedingt die hei\u00dfeste Info, wenn es darum geht, jemand zu identifizieren: Augenfarbe viel besser! Aber wer weiss: Vielleicht schadet es auch nicht, genau die Leute mit den oft wechselnden oder besonders seltsamen Haarfarben rauszufinden? Deine Datenbank freut sich immer, wenn sie gef\u00fcttert wird!", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du die Haarfarbe.", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen kennst du die Haarfarbe.", 
+        "label": "Haarfarbe", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 160, 
+              "y": 640
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Haarfarbe", 
+        "xp_inc": 1
+      }
+    }, 
+    "token034": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Ungef\u00e4hr 90% der Weltbev\u00f6lkerung haben braune Augen, alle anderen sind haupts\u00e4chlich gr\u00fcn, blau und grau. Rote Augen gibt`s nur auf Fotos oder nach tr\u00e4nenreichen Dramen. Die Augenfarbe ist jedenfalls nicht ganz unwesentlich f\u00fcrs Erscheinungsbild eines Menschen. Auch wenn diese gef\u00e4rbte Augenlinsen noch so beliebt werden: Die Augenfarbe ist ein weitgehend unver\u00e4nderliches biologisches K\u00f6rpermerkmal und wird darum immer noch weltweit in jeden Personalausweis eingetragen. Und geh\u00f6rt zur Pflichtausstattung deiner Datenbank.", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du die Augenfarbe", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen weisst du die Augenfarbe", 
+        "label": "Augenfarbe", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 80, 
+              "y": 640
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Augenfarbe", 
+        "xp_inc": 1
+      }
+    }, 
+    "token035": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 35 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 35 (%s)", 
+        "label": "Fingerabdruck", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 0, 
+              "y": 640
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Fingerabdruck", 
+        "xp_inc": 1
+      }
+    }, 
+    "token036": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Fotos sind so richtig cool. Besonders dann, wenn diese Fotos mit konkreten Personen in Verbindung stehen. Du solltest alles nehmen, was du in die Finger bekommst. Was gar nicht so schwer ist, denn die Leute lieben Fotos. Die Technik der automatischen Gesichtserkennung entwickelt sich rasant und wird dir jede Menge M\u00f6glichkeiten bieten. Wenn du in Zukunft Personen anhand ihrer Fotos automatisch identifizieren kannst, brauchst du ihnen nicht mehr m\u00fchsam ihre Email-Adressen oder Namen herauszulocken. Im Ernst: Sammle jedes Foto, das du kriegen kannst!", 
+        "findings_text": "Du bekommst Fotos von %s Personen", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Du hast Fotos von %s Personen", 
+        "label": "Foto", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 640, 
+              "y": 560
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Foto", 
+        "xp_inc": 1
+      }
+    }, 
+    "token038": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 38 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 38 (%s)", 
+        "label": "Iris Scan", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 640, 
+              "y": 480
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Iris Scan", 
+        "xp_inc": 1
+      }
+    }, 
+    "token039": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 39 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 39 (%s)", 
+        "label": "DNA-Profil", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 640, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "DNA-Profil", 
+        "xp_inc": 1
+      }
+    }, 
+    "token040": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Wie sch\u00f6n w\u00e4r dein Leben, wenn die Leute immer mit ihrem richtigen Namen im Netz unterwegs w\u00e4ren! Aber nein. \u00dcberall verwenden sie irgendwelche Pseudonyme. Das macht alles m\u00fchsamer f\u00fcr dich. Aber keine Sorge: Sobald du gen\u00fcgend Nicknames gespeichert hast, kannst du sie mit deinen gesammelten Namen, Telefonnummern, Email- und IP-Adressen abgleichen. Problem gel\u00f6st.\r\n\r\nUnd immerhin: Ein paar gro\u00dfe Firmen haben die Nutzung von Pseudonymen inzwischen einfach verboten. Vorbildlich!", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du, welche Nicknames sie im Netz benutzen", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen weisst du, welche Nicknames sie im Netz benutzen", 
+        "label": "Nicknames\r\n& Pseudonyme", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 640, 
+              "y": 320
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Nicknames & Pseudonyme", 
+        "xp_inc": 1
+      }
+    }, 
+    "token041": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Fast in jedem Land gibts sowas wie eine Versicherungsnummer. Sozial- oder Rentenversicherungsnummer, \u00fcberall heisst es ein wenig anders. Auch die Abk\u00fcrzungen sind verschieden. Aber eines ist sie immer: Eine m\u00e4chtige Information! Denn sie hilft dir bei der eindeutigen Identifizierung von Personen. Mehrere Personen mit dem gleichen Namen? Die Versicherungsnummer verschafft dir Gewissheit. Gut f\u00fcr dich, dass viele so leichtfertig damit umgehen. Wenn du die Versicherungsnummer kennst, kannst du dich \u00fcbrigens auch gut als jemand anders ausgeben.", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du die Versicherungsnummer", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen kennst du die Versicherungsnummer", 
+        "label": "Versicherungs-\r\nNummer", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 640, 
+              "y": 240
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Versicherungsnummer", 
+        "xp_inc": 1
+      }
+    }, 
+    "token042": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 42 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 42 (%s)", 
+        "label": "Passnummer", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 640, 
+              "y": 160
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Passnummer", 
+        "xp_inc": 1
+      }
+    }, 
+    "token043": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 43 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 43 (%s)", 
+        "label": "Staatsb\u00fcrgerschaft", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 640, 
+              "y": 80
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Staatsb\u00fcrgerschaft", 
+        "xp_inc": 1
+      }
+    }, 
+    "token044": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 44 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 44 (%s)", 
+        "label": "Kontonummer", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 800, 
+              "y": 320
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Kontonummer", 
+        "xp_inc": 1
+      }
+    }, 
+    "token045": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 45 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 45 (%s)", 
+        "label": "Beruf", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 800, 
+              "y": 240
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Beruf", 
+        "xp_inc": 1
+      }
+    }, 
+    "token046": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 46 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 46 (%s)", 
+        "label": "Fr\u00fchere\r\nArbeitgeber", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 640, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Fr\u00fchere Arbeitgeber", 
+        "xp_inc": 1
+      }
+    }, 
+    "token047": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Gewerkschaften! Die meisten Firmen-Bosse w\u00fcrden die am liebsten verbieten. Wie soll das je klappen mit den Millionen-Gewinnen, wenn die Gewerkschaften andauernd mehr Lohn und bessere Arbeitsbedingungen fordern? Und dann bringen sie die Mitarbeiter auch noch dazu, sich gegen sie zu verschw\u00f6ren, bringen Unruhe in den Betrieb oder streiken gar! Katastrophe. Darum stellen diese Firmen-Bosse am liebsten Leute ein, die bitte ganz sicher bei keiner Gewerkschaft dabei sind. Aber wie sollen sie das nur rausfinden?", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du, ob sie Gewerkschaftsmitglied sind oder nicht", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen weisst du, ob sie Gewerkschaftsmitglied sind oder nicht", 
+        "label": "Gewerkschafts-\r\nmitglied", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 560, 
+              "y": 560
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Gewerkschaftsmitglied", 
+        "xp_inc": 1
+      }
+    }, 
+    "token048": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "In Mathe immer voll versagt? In Informatik und Sprachen ganz schlecht? Oder \u00fcberall Top? Schulzeugnisse. Manche bekommen die Krise, wenn sie nur daran denken. Sp\u00e4testens im Arbeitsleben werden die allerdings wieder interessant. Die meisten Chefs sind leider ziemlich neugierig und wollen immer alles ganz genau wissen. Schlechte Noten? Und raus!\r\n\r\nAuch wenn so manche schlechte Note auch auf miese und gemeine Lehrer oder gar auf das Schulsystem ingesamt zur\u00fcckzuf\u00fchren sein mag: Mit Schulnoten kannst du sicher was anfangen!", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du, in welchen Schulf\u00e4chern sie voll abgekackt haben.", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen weisst du, in welchen Schulf\u00e4chern sie voll abgekackt haben.", 
+        "label": "Schulnoten", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 480, 
+              "y": 560
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Schulnoten", 
+        "xp_inc": 1
+      }
+    }, 
+    "token049": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 49 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 49 (%s)", 
+        "label": "Arbeitslosigkeit", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 800, 
+              "y": 160
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Arbeitslosigkeit", 
+        "xp_inc": 1
+      }
+    }, 
+    "token050": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 50 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 50 (%s)", 
+        "label": "Verm\u00f6gen", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 400, 
+              "y": 560
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Verm\u00f6gen", 
+        "xp_inc": 1
+      }
+    }, 
+    "token051": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 51 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 51 (%s)", 
+        "label": "Ratenzahlungen", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 800, 
+              "y": 80
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Ratenzahlungen", 
+        "xp_inc": 1
+      }
+    }, 
+    "token052": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 52 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 52 (%s)", 
+        "label": "Leasingvertr\u00e4ge", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 800, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Leasingvertr\u00e4ge", 
+        "xp_inc": 1
+      }
+    }, 
+    "token053": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Total abstinent oder regelm\u00e4\u00dfiges Vernichtungs-Komasaufen am Wochenende? Dann und wann ein Gl\u00e4schen zum Essen oder schon Alkoholismus im Endstadium? Wenn du wei\u00dft, ob und wenn ja, wie oft, wieviel jemand wovon trinkt, lassen sich verschiedenste Prognosen anstellen. Nicht nur was den zuk\u00fcnftigen Zustand der Gehirnzellen betrifft.\r\nDas ist vor allem bei Leuten interessant, die ihrer Meinung nach ganz harmlos unterwegs sind. Aber auch bei den wirklich schweren F\u00e4llen kann dir das helfen. Diese armen Schweine neigen doch oft sehr zur Heimlichtuerei.", 
+        "findings_text": "Von %s Personen wei\u00dft du, wie sehr sie dem Alkohol zugeneigt sind", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen erf\u00e4hrst du, wie sehr sie dem Alkohol zugeneigt sind", 
+        "label": "Alkoholkonsum", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 720, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Alkoholkonsum", 
+        "xp_inc": 1
+      }
+    }, 
+    "token054": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Rauchen ist t\u00f6dlich. Und teuer. Und einmal angefangen ist es schwer, wieder aufzuh\u00f6ren. Trotzdem gibts immer noch viele, die es tun. Manche sind sogar \u00fcberzeugt davon, dass ihnen das niemand verbieten kann. Jedenfalls: Zu wissen ob und wieviel jemand raucht wird heutzutage immer interessanter. Denn im Gegensatz zu fr\u00fcher wird Rauchen n\u00e4mlich mittlerweile sehr ungern gesehen. Nicht nur von Beh\u00f6rden, Vermietern, Personalabteilungen oder Versicherungen.", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du, ob sie rauchen oder nicht", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen wei\u00dft du, ob sie rauchen oder nicht", 
+        "label": "Nikotingenuss", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 320, 
+              "y": 560
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Nikotingenuss", 
+        "xp_inc": 1
+      }
+    }, 
+    "token055": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 120000, 
+        "contained_tokens": [
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token014", 
+            "gestalt": "token014", 
+            "is_required": true, 
+            "position": 1
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token015", 
+            "gestalt": "token015", 
+            "is_required": true, 
+            "position": 2
+          }
+        ], 
+        "description": "Der BMI ist ein beliebtes Mass daf\u00fcr, ob jemand unter- oder \u00fcber- gewichtig ist. Oder eh normal, was auch immer das hei\u00dft. Er berechnet sich aus K\u00f6rpergr\u00f6\u00dfe und Gewicht, die Formel ist nicht schwer. Auch wenn manche bezweifeln, ob denn dieser BMI wirklich so aussagekr\u00e4ftig ist, wirst du damit sicher gutes Geld verdienen! Wenn du deine Datenbank um den BMI erweitert hast, kannst du den aus Gr\u00f6\u00dfe & Gewicht berechnen. Von umso mehr Menschen du beide Eigenschaften kennst, desto h\u00f6her kannst du den BMI-Anteil schrauben.", 
+        "findings_text": "Token 55 (%s)", 
+        "is_buyable": true, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen kennst du den Body Mass Index", 
+        "label": "Body Mass Index", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 640, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 300, 
+        "required_level": 7, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "story": {
+          "text": "Klick auf den Body Mass Index und starte die Berechnung. Je mehr neue Profile mit Gr\u00f6sse & Gewicht du gesammelt hast, desto besser!", 
+          "trigger": "buy"
+        }, 
+        "title": "Body Mass Index", 
+        "xp_inc": 1
+      }
+    }, 
+    "token056": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 56 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 56 (%s)", 
+        "label": "PartnerInnen", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 240, 
+              "y": 560
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "PartnerInnen", 
+        "xp_inc": 1
+      }
+    }, 
+    "token057": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 57 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 57 (%s)", 
+        "label": "Familie", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 160, 
+              "y": 560
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Familie", 
+        "xp_inc": 1
+      }
+    }, 
+    "token058": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 58 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 58 (%s)", 
+        "label": "Verwandte", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 80, 
+              "y": 560
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Verwandte", 
+        "xp_inc": 1
+      }
+    }, 
+    "token059": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 59 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 59 (%s)", 
+        "label": "FreundInnen", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 0, 
+              "y": 560
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "FreundInnen", 
+        "xp_inc": 1
+      }
+    }, 
+    "token060": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 60 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 60 (%s)", 
+        "label": "Bekannte", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 560, 
+              "y": 480
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Bekannte", 
+        "xp_inc": 1
+      }
+    }, 
+    "token061": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Wer kennt wen? Wie stehen die Leute miteinander in Verbindung? Auch wenn sich im Lauf der Jahre vielleicht einige aus den Augen verlieren - die SchulkollegInnen sind ein wichtiger Teil des pers\u00f6nlichen Umfelds deiner Profile. \r\n\r\nJe genauer du das pers\u00f6nliche Umfeld deiner Profile kennst, desto mehr kannst du auf lange Sicht \u00fcber sie rausfinden. Das wird dir noch mal gewaltig was n\u00fctzen! Denn es kommt noch besser: Du erf\u00e4hrst damit auch etwas \u00fcber Leute, \u00fcber die noch gar keine Daten gesammelt hast.\r\n\r\n", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du, mit wem sie in der Klasse waren.", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen weisst du, mit wem sie in der Klasse waren.", 
+        "label": "SchulkollegInnen", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 560, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "SchulkollegInnen", 
+        "xp_inc": 1
+      }
+    }, 
+    "token062": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 62 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 62 (%s)", 
+        "label": "Berufliche\r\nKontakte", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 560, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Berufliche Kontakte", 
+        "xp_inc": 1
+      }
+    }, 
+    "token064": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Keins oder halt eins, so sieht das meistens aus. Dann solls vereinzelt sogar Drei- oder Vierkinder-Haushalte geben. Jedenfalls: Im Zeitalter der Patchwork-Familie ist die Sache sowieso verschwommen. Aber ob diese Kinder aus einem total eigenem prallen Ei bzw. Glitsche-Sperma entstanden sind, interessiert dich erstmal wenig. Es geht vor allem darum, wo diese Kinder leben. Leute mit Kindern im Haus brauchen mehr Kohle, eine gr\u00f6\u00dfere Wohnung, m\u00fcssen sich k\u00fcmmern und sind unflexibel. Und diese B\u00e4lger haben betr\u00e4chtliches nachbarschaftliches St\u00f6rpotenzial!", 
+        "findings_text": "Von %s Personen wei\u00dft du, wieviele Kinder im Haus sind", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen erf\u00e4hrst du, wieviele Kinder im Haus sind", 
+        "label": "Kinder", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 560, 
+              "y": 320
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Anzahl der Kinder", 
+        "xp_inc": 1
+      }
+    }, 
+    "token065": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 1800000, 
+        "contained_tokens": [
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token071", 
+            "gestalt": "token071", 
+            "is_required": false, 
+            "position": 5
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token072", 
+            "gestalt": "token072", 
+            "is_required": false, 
+            "position": 6
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token125", 
+            "gestalt": "token125", 
+            "is_required": true, 
+            "position": 2
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token006", 
+            "gestalt": "token006", 
+            "is_required": true, 
+            "position": 1
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token068", 
+            "gestalt": "token068", 
+            "is_required": false, 
+            "position": 7
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token067", 
+            "gestalt": "token067", 
+            "is_required": false, 
+            "position": 3
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token128", 
+            "gestalt": "token128", 
+            "is_required": false, 
+            "position": 4
+          }
+        ], 
+        "description": "Sagen wir, du bist Personalchef. Nach 400 Bewerbungen hast du genau 10 rausgefiltert, die alle deine Anforderungen erf\u00fcllen. Davon 3 Frauen. Bewerbungsgespr\u00e4ch. Eine davon Favoritin, sie ist 25. Und behauptet, in n\u00e4chster Zeit keine Kinderpl\u00e4ne zu haben. Rechtlich h\u00e4ttest du eigentlich gar nicht fragen d\u00fcrfen. Aber w\u00e4r doch bl\u00f6d: Aufw\u00e4ndig einschulen und dann ist sie schon wieder weg! W\u00fcrdest du da nicht wissen wollen, dass ihre Buchbestellungen, ihre Suchbegriffe im Netz und ihre Ern\u00e4hrung eigentlich auf eine Schwangerschaft hindeuten?", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du, ob sie gern Kinder h\u00e4tten und wie bald", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen weisst du, ob sie gern Kinder h\u00e4tten und wie bald", 
+        "label": "Kinderwunsch", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 400, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Kinderwunsch", 
+        "xp_inc": 3
+      }
+    }, 
+    "token066": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Immer auf der Jagd nach der n\u00e4chsten Troph\u00e4e oder mit dreissig noch Jungfrau? Sexs\u00fcchtig wie Michael Douglas in besseren Zeiten oder eher auf dem Pfarrer- oder Nonnen-Trip? Eher wilder unterwegs oder voll im Durchschnitt?\r\nWenn jemand eher wilder unterwegs ist, bedeutet das nun unzuverl\u00e4ssig und illoyal? Oder neugierig und risikobereit im positiven Sinn? \u00dcberlass doch diese Entscheidung einfach deinen Abnehmern.", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du, wieviel sie schon rumgefickt haben.", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen wei\u00dft du, wieviel sie schon rumgefickt haben.", 
+        "label": "Anzahl der\r\nSex-PartnerInnen", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 320, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Anzahl der Sex-PartnerInnen", 
+        "xp_inc": 1
+      }
+    }, 
+    "token067": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Comics oder anspruchsvolle Romane? Kritische Sachb\u00fccher oder seichte Flie\u00dfband-Geschichten? Stricken, Heimwerkerei, Esoterik oder Koran? Haustiere, Computer-Hacking oder unbequeme politische Themen? Oder gar Ratgeber-Literatur \u00fcber Krankheiten oder Lebenskrisen? Sag mir was du liest und ich sage dir wer du bist. Aus den gekauften B\u00fcchern l\u00e4sst sich nicht nur auf die politische Einstellung schlie\u00dfen, sondern auch auf sehr viele andere Dinge. ", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du, welche B\u00fccher sie kaufen", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen weisst du, welche B\u00fccher sie kaufen", 
+        "label": "Gekaufte B\u00fccher", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 240, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 0, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Gekaufte B\u00fccher", 
+        "xp_inc": 1
+      }
+    }, 
+    "token068": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 68 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 68 (%s)", 
+        "label": "Online-Postings", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 560, 
+              "y": 240
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Online-Postings", 
+        "xp_inc": 1
+      }
+    }, 
+    "token069": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Wenn du weisst, ob und welche M\u00f6bel jemand \u00fcber einen l\u00e4ngeren Zeitraum gekauft hat, sagt das einiges aus. Einmal im Jahr das billigste Regal? Die schicke Einbauk\u00fcche und eine Wohnzimmer-Couch der teuersten Sorte obendrauf? Protziger Kitsch oder edles Design? Und unabh\u00e4ngig davon, ob es um ein Besteck-Set geht oder um die komplette Schlafzimmer-Einrichtung ist auch eines interessant: Nehmen sie immer die billigste Variante oder entscheiden sie sich regelm\u00e4\u00dfig f\u00fcr die exklusivsten St\u00fccke?", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du, welche M\u00f6bel sie kaufen", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen weisst du, welche M\u00f6bel sie kaufen", 
+        "label": "Gekaufte M\u00f6bel", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 560, 
+              "y": 160
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 0, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Gekaufte M\u00f6bel", 
+        "xp_inc": 1
+      }
+    }, 
+    "token070": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Unsere Kleidung wird heute immer mehr in Billiglohnl\u00e4ndern produziert. Von beschissen bezahlten armen Schweinen, die sieben Tage die Woche und zw\u00f6lf Stunden am Tag an der N\u00e4hmaschine sitzen. Trotzdem geh\u00f6rt die Bekleidungsindustrie nach den Superm\u00e4rkten zu den wichtigsten Wirtschaftsfaktoren. Denn die Leute kaufen ein wie die Wahnsinnigen. Und was sie da genau kaufen, das willst du ganz genau wissen. Daraus kannst du nicht nur gute Konsum- und Charakterprofile erstellen, sondern auch ganz gut einsch\u00e4tzen, ob arm oder reich.", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du, welche Kleidung sie kaufen", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen weisst du, welche Kleidung sie kaufen", 
+        "label": "Gekaufte Kleidung", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 560, 
+              "y": 80
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 0, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Gekaufte Kleidung", 
+        "xp_inc": 1
+      }
+    }, 
+    "token071": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 71 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 71 (%s)", 
+        "label": "Suchbegriffe\r\nim Internet", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 780, 
+              "y": 560
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-005.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Suchbegriffe im Internet", 
+        "xp_inc": 1
+      }
+    }, 
+    "token072": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 72 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 72 (%s)", 
+        "label": "Regelm\u00e4\u00dfig aufgerufene Websites", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 160, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Regelm\u00e4\u00dfig aufgerufene Websites", 
+        "xp_inc": 1
+      }
+    }, 
+    "token073": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 73 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 73 (%s)", 
+        "label": "Online\r\nUnterschriftenlisten", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 560, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Online Unterschriftenlisten", 
+        "xp_inc": 1
+      }
+    }, 
+    "token074": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 74 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 74 (%s)", 
+        "label": "Gef\u00e4llt-mir-Seiten", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 480, 
+              "y": 480
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Gef\u00e4llt-mir-Seiten", 
+        "xp_inc": 1
+      }
+    }, 
+    "token075": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 75 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 75 (%s)", 
+        "label": "H\u00e4ufigste\r\nEmail-Kontakte", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 400, 
+              "y": 480
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "H\u00e4ufigste Email-Kontakte", 
+        "xp_inc": 1
+      }
+    }, 
+    "token076": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 76 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 76 (%s)", 
+        "label": "Meistangerufene\r\nTelefonnummern", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 320, 
+              "y": 480
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Meistangerufene Telefonnummern", 
+        "xp_inc": 1
+      }
+    }, 
+    "token077": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 77 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 77 (%s)", 
+        "label": "Online B\u00fccher-\r\nWunschliste", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 240, 
+              "y": 480
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Online B\u00fccher-Wunschliste", 
+        "xp_inc": 1
+      }
+    }, 
+    "token078": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 78 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 78 (%s)", 
+        "label": "Raubkopierte Filme", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 80, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Raubkopierte Filme", 
+        "xp_inc": 1
+      }
+    }, 
+    "token079": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 79 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 79 (%s)", 
+        "label": "Verkehrsstrafen", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 160, 
+              "y": 480
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Verkehrsstrafen", 
+        "xp_inc": 1
+      }
+    }, 
+    "token080": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 80 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 80 (%s)", 
+        "label": "Strafregister", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 80, 
+              "y": 480
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Strafregister", 
+        "xp_inc": 1
+      }
+    }, 
+    "token081": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Wiesel oder Faultier? Karrieregeil oder lieber ruhig und gem\u00fctlich? David Allen oder Paul Lafargue? Wenn du das \u00fcber m\u00f6glichst viele Menschen einigermassen zuverl\u00e4ssig rausfindest, l\u00e4sst sich damit sicher was anfangen. M\u00f6glichst ausf\u00fchrliche Frage- und Antwortspiele bei Partnerb\u00f6rsen oder Online-Psychotests eignen sich besonders gut f\u00fcr die Untersuchung solcher Charakter-Eigenschaften. Ob die Unterteilung der Menschheit in \"ehrgeizig\" und \"faul\" allerdings wirklich eine gute Idee ist, ist eine andere Frage.", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du, ob sie voll ehrgeizig oder eher faul sind", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen weisst du, ob sie voll ehrgeizig oder eher faul sind", 
+        "label": "Ehrgeizig\r\noder Faul?", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 0, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Ehrgeizig oder Faul?", 
+        "xp_inc": 1
+      }
+    }, 
+    "token082": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Manche denken ja, Allgemeinbildung h\u00f6rt bei Trivial Pursuit und Millionenshow auf. Sicher: Es ist schon ganz nett, wenn jemand wie aus der Pistole geschossen das Geburtsdatum der Schwester des siebten Komponisten von hinten links parat hat. Und dass so ein Wissen mehr Erfolg verspricht als alle Folgen von Friends zu kennen, geh\u00f6rt auch irgendwie zur Allgemeinbildung. Nicht nur f\u00fcr so manchen Job ist es einfach unerl\u00e4sslich, mitreden zu k\u00f6nnen. Und sich nicht dauernd voll zu blamieren. Ein wenig Geschichte, ein wenig Kultur, dazu eine kleine Prise Wissenschaft und zum dr\u00fcberstreuen ein wenig Tagespolitik - das geh\u00f6rt einfach dazu. Das zeigt zumindest ungef\u00e4hr, wo jemand so ganz generell einzuordnen ist.", 
+        "findings_text": "wei\u00dft du, wie es um ihre Allgemeinbildung bestellt ist", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "erf\u00e4hrst du, wie es um die Allgemeinbildung bestellt ist", 
+        "label": "Allgemeinbildung", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 0, 
+              "y": 480
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Allgemeinbildung", 
+        "xp_inc": 1
+      }
+    }, 
+    "token083": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "In vielen Jobs ist es heute so: Es gibt zu wenig Personal und dann verl\u00e4uft auch noch alles anders als geplant. Zehn Dinge stehen gleichzeitig an, alles ist superdringend und sollte schon vorgestern erledigt sein. Dann bloss nicht \u00fcberfordert sein! Pulverfass oder Ruhepol? Multitasking-Talent oder steigt bei zwei parallel ge\u00f6ffneten Websites schon die Nervosit\u00e4t? Immer cool, voll \u00fcberfordert oder gar schon halb im Burnout? Finds raus. Denn Belastbarkeit und Flexibilit\u00e4t sind h\u00f6chst gefragt. Genauso wertvoll ist eine Einsch\u00e4tzung dar\u00fcber, wer das nicht schafft!", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du, wie belastbar und flexibel sie sind", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen weisst du, wie belastbar und flexibel sie sind", 
+        "label": "Belastbarkeit", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 720, 
+              "y": 640
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Belastbarkeit", 
+        "xp_inc": 1
+      }
+    }, 
+    "token084": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Manche fallen echt auf jeden Scheiss rein. Mal kurz denken oder gar kritisch hinterfragen? Fehlanzeige. Ob einmaliges Sonderangebot, unm\u00f6gliches Wahlversprechen oder die Chance auf den Hauptgewinn im Lotto - sie lassen sich manipulieren wie die Lemminge und machen alles genau wie geplant: Sie kaufen, was sie kaufen sollen. Sie glauben, was sie glauben sollen. Sie emp\u00f6ren sich, \u00fcber wen sie sich emp\u00f6ren sollen. Und sie halten die Klappe, wenn sie die Klappe halten sollen. Wer geh\u00f6rt da voll dazu und wer weniger? Dieses Wissen ist nicht nur f\u00fcr Werbezwecke interessant!", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du, wie naiv und leichtgl\u00e4ubig sie sind", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen weisst du, wie naiv und leichtgl\u00e4ubig sie sind", 
+        "label": "Naiv oder kritisch?", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 480, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Naiv oder kritisch?", 
+        "xp_inc": 1
+      }
+    }, 
+    "token085": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Teamplayer oder nicht, das ist hier die Frage? Schliesslich soll das Unternehmen funktionieren wie eine gut ge\u00f6lte Maschine. Da gibts die einen, die k\u00f6nnen das perfekt. Eigenbr\u00f6tler und andere schwierige Charaktere sind hingegen kaum begehrt. Die sind wie Sand im Getriebe dieser Uhrwerke aus menschlichen Zahnr\u00e4dern. Darum: Finde raus, wie es um die Teamf\u00e4higkeit deiner Profile bestellt ist! Sehr wertvoll vor allem in Kombination mit anderen Charakter-Eigenschaften.", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du, wie reibungslos sie mit anderen zusammenarbeiten", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen weisst du, wie reibungslos sie mit anderen zusammenarbeiten", 
+        "label": "Teamf\u00e4higkeit", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 720, 
+              "y": 560
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Teamf\u00e4higkeit", 
+        "xp_inc": 1
+      }
+    }, 
+    "token086": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 86 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 86 (%s)", 
+        "label": "Attraktivit\u00e4t", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 480, 
+              "y": 320
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Attraktivit\u00e4t", 
+        "xp_inc": 1
+      }
+    }, 
+    "token087": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 87 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 87 (%s)", 
+        "label": "Lieblingsfilme", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 480, 
+              "y": 240
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Lieblingsfilme", 
+        "xp_inc": 1
+      }
+    }, 
+    "token088": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Schwimmen, Radfahren, Skateboard, Fitness-Center? Oder voll die lahme Couch-Kartoffel? Jeden Tag ganz brav eine Runde im Laufschritt unterwegs? Oder ist etwa schon das \u00d6ffnen der K\u00fchlschrankt\u00fcr fast zu anstrengend? Wer sich bewegt, bleibt k\u00f6rperlich und geistig fit, wird behauptet. Oder besser gesagt: Gefordert! Lahme \u00c4rsche? Die werden sp\u00e4ter vielleicht fr\u00fcher alt, gebrechlich und krank. Und was das dann wieder kostet! Darum sicher kein Fehler, gleich mal so viel als m\u00f6glich \u00fcber den Bewegungsdrang deiner Profile rauszufinden.", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du, wie sportlich sie unterwegs sind.", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen weisst du, wie sportlich sie unterwegs sind.", 
+        "label": "Sportlich oder \r\nlahm?", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 480, 
+              "y": 160
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Sportlich oder lahm?", 
+        "xp_inc": 1
+      }
+    }, 
+    "token089": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Diese Leute sind kein Spass. Der geringste Anlass und sie explodieren wie ein am Herd vergessener Dampfdruck-Kochtopf. Es w\u00e4re besser, mit denen nichts zu tun zu haben. Weder in der Arbeit noch beim Wohnen. Trollt andauernd aggressiv im Netz herum? Irgendwelche andere Indizien, die darauf hindeuten, wie jemand diesbez\u00fcglich tickt? Versuch, die Leute einzuordnen. Gut oder b\u00f6se? Aber denk dran: Es geht nicht darum, das wirklich immer zuverl\u00e4ssig rauszufinden. Kannst du auch gar nicht. Hauptsache, es stimmt manchmal!", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du, wie schnell sie explodieren", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen weisst du, wie schnell sie explodieren", 
+        "label": "J\u00e4hzornig\r\noder kontrolliert?", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 480, 
+              "y": 80
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "J\u00e4hzornig \r\noder kontrolliert?", 
+        "xp_inc": 1
+      }
+    }, 
+    "token090": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Schwei\u00dfausbruch, Herzrasen, Stottern und pl\u00f6tzlich ganz rot im Gesicht: Das passiert bei manchen, sobald sie mit einer Gruppe zu tun haben, die aus mehr als einem Menschen besteht. Es muss nat\u00fcrlich nicht immer ganz so schlimm sein.\r\n\r\n\u00dcberzeugend oder verklemmt? Rhetorisches Supertalent oder unsichere Pers\u00f6nlichkeit? Finde raus, wie redegewandt oder sch\u00fcchtern sich deine Profile verhalten.", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du, ob sie eher \u00fcberzeugend oder total verklemmt sind", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen weisst du, ob sie eher \u00fcberzeugend oder total verklemmt sind", 
+        "label": "Redegewandt\r\noder sch\u00fcchtern?", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 480, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Redegewandt oder sch\u00fcchtern?", 
+        "xp_inc": 1
+      }
+    }, 
+    "token091": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 91 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 91 (%s)", 
+        "label": "neigt zum\r\nKrankfeiern", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 400, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "neigt zum Krankfeiern", 
+        "xp_inc": 1
+      }
+    }, 
+    "token092": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Psychos! Das sind nicht nur so v\u00f6llig durchgeknallte Wahnsinnige. Wie hei\u00dft das nochmal alles? ADHS, Depression, Burnout, Borderline. Da gibts noch mehr. Also all diejenigen, die nicht so ganz normal sind, die nicht ganz angepasst sind und alle, die nicht so ganz funktionieren wie erwartet. Die in der Schule, am Arbeitsplatz und im Alltag nicht die effizienten Maschinen sind, die sie sein sollten. Und nicht alles auf die Reihe bekommen. Also ziemlich viele. Finde raus, wer dazugeh\u00f6rt - nicht nur Arbeitgeber interessieren sich brennend daf\u00fcr!", 
+        "findings_text": "You erf\u00e4hrst von %s Personen, wie es ihnen psychisch so geht.", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You weisst von %s Personen, wie es ihnen psychisch so geht.", 
+        "label": "Psychische\r\nProbleme?", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 320, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Psychische Probleme?", 
+        "xp_inc": 1
+      }
+    }, 
+    "token093": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Vor 100 Jahren war das Reisen eine Sache f\u00fcr die Reichen. Inzwischen wird herumgeflogen, was das Zeug h\u00e4lt. Europa, USA, S\u00fcdamerika, dazwischen mal Australien, Afrika, Fernost und Karibik? St\u00e4dtereisen, Meer oder Abenteuer? Luxuskreuzfahrt oder Lonely Planet? Oder doch eher regional und auf kurzer Distanz? Wenn du wei\u00dft, in welche L\u00e4nder und Gegenden jemand reist, kannst du das in deine Pers\u00f6nlichkeitsprofile mit einflie\u00dfen lassen. Nicht nur f\u00fcr Werbezwecke geeignet! Auch staatliche Beh\u00f6rden interessieren sich f\u00fcr Reisen in verd\u00e4chtige L\u00e4nder.", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du, wo sie herumreisen.", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen weisst du, wo sie herumreisen.", 
+        "label": "Reise-\r\ngewohnheiten", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 240, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Reisegewohnheiten", 
+        "xp_inc": 1
+      }
+    }, 
+    "token094": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [
+          {
+            "amount": 25, 
+            "full_type": "TokenPerp:token128", 
+            "gestalt": "token128", 
+            "is_required": false, 
+            "position": 2
+          }, 
+          {
+            "amount": 25, 
+            "full_type": "TokenPerp:token072", 
+            "gestalt": "token072", 
+            "is_required": true, 
+            "position": 1
+          }
+        ], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 94 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 94 (%s)", 
+        "label": "Hobbies", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 160, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Hobbies", 
+        "xp_inc": 1
+      }
+    }, 
+    "token095": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 95 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 95 (%s)", 
+        "label": "Handyvertr\u00e4ge", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 80, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Handyvertr\u00e4ge", 
+        "xp_inc": 1
+      }
+    }, 
+    "token096": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 96 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 96 (%s)", 
+        "label": "GPS-Daten", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 0, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "GPS-Daten", 
+        "xp_inc": 1
+      }
+    }, 
+    "token097": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Nerviges Bongogetrommel, sch\u00f6ngeistige Klassik oder harte Techno-Beats? Christlicher Death Metal oder r\u00fchrselige Schlager-Melodien aus Gr\u00f6nland? Protziger Hip Hop aus den Ghettos von Berlin oder altmodischer Indie-Rock aus den 90er-Jahren? \u00dcber Musikgeschmack l\u00e4sst sich nicht streiten. Oder doch? Finde raus, auf welche Sounds die Leute stehen. Und auf welche Bands & Artists, und auf welche gar nicht. Das ist eine wichtige Lifestyle-Info, die dir gut dabei helfen kann, deine Profile besser einzuordnen und zu sortieren. ", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du, auf welchen Sound sie stehen", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen weisst du, auf welchen Sound sie stehen", 
+        "label": "Musikgeschmack", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 400, 
+              "y": 320
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Musikgeschmack", 
+        "xp_inc": 1
+      }
+    }, 
+    "token098": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 3600000, 
+        "contained_tokens": [
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token067", 
+            "gestalt": "token067", 
+            "is_required": true, 
+            "position": 1
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token128", 
+            "gestalt": "token128", 
+            "is_required": false, 
+            "position": 2
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token072", 
+            "gestalt": "token072", 
+            "is_required": false, 
+            "position": 3
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token071", 
+            "gestalt": "token071", 
+            "is_required": false, 
+            "position": 4
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token068", 
+            "gestalt": "token068", 
+            "is_required": false, 
+            "position": 5
+          }
+        ], 
+        "description": "Gott ist tot? Echt nicht. Was darfs denn sein? Eine der Weltreligionen oder irgendeine dubiose Sekte? Wellness-Esoterik oder konsequenter Atheismus? Es soll auch Leute geben, die glauben an fliegende Spagetti-Monster. Au\u00dferdem stellt sich die Frage, wie sehr jemand glaubt. Die Religion deiner Profile ist in mehrfacher Hinsicht attraktiv f\u00fcr dich. Erstens l\u00e4sst sich die f\u00fcr Werbezwecke einsetzen, zweitens ist sie zentral f\u00fcrs Charakter-Profil und drittens soll es staatliche Beh\u00f6rden geben, die auf bestimmte Religionen gar nicht gut zu sprechen sind.", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du, woran sie glauben", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen weisst du, woran sie glauben", 
+        "label": "Religion", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 780, 
+              "y": 480
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-005.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Religion", 
+        "xp_inc": 7
+      }
+    }, 
+    "token099": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Immer auf der Suche. Da flattert die Hochglanz-Werbebrosch\u00fcre mit den Sonderangeboten ins Haus: Am n\u00e4chsten Tag k\u00e4mpfen sie um 6 Uhr fr\u00fch um den Platz in der Schlange, um einen der 5 verbilligten Flatscreen-TVs zu ergattern. Sie vergleichen w\u00f6chentlich akribisch die Preise und gehen immer genau dorthin, wo das Shampoo gerade 50 Cent (!) g\u00fcnstiger zu haben ist. Und schlagen beim restlichen Einkauf gleich umso hemmungsloser zu. Zum Beispiel diese verbilligte Zweierpackung. Wir br\u00e4uchten zwar nur eine, aber wenn ich 2 nehme...diese Leute sind Gold wert!", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du, ob sie auf jedes Sonderangebot abfahren oder da eher immun sind", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen weisst du, ob sie auf jedes Sonderangebot abfahren oder da eher immun sind", 
+        "label": "Schn\u00e4ppchen-\r\nj\u00e4ger", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 400, 
+              "y": 240
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Schn\u00e4ppchenj\u00e4ger", 
+        "xp_inc": 1
+      }
+    }, 
+    "token100": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 100 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 100 (%s)", 
+        "label": "Mobile ID", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 400, 
+              "y": 160
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 0, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Mobile ID", 
+        "xp_inc": 1
+      }
+    }, 
+    "token102": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Ausgesorgt? Wer h\u00e4tte nicht gern den Millionen-Gewinn. Je weniger Kohle, desto gr\u00f6\u00dfer die Hoffnung auf den Haupttreffer in der Lotterie. Aber Gl\u00fccksspiel-Junkies gibts in allen Schichten. Gewinnspiele, Casino oder Online-Wetten - es gibt viele M\u00f6glichkeiten, damit Cash zu machen. Wenn du weisst, wer daf\u00fcr anf\u00e4llig ist, kannst du das nicht nur an die Gl\u00fcckspiel-Industrie verkaufen. Dieses Wissen hilft auch in vielen anderen Bereichen, zum Beispiel ganz generell in der Werbung. Denn diese Leute lassen sich mit bestimmten Tricks besonders gut manipulieren.", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du, wie sehr sie auf das Gl\u00fcck hoffen", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen weisst du, wie sehr sie auf das Gl\u00fcck hoffen", 
+        "label": "Gl\u00fccksspiel\r\nJunkie?", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 400, 
+              "y": 80
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Gl\u00fccksspiel-Junkie?", 
+        "xp_inc": 1
+      }
+    }, 
+    "token103": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Neben Joggen, Schwimmen oder Tischtennis gibts auch noch den Abenteuer-Sport. Es muss ja nicht gleich der Sprung aus der Stratosph\u00e4re, Canyoning, Tauchen, Eisklettern oder Paragleiten sein. Auch Skateboard, Skifahren oder das ganz normale Fahrrad bergen so ihre Gefahren. Was dir diese Info n\u00fctzt? Finde raus, wie riskant die Leute unterwegs sind und verkaufs zum Beispiel an Versicherungen. Auch f\u00fcr Marketing-Zwecke nicht uninteressant. Bei manchen dieser Sportarten ist teures Equipment erforderlich, darum ist diese Zielgruppe bares Geld wert!", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du, wie riskant sie unterwegs sind.", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen weisst du, wie riskant sie unterwegs sind.", 
+        "label": "Risikosportarten", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 400, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Risikosportarten", 
+        "xp_inc": 1
+      }
+    }, 
+    "token104": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 104 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 104 (%s)", 
+        "label": "Schlafrhythmus", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 320, 
+              "y": 320
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Schlafrhythmus", 
+        "xp_inc": 1
+      }
+    }, 
+    "token105": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 105 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 105 (%s)", 
+        "label": "Herzrhythmus", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 720, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Herzrhythmus", 
+        "xp_inc": 1
+      }
+    }, 
+    "token106": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 106 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 106 (%s)", 
+        "label": "Aktivit\u00e4t", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 240, 
+              "y": 320
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Aktivit\u00e4t", 
+        "xp_inc": 1
+      }
+    }, 
+    "token107": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 107 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 107 (%s)", 
+        "label": "Stimmung", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 160, 
+              "y": 320
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Stimmung", 
+        "xp_inc": 1
+      }
+    }, 
+    "token108": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 108 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 108 (%s)", 
+        "label": "Hormonspiegel", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 80, 
+              "y": 320
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Hormonspiegel", 
+        "xp_inc": 1
+      }
+    }, 
+    "token109": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 109 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 109 (%s)", 
+        "label": "Blutdruck", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 0, 
+              "y": 320
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Blutdruck", 
+        "xp_inc": 1
+      }
+    }, 
+    "token111": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 111 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 111 (%s)", 
+        "label": "Internet Junkie?", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 720, 
+              "y": 320
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Internet Junkie?", 
+        "xp_inc": 1
+      }
+    }, 
+    "token113": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Markentreue Menschen sind echt was wert. Nein, viel besser: Das sind Goldesel. Denn die bezahlen f\u00fcr: nichts! Und zwar: viel mehr! Erstens sind sie gerne bereit, das Zehnfache von dem zu bezahlen, was vergleichbare Produkte ohne das sch\u00f6ne Logo kosten. Und zweitens kaufen sie immer wieder die gleiche Marke. Vor allem Jugendliche sind hier anf\u00e4llig. Perfekt!\r\n\r\nDarum verkaufen viele Unternehmen heute haupts\u00e4chlich nur mehr eines: Ihr Logo. Sonst nicht viel dahinter. Und was brauchen sie? Die entsprechenden Namen und Adressen. Gib ihnen, was sie brauchen. Just do it.", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du, wie sehr sie auf Logos abfahren", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen weisst du, wie sehr sie auf Logos abfahren", 
+        "label": "Marken-\r\nfetischismus", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 320, 
+              "y": 80
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Markenfetischismus", 
+        "xp_inc": 1
+      }
+    }, 
+    "token114": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Insulin, Herzmedikamente oder Antidepressiva? Eine Kopfschmerz-Tablette zum Fr\u00fchst\u00fcck, ein paar Stimmungsaufheller zwischendurch und jeden Abend der Griff zum Schlafmittel? Ob leichtfertiger Missbrauch oder sinnvolle Nutzung von Medikamenten bei schweren Krankheiten - du interessierst dich f\u00fcr alles!\r\n\r\nDie Pharma- und Gesundheitsindustrie hat jede Menge Geld und interessiert sich brennend f\u00fcr diese Infos. Dar\u00fcber hinaus kannst du von den genutzten Medikamenten auf viele andere Dinge schlie\u00dfen.", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du, welche Pillen sie schlucken", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen weisst du, welche Pillen sie schlucken", 
+        "label": "Pillen &\r\nMedikamente", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 320, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Pillen &\r\nMedikamente", 
+        "xp_inc": 1
+      }
+    }, 
+    "token115": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Comics oder anspruchsvolle Romane? Kritische Sachb\u00fccher oder seichte Flie\u00dfband-Geschichten? Stricken, Heimwerkerei, Esoterik oder Koran? Haustiere, Computer-Hacking oder unbequeme politische Themen? Oder gar Ratgeber-Literatur \u00fcber Krankheiten oder Lebenskrisen? Sag mir was du liest und ich sage dir wer du bist. Aus den ausgeliehenen B\u00fcchern l\u00e4sst sich nicht nur auf die politische Einstellung schlie\u00dfen, sondern auch auf sehr viele andere Dinge. ", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du, welche B\u00fccher sie sich regelm\u00e4ssig ausleihen", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen weisst du, welche B\u00fccher sie sich regelm\u00e4ssig ausleihen", 
+        "label": "Bibliotheks-\r\nAusleihen", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 240, 
+              "y": 240
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Bibliotheks-Ausleihen", 
+        "xp_inc": 1
+      }
+    }, 
+    "token116": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 116 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 116 (%s)", 
+        "label": "Lieblings-\r\nFernsehsendungen", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 160, 
+              "y": 240
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Lieblings-Fernsehsendungen", 
+        "xp_inc": 1
+      }
+    }, 
+    "token117": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Obwohl es umstritten ist und oft widerlegt wurde, glauben manche Leute immer noch daran, dass die Handschrift etwas \u00fcber die Charaktereigenschaften eines Menschen aussagt. Ob jemand unleserlich und klein schreibt oder gro\u00dfe, runde, nach rechts geneigte Buchstaben macht, wollen manche Arbeitgeber noch immer wissen, bevor sie jemanden einstellen.", 
+        "findings_text": "Token 117 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 117 (%s)", 
+        "label": "Handschrift", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 720, 
+              "y": 240
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Handschrift", 
+        "xp_inc": 1
+      }
+    }, 
+    "token119": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 119 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 119 (%s)", 
+        "label": "Fr\u00fchere\r\nWohnadressen", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 720, 
+              "y": 160
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Fr\u00fchere Wohnadressen", 
+        "xp_inc": 1
+      }
+    }, 
+    "token120": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Drogen sind ein vielf\u00e4ltiges Thema. Kaffee, Zigaretten, Alkohol und diverse Medikamente geh\u00f6ren wohl zu den am h\u00e4ufigsten konsumierten Drogen. Ob Gebrauch oder Missbrauch, bekanntlich macht meistens die Dosis das Gift. Dann gibts noch diese illegalen Drogen. Auch wenn umstritten ist, ob nicht etwa Alkohol viel schlimmer sei als so manche verbotene Droge - eins ist klar: Illegaler Drogenkonsum? Das ist eine schwierig zu erhaltende und wertvolle Information! Nicht nur f\u00fcr staatliche Beh\u00f6rden, Arbeitgeber und Vermieter interessant.", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du was sie sich reinziehen", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen wei\u00dft du was sie sich reinziehen", 
+        "label": "Drogenkonsum", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 80, 
+              "y": 240
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Drogenkonsum", 
+        "xp_inc": 1
+      }
+    }, 
+    "token121": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 121 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 121 (%s)", 
+        "label": "Digitaler\r\nFingerabdruck", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 0, 
+              "y": 240
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-005.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Digitaler Fingerabdruck", 
+        "xp_inc": 1
+      }
+    }, 
+    "token122": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 122 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 122 (%s)", 
+        "label": "Raubkopierte\r\nSpiele", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 240, 
+              "y": 160
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Raubkopierte Spiele", 
+        "xp_inc": 1
+      }
+    }, 
+    "token123": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Fast alle machen es. Seit etwas mehr als 10 Jahren ist Raubkopieren zu einem Volkssport geworden. Vor allem im Kinder- und Jugendzimmern ist das notorische Copyright-Verbrechen heute Alltag! Die Musikindustrie hat da wohl irgendwas verschlafen.\r\n\r\nGut, dass die gro\u00dfen Plattenfirmen eine bessere Methode zum Geldverdienen entdeckt haben: Raubkopierer verklagen! Wenn du rausfindest, wer welche Songs runtergeladen hat, kannst du denen das teuer verkaufen.", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du, welche Songs sie runterladen", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen weisst du, welche Songs sie runterladen", 
+        "label": "Raubkopierte Songs", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 240, 
+              "y": 80
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Raubkopierte\r\nSongs", 
+        "xp_inc": 1
+      }
+    }, 
+    "token124": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 124 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 124 (%s)", 
+        "label": "Raubkopierte\r\nProgramme", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 240, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Raubkopierte Programme", 
+        "xp_inc": 1
+      }
+    }, 
+    "token125": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Raue Mengen an Fleisch oder haupts\u00e4chlich vegetarisch? Chips, Cola und jeden Tag Tiefk\u00fchlkost oder Bio, leicht und mit viel Gem\u00fcse? Aus einer Liste der Eink\u00e4ufe lassen sich Ern\u00e4hrungsprofile erstellen, aus denen sich mit einer gewissen Sicherheit auf Gesundheitszustand und -prognose schlie\u00dfen l\u00e4sst. Der erfasste Zeitraum muss gar nicht mal so lang sein, ein paar Wochen gen\u00fcgen in der Regel.", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du, was sie t\u00e4glich in sich reinstopfen", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen wei\u00dft du, was sie t\u00e4glich in sich reinstopfen", 
+        "label": "Ern\u00e4hrungs-\r\nverhalten", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 160, 
+              "y": 160
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 7, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Ern\u00e4hrungsverhalten", 
+        "xp_inc": 1
+      }
+    }, 
+    "token127": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 127 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 127 (%s)", 
+        "label": "Polizeiakten", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 0, 
+              "y": 160
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Polizeiakten", 
+        "xp_inc": 1
+      }
+    }, 
+    "token128": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du, welche Magazine und Zeitungen sie abonniert haben", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen weisst du, welche Magazine und Zeitungen sie abonniert haben", 
+        "label": "Magazin- &\r\nZeitungsabos", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 160, 
+              "y": 80
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Elite-Zeitung oder Boulevard? Konservativer Feuilleton, kritisches Alternativ-Blatt oder die Wochenrundschau f\u00fcr erfolgreiche Unternehmer? Bunte Illustrierte \u00fcber Tiere, Umwelt, Wissen, Promis, Modellbau, Feminismus, Waffen, Porno oder das lokale Kirchenblatt? Vielleicht gar alles zusammen?\r\n\r\nSag mir was du liest und ich sage dir wer du bist. Aus den abonnierten Magazinen und Zeitungen l\u00e4sst sich nicht nur auf die politische Einstellung schlie\u00dfen, sondern auch auf sehr viele andere Dinge.", 
+        "title": "Magazin- & Zeitungsabos", 
+        "xp_inc": 1
+      }
+    }, 
+    "token129": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 1800000, 
+        "contained_tokens": [
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token128", 
+            "gestalt": "token128", 
+            "is_required": false, 
+            "position": 2
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token071", 
+            "gestalt": "token071", 
+            "is_required": false, 
+            "position": 3
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token072", 
+            "gestalt": "token072", 
+            "is_required": false, 
+            "position": 4
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token068", 
+            "gestalt": "token068", 
+            "is_required": false, 
+            "position": 5
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token067", 
+            "gestalt": "token067", 
+            "is_required": false, 
+            "position": 1
+          }
+        ], 
+        "description": "Treuherziger Sklave oder kratziges Schmusetier? Hund oder Katze? Grundsatzfrage! Dann gibts nat\u00fcrlich auch exotischere Varianten. Haustiere sind jedenfalls ein Mega-Business: Von exquisiter Hunde- und Katzennahrung bis zur Tier-Hom\u00f6opathie leben ganze Wirtschaftszweige davon. Tipp: Ob und welche Haustiere deine Profile vermutlich besitzen, musst du nicht von ihnen direkt erfahren. Deine Datenbank kann das auch aus deinen anderen gesammelten Infos berechnen.", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du, welche Haustiere sie haben", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen weisst du, welche Haustiere sie haben", 
+        "label": "Haustiere", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 160, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Haustiere", 
+        "xp_inc": 3
+      }
+    }, 
+    "token130": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Mehrfach-Studium an der Universit\u00e4t oder nicht einmal Pflichtschulabschluss? Auch wenns Leute gibt, die auch ohne Schulabschluss h\u00f6chst erfolgreich sind, in vielen Bereichen ist die sogenannte formale Schulbildung immer noch zentral. Nicht nur Arbeitgeber interessieren sich daf\u00fcr. Der Bildungsgrad ist auch f\u00fcr die allgemeine Einordnung einer Person sowie f\u00fcr die Erstellung von gezielten Konsumprofilen n\u00fctzlich.", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du deren h\u00f6chsten Schulabschluss.", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen kennst du deren h\u00f6chsten Schulabschluss.", 
+        "label": "Schulabschluss", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 720, 
+              "y": 80
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Schulabschluss", 
+        "xp_inc": 1
+      }
+    }, 
+    "token131": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "findings_text": "Token 131 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 131 (%s)", 
+        "label": "Besuchte\r\nVeranstaltungen", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 720, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Besuchte Veranstaltungen", 
+        "xp_inc": 1
+      }
+    }, 
+    "token132": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Nehmen wir an: Du machst Werbung f\u00fcr irgendein bl\u00f6des Produkt. Mit Inseraten, Plakaten, Radio, TV oder im Netz. M\u00f6glichst originell, attraktiv, dramatisch und nat\u00fcrlich mit Pointe. Du dr\u00fcckst den Leuten rein, dass sie gerade eine EINMALIGE Chance verpassen.  Das kostet! Nun. Bei den einen funktioniert das wunderbar. Bei den anderen weniger. Das l\u00e4sst sich messen. Die einen kaufen nach deiner Werbekampagne eindeutig eher. Spontan und entschlussfreudig! Am besten sind die, die glauben, sie w\u00fcrden sich doch eh nicht beeinflussen lassen, ha!", 
+        "findings_text": "Von %s Personen erf\u00e4hrst du, ob Werbung bei denen was n\u00fctzt", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Von %s Personen weisst du, ob Werbung bei denen was n\u00fctzt", 
+        "label": "Reagiert\r\nauf Werbung?", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 80, 
+              "y": 80
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "Dieser Textteil zu diesem sch\u00f6nen Spielelement befindet sich derzeit in der Review-Schlange unseres flei\u00dfigen Redaktionsteams. Er wird in K\u00fcrze an dieser Stelle erscheinen. Vielen Dank f\u00fcrs Verst\u00e4ndnis.", 
+        "title": "Reagiert auf Werbung?", 
+        "xp_inc": 1
+      }
+    }
+  }, 
+  "version": 1
+}

--- a/data/ruleset_3.en.json
+++ b/data/ruleset_3.en.json
@@ -1,0 +1,18186 @@
+{
+  "karmalauters": [
+    {
+      "game_type": "Karmalauter", 
+      "type_data": {
+        "description": "These days, some blogs are more influential than TV and newspapers combined. Get them on your side! Organize an event and invite some blogosphere celebrities. Cool, exclusive location, extravagant buffet, hip DJ \u2013 and tell them you value their opinion. They\u2019ll be eating out of your hands in no time.", 
+        "gestalt": "karma004", 
+        "karma_points": 20, 
+        "label": "Organize blogger event", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-025.png"
+        }, 
+        "price": 1300, 
+        "required_level": 7, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 680, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "title": "Organize blogger event"
+      }
+    }, 
+    {
+      "game_type": "Karmalauter", 
+      "type_data": {
+        "description": "Corporate Social Responsibility. Sounds really neat, right? And it\u2019s pretty easy, too: Just donate some money to help sick children or to fight famine in developing countries. Politicians and media will think twice before they criticize you again!", 
+        "gestalt": "karma005", 
+        "karma_points": 50, 
+        "label": "CSR Campaign", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-024.png"
+        }, 
+        "price": 4000, 
+        "required_level": 10, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 680, 
+              "y": 300
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "title": "CSR Campaign"
+      }
+    }, 
+    {
+      "game_type": "Karmalauter", 
+      "type_data": {
+        "description": "Hire a very special man to clean up your bad image. He\u2019s powerful, cynical, and cunning. He loves his command centers to look like something straight out of Star Trek. He knows the real players \u2013 and how to use them to your advantage.", 
+        "gestalt": "karma019", 
+        "karma_points": 70, 
+        "label": "Former intelligence boss", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-025.png"
+        }, 
+        "price": 6000, 
+        "required_level": 10, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 580, 
+              "y": 200
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "title": "Former intelligence boss"
+      }
+    }, 
+    {
+      "game_type": "Karmalauter", 
+      "type_data": {
+        "description": "Organize a conference and invite all those renowned professors from elite universities to give presentations. Won\u2019t be easy, but here\u2019s the thing: Just tell them everyone else has already accepted, and vice versa. In the end, they\u2019ve got another paper presented at a prestigious event \u2013 and you\u2019ve got them all in your pocket.", 
+        "gestalt": "karma007", 
+        "karma_points": 25, 
+        "label": "Organize conference", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-024.png"
+        }, 
+        "price": 1700, 
+        "required_level": 9, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 680, 
+              "y": 100
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "title": "Organize conference"
+      }
+    }, 
+    {
+      "game_type": "Karmalauter", 
+      "type_data": {
+        "description": "Lobbying is the supreme discipline when it comes to influencing public opinion. And there\u2019s professionals who know how best to sell your interests to the right people. Whether it\u2019s some inconvenient legislation or you\u2019re threatened by actual law enforcement \u2013 good lobbying can solve all sorts of problems.", 
+        "gestalt": "karma006", 
+        "karma_points": 14, 
+        "label": "Lobbying", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-024.png"
+        }, 
+        "price": 900, 
+        "required_level": 7, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 680, 
+              "y": 200
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "title": "Lobbying"
+      }
+    }, 
+    {
+      "game_type": "Karmalauter", 
+      "type_data": {
+        "description": "The basis for keeping up appearances is taking good care of your network. Visit promising events, be nice to the right people, and scratch their backs a little \u2013 who knows, you might need them to return the favor some day.", 
+        "gestalt": "karma001", 
+        "karma_points": 5, 
+        "label": "Networking", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-025.png"
+        }, 
+        "price": 250, 
+        "required_level": 5, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 100, 
+              "y": 660
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "title": "Networking"
+      }
+    }, 
+    {
+      "game_type": "Karmalauter", 
+      "type_data": {
+        "description": "The best way to deal with negative press? Give them something nice to talk about instead! Invite journalists on fancy trips, pay for their drinks and hand out goodies. People love receiving little presents \u2013 and it might just make them like you as well.", 
+        "gestalt": "karma008", 
+        "karma_points": 10, 
+        "label": "Giveaways for journalists", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-024.png"
+        }, 
+        "price": 600, 
+        "required_level": 5, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 680, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "title": "Giveaways for journalists"
+      }
+    }, 
+    {
+      "game_type": "Karmalauter", 
+      "type_data": {
+        "description": "Scientists are always in desperate need of funding. Just get some university contacts and commission an in-depth study. Of course you\u2019re only paying for research that favors your position. Maybe include some minor criticism to make it more believable, but not too much \u2013 or you\u2019re taking your money elsewhere. ", 
+        "gestalt": "karma003", 
+        "karma_points": 40, 
+        "label": "Study funding", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-024.png"
+        }, 
+        "price": 3000, 
+        "required_level": 9, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 680, 
+              "y": 500
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "title": "Study funding/Fund a study/Paid research"
+      }
+    }, 
+    {
+      "game_type": "Karmalauter", 
+      "type_data": {
+        "description": "A comprehensive, in-depth campaign to boost your image will certainly cost you some dough, but judging from your situation, it could be the one thing keeping you from prison. Hire a well-known public relations agency \u2013 they know exactly how best to convey your message to your audience. ", 
+        "gestalt": "karma009", 
+        "karma_points": 100, 
+        "label": "Broad image campaign", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-024.png"
+        }, 
+        "price": 9000, 
+        "required_level": 11, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 500, 
+              "y": 560
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "title": "Broad/major/comprehensive/all-round image campaign"
+      }
+    }, 
+    {
+      "game_type": "Karmalauter", 
+      "type_data": {
+        "description": "Some of your entries on Wikipedia could really end up harming your reputation. Those wise guys actually think they\u2019ve got one on you. They may be right \u2013 but your rewrite makes you sound so much better. Just try to be as unobtrusive as possible.", 
+        "gestalt": "karma002", 
+        "karma_points": 7, 
+        "label": "Manipulate Wikipedia", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-024.png"
+        }, 
+        "price": 400, 
+        "required_level": 5, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 0, 
+              "y": 660
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "title": "Manipulate Wikipedia"
+      }
+    }
+  ], 
+  "karmalizers": [
+    {
+      "game_type": "Karmalizer", 
+      "type_data": {
+        "description": "Sensitive internal documents about your activities have been leaked to the public? Oops \u2013 seems like you got a taste of your own medicine. Tough luck!", 
+        "gestalt": "karma013", 
+        "karma_points": -3, 
+        "label": "Data Leak", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-025.png"
+        }, 
+        "price": 0, 
+        "required_level": 5, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 100, 
+              "y": 560
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "title": "Data Leak"
+      }
+    }, 
+    {
+      "game_type": "Karmalizer", 
+      "type_data": {
+        "description": "A small group of unrelenting privacy advocates has succeeded in inciting the populace against you. You've been a little careless lately and did too much risky trading.", 
+        "gestalt": "karma014", 
+        "karma_points": -4, 
+        "label": "Protests against data abuse", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-025.png"
+        }, 
+        "price": 0, 
+        "required_level": 5, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 0, 
+              "y": 560
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "title": "Protests against data abuse"
+      }
+    }, 
+    {
+      "game_type": "Karmalizer", 
+      "type_data": {
+        "description": "Some jokers online are sharing insipid pics that make you look rather bad \u2013 filled with nasty falsehoods that are really inconvenient. Too bad those pictures spread so fast. Guess it\u2019s high time you do something about it\u2026", 
+        "gestalt": "karma016", 
+        "karma_points": -6, 
+        "label": "Insulting memes", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-024.png"
+        }, 
+        "price": 0, 
+        "required_level": 6, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 580, 
+              "y": 300
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "title": "Insulting memes"
+      }
+    }, 
+    {
+      "game_type": "Karmalizer", 
+      "type_data": {
+        "description": "There\u2019s this one strange guy that\u2019s been annoying you for a while. Seems like he\u2019s gotten his teeth into you for some reason. Now he clings to you like a lamprey and keeps on criticizing the glorious deals you\u2019re making. He really needs to get a life \u2013 and learn how to keep his mouth shut.", 
+        "gestalt": "karma018", 
+        "karma_points": -2, 
+        "label": "Annoying privacy guy", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-025.png"
+        }, 
+        "price": 0, 
+        "required_level": 5, 
+        "slot_sprite": [], 
+        "title": "Annoying privacy guy"
+      }
+    }, 
+    {
+      "game_type": "Karmalizer", 
+      "type_data": {
+        "description": "Seems like you went too far this time, and this is what you get for it. Congress and media are discussing new privacy regulations that could have dire consequences for your business. High time you acted to ensure those regulations are worded a little more favourably.", 
+        "gestalt": "karma010", 
+        "karma_points": -5, 
+        "label": "Data privacy regulations", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-024.png"
+        }, 
+        "price": 0, 
+        "required_level": 5, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 400, 
+              "y": 560
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "title": "Data privacy regulations"
+      }
+    }, 
+    {
+      "game_type": "Karmalizer", 
+      "type_data": {
+        "description": "Damn! Media are poking around things that are none of their business. And putting it on the front page too! This is not going to be cheap. Let\u2019s hope the next humanitarian crisis will wipe this off everyone\u2019s radar soon.", 
+        "gestalt": "karma011", 
+        "karma_points": -8, 
+        "label": "Bad press", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-025.png"
+        }, 
+        "price": 0, 
+        "required_level": 8, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 300, 
+              "y": 560
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "title": "Bad press"
+      }
+    }, 
+    {
+      "game_type": "Karmalizer", 
+      "type_data": {
+        "description": "Holy crap! Left things a little too long, huh? The internet is boiling over with wrong accusations, and throusands of angry postings have caused a veritable storm of outrage to be unleashed against you. Duck and cover would be your best strategy \u2013 who knows, it might blow over soon.", 
+        "gestalt": "karma015", 
+        "karma_points": -10, 
+        "label": "Shitstorm", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-024.png"
+        }, 
+        "price": 0, 
+        "required_level": 10, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 580, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "title": "Shitstorm"
+      }
+    }, 
+    {
+      "game_type": "Karmalizer", 
+      "type_data": {
+        "description": "Well, damn. A former employee has copied all the dirty details of your secret dealings and is sharing them all over the media. You need to shut that guy up, and fast! Pull out all the stops \u2013 threaten him with legal action, paint him as an untrustworthy traitor to mankind, put pressure on his family and friends. You can do it!", 
+        "gestalt": "karma017", 
+        "karma_points": -15, 
+        "label": "Whistleblower", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-024.png"
+        }, 
+        "price": 0, 
+        "required_level": 12, 
+        "slot_sprite": [], 
+        "title": "Whistleblower"
+      }
+    }, 
+    {
+      "game_type": "Karmalizer", 
+      "type_data": {
+        "description": "Angry users complaining online? Man, don\u2019t they have anything else do to? Can\u2019t they just leave you and your thriving business alone? Still, you better pay some attention, before things get out of hand and they unleash a full-blown shitstorm.", 
+        "gestalt": "karma012", 
+        "karma_points": -8, 
+        "label": "Angry users", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-025.png"
+        }, 
+        "price": 0, 
+        "required_level": 7, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 200, 
+              "y": 560
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "title": "Angry users"
+      }
+    }
+  ], 
+  "levels": [
+    {
+      "ap_inc_interval": 120000, 
+      "ap_inc_value": 1, 
+      "ap_max": 6, 
+      "number": 1, 
+      "xp_max": 10, 
+      "xp_min": 0
+    }, 
+    {
+      "ap_inc_interval": 120000, 
+      "ap_inc_value": 1, 
+      "ap_max": 8, 
+      "number": 2, 
+      "xp_max": 30, 
+      "xp_min": 11
+    }, 
+    {
+      "ap_inc_interval": 120000, 
+      "ap_inc_value": 1, 
+      "ap_max": 12, 
+      "number": 3, 
+      "xp_max": 54, 
+      "xp_min": 31
+    }, 
+    {
+      "ap_inc_interval": 120000, 
+      "ap_inc_value": 1, 
+      "ap_max": 14, 
+      "number": 4, 
+      "xp_max": 80, 
+      "xp_min": 55
+    }, 
+    {
+      "ap_inc_interval": 120000, 
+      "ap_inc_value": 1, 
+      "ap_max": 18, 
+      "number": 5, 
+      "xp_max": 111, 
+      "xp_min": 81
+    }, 
+    {
+      "ap_inc_interval": 120000, 
+      "ap_inc_value": 1, 
+      "ap_max": 20, 
+      "number": 6, 
+      "xp_max": 152, 
+      "xp_min": 112
+    }, 
+    {
+      "ap_inc_interval": 120000, 
+      "ap_inc_value": 1, 
+      "ap_max": 24, 
+      "number": 7, 
+      "xp_max": 213, 
+      "xp_min": 153
+    }, 
+    {
+      "ap_inc_interval": 120000, 
+      "ap_inc_value": 1, 
+      "ap_max": 28, 
+      "number": 8, 
+      "xp_max": 290, 
+      "xp_min": 214
+    }, 
+    {
+      "ap_inc_interval": 120000, 
+      "ap_inc_value": 1, 
+      "ap_max": 30, 
+      "number": 9, 
+      "xp_max": 381, 
+      "xp_min": 291
+    }, 
+    {
+      "ap_inc_interval": 120000, 
+      "ap_inc_value": 1, 
+      "ap_max": 32, 
+      "number": 10, 
+      "xp_max": 522, 
+      "xp_min": 382
+    }, 
+    {
+      "ap_inc_interval": 120000, 
+      "ap_inc_value": 1, 
+      "ap_max": 34, 
+      "number": 11, 
+      "xp_max": 664, 
+      "xp_min": 523
+    }, 
+    {
+      "ap_inc_interval": 120000, 
+      "ap_inc_value": 1, 
+      "ap_max": 36, 
+      "number": 12, 
+      "xp_max": 877, 
+      "xp_min": 665
+    }, 
+    {
+      "ap_inc_interval": 120000, 
+      "ap_inc_value": 1, 
+      "ap_max": 38, 
+      "number": 13, 
+      "xp_max": 1171, 
+      "xp_min": 878
+    }, 
+    {
+      "ap_inc_interval": 120000, 
+      "ap_inc_value": 1, 
+      "ap_max": 40, 
+      "number": 14, 
+      "xp_max": 1483, 
+      "xp_min": 1172
+    }, 
+    {
+      "ap_inc_interval": 120000, 
+      "ap_inc_value": 1, 
+      "ap_max": 42, 
+      "number": 15, 
+      "xp_max": 1909, 
+      "xp_min": 1484
+    }, 
+    {
+      "ap_inc_interval": 120000, 
+      "ap_inc_value": 1, 
+      "ap_max": 46, 
+      "number": 16, 
+      "xp_max": 2684, 
+      "xp_min": 1910
+    }, 
+    {
+      "ap_inc_interval": 120000, 
+      "ap_inc_value": 1, 
+      "ap_max": 48, 
+      "number": 17, 
+      "xp_max": 3871, 
+      "xp_min": 2685
+    }, 
+    {
+      "ap_inc_interval": 120000, 
+      "ap_inc_value": 1, 
+      "ap_max": 50, 
+      "number": 18, 
+      "xp_max": 5426, 
+      "xp_min": 3872
+    }, 
+    {
+      "ap_inc_interval": 120000, 
+      "ap_inc_value": 1, 
+      "ap_max": 54, 
+      "number": 19, 
+      "xp_max": 6981, 
+      "xp_min": 5427
+    }, 
+    {
+      "ap_inc_interval": 120000, 
+      "ap_inc_value": 1, 
+      "ap_max": 56, 
+      "number": 20, 
+      "xp_max": 66673647, 
+      "xp_min": 6982
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 36, 
+      "number": 21, 
+      "xp_max": 733340313, 
+      "xp_min": 66673648
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 40, 
+      "number": 22, 
+      "xp_max": 733340475, 
+      "xp_min": 733340314
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 45, 
+      "number": 23, 
+      "xp_max": 733340656, 
+      "xp_min": 733340476
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 51, 
+      "number": 24, 
+      "xp_max": 733340859, 
+      "xp_min": 733340657
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 57, 
+      "number": 25, 
+      "xp_max": 733341086, 
+      "xp_min": 733340860
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 57, 
+      "number": 26, 
+      "xp_max": 733341341, 
+      "xp_min": 733341087
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 71, 
+      "number": 27, 
+      "xp_max": 733341626, 
+      "xp_min": 733341342
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 80, 
+      "number": 28, 
+      "xp_max": 733341946, 
+      "xp_min": 733341627
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 90, 
+      "number": 29, 
+      "xp_max": 733342304, 
+      "xp_min": 733341947
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 100, 
+      "number": 30, 
+      "xp_max": 733342704, 
+      "xp_min": 733342305
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 149, 
+      "number": 31, 
+      "xp_max": 733343304, 
+      "xp_min": 733342705
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 167, 
+      "number": 32, 
+      "xp_max": 733344004, 
+      "xp_min": 733343305
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 187, 
+      "number": 33, 
+      "xp_max": 733344754, 
+      "xp_min": 733344005
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 210, 
+      "number": 34, 
+      "xp_max": 733345604, 
+      "xp_min": 733344755
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 234, 
+      "number": 35, 
+      "xp_max": 733346554, 
+      "xp_min": 733345605
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 263, 
+      "number": 36, 
+      "xp_max": 733347554, 
+      "xp_min": 733346555
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 295, 
+      "number": 37, 
+      "xp_max": 733348704, 
+      "xp_min": 733347555
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 331, 
+      "number": 38, 
+      "xp_max": 733350004, 
+      "xp_min": 733348705
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 370, 
+      "number": 39, 
+      "xp_max": 733351504, 
+      "xp_min": 733350005
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 415, 
+      "number": 40, 
+      "xp_max": 733353154, 
+      "xp_min": 733351505
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 436, 
+      "number": 41, 
+      "xp_max": 733355054, 
+      "xp_min": 733353155
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 446, 
+      "number": 42, 
+      "xp_max": 733357154, 
+      "xp_min": 733355055
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 466, 
+      "number": 43, 
+      "xp_max": 733359454, 
+      "xp_min": 733357155
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 522, 
+      "number": 44, 
+      "xp_max": 733362054, 
+      "xp_min": 733359455
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 585, 
+      "number": 45, 
+      "xp_max": 733364954, 
+      "xp_min": 733362055
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 655, 
+      "number": 46, 
+      "xp_max": 733368254, 
+      "xp_min": 733364955
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 734, 
+      "number": 47, 
+      "xp_max": 733371954, 
+      "xp_min": 733368255
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 822, 
+      "number": 48, 
+      "xp_max": 733376054, 
+      "xp_min": 733371955
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 921, 
+      "number": 49, 
+      "xp_max": 733380654, 
+      "xp_min": 733376055
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 1032, 
+      "number": 50, 
+      "xp_max": 733385854, 
+      "xp_min": 733380655
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 1156, 
+      "number": 51, 
+      "xp_max": 733391654, 
+      "xp_min": 733385855
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 1294, 
+      "number": 52, 
+      "xp_max": 733398154, 
+      "xp_min": 733391655
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 1450, 
+      "number": 53, 
+      "xp_max": 733405354, 
+      "xp_min": 733398155
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 1624, 
+      "number": 54, 
+      "xp_max": 733413454, 
+      "xp_min": 733405355
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 1819, 
+      "number": 55, 
+      "xp_max": 733422454, 
+      "xp_min": 733413455
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 2037, 
+      "number": 56, 
+      "xp_max": 733432554, 
+      "xp_min": 733422455
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 2281, 
+      "number": 57, 
+      "xp_max": 733443954, 
+      "xp_min": 733432555
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 2555, 
+      "number": 58, 
+      "xp_max": 733456754, 
+      "xp_min": 733443955
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 2862, 
+      "number": 59, 
+      "xp_max": 733471054, 
+      "xp_min": 733456755
+    }, 
+    {
+      "ap_inc_interval": 5000, 
+      "ap_inc_value": 1, 
+      "ap_max": 3205, 
+      "number": 60, 
+      "xp_max": 734471053, 
+      "xp_min": 733471055
+    }
+  ], 
+  "missions": [
+    {
+      "game_type": "Mission", 
+      "type_data": {
+        "branch": "trunk", 
+        "description": "Your first mission! Click on Jessica, feed her some cash and soon you\u2019ll collect your first profiles! Neat!", 
+        "gestalt": "mission001", 
+        "goals": [
+          {
+            "amount": 900, 
+            "position": 2, 
+            "project": null, 
+            "target": "contact035", 
+            "workflow": "collect_profiles"
+          }
+        ], 
+        "price": 0, 
+        "required_level": 0, 
+        "rewards": [
+          {
+            "amount": 2, 
+            "target": "xp_value"
+          }
+        ], 
+        "title": "First Profiles", 
+        "tutorial": [
+          {
+            "delay": 0, 
+            "description": "Hey there! My name\u2019s Marco, and I\u2019ll be your personal advisor. Ready?", 
+            "name": "tut01: willkommen", 
+            "viewmap": "empire001", 
+            "viewmapPos": {
+              "x": 1024, 
+              "y": 1
+            }
+          }, 
+          {
+            "delay": 0, 
+            "description": "I\u2019ll guide you on your way to become a mighty Data Dealer! Just think of me as a <i>Big Brother</i>.", 
+            "name": "tut02: willkommen 2", 
+            "viewmap": "empire001", 
+            "viewmapPos": {
+              "x": 1024, 
+              "y": 1
+            }
+          }, 
+          {
+            "delay": 0, 
+            "description": "This is your database. Ready for millions of high-class personality profiles.", 
+            "name": "tut03: datenbank perp", 
+            "viewmap": "empire001", 
+            "viewmapPos": {
+              "x": 1024, 
+              "y": 840
+            }
+          }, 
+          {
+            "buyParent": "database001", 
+            "buyPerp": "city002", 
+            "buyPerpPos": {
+              "x": 805, 
+              "y": 865
+            }, 
+            "delay": 0, 
+            "description": "Your data empire needs a homebase, and Little Rock is just the place. Why? We\u2019ll discuss that later.", 
+            "name": "tut04: first city", 
+            "viewmap": "empire001"
+          }, 
+          {
+            "delay": 0, 
+            "description": "Let\u2019s take a look inside your database first.", 
+            "name": "tut05: first city 2", 
+            "viewmap": "empire001"
+          }, 
+          {
+            "delay": 0, 
+            "description": "This is what\u2019s inside your database.\r\nLots of space to fill!", 
+            "name": "tut06: datenbank leer", 
+            "viewmap": "database001", 
+            "viewmapPos": {
+              "x": 1024, 
+              "y": 800
+            }
+          }, 
+          {
+            "delay": 0, 
+            "description": "To get you started, here's a neat DVD chock full of yummy phone book data. Just look at it go!", 
+            "name": "tut07: telefonbuch integrieren", 
+            "viewmap": "database001"
+          }, 
+          {
+            "delay": 0, 
+            "description": "Well, that\u2019s an improvement. Look, up there, on the left: 100,000 profiles!\r\nThat's a solid foundation!", 
+            "integrateProfileSet": "city002", 
+            "name": "tut08: telefonbuch integrieren 2", 
+            "viewmap": "database001"
+          }, 
+          {
+            "delay": 0, 
+            "description": "Now on with your future empire. 100,000 names, addresses and phone numbers are nice and all, but you really need some more delicate info.", 
+            "name": "tut09: back in imperium", 
+            "viewmap": "empire001"
+          }, 
+          {
+            "buyParent": "city002", 
+            "buyPerp": "agent002", 
+            "buyPerpPos": {
+              "x": 625, 
+              "y": 900
+            }, 
+            "delay": 0, 
+            "description": "May I introduce: Manny Mayer, private detective and an old friend. Had some big successes a while back, but those golden years are long gone now. ", 
+            "name": "tut10: manny 1", 
+            "viewmap": "empire001"
+          }, 
+          {
+            "delay": 0, 
+            "description": "Underpaid, bored and hungry for action, Manny has become a big-time expert in tracking down small-time sources\u2026 ", 
+            "name": "tut11: manny 2", 
+            "viewmap": "empire001"
+          }, 
+          {
+            "delay": 0, 
+            "description": "...especially those who handle personal data! Like Jessica Seno, a low-level clerk in a big-ass casino. ", 
+            "name": "tut12: manny kennt jessica", 
+            "viewmap": "empire001"
+          }, 
+          {
+            "buyParent": "agent002", 
+            "buyPerp": "contact035", 
+            "buyPerpPos": {
+              "x": 485, 
+              "y": 840
+            }, 
+            "delay": 0, 
+            "description": "As luck would have it, Jessica is also underpaid, bored and hungry for action. And she has full access to the casino\u2019s central computer. Nice! ", 
+            "name": "tut13: jessica 1", 
+            "viewmap": "empire001"
+          }, 
+          {
+            "delay": 0, 
+            "description": "Send a little cash her way now and then, and she\u2019ll supply you with interesting info on people who regularly gamble away their paycheck.", 
+            "name": "tut14: jessica 2", 
+            "viewmap": "empire001"
+          }
+        ]
+      }
+    }, 
+    {
+      "game_type": "Mission", 
+      "type_data": {
+        "branch": "trunk", 
+        "description": "New mission! Enter your database and integrate the new profiles you got from Jessica. Hint: Check the conveyor at the bottom left.", 
+        "gestalt": "mission002", 
+        "goals": [
+          {
+            "amount": 900, 
+            "position": 1, 
+            "project": null, 
+            "target": "token008", 
+            "workflow": "integrate_profiles"
+          }
+        ], 
+        "price": 0, 
+        "required_level": 0, 
+        "required_mission": "mission001", 
+        "rewards": [
+          {
+            "amount": 100, 
+            "target": "cash_value"
+          }, 
+          {
+            "amount": 1, 
+            "target": "xp_value"
+          }
+        ], 
+        "title": "Enter the Vault!"
+      }
+    }, 
+    {
+      "game_type": "Mission", 
+      "type_data": {
+        "branch": "trunk", 
+        "description": "New mission! Sell your data \u2013 click on the car company and make your first deal.", 
+        "gestalt": "mission003", 
+        "goals": [
+          {
+            "amount": null, 
+            "position": 1, 
+            "project": null, 
+            "target": "client007", 
+            "workflow": "charge_perp"
+          }
+        ], 
+        "price": 0, 
+        "required_level": 0, 
+        "required_mission": "mission002", 
+        "rewards": [
+          {
+            "amount": 600, 
+            "target": "cash_value"
+          }, 
+          {
+            "amount": 1, 
+            "target": "xp_value"
+          }
+        ], 
+        "title": "Rookie Dealer", 
+        "tutorial": [
+          {
+            "delay": 0, 
+            "description": "You've already learned 8 different things about more than 100,000 people! Yeah!", 
+            "name": "Vor Mission 3 (1): Datenbank", 
+            "viewmap": "database001"
+          }, 
+          {
+            "delay": 0, 
+            "description": "Back to your empire. Your data is worth its weight in gold. You should sell it. But to whom?", 
+            "name": "Vor Mission 3 (2): Verkaufen", 
+            "viewmap": "empire001"
+          }, 
+          {
+            "buyParent": "city002", 
+            "buyPerp": "pusher004", 
+            "buyPerpPos": {
+              "x": 920, 
+              "y": 980
+            }, 
+            "delay": 0, 
+            "description": "This is Denise. She\u2019s a pro and procures new clients for you who are very keen to get their hands on your data.", 
+            "name": "Vor Mission 3 (3): Denise", 
+            "viewmap": "empire001"
+          }, 
+          {
+            "buyParent": "pusher004", 
+            "buyPerp": "client007", 
+            "buyPerpPos": {
+              "x": 1055, 
+              "y": 1070
+            }, 
+            "delay": 0, 
+            "description": "Let\u2019s take this car company for example. They\u2019d be really interested in the names and addresses of gullible people\u2026", 
+            "name": "Vor Mission 3 (4): Autoh\u00e4ndler", 
+            "viewmap": "empire001"
+          }, 
+          {
+            "delay": 0, 
+            "description": "\u2026who will fall for their super-cheap offers in those glossy brochures. You know, deals that later turn out not to be that cheap after all.", 
+            "name": "Vor Mission 3 (4): Autoh\u00e4ndler 2", 
+            "viewmap": "empire001"
+          }
+        ]
+      }
+    }, 
+    {
+      "game_type": "Mission", 
+      "type_data": {
+        "branch": "trunk", 
+        "description": "New mission! There\u2019s lots of profiles to gain with a raffle. Click on your bogus company and start sweepstakes!", 
+        "gestalt": "mission004", 
+        "goals": [
+          {
+            "amount": null, 
+            "position": 1, 
+            "project": null, 
+            "target": "project001", 
+            "workflow": "buy_perp"
+          }, 
+          {
+            "amount": null, 
+            "position": 2, 
+            "project": null, 
+            "target": "project001", 
+            "workflow": "charge_perp"
+          }
+        ], 
+        "price": 0, 
+        "required_level": 0, 
+        "required_mission": "mission003", 
+        "rewards": [
+          {
+            "amount": 100, 
+            "target": "cash_value"
+          }, 
+          {
+            "amount": 5, 
+            "target": "xp_value"
+          }
+        ], 
+        "title": "You\u2019re a winner!", 
+        "tutorial": [
+          {
+            "delay": 0, 
+            "description": "Don't just rely on others to get you some new data sources. Get active and start up your own data collection agency.", 
+            "name": "Vor Mission 4 (1): Intro", 
+            "viewmap": "empire001"
+          }, 
+          {
+            "buyParent": "city002", 
+            "buyPerp": "proxy001", 
+            "buyPerpPos": {
+              "x": 680, 
+              "y": 680
+            }, 
+            "delay": 0, 
+            "description": "But first you need to set up a letterbox company. Your dealings are a little dodgy sometimes? Better use a bogus company for camouflage.", 
+            "name": "Vor Mission 4 (2): Briefkastenfirma", 
+            "viewmap": "empire001"
+          }
+        ]
+      }
+    }, 
+    {
+      "game_type": "Mission", 
+      "type_data": {
+        "branch": "trunk", 
+        "description": "New mission! Sealed your first deal? Collect at least $500 from the car company for the data sold.", 
+        "gestalt": "a388da08d87dc9fd6d543977a2047262000", 
+        "goals": [
+          {
+            "amount": 500, 
+            "position": 1, 
+            "project": null, 
+            "target": "client007", 
+            "workflow": "collect_cash"
+          }
+        ], 
+        "price": 0, 
+        "required_level": 0, 
+        "required_mission": "mission004", 
+        "rewards": [
+          {
+            "amount": 200, 
+            "target": "cash_value"
+          }, 
+          {
+            "amount": 1, 
+            "target": "xp_value"
+          }
+        ], 
+        "title": "Cash in!"
+      }
+    }, 
+    {
+      "game_type": "Mission", 
+      "type_data": {
+        "branch": "trunk", 
+        "description": "New mission! Upgrade your raffle, advertise, and expand your team! Get more profiles in the same time!", 
+        "gestalt": "mission006", 
+        "goals": [
+          {
+            "amount": null, 
+            "position": 1, 
+            "project": "project001", 
+            "target": "upgrade001", 
+            "workflow": "buy_powerup"
+          }, 
+          {
+            "amount": null, 
+            "position": 2, 
+            "project": "project001", 
+            "target": "ad002", 
+            "workflow": "buy_powerup"
+          }, 
+          {
+            "amount": null, 
+            "position": 3, 
+            "project": "project001", 
+            "target": "teammember020", 
+            "workflow": "buy_powerup"
+          }
+        ], 
+        "price": 0, 
+        "required_level": 0, 
+        "required_mission": "a388da08d87dc9fd6d543977a2047262000", 
+        "rewards": [
+          {
+            "amount": 800, 
+            "target": "cash_value"
+          }, 
+          {
+            "amount": 3, 
+            "target": "xp_value"
+          }
+        ], 
+        "title": "Upgrade raffle"
+      }
+    }, 
+    {
+      "game_type": "Mission", 
+      "type_data": {
+        "branch": "trunk", 
+        "description": "New mission! Recruit Nurse Helen and get her to pass you 3,000 patient records for your database.", 
+        "gestalt": "mission007", 
+        "goals": [
+          {
+            "amount": null, 
+            "position": 1, 
+            "project": null, 
+            "target": "contact001", 
+            "workflow": "buy_perp"
+          }, 
+          {
+            "amount": 3000, 
+            "position": 2, 
+            "project": null, 
+            "target": "contact001", 
+            "workflow": "collect_profiles"
+          }, 
+          {
+            "amount": 3000, 
+            "position": 3, 
+            "project": null, 
+            "target": "token017", 
+            "workflow": "integrate_profiles"
+          }
+        ], 
+        "price": 0, 
+        "required_level": 0, 
+        "required_mission": "mission006", 
+        "rewards": [
+          {
+            "amount": 10, 
+            "target": "xp_value"
+          }
+        ], 
+        "title": "Nurse Helen"
+      }
+    }, 
+    {
+      "game_type": "Mission", 
+      "type_data": {
+        "branch": "trunk", 
+        "description": "New mission! Click on Sex and use your collected first names to calculate the sex of previously unclassified profiles.", 
+        "gestalt": "e59302bed28769c3c76761c14516e764000", 
+        "goals": [
+          {
+            "amount": null, 
+            "position": 1, 
+            "project": null, 
+            "target": "token007", 
+            "workflow": "upgrade_token"
+          }
+        ], 
+        "price": 0, 
+        "required_level": 0, 
+        "required_mission": "mission007", 
+        "rewards": [
+          {
+            "amount": 1000, 
+            "target": "cash_value"
+          }, 
+          {
+            "amount": 5, 
+            "target": "xp_value"
+          }
+        ], 
+        "title": "Database machine", 
+        "tutorial": [
+          {
+            "delay": 0, 
+            "description": "Hint: Attributes with a little cog in the upper right corner offer rather special opportunities.", 
+            "name": "Vor Mission 8 Geschlecht (1)", 
+            "viewmap": "database001"
+          }, 
+          {
+            "delay": 0, 
+            "description": "Let\u2019s take sex for example: You can analyse the first names you\u2019ve collected and use them to calculate people\u2019s sex.", 
+            "name": "Vor Mission 8 Geschlecht (2)", 
+            "viewmap": "database001"
+          }
+        ]
+      }
+    }, 
+    {
+      "game_type": "Mission", 
+      "type_data": {
+        "branch": "trunk", 
+        "description": "New mission! Click on Denise and make a deal with the insurance company. You need the money! And ask Manny about Alexa.", 
+        "gestalt": "mission008", 
+        "goals": [
+          {
+            "amount": null, 
+            "position": 1, 
+            "project": null, 
+            "target": "client002", 
+            "workflow": "buy_perp"
+          }, 
+          {
+            "amount": null, 
+            "position": 2, 
+            "project": null, 
+            "target": "client002", 
+            "workflow": "charge_perp"
+          }, 
+          {
+            "amount": null, 
+            "position": 3, 
+            "project": null, 
+            "target": "contact019", 
+            "workflow": "buy_perp"
+          }
+        ], 
+        "price": 0, 
+        "required_level": 0, 
+        "required_mission": "e59302bed28769c3c76761c14516e764000", 
+        "rewards": [
+          {
+            "amount": 500, 
+            "target": "cash_value"
+          }, 
+          {
+            "amount": 10, 
+            "target": "xp_value"
+          }
+        ], 
+        "title": "Sick World"
+      }
+    }, 
+    {
+      "game_type": "Mission", 
+      "type_data": {
+        "branch": "trunk", 
+        "description": "New mission! Get data from at least 10,000 people on how naive they are. Then sell that data to the car company.", 
+        "gestalt": "mission005", 
+        "goals": [
+          {
+            "amount": 10000, 
+            "position": 1, 
+            "project": null, 
+            "target": "token084", 
+            "workflow": "integrate_profiles"
+          }, 
+          {
+            "amount": 500, 
+            "position": 2, 
+            "project": null, 
+            "target": "client007", 
+            "workflow": "collect_cash"
+          }
+        ], 
+        "price": 0, 
+        "required_level": 0, 
+        "required_mission": "mission008", 
+        "rewards": [
+          {
+            "amount": 1000, 
+            "target": "cash_value"
+          }, 
+          {
+            "amount": 5, 
+            "target": "xp_value"
+          }
+        ], 
+        "title": "So green!"
+      }
+    }, 
+    {
+      "game_type": "Mission", 
+      "type_data": {
+        "branch": "trunk", 
+        "description": "New mission! Click on your bogus company, get the personality test, and upgrade it with \u201eHow faithful are you?\u201c.", 
+        "gestalt": "e33a3ef9d70038e0a9c6d088f37d02cb000", 
+        "goals": [
+          {
+            "amount": null, 
+            "position": 1, 
+            "project": null, 
+            "target": "project003", 
+            "workflow": "buy_perp"
+          }, 
+          {
+            "amount": null, 
+            "position": 2, 
+            "project": "project003", 
+            "target": "upgrade015", 
+            "workflow": "buy_powerup"
+          }, 
+          {
+            "amount": null, 
+            "position": 3, 
+            "project": null, 
+            "target": "project003", 
+            "workflow": "charge_perp"
+          }
+        ], 
+        "price": 0, 
+        "required_level": 0, 
+        "required_mission": "mission005", 
+        "rewards": [
+          {
+            "amount": 20, 
+            "target": "xp_value"
+          }, 
+          {
+            "amount": 2000, 
+            "target": "cash_value"
+          }
+        ], 
+        "title": "Psycho"
+      }
+    }, 
+    {
+      "game_type": "Mission", 
+      "type_data": {
+        "branch": "trunk", 
+        "description": "New mission! Get data on 6000 people showing whether they\u2019re slackers or not and sell it to the insurance company.", 
+        "gestalt": "af1149c315321ef4f477893fcc1807e1000", 
+        "goals": [
+          {
+            "amount": 6000, 
+            "position": 1, 
+            "project": null, 
+            "target": "contact019", 
+            "workflow": "collect_profiles"
+          }, 
+          {
+            "amount": 6000, 
+            "position": 2, 
+            "project": null, 
+            "target": "token088", 
+            "workflow": "integrate_profiles"
+          }, 
+          {
+            "amount": 500, 
+            "position": 3, 
+            "project": null, 
+            "target": "client002", 
+            "workflow": "collect_cash"
+          }
+        ], 
+        "price": 0, 
+        "required_level": 0, 
+        "required_mission": "e33a3ef9d70038e0a9c6d088f37d02cb000", 
+        "rewards": [
+          {
+            "amount": 10000, 
+            "target": "cash_value"
+          }, 
+          {
+            "amount": 1, 
+            "target": "xp_value"
+          }
+        ], 
+        "title": "Couch Potato"
+      }
+    }, 
+    {
+      "game_type": "Mission", 
+      "type_data": {
+        "branch": "trunk", 
+        "description": "New mission! Click on Denise, aquire new customers and collect at least $2000!", 
+        "gestalt": "b638f35b5ec6b0558981378c9037c3d3000", 
+        "goals": [
+          {
+            "amount": null, 
+            "position": 1, 
+            "project": null, 
+            "target": "client006", 
+            "workflow": "buy_perp"
+          }, 
+          {
+            "amount": 2000, 
+            "position": 2, 
+            "project": null, 
+            "target": "client006", 
+            "workflow": "collect_cash"
+          }
+        ], 
+        "price": 0, 
+        "required_level": 0, 
+        "required_mission": "af1149c315321ef4f477893fcc1807e1000", 
+        "rewards": [
+          {
+            "amount": 5000, 
+            "target": "cash_value"
+          }, 
+          {
+            "amount": 1, 
+            "target": "xp_value"
+          }
+        ], 
+        "title": "Employee Monitoring"
+      }
+    }, 
+    {
+      "game_type": "Mission", 
+      "type_data": {
+        "branch": "trunk", 
+        "description": "New mission! Collecting profiles is quite risky. Promote the personality test and hire a lawyer to lower your risk.", 
+        "gestalt": "9f5735d01587f640cc862e0a82280d3f000", 
+        "goals": [
+          {
+            "amount": null, 
+            "position": 1, 
+            "project": "project003", 
+            "target": "teammember043", 
+            "workflow": "buy_powerup"
+          }, 
+          {
+            "amount": null, 
+            "position": 2, 
+            "project": "project003", 
+            "target": "ad006", 
+            "workflow": "buy_powerup"
+          }
+        ], 
+        "price": 0, 
+        "required_level": 0, 
+        "required_mission": "b638f35b5ec6b0558981378c9037c3d3000", 
+        "rewards": [
+          {
+            "amount": 2000, 
+            "target": "cash_value"
+          }, 
+          {
+            "amount": 1, 
+            "target": "xp_value"
+          }
+        ], 
+        "title": "Improve your image"
+      }
+    }, 
+    {
+      "game_type": "Mission", 
+      "type_data": {
+        "branch": "trunk", 
+        "description": "New mission! Click on Little Rock and recruit Heidi Plum. Doesn\u2019t come cheap, but she\u2019s got excellent contacts.", 
+        "gestalt": "16f302f84b84498a734dfdbe1a7794b9000", 
+        "goals": [
+          {
+            "amount": null, 
+            "position": 1, 
+            "project": null, 
+            "target": "agent004", 
+            "workflow": "buy_perp"
+          }, 
+          {
+            "amount": null, 
+            "position": 2, 
+            "project": null, 
+            "target": "contact026", 
+            "workflow": "buy_perp"
+          }
+        ], 
+        "price": 0, 
+        "required_level": 0, 
+        "required_mission": "9f5735d01587f640cc862e0a82280d3f000", 
+        "rewards": [
+          {
+            "amount": 2000, 
+            "target": "cash_value"
+          }, 
+          {
+            "amount": 1, 
+            "target": "xp_value"
+          }
+        ], 
+        "title": "Unofficial collaboration"
+      }
+    }, 
+    {
+      "game_type": "Mission", 
+      "type_data": {
+        "branch": "trunk", 
+        "description": "New mission! Click on Little Rock, recruit Alfonso, and he\u2019ll procure lots of lucrative customers for your data!", 
+        "gestalt": "dc481d7863ceb18575c50d36e2c5ecfe000", 
+        "goals": [
+          {
+            "amount": null, 
+            "position": 1, 
+            "project": null, 
+            "target": "pusher003", 
+            "workflow": "buy_perp"
+          }
+        ], 
+        "price": 0, 
+        "required_level": 0, 
+        "required_mission": "16f302f84b84498a734dfdbe1a7794b9000", 
+        "rewards": [
+          {
+            "amount": 5000, 
+            "target": "cash_value"
+          }, 
+          {
+            "amount": 1, 
+            "target": "xp_value"
+          }
+        ], 
+        "title": "Alfonso"
+      }
+    }, 
+    {
+      "game_type": "Mission", 
+      "type_data": {
+        "branch": "trunk", 
+        "description": "New mission! Reach Level 9, click on Little Rock and get a second bogus company so you can start additional ventures.", 
+        "gestalt": "3cb9492322191121ebf7a10aafd0fc4a000", 
+        "goals": [
+          {
+            "amount": null, 
+            "position": 1, 
+            "project": null, 
+            "target": "proxy004", 
+            "workflow": "buy_perp"
+          }
+        ], 
+        "price": 0, 
+        "required_level": 0, 
+        "required_mission": "dc481d7863ceb18575c50d36e2c5ecfe000", 
+        "rewards": [
+          {
+            "amount": 2000, 
+            "target": "cash_value"
+          }, 
+          {
+            "amount": 1, 
+            "target": "xp_value"
+          }
+        ], 
+        "title": "Bogus company tangle"
+      }
+    }, 
+    {
+      "game_type": "Mission", 
+      "type_data": {
+        "branch": "trunk", 
+        "description": "New mission! Enter your database, buy the expansion Body Mass Index and start your calculations.", 
+        "gestalt": "1da63b8adf60878f693dfb9d9f73690f000", 
+        "goals": [
+          {
+            "amount": null, 
+            "position": 1, 
+            "project": null, 
+            "target": "token055", 
+            "workflow": "buy_perp"
+          }, 
+          {
+            "amount": null, 
+            "position": 2, 
+            "project": null, 
+            "target": "token055", 
+            "workflow": "upgrade_token"
+          }
+        ], 
+        "price": 0, 
+        "required_level": 0, 
+        "required_mission": "3cb9492322191121ebf7a10aafd0fc4a000", 
+        "rewards": [
+          {
+            "amount": 2000, 
+            "target": "cash_value"
+          }, 
+          {
+            "amount": 1, 
+            "target": "xp_value"
+          }
+        ], 
+        "title": "Multiplication 101"
+      }
+    }, 
+    {
+      "game_type": "Mission", 
+      "type_data": {
+        "branch": "trunk", 
+        "description": "New mission! Reach Level 11, click on Little Rock and expand to New York City. Your target group will multiply tenfold!", 
+        "gestalt": "2f59d10a67ca7ee9006dfe5db31a4c5f000", 
+        "goals": [
+          {
+            "amount": null, 
+            "position": 1, 
+            "project": null, 
+            "target": "city004", 
+            "workflow": "buy_perp"
+          }
+        ], 
+        "price": 0, 
+        "required_level": 0, 
+        "required_mission": "1da63b8adf60878f693dfb9d9f73690f000", 
+        "rewards": [
+          {
+            "amount": 10000, 
+            "target": "cash_value"
+          }, 
+          {
+            "amount": 1, 
+            "target": "xp_value"
+          }
+        ], 
+        "title": "Big Apple, Big Data!"
+      }
+    }
+  ], 
+  "perps": {
+    "13fee24f6edc8f796903e5b1fad001d3000": {
+      "game_type": "StoryPerp", 
+      "type_data": {
+        "perp_sprite": [], 
+        "popup_sprite": [], 
+        "price": 0, 
+        "required_level": 0, 
+        "text": "New customers - perfect! Hint: Take a look at what data Edu Inc is especially interested in and collect more of it."
+      }
+    }, 
+    "48f7fea778e2ceb1d209a8ba4f2eb4a3000": {
+      "game_type": "StoryPerp", 
+      "type_data": {
+        "perp_sprite": [], 
+        "popup_sprite": [], 
+        "price": 0, 
+        "required_level": 0, 
+        "text": "New customers \u2013 perfect! Click on them right away and make a deal. You need more money for your empire!"
+      }
+    }, 
+    "4f74159de0af2bb6b1806091abe8fd7d000": {
+      "game_type": "StoryPerp", 
+      "type_data": {
+        "perp_sprite": [], 
+        "popup_sprite": [], 
+        "price": 0, 
+        "required_level": 0, 
+        "text": "Yeah, your new office in New York City is all set up! Click on it right away and get new bogus companies, agents and brokers for your empire!"
+      }
+    }, 
+    "8ae826a6f66442819cb913f7507dae2b000": {
+      "game_type": "StoryPerp", 
+      "type_data": {
+        "perp_sprite": [], 
+        "popup_sprite": [], 
+        "price": 0, 
+        "required_level": 0, 
+        "text": "By the way: Your customers will pay you more if you can offer them more of the desired data."
+      }
+    }, 
+    "a867c7ac1fffeaec009c8be4baa6f375000": {
+      "game_type": "StoryPerp", 
+      "type_data": {
+        "perp_sprite": [], 
+        "popup_sprite": [], 
+        "price": 0, 
+        "required_level": 0, 
+        "text": "Alfonso is the bomb! Click on him and check whether he has procured a profitable data source for you."
+      }
+    }, 
+    "agent002": {
+      "game_type": "AgentPerp", 
+      "type_data": {
+        "description": "He had a few big cases a decade ago, but the good old days are over. Underpaid, bored and hungry for action, Manny has become quite the expert in sniffing out low-level clerks who have daily access to some fairly personal data. Offer a little cash, and they\u2019ll get you some tasty bits and pieces for your database in return.", 
+        "label": "Manny Mayer", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 780, 
+              "y": 200
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "price": 0, 
+        "provided_perps": [
+          "contact035", 
+          "contact001", 
+          "contact019", 
+          "contact022"
+        ], 
+        "required_level": 1, 
+        "subtitle": "is a private detective and an old friend", 
+        "title": "Manny Mayer"
+      }
+    }, 
+    "agent003": {
+      "game_type": "AgentPerp", 
+      "type_data": {
+        "description": "You\u2019ve never met her in person. Any contact you have is initiated by her. Loft is a phantom, and yet one of your most valuable resources. She\u2019s in contact with some shadowy circles where large packets of delicate data are sold for a song. Even the big companies - eventually, someone always gets in and sneaks out with something worth selling.", 
+        "label": "Mara Loft", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 780, 
+              "y": 100
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "price": 2500, 
+        "provided_perps": [
+          "contact003"
+        ], 
+        "required_level": 19, 
+        "subtitle": "knows the hacker world inside out", 
+        "title": "Mara Loft"
+      }
+    }, 
+    "agent004": {
+      "game_type": "AgentPerp", 
+      "type_data": {
+        "description": "Everybody\u2019s darling on TV and all other media \u2013 those were the days. Ever since she beat up a 12-year old contestant on her live TV show, she\u2019s been out of the picture. However, she still has good contacts, some of whom wouldn\u2019t mind a cash boost and could offer you access to some delicate data. ", 
+        "label": "Heidi Plum", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 780, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-019.png"
+        }, 
+        "price": 800, 
+        "provided_perps": [
+          "contact007", 
+          "contact026", 
+          "contact008", 
+          "contact033"
+        ], 
+        "required_level": 6, 
+        "subtitle": "Knows how to play the media", 
+        "title": "Heidi Plum"
+      }
+    }, 
+    "agent008": {
+      "game_type": "AgentPerp", 
+      "type_data": {
+        "description": "Whether they\u2019re politicians or bureaucrats, serve on boards or with the police: Barnie Maddog knows them all. Or knows someone who does. After all, he used to be a very important man. Those days may be long gone, but he can still hook you up with interesting people who have access to some especially juicy tidbits.", 
+        "label": "Barnie Maddog", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 300, 
+              "y": 660
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 179, 
+              "width": 180, 
+              "x": 720, 
+              "y": 537
+            }
+          }, 
+          "frameSrc": "sprite-019.png"
+        }, 
+        "price": 1700, 
+        "provided_perps": [
+          "contact005", 
+          "contact004"
+        ], 
+        "required_level": 11, 
+        "subtitle": "knows all the political bigwigs", 
+        "title": "Barnie Maddog"
+      }
+    }, 
+    "city002": {
+      "game_type": "CityPerp", 
+      "type_data": {
+        "description": "Little Rock may not be the center of the world, but it makes a pretty good operational base. It\u2019s already home to another data collection company, in fact. From here you can easily expand your empire, control your bogus companies and stay in touch with your network.", 
+        "label": "Little Rock", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 150, 
+              "width": 120, 
+              "x": 0, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-001.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "price": 0, 
+        "profiles_max": 2915918, 
+        "profileset_size": 100000, 
+        "provided_perps": [
+          "agent002", 
+          "agent004", 
+          "pusher004", 
+          "pusher003", 
+          "proxy001", 
+          "proxy004"
+        ], 
+        "required_level": 1, 
+        "title": "Little Rock", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token005", 
+            "gestalt": "token005"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin001", 
+            "gestalt": "origin001"
+          }
+        ]
+      }
+    }, 
+    "city004": {
+      "game_type": "CityPerp", 
+      "type_data": {
+        "description": "New York isn\u2019t exactly cheap, but the perfect location for your second office nonetheless! The Big Apple is where it all comes together. By expanding to New York, your catchment area increases to 40 million people, which means: More profiles for you! From here you control your bogus companies and stay in touch with your network.", 
+        "label": "New York City", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 150, 
+              "width": 120, 
+              "x": 360, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "price": 15000, 
+        "profiles_max": 19378102, 
+        "profileset_size": 1000000, 
+        "provided_perps": [
+          "agent008", 
+          "agent003", 
+          "pusher001", 
+          "proxy002", 
+          "proxy003"
+        ], 
+        "required_level": 11, 
+        "story": {
+          "text": "Yeah, your new office in New York City is all set up! Click on it right away and get new bogus companies, agents and brokers for your empire!", 
+          "trigger": "buy"
+        }, 
+        "title": "New York City", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token005", 
+            "gestalt": "token005"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin014", 
+            "gestalt": "origin014"
+          }
+        ]
+      }
+    }, 
+    "client002": {
+      "game_type": "ClientPerp", 
+      "type_data": {
+        "charge_time": 180000, 
+        "consumed_tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token053", 
+            "gestalt": "token053", 
+            "is_query": false
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token055", 
+            "gestalt": "token055", 
+            "is_query": false
+          }, 
+          {
+            "amount": 70, 
+            "full_type": "TokenPerp:token018", 
+            "gestalt": "token018", 
+            "is_query": false
+          }, 
+          {
+            "amount": 40, 
+            "full_type": "TokenPerp:token125", 
+            "gestalt": "token125", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token006", 
+            "gestalt": "token006", 
+            "is_query": true
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token007", 
+            "gestalt": "token007", 
+            "is_query": true
+          }, 
+          {
+            "amount": 70, 
+            "full_type": "TokenPerp:token017", 
+            "gestalt": "token017", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002", 
+            "is_query": true
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token054", 
+            "gestalt": "token054", 
+            "is_query": false
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token114", 
+            "gestalt": "token114", 
+            "is_query": false
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token092", 
+            "gestalt": "token092", 
+            "is_query": false
+          }, 
+          {
+            "amount": 30, 
+            "full_type": "TokenPerp:token103", 
+            "gestalt": "token103", 
+            "is_query": false
+          }, 
+          {
+            "amount": 30, 
+            "full_type": "TokenPerp:token088", 
+            "gestalt": "token088", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001", 
+            "is_query": true
+          }
+        ], 
+        "description": "Great coverage, low deductible, of course they all want our policy! People are terrified of what could happen if worse came to worst, so we can be choosy. But treating some diseases costs us a pretty penny, and we\u2019d rather avoid that. Before we take on someone new, we need information, like pre-existing conditions and risky behaviors, so we can decide how much we\u2019ll make them pay for the honor. ", 
+        "income_base": 1050, 
+        "income_factor": 143, 
+        "label": "Health Insurance\r\nCompany", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 820, 
+              "y": 300
+            }
+          }, 
+          "frameSrc": "sprite-024.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-019.png"
+        }, 
+        "price": 200, 
+        "provided_tokens": [
+          "token006", 
+          "token007", 
+          "token002", 
+          "token001"
+        ], 
+        "required_level": 1, 
+        "required_providers": [
+          "contact001"
+        ], 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "story": {
+          "text": "New customers \u2013 perfect! Click on them right away and make a deal. You need more money for your empire!", 
+          "trigger": "buy"
+        }, 
+        "title": "Health Insurance", 
+        "xp_inc": 1
+      }
+    }, 
+    "client005": {
+      "game_type": "ClientPerp", 
+      "type_data": {
+        "charge_time": 1800000, 
+        "consumed_tokens": [
+          {
+            "amount": 30, 
+            "full_type": "TokenPerp:token053", 
+            "gestalt": "token053", 
+            "is_query": false
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token115", 
+            "gestalt": "token115", 
+            "is_query": true
+          }, 
+          {
+            "amount": 70, 
+            "full_type": "TokenPerp:token120", 
+            "gestalt": "token120", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token006", 
+            "gestalt": "token006", 
+            "is_query": true
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token067", 
+            "gestalt": "token067", 
+            "is_query": false
+          }, 
+          {
+            "amount": 20, 
+            "full_type": "TokenPerp:token102", 
+            "gestalt": "token102", 
+            "is_query": false
+          }, 
+          {
+            "amount": 30, 
+            "full_type": "TokenPerp:token089", 
+            "gestalt": "token089", 
+            "is_query": false
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token128", 
+            "gestalt": "token128", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002", 
+            "is_query": true
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token030", 
+            "gestalt": "token030", 
+            "is_query": false
+          }, 
+          {
+            "amount": 60, 
+            "full_type": "TokenPerp:token092", 
+            "gestalt": "token092", 
+            "is_query": false
+          }, 
+          {
+            "amount": 20, 
+            "full_type": "TokenPerp:token098", 
+            "gestalt": "token098", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001", 
+            "is_query": true
+          }
+        ], 
+        "description": "Placid, quiet, orderly \u2013 that\u2019s how we like things around here. And we intend to keep them this way. So we need to act quickly to prevent rowdies, punks and other hooligans from gaining a foothold in our beautiful city. And as for political and religious fanatics, we need to keep a watchful eye on them too \u2013 you can\u2019t be too careful with those people!", 
+        "income_base": 4550, 
+        "income_factor": 129, 
+        "label": "City Council", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 820, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-024.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-018.png"
+        }, 
+        "price": 1500, 
+        "provided_tokens": [
+          "token006", 
+          "token002", 
+          "token001"
+        ], 
+        "required_level": 1, 
+        "required_providers": [
+          "contact026"
+        ], 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "story": {
+          "text": "New customers - perfect! Hint: You should always have a few deals on the go to bring in the money.", 
+          "trigger": "buy"
+        }, 
+        "title": "City Council", 
+        "xp_inc": 3
+      }
+    }, 
+    "client006": {
+      "game_type": "ClientPerp", 
+      "type_data": {
+        "charge_time": 180000, 
+        "consumed_tokens": [
+          {
+            "amount": 30, 
+            "full_type": "TokenPerp:token083", 
+            "gestalt": "token083", 
+            "is_query": false
+          }, 
+          {
+            "amount": 30, 
+            "full_type": "TokenPerp:token081", 
+            "gestalt": "token081", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token006", 
+            "gestalt": "token006", 
+            "is_query": true
+          }, 
+          {
+            "amount": 30, 
+            "full_type": "TokenPerp:token047", 
+            "gestalt": "token047", 
+            "is_query": false
+          }, 
+          {
+            "amount": 30, 
+            "full_type": "TokenPerp:token026", 
+            "gestalt": "token026", 
+            "is_query": false
+          }, 
+          {
+            "amount": 20, 
+            "full_type": "TokenPerp:token065", 
+            "gestalt": "token065", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002", 
+            "is_query": true
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token023", 
+            "gestalt": "token023", 
+            "is_query": false
+          }, 
+          {
+            "amount": 30, 
+            "full_type": "TokenPerp:token030", 
+            "gestalt": "token030", 
+            "is_query": false
+          }, 
+          {
+            "amount": 20, 
+            "full_type": "TokenPerp:token090", 
+            "gestalt": "token090", 
+            "is_query": false
+          }, 
+          {
+            "amount": 25, 
+            "full_type": "TokenPerp:token085", 
+            "gestalt": "token085", 
+            "is_query": false
+          }, 
+          {
+            "amount": 30, 
+            "full_type": "TokenPerp:token024", 
+            "gestalt": "token024", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001", 
+            "is_query": true
+          }
+        ], 
+        "description": "With almost 2 million employees, we\u2019re one of the country\u2019s biggest employers. Consequently, our human resources department needs to process thousands of applications every year, ranging from apprentices to managers. We need some background information on our current and future employees so we can sort out the bad eggs more easily.", 
+        "income_base": 1120, 
+        "income_factor": 172, 
+        "label": "Star Mart", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 700, 
+              "y": 640
+            }
+          }, 
+          "frameSrc": "sprite-024.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-019.png"
+        }, 
+        "price": 400, 
+        "provided_tokens": [
+          "token006", 
+          "token002", 
+          "token001"
+        ], 
+        "required_level": 1, 
+        "required_providers": [
+          "project003"
+        ], 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "story": {
+          "text": "By the way: Your customers will pay you more if you can offer them more of the desired data.", 
+          "trigger": "buy"
+        }, 
+        "title": "Star Mart", 
+        "xp_inc": 1
+      }
+    }, 
+    "client007": {
+      "game_type": "ClientPerp", 
+      "type_data": {
+        "charge_time": 60000, 
+        "consumed_tokens": [
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003", 
+            "is_query": false
+          }, 
+          {
+            "amount": 20, 
+            "full_type": "TokenPerp:token012", 
+            "gestalt": "token012", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002", 
+            "is_query": false
+          }, 
+          {
+            "amount": 40, 
+            "full_type": "TokenPerp:token084", 
+            "gestalt": "token084", 
+            "is_query": true
+          }, 
+          {
+            "amount": 40, 
+            "full_type": "TokenPerp:token132", 
+            "gestalt": "token132", 
+            "is_query": true
+          }, 
+          {
+            "amount": 25, 
+            "full_type": "TokenPerp:token099", 
+            "gestalt": "token099", 
+            "is_query": true
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004", 
+            "is_query": false
+          }
+        ], 
+        "description": "Car leasing, what a gold mine! Our ads are filled with super-cheap offers, so people think our cars cost next to nothing. Luckily no one bothers to read the small print, because that\u2019s where we hide the real costs. What we really need are the names and addresses of particularly gullible people that are likely to be taken in by our offers, so we can send them our shiny brochures and wait for them to take the bait.", 
+        "income_base": 584, 
+        "income_factor": 358, 
+        "label": "Car company", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 600, 
+              "y": 640
+            }
+          }, 
+          "frameSrc": "sprite-024.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-019.png"
+        }, 
+        "price": 30, 
+        "provided_tokens": [
+          "token084", 
+          "token132", 
+          "token099"
+        ], 
+        "required_level": 1, 
+        "required_providers": [
+          "contact035"
+        ], 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Car company", 
+        "xp_inc": 1
+      }
+    }, 
+    "client008": {
+      "game_type": "ClientPerp", 
+      "type_data": {
+        "charge_time": 3600000, 
+        "consumed_tokens": [
+          {
+            "amount": 30, 
+            "full_type": "TokenPerp:token053", 
+            "gestalt": "token053", 
+            "is_query": false
+          }, 
+          {
+            "amount": 30, 
+            "full_type": "TokenPerp:token020", 
+            "gestalt": "token020", 
+            "is_query": false
+          }, 
+          {
+            "amount": 20, 
+            "full_type": "TokenPerp:token032", 
+            "gestalt": "token032", 
+            "is_query": false
+          }, 
+          {
+            "amount": 20, 
+            "full_type": "TokenPerp:token022", 
+            "gestalt": "token022", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token006", 
+            "gestalt": "token006", 
+            "is_query": true
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002", 
+            "is_query": true
+          }, 
+          {
+            "amount": 30, 
+            "full_type": "TokenPerp:token040", 
+            "gestalt": "token040", 
+            "is_query": false
+          }, 
+          {
+            "amount": 20, 
+            "full_type": "TokenPerp:token054", 
+            "gestalt": "token054", 
+            "is_query": false
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token023", 
+            "gestalt": "token023", 
+            "is_query": false
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token030", 
+            "gestalt": "token030", 
+            "is_query": false
+          }, 
+          {
+            "amount": 60, 
+            "full_type": "TokenPerp:token092", 
+            "gestalt": "token092", 
+            "is_query": false
+          }, 
+          {
+            "amount": 20, 
+            "full_type": "TokenPerp:token021", 
+            "gestalt": "token021", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001", 
+            "is_query": true
+          }
+        ], 
+        "description": "First off, we don\u2019t need any riffraff at our school. Second, no harm knowing a little about what our students are up to in their free time. Mental problems? Smoking? Playing video games all night? Good to know. Our schools have a reputation to protect!", 
+        "income_base": 6300, 
+        "income_factor": 122, 
+        "label": "Edu Inc", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 500, 
+              "y": 640
+            }
+          }, 
+          "frameSrc": "sprite-024.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-018.png"
+        }, 
+        "price": 2100, 
+        "provided_tokens": [
+          "token006", 
+          "token002", 
+          "token001"
+        ], 
+        "required_level": 1, 
+        "required_providers": [
+          "contact008"
+        ], 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "story": {
+          "text": "New customers - perfect! Hint: Take a look at what data Edu Inc is especially interested in and collect more of it.", 
+          "trigger": "buy"
+        }, 
+        "title": "Edu Inc", 
+        "xp_inc": 4
+      }
+    }, 
+    "client010": {
+      "game_type": "ClientPerp", 
+      "type_data": {
+        "charge_time": 7200000, 
+        "consumed_tokens": [
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003", 
+            "is_query": false
+          }, 
+          {
+            "amount": 20, 
+            "full_type": "TokenPerp:token064", 
+            "gestalt": "token064", 
+            "is_query": false
+          }, 
+          {
+            "amount": 20, 
+            "full_type": "TokenPerp:token012", 
+            "gestalt": "token012", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token007", 
+            "gestalt": "token007", 
+            "is_query": false
+          }, 
+          {
+            "amount": 20, 
+            "full_type": "TokenPerp:token065", 
+            "gestalt": "token065", 
+            "is_query": true
+          }, 
+          {
+            "amount": 20, 
+            "full_type": "TokenPerp:token113", 
+            "gestalt": "token113", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002", 
+            "is_query": false
+          }, 
+          {
+            "amount": 20, 
+            "full_type": "TokenPerp:token084", 
+            "gestalt": "token084", 
+            "is_query": false
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token132", 
+            "gestalt": "token132", 
+            "is_query": false
+          }, 
+          {
+            "amount": 4, 
+            "full_type": "TokenPerp:token005", 
+            "gestalt": "token005", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004", 
+            "is_query": false
+          }
+        ], 
+        "description": "We sell toys. All kinds of toys. Toys for babies, toys for teens. And we need the addresses of parents. Or parents-to-be. Ideally parents who only want what\u2019s best for their kids. And what is best for their kids? Why, our products of course! And get us those parents who won\u2019t just trash our brochures \u2013 get us those who\u2019ll buy.", 
+        "income_base": 8050, 
+        "income_factor": 64, 
+        "label": "Toys \u00b4R\u00b4 Nice", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 300, 
+              "y": 640
+            }
+          }, 
+          "frameSrc": "sprite-024.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-019.png"
+        }, 
+        "price": 2400, 
+        "provided_tokens": [
+          "token064", 
+          "token065"
+        ], 
+        "required_level": 1, 
+        "required_providers": [
+          "project002"
+        ], 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Toys \u00b4R\u00b4 Nice", 
+        "xp_inc": 6
+      }
+    }, 
+    "client011": {
+      "game_type": "ClientPerp", 
+      "type_data": {
+        "charge_time": 14400000, 
+        "consumed_tokens": [
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003", 
+            "is_query": false
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token029", 
+            "gestalt": "token029", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002", 
+            "is_query": false
+          }, 
+          {
+            "amount": 30, 
+            "full_type": "TokenPerp:token040", 
+            "gestalt": "token040", 
+            "is_query": false
+          }, 
+          {
+            "amount": 70, 
+            "full_type": "TokenPerp:token123", 
+            "gestalt": "token123", 
+            "is_query": true
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004", 
+            "is_query": false
+          }
+        ], 
+        "description": "It used to be so easy: Every year we created another cookie-cutter superstar, produced a few hits and made millions. But every since those MP3s appeared, everything\u2019s gone to hell. No one buys our pricey CDs anymore! Instead, every child now knows how to download songs off the net. If only we could track all those copyright infringers, we\u2019d sue them and get our money that way...", 
+        "income_base": 11200, 
+        "income_factor": 3, 
+        "label": "Major Label", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 200, 
+              "y": 640
+            }
+          }, 
+          "frameSrc": "sprite-024.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-018.png"
+        }, 
+        "price": 3700, 
+        "provided_tokens": [
+          "token123"
+        ], 
+        "required_level": 1, 
+        "required_providers": [
+          "project007"
+        ], 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Major Label", 
+        "xp_inc": 9
+      }
+    }, 
+    "client014": {
+      "game_type": "ClientPerp", 
+      "type_data": {
+        "charge_time": 7200000, 
+        "consumed_tokens": [
+          {
+            "amount": 20, 
+            "full_type": "TokenPerp:token064", 
+            "gestalt": "token064", 
+            "is_query": false
+          }, 
+          {
+            "amount": 20, 
+            "full_type": "TokenPerp:token032", 
+            "gestalt": "token032", 
+            "is_query": false
+          }, 
+          {
+            "amount": 80, 
+            "full_type": "TokenPerp:token018", 
+            "gestalt": "token018", 
+            "is_query": false
+          }, 
+          {
+            "amount": 70, 
+            "full_type": "TokenPerp:token120", 
+            "gestalt": "token120", 
+            "is_query": false
+          }, 
+          {
+            "amount": 20, 
+            "full_type": "TokenPerp:token012", 
+            "gestalt": "token012", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token006", 
+            "gestalt": "token006", 
+            "is_query": true
+          }, 
+          {
+            "amount": 20, 
+            "full_type": "TokenPerp:token102", 
+            "gestalt": "token102", 
+            "is_query": false
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:supertoken014", 
+            "gestalt": "supertoken014", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002", 
+            "is_query": true
+          }, 
+          {
+            "amount": 70, 
+            "full_type": "TokenPerp:token013", 
+            "gestalt": "token013", 
+            "is_query": false
+          }, 
+          {
+            "amount": 30, 
+            "full_type": "TokenPerp:token024", 
+            "gestalt": "token024", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001", 
+            "is_query": true
+          }
+        ], 
+        "description": "Our establishment doesn\u2019t just give out accounts to anyone. And loans? Don\u2019t make me laugh. Even when we do, there\u2019s still the question of what it will cost each client. To make this kind of decision, we need EVERY bit of info that can help us assess current and potential customers and decide who to blacklist (and who to woo). Doesn't matter whether those predictions hold true in every case, as long as we make a tidy profit.", 
+        "income_base": 8400, 
+        "income_factor": 43, 
+        "label": "Bank", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 720, 
+              "y": 500
+            }
+          }, 
+          "frameSrc": "sprite-024.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-019.png"
+        }, 
+        "price": 2800, 
+        "provided_tokens": [
+          "token006", 
+          "token002", 
+          "token001"
+        ], 
+        "required_level": 1, 
+        "required_providers": [
+          "contact004"
+        ], 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Bank", 
+        "xp_inc": 6
+      }
+    }, 
+    "client016": {
+      "game_type": "ClientPerp", 
+      "type_data": {
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "label": "Company.Com", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 720, 
+              "y": 300
+            }
+          }, 
+          "frameSrc": "sprite-024.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-019.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Company.Com"
+      }
+    }, 
+    "client019": {
+      "game_type": "ClientPerp", 
+      "type_data": {
+        "charge_time": 28800000, 
+        "consumed_tokens": [
+          {
+            "amount": 20, 
+            "full_type": "TokenPerp:token064", 
+            "gestalt": "token064", 
+            "is_query": false
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token066", 
+            "gestalt": "token066", 
+            "is_query": false
+          }, 
+          {
+            "amount": 20, 
+            "full_type": "TokenPerp:token032", 
+            "gestalt": "token032", 
+            "is_query": false
+          }, 
+          {
+            "amount": 20, 
+            "full_type": "TokenPerp:token022", 
+            "gestalt": "token022", 
+            "is_query": false
+          }, 
+          {
+            "amount": 70, 
+            "full_type": "TokenPerp:token120", 
+            "gestalt": "token120", 
+            "is_query": false
+          }, 
+          {
+            "amount": 20, 
+            "full_type": "TokenPerp:token012", 
+            "gestalt": "token012", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token006", 
+            "gestalt": "token006", 
+            "is_query": true
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token129", 
+            "gestalt": "token129", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002", 
+            "is_query": true
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token030", 
+            "gestalt": "token030", 
+            "is_query": false
+          }, 
+          {
+            "amount": 70, 
+            "full_type": "TokenPerp:token013", 
+            "gestalt": "token013", 
+            "is_query": false
+          }, 
+          {
+            "amount": 20, 
+            "full_type": "TokenPerp:token021", 
+            "gestalt": "token021", 
+            "is_query": false
+          }, 
+          {
+            "amount": 2, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001", 
+            "is_query": true
+          }
+        ], 
+        "description": "Our members own a plenty of houses and apartments \u2013 and they would really like to \u201cget to know\u201c their new tenants a little better before they move in. People who live beyond their means or \u2013 heaven forbid \u2013 are in debt are out of the question anyway. And some want nothing else but boring hetero couples without pets, kids or drugs. Everyone else can very kindly piss off.", 
+        "income_base": 15750, 
+        "income_factor": 1, 
+        "label": "National Rental Housing", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 720, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-024.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-018.png"
+        }, 
+        "price": 5300, 
+        "provided_tokens": [
+          "token006", 
+          "token002", 
+          "token001"
+        ], 
+        "required_level": 1, 
+        "required_providers": [
+          "project006"
+        ], 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "National Rental Housing", 
+        "xp_inc": 12
+      }
+    }, 
+    "contact001": {
+      "game_type": "ContactPerp", 
+      "type_data": {
+        "charge_cost": 190, 
+        "charge_time": 120000, 
+        "collect_amount": 3300, 
+        "collect_risk": 1, 
+        "description": "Nurse Helen works at the county\u2019s largest hospital. For 20 years she\u2019s slaved away in the sick ward. Now her hours have been increased and her wages cut. Incidentally, she\u2019s got full access to the hospital\u2019s central database. She needs the money, and would be willing to supply you with reliable data on her patients\u2019 health status.", 
+        "label": "Nurse Helen", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 900, 
+              "y": 240
+            }
+          }, 
+          "frameSrc": "sprite-010.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 900
+            }
+          }, 
+          "frameSrc": "sprite-017.png"
+        }, 
+        "price": 400, 
+        "required_level": 3, 
+        "title": "Nurse Helen", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token006", 
+            "gestalt": "token006"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token007", 
+            "gestalt": "token007"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token005", 
+            "gestalt": "token005"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token014", 
+            "gestalt": "token014"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token015", 
+            "gestalt": "token015"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token017", 
+            "gestalt": "token017"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token018", 
+            "gestalt": "token018"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin012", 
+            "gestalt": "origin012"
+          }
+        ], 
+        "xp_inc": 1
+      }
+    }, 
+    "contact003": {
+      "game_type": "ContactPerp", 
+      "type_data": {
+        "charge_cost": 1620, 
+        "charge_time": 3600000, 
+        "collect_amount": 25900, 
+        "collect_risk": 2, 
+        "description": "He calls himself Uncle Enzo and claims to have hacked into the online network of a global game console provider. Says it was pretty easy, too. He\u2019s not just offering names and addresses, but passwords, credit card numbers and game lists. All in all, he\u2019s sitting on almost a million data sets for your country alone \u2013 you really need to get your hands on those!", 
+        "label": "Uncle Enzo", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 900, 
+              "y": 160
+            }
+          }, 
+          "frameSrc": "sprite-010.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-016.png"
+        }, 
+        "price": 4900, 
+        "required_level": 19, 
+        "title": "Uncle Enzo", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token006", 
+            "gestalt": "token006"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token007", 
+            "gestalt": "token007"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token005", 
+            "gestalt": "token005"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token008", 
+            "gestalt": "token008"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token029", 
+            "gestalt": "token029"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token027", 
+            "gestalt": "token027"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token028", 
+            "gestalt": "token028"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token032", 
+            "gestalt": "token032"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin022", 
+            "gestalt": "origin022"
+          }
+        ], 
+        "xp_inc": 9
+      }
+    }, 
+    "contact004": {
+      "game_type": "ContactPerp", 
+      "type_data": {
+        "charge_cost": 1320, 
+        "charge_time": 1800000, 
+        "collect_amount": 22600, 
+        "collect_risk": 3, 
+        "description": "For thirty years, Paul Peeves has done foreclosures and he grew sick long ago of visiting those poor, heavily indebted bastards, hauling away their TVs, computers and cars. No surprise he\u2019s turned a little cynical (can you say \u201cburnout\u201d?) If you soothe his pain with a few bucks, he\u2019ll gladly send you the details on his \u201ccustomers\u201d - and those of a few associates as well.", 
+        "label": "Paul Peeves", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 900, 
+              "y": 80
+            }
+          }, 
+          "frameSrc": "sprite-010.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 900
+            }
+          }, 
+          "frameSrc": "sprite-017.png"
+        }, 
+        "price": 4000, 
+        "required_level": 11, 
+        "title": "Paul Peeves", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token006", 
+            "gestalt": "token006"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token007", 
+            "gestalt": "token007"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token013", 
+            "gestalt": "token013"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin020", 
+            "gestalt": "origin020"
+          }
+        ], 
+        "xp_inc": 5
+      }
+    }, 
+    "contact005": {
+      "game_type": "ContactPerp", 
+      "type_data": {
+        "charge_cost": 970, 
+        "charge_time": 1800000, 
+        "collect_amount": 4850, 
+        "collect_risk": 1, 
+        "description": "Beverly Compton-Burr works at the Department of Education and heads the division that manages the fancy new central student database \u2013 storing all the minute details of each and every student file, to \u201csimplify administration.\u201d She earns good money, but she may have gotten in a little over her head with that new penthouse suite...", 
+        "label": "Beverly\r\nCompton-Burr", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 900, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-010.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-016.png"
+        }, 
+        "price": 2900, 
+        "required_level": 16, 
+        "title": "Beverly Compton-Burr", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token006", 
+            "gestalt": "token006"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token007", 
+            "gestalt": "token007"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token011", 
+            "gestalt": "token011"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token048", 
+            "gestalt": "token048"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token130", 
+            "gestalt": "token130"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin021", 
+            "gestalt": "origin021"
+          }
+        ], 
+        "xp_inc": 6
+      }
+    }, 
+    "contact007": {
+      "game_type": "ContactPerp", 
+      "type_data": {
+        "charge_cost": 240, 
+        "charge_time": 240000, 
+        "collect_amount": 5400, 
+        "collect_risk": 1, 
+        "description": "Sadik attends at least 10 events every night, taking rapid fire photos without rest. Of course he makes sure to get the email addresses of the over-illuminated subjects of his pictures \u2013 so he can send them the photos! Then he spends the rest of the night uploading everything to a party photo site. Too bad they don\u2019t pay so well. At least he has full access to each and every picture on site.", 
+        "label": "Sadik Guerrero", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 720, 
+              "y": 800
+            }
+          }, 
+          "frameSrc": "sprite-010.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-016.png"
+        }, 
+        "price": 700, 
+        "required_level": 6, 
+        "title": "Sadik Guerrero", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token007", 
+            "gestalt": "token007"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token008", 
+            "gestalt": "token008"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token023", 
+            "gestalt": "token023"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token036", 
+            "gestalt": "token036"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin009", 
+            "gestalt": "origin009"
+          }
+        ], 
+        "xp_inc": 2
+      }
+    }, 
+    "contact008": {
+      "game_type": "ContactPerp", 
+      "type_data": {
+        "charge_cost": 460, 
+        "charge_time": 300000, 
+        "collect_amount": 7100, 
+        "collect_risk": 1, 
+        "description": "Lennon has been a youth worker at the local center for years. He started out motivated and badly paid \u2013 now the bad pay is all that remains. He recently started using a program common to many youth centers across the country. It logs all sorts of data about the teens frequenting the center \u2013 whether they\u2019ve got a criminal record, whether they smoke, that kind of thing. Sounds handy, right?", 
+        "label": "Lennon Che Ramirez", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 640, 
+              "y": 800
+            }
+          }, 
+          "frameSrc": "sprite-010.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-016.png"
+        }, 
+        "price": 1400, 
+        "required_level": 8, 
+        "title": "Lennon Che\r\nRamirez", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token006", 
+            "gestalt": "token006"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token085", 
+            "gestalt": "token085"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token088", 
+            "gestalt": "token088"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token089", 
+            "gestalt": "token089"
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token092", 
+            "gestalt": "token092"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token120", 
+            "gestalt": "token120"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token054", 
+            "gestalt": "token054"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token053", 
+            "gestalt": "token053"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin008", 
+            "gestalt": "origin008"
+          }
+        ], 
+        "xp_inc": 2
+      }
+    }, 
+    "contact019": {
+      "game_type": "ContactPerp", 
+      "type_data": {
+        "charge_cost": 210, 
+        "charge_time": 180000, 
+        "collect_amount": 4000, 
+        "collect_risk": 1, 
+        "description": "Alexa is a personal trainer at a popular nationwide fitness chain. Ten years ago she had her moment in the limelight, even had her own DVD. But those days are long gone, and spandex stardom is a faded memory. Thankfully, she has admin access to the chain's database, which stores everything from attendance records to health details from members' wellness and nutrition counseling.", 
+        "label": "Alexa C. Tivia", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 80, 
+              "y": 800
+            }
+          }, 
+          "frameSrc": "sprite-010.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-016.png"
+        }, 
+        "price": 500, 
+        "required_level": 4, 
+        "title": "Alexa C. Tivia", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token006", 
+            "gestalt": "token006"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token005", 
+            "gestalt": "token005"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token014", 
+            "gestalt": "token014"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token015", 
+            "gestalt": "token015"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token088", 
+            "gestalt": "token088"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token083", 
+            "gestalt": "token083"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token125", 
+            "gestalt": "token125"
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token065", 
+            "gestalt": "token065"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin010", 
+            "gestalt": "origin010"
+          }
+        ], 
+        "xp_inc": 1
+      }
+    }, 
+    "contact022": {
+      "game_type": "ContactPerp", 
+      "type_data": {
+        "charge_cost": 320, 
+        "charge_time": 240000, 
+        "collect_amount": 5700, 
+        "collect_risk": 1, 
+        "description": "Riley delivers pizza for one of those big fast food chains. Quite stressful, that. By now she knows what her regulars usually want. Four beers and a quattro formaggio with extra cheese every day? Or a once-in-a-while salad pizza and still water? She recently started receiving those orders straight to her smartphone \u2013 so she can always keep track of what\u2019s waiting for her at the next address.", 
+        "label": "Riley V. Red", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 720, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-010.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-016.png"
+        }, 
+        "price": 1000, 
+        "required_level": 6, 
+        "title": "Riley V. Red", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token005", 
+            "gestalt": "token005"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token008", 
+            "gestalt": "token008"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token125", 
+            "gestalt": "token125"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token132", 
+            "gestalt": "token132"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin013", 
+            "gestalt": "origin013"
+          }
+        ], 
+        "xp_inc": 2
+      }
+    }, 
+    "contact026": {
+      "game_type": "ContactPerp", 
+      "type_data": {
+        "charge_cost": 400, 
+        "charge_time": 300000, 
+        "collect_amount": 6800, 
+        "collect_risk": 1, 
+        "description": "Elly works at a public library which is connected to a nationwide network. The new computer system they recently had installed collects very detailed information on each and every loan. Not only can Elly search who borrowed which books and for how long \u2013 she can print off whole lists of that sort! Pretty sweet!", 
+        "label": "Elly DeTelly ", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 400, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-010.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-016.png"
+        }, 
+        "price": 1200, 
+        "required_level": 7, 
+        "title": "Elly DeTelly ", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token006", 
+            "gestalt": "token006"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token007", 
+            "gestalt": "token007"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token005", 
+            "gestalt": "token005"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token008", 
+            "gestalt": "token008"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token115", 
+            "gestalt": "token115"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin006", 
+            "gestalt": "origin006"
+          }
+        ], 
+        "xp_inc": 2
+      }
+    }, 
+    "contact033": {
+      "game_type": "ContactPerp", 
+      "type_data": {
+        "charge_cost": 1130, 
+        "charge_time": 1800000, 
+        "collect_amount": 18900, 
+        "collect_risk": 1, 
+        "description": "Hana works for a large publishing house distributing hundreds of newspapers and magazines. Yeah, one of the real big ones. That means she has access to some comprehensive subscription lists \u2013 everything from Lonely Hearts Gazette to Guinea Pig Monthly and MAD Management Mag. There must be something in there you can use \u2013 so don\u2019t let this opportunity pass you by.", 
+        "label": "Hana Blum", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 720, 
+              "y": 620
+            }
+          }, 
+          "frameSrc": "sprite-010.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-017.png"
+        }, 
+        "price": 3400, 
+        "required_level": 16, 
+        "title": "Hana Blum", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token006", 
+            "gestalt": "token006"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token007", 
+            "gestalt": "token007"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token005", 
+            "gestalt": "token005"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token008", 
+            "gestalt": "token008"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token128", 
+            "gestalt": "token128"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token132", 
+            "gestalt": "token132"
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token028", 
+            "gestalt": "token028"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin007", 
+            "gestalt": "origin007"
+          }
+        ], 
+        "xp_inc": 3
+      }
+    }, 
+    "contact035": {
+      "game_type": "ContactPerp", 
+      "type_data": {
+        "charge_cost": 60, 
+        "charge_time": 30000, 
+        "collect_amount": 1100, 
+        "collect_risk": 1, 
+        "description": "Jessica works at the city\u2019s largest casino, and it\u2019s a complete drag. Once people get started with roulette, poker or slot machines, there\u2019s no end in sight until they\u2019re flat broke. Security is essential, so every guest is logged. Seeing those poor bastards gamble away more money than she\u2019s ever going to earn has made Jessica somewhat cynical, so if you send a little sugar her way, she\u2019ll let you know who the regulars are.", 
+        "label": "Jessica Seno", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 720, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-010.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-016.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Jessica Seno", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token005", 
+            "gestalt": "token005"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token008", 
+            "gestalt": "token008"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token084", 
+            "gestalt": "token084"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token102", 
+            "gestalt": "token102"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin011", 
+            "gestalt": "origin011"
+          }
+        ], 
+        "xp_inc": 1
+      }
+    }, 
+    "database001": {
+      "game_type": "DatabasePerp", 
+      "type_data": {
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "label": "Database", 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Database"
+      }
+    }, 
+    "ddd374508122aa3ca8c1bc8e72b9bcf4000": {
+      "game_type": "StoryPerp", 
+      "type_data": {
+        "perp_sprite": [], 
+        "popup_sprite": [], 
+        "price": 0, 
+        "required_level": 0, 
+        "text": "New customers - perfect! Hint: You should always have a few deals on the go to bring in the money."
+      }
+    }, 
+    "project001": {
+      "game_type": "ProjectPerp", 
+      "type_data": {
+        "ad_slots": 3, 
+        "charge_cost": 190, 
+        "charge_time": 300000, 
+        "collect_amount": 3600, 
+        "collect_risk": 2, 
+        "description": "Dangle a big fat carrot in front of their nose and they won\u2019t be able to resist!\r\nYou can rake in the info with an attractive sweepstakes prize.\r\nThe hotter the ticket, the more suckers will go for it!", 
+        "label": "Sweepstakes", 
+        "max_ad_slots": 7, 
+        "max_teammember_slots": 14, 
+        "max_upgrade_slots": 10, 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 300, 
+              "y": 700
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "price": 300, 
+        "provided_ads": [
+          {
+            "charge_cost_modifier": 35, 
+            "collect_amount_modifier": 160, 
+            "collect_risk_modifier": 0, 
+            "full_type": "AdPowerup:ad002", 
+            "gestalt": "ad002", 
+            "notification": false, 
+            "price": 90, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 55, 
+            "collect_amount_modifier": 390, 
+            "collect_risk_modifier": 0, 
+            "full_type": "AdPowerup:ad003", 
+            "gestalt": "ad003", 
+            "notification": false, 
+            "price": 130, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 80, 
+            "collect_amount_modifier": 870, 
+            "collect_risk_modifier": 0, 
+            "full_type": "AdPowerup:ad001", 
+            "gestalt": "ad001", 
+            "notification": false, 
+            "price": 180, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 111, 
+            "collect_amount_modifier": 1340, 
+            "collect_risk_modifier": 0, 
+            "full_type": "AdPowerup:ad004", 
+            "gestalt": "ad004", 
+            "notification": false, 
+            "price": 240, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 139, 
+            "collect_amount_modifier": 1580, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad010", 
+            "gestalt": "ad010", 
+            "notification": false, 
+            "price": 420, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 150, 
+            "collect_amount_modifier": 1730, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad012", 
+            "gestalt": "ad012", 
+            "notification": true, 
+            "price": 450, 
+            "required_level": 14
+          }
+        ], 
+        "provided_teammembers": [
+          {
+            "charge_cost_modifier": 41, 
+            "collect_amount_modifier": 160, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember020", 
+            "gestalt": "teammember020", 
+            "notification": false, 
+            "price": 110, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 35, 
+            "collect_amount_modifier": 180, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember021", 
+            "gestalt": "teammember021", 
+            "notification": false, 
+            "price": 100, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 47, 
+            "collect_amount_modifier": 240, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember014", 
+            "gestalt": "teammember014", 
+            "notification": false, 
+            "price": 130, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 41, 
+            "collect_amount_modifier": 270, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember015", 
+            "gestalt": "teammember015", 
+            "notification": false, 
+            "price": 110, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 56, 
+            "collect_amount_modifier": 360, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember001", 
+            "gestalt": "teammember001", 
+            "notification": true, 
+            "price": 150, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 50, 
+            "collect_amount_modifier": 410, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember023", 
+            "gestalt": "teammember023", 
+            "notification": false, 
+            "price": 130, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 50, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -2, 
+            "full_type": "TeamMemberPowerup:teammember044", 
+            "gestalt": "teammember044", 
+            "notification": false, 
+            "price": 150, 
+            "required_level": 6
+          }, 
+          {
+            "charge_cost_modifier": 45, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -2, 
+            "full_type": "TeamMemberPowerup:teammember043", 
+            "gestalt": "teammember043", 
+            "notification": true, 
+            "price": 140, 
+            "required_level": 6
+          }, 
+          {
+            "charge_cost_modifier": 67, 
+            "collect_amount_modifier": 500, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember026", 
+            "gestalt": "teammember026", 
+            "notification": false, 
+            "price": 170, 
+            "required_level": 10
+          }, 
+          {
+            "charge_cost_modifier": 60, 
+            "collect_amount_modifier": 570, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember042", 
+            "gestalt": "teammember042", 
+            "notification": true, 
+            "price": 150, 
+            "required_level": 10
+          }, 
+          {
+            "charge_cost_modifier": 67, 
+            "collect_amount_modifier": 500, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember005", 
+            "gestalt": "teammember005", 
+            "notification": true, 
+            "price": 170, 
+            "required_level": 13
+          }, 
+          {
+            "charge_cost_modifier": 60, 
+            "collect_amount_modifier": 570, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember006", 
+            "gestalt": "teammember006", 
+            "notification": false, 
+            "price": 150, 
+            "required_level": 13
+          }, 
+          {
+            "charge_cost_modifier": 71, 
+            "collect_amount_modifier": 790, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember012", 
+            "gestalt": "teammember012", 
+            "notification": false, 
+            "price": 180, 
+            "required_level": 15
+          }, 
+          {
+            "charge_cost_modifier": 64, 
+            "collect_amount_modifier": 890, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember036", 
+            "gestalt": "teammember036", 
+            "notification": true, 
+            "price": 160, 
+            "required_level": 15
+          }
+        ], 
+        "provided_upgrades": [
+          {
+            "charge_cost_modifier": 41, 
+            "collect_amount_modifier": 320, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade001", 
+            "gestalt": "upgrade001", 
+            "notification": false, 
+            "price": 160, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 53, 
+            "collect_amount_modifier": 790, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade002", 
+            "gestalt": "upgrade002", 
+            "notification": false, 
+            "price": 230, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 119, 
+            "collect_amount_modifier": 1580, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade004", 
+            "gestalt": "upgrade004", 
+            "notification": false, 
+            "price": 540, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 101, 
+            "collect_amount_modifier": 1260, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade003", 
+            "gestalt": "upgrade003", 
+            "notification": false, 
+            "price": 450, 
+            "required_level": 10
+          }, 
+          {
+            "charge_cost_modifier": 45, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -2, 
+            "full_type": "UpgradePowerup:upgrade008", 
+            "gestalt": "upgrade008", 
+            "notification": true, 
+            "price": 140, 
+            "required_level": 9
+          }, 
+          {
+            "charge_cost_modifier": 32, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 2, 
+            "full_type": "UpgradePowerup:upgrade006", 
+            "gestalt": "upgrade006", 
+            "notification": false, 
+            "price": 100, 
+            "required_level": 8
+          }, 
+          {
+            "charge_cost_modifier": 63, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 2, 
+            "full_type": "UpgradePowerup:upgrade007", 
+            "gestalt": "upgrade007", 
+            "notification": false, 
+            "price": 190, 
+            "required_level": 8
+          }, 
+          {
+            "charge_cost_modifier": 51, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 2, 
+            "full_type": "UpgradePowerup:upgrade005", 
+            "gestalt": "upgrade005", 
+            "notification": true, 
+            "price": 150, 
+            "required_level": 8
+          }, 
+          {
+            "charge_cost_modifier": 24, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade112", 
+            "gestalt": "upgrade112", 
+            "notification": true, 
+            "price": 70, 
+            "required_level": 10
+          }, 
+          {
+            "charge_cost_modifier": 49, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade146", 
+            "gestalt": "upgrade146", 
+            "notification": true, 
+            "price": 150, 
+            "required_level": 10
+          }
+        ], 
+        "rename_ads_tab": false, 
+        "required_level": 2, 
+        "slot_cost": 10, 
+        "slot_cost_modifier": 1, 
+        "story": {
+          "text": "Your first venture, yeah! Hint: To make sure your raffle collects lots of data you need to invest some money first.", 
+          "trigger": "buy"
+        }, 
+        "teammember_slots": 3, 
+        "title": "Sweepstakes", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004"
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token006", 
+            "gestalt": "token006"
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token005", 
+            "gestalt": "token005"
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token008", 
+            "gestalt": "token008"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token084", 
+            "gestalt": "token084"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token102", 
+            "gestalt": "token102"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token132", 
+            "gestalt": "token132"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token012", 
+            "gestalt": "token012"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token129", 
+            "gestalt": "token129"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token064", 
+            "gestalt": "token064"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token065", 
+            "gestalt": "token065"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token011", 
+            "gestalt": "token011"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token130", 
+            "gestalt": "token130"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin001", 
+            "gestalt": "origin001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin002", 
+            "gestalt": "origin002"
+          }
+        ], 
+        "upgrade_slots": 3, 
+        "xp_inc": 2
+      }
+    }, 
+    "project002": {
+      "game_type": "ProjectPerp", 
+      "type_data": {
+        "ad_slots": 3, 
+        "charge_cost": 1330, 
+        "charge_time": 7200000, 
+        "collect_amount": 25900, 
+        "collect_risk": 3, 
+        "description": "For the chance to find their soulmate, lonely souls will pour out their hearts to you, and let you in on their deepest secrets. Once you line up email-addresses and pseudonyms with the real names, things start to get interesting.", 
+        "label": "Dating Site", 
+        "max_ad_slots": 10, 
+        "max_teammember_slots": 18, 
+        "max_upgrade_slots": 10, 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 200, 
+              "y": 700
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-005.png"
+        }, 
+        "price": 4000, 
+        "provided_ads": [
+          {
+            "charge_cost_modifier": 138, 
+            "collect_amount_modifier": 520, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad006", 
+            "gestalt": "ad006", 
+            "notification": false, 
+            "price": 390, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 176, 
+            "collect_amount_modifier": 1030, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad007", 
+            "gestalt": "ad007", 
+            "notification": true, 
+            "price": 530, 
+            "required_level": 12
+          }, 
+          {
+            "charge_cost_modifier": 282, 
+            "collect_amount_modifier": 2930, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad005", 
+            "gestalt": "ad005", 
+            "notification": true, 
+            "price": 700, 
+            "required_level": 12
+          }, 
+          {
+            "charge_cost_modifier": 269, 
+            "collect_amount_modifier": 3100, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad012", 
+            "gestalt": "ad012", 
+            "notification": true, 
+            "price": 660, 
+            "required_level": 14
+          }, 
+          {
+            "charge_cost_modifier": 181, 
+            "collect_amount_modifier": 1380, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad013", 
+            "gestalt": "ad013", 
+            "notification": false, 
+            "price": 490, 
+            "required_level": 9
+          }, 
+          {
+            "charge_cost_modifier": 231, 
+            "collect_amount_modifier": 2410, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad014", 
+            "gestalt": "ad014", 
+            "notification": false, 
+            "price": 690, 
+            "required_level": 9
+          }, 
+          {
+            "charge_cost_modifier": 252, 
+            "collect_amount_modifier": 2760, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad015", 
+            "gestalt": "ad015", 
+            "notification": false, 
+            "price": 970, 
+            "required_level": 9
+          }, 
+          {
+            "charge_cost_modifier": 293, 
+            "collect_amount_modifier": 3450, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad009", 
+            "gestalt": "ad009", 
+            "notification": false, 
+            "price": 880, 
+            "required_level": 9
+          }, 
+          {
+            "charge_cost_modifier": 233, 
+            "collect_amount_modifier": 2070, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad025", 
+            "gestalt": "ad025", 
+            "notification": true, 
+            "price": 700, 
+            "required_level": 18
+          }
+        ], 
+        "provided_teammembers": [
+          {
+            "charge_cost_modifier": 127, 
+            "collect_amount_modifier": 690, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember020", 
+            "gestalt": "teammember020", 
+            "notification": false, 
+            "price": 360, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 109, 
+            "collect_amount_modifier": 780, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember021", 
+            "gestalt": "teammember021", 
+            "notification": false, 
+            "price": 300, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 144, 
+            "collect_amount_modifier": 1030, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember014", 
+            "gestalt": "teammember014", 
+            "notification": false, 
+            "price": 400, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 126, 
+            "collect_amount_modifier": 1160, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember015", 
+            "gestalt": "teammember015", 
+            "notification": false, 
+            "price": 340, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 162, 
+            "collect_amount_modifier": 1380, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember001", 
+            "gestalt": "teammember001", 
+            "notification": true, 
+            "price": 430, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 142, 
+            "collect_amount_modifier": 1550, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember023", 
+            "gestalt": "teammember023", 
+            "notification": false, 
+            "price": 380, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 151, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -1, 
+            "full_type": "TeamMemberPowerup:teammember044", 
+            "gestalt": "teammember044", 
+            "notification": false, 
+            "price": 450, 
+            "required_level": 6
+          }, 
+          {
+            "charge_cost_modifier": 136, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -1, 
+            "full_type": "TeamMemberPowerup:teammember043", 
+            "gestalt": "teammember043", 
+            "notification": true, 
+            "price": 410, 
+            "required_level": 6
+          }, 
+          {
+            "charge_cost_modifier": 196, 
+            "collect_amount_modifier": 2070, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember026", 
+            "gestalt": "teammember026", 
+            "notification": false, 
+            "price": 510, 
+            "required_level": 10
+          }, 
+          {
+            "charge_cost_modifier": 174, 
+            "collect_amount_modifier": 2330, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember042", 
+            "gestalt": "teammember042", 
+            "notification": true, 
+            "price": 450, 
+            "required_level": 10
+          }, 
+          {
+            "charge_cost_modifier": 213, 
+            "collect_amount_modifier": 2410, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember005", 
+            "gestalt": "teammember005", 
+            "notification": true, 
+            "price": 550, 
+            "required_level": 13
+          }, 
+          {
+            "charge_cost_modifier": 190, 
+            "collect_amount_modifier": 2720, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember006", 
+            "gestalt": "teammember006", 
+            "notification": false, 
+            "price": 490, 
+            "required_level": 13
+          }, 
+          {
+            "charge_cost_modifier": 176, 
+            "collect_amount_modifier": 2550, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember012", 
+            "gestalt": "teammember012", 
+            "notification": false, 
+            "price": 450, 
+            "required_level": 15
+          }, 
+          {
+            "charge_cost_modifier": 157, 
+            "collect_amount_modifier": 2870, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember036", 
+            "gestalt": "teammember036", 
+            "notification": true, 
+            "price": 400, 
+            "required_level": 15
+          }, 
+          {
+            "charge_cost_modifier": 231, 
+            "collect_amount_modifier": 2760, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember035", 
+            "gestalt": "teammember035", 
+            "notification": true, 
+            "price": 590, 
+            "required_level": 19
+          }, 
+          {
+            "charge_cost_modifier": 207, 
+            "collect_amount_modifier": 3100, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember049", 
+            "gestalt": "teammember049", 
+            "notification": false, 
+            "price": 530, 
+            "required_level": 19
+          }
+        ], 
+        "provided_upgrades": [
+          {
+            "charge_cost_modifier": 123, 
+            "collect_amount_modifier": 1380, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade001", 
+            "gestalt": "upgrade001", 
+            "notification": false, 
+            "price": 310, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 136, 
+            "collect_amount_modifier": 1720, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade009", 
+            "gestalt": "upgrade009", 
+            "notification": false, 
+            "price": 340, 
+            "required_level": 9
+          }, 
+          {
+            "charge_cost_modifier": 114, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 4, 
+            "full_type": "UpgradePowerup:upgrade012", 
+            "gestalt": "upgrade012", 
+            "notification": true, 
+            "price": 340, 
+            "required_level": 14
+          }, 
+          {
+            "charge_cost_modifier": 194, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -2, 
+            "full_type": "UpgradePowerup:upgrade008", 
+            "gestalt": "upgrade008", 
+            "notification": true, 
+            "price": 580, 
+            "required_level": 9
+          }, 
+          {
+            "charge_cost_modifier": 404, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 2, 
+            "full_type": "UpgradePowerup:upgrade114", 
+            "gestalt": "upgrade114", 
+            "notification": false, 
+            "price": 1210, 
+            "required_level": 9
+          }, 
+          {
+            "charge_cost_modifier": 298, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 3, 
+            "full_type": "UpgradePowerup:upgrade113", 
+            "gestalt": "upgrade113", 
+            "notification": true, 
+            "price": 890, 
+            "required_level": 14
+          }, 
+          {
+            "charge_cost_modifier": 188, 
+            "collect_amount_modifier": 3100, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade013", 
+            "gestalt": "upgrade013", 
+            "notification": false, 
+            "price": 780, 
+            "required_level": 12
+          }, 
+          {
+            "charge_cost_modifier": 234, 
+            "collect_amount_modifier": 3790, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade010", 
+            "gestalt": "upgrade010", 
+            "notification": true, 
+            "price": 1000, 
+            "required_level": 12
+          }, 
+          {
+            "charge_cost_modifier": 233, 
+            "collect_amount_modifier": 4830, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade109", 
+            "gestalt": "upgrade109", 
+            "notification": true, 
+            "price": 830, 
+            "required_level": 20
+          }
+        ], 
+        "rename_ads_tab": false, 
+        "required_level": 9, 
+        "slot_cost": 30, 
+        "slot_cost_modifier": 0, 
+        "teammember_slots": 3, 
+        "title": "Dating Site", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token006", 
+            "gestalt": "token006"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token007", 
+            "gestalt": "token007"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token008", 
+            "gestalt": "token008"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token036", 
+            "gestalt": "token036"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token015", 
+            "gestalt": "token015"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token014", 
+            "gestalt": "token014"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token033", 
+            "gestalt": "token033"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token034", 
+            "gestalt": "token034"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token022", 
+            "gestalt": "token022"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token021", 
+            "gestalt": "token021"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token040", 
+            "gestalt": "token040"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token029", 
+            "gestalt": "token029"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token086", 
+            "gestalt": "token086"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token081", 
+            "gestalt": "token081"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token129", 
+            "gestalt": "token129"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token097", 
+            "gestalt": "token097"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token030", 
+            "gestalt": "token030"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token020", 
+            "gestalt": "token020"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token066", 
+            "gestalt": "token066"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token024", 
+            "gestalt": "token024"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token025", 
+            "gestalt": "token025"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin001", 
+            "gestalt": "origin001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin005", 
+            "gestalt": "origin005"
+          }
+        ], 
+        "upgrade_slots": 3, 
+        "xp_inc": 11
+      }
+    }, 
+    "project003": {
+      "game_type": "ProjectPerp", 
+      "type_data": {
+        "ad_slots": 3, 
+        "charge_cost": 360, 
+        "charge_time": 1800000, 
+        "collect_amount": 11000, 
+        "collect_risk": 2, 
+        "description": "Everyone loves online personality tests! And with their help, you can create detailed character profiles. Of course, to see the premium analysis of their laboriously filled out tests, participants just need to enter a few personal details...", 
+        "label": "Personality Tests", 
+        "max_ad_slots": 8, 
+        "max_teammember_slots": 18, 
+        "max_upgrade_slots": 13, 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 300, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-024.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-005.png"
+        }, 
+        "price": 1100, 
+        "provided_ads": [
+          {
+            "charge_cost_modifier": 376, 
+            "collect_amount_modifier": 730, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad006", 
+            "gestalt": "ad006", 
+            "notification": false, 
+            "price": 1130, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 392, 
+            "collect_amount_modifier": 1280, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad007", 
+            "gestalt": "ad007", 
+            "notification": true, 
+            "price": 1130, 
+            "required_level": 12
+          }, 
+          {
+            "charge_cost_modifier": 482, 
+            "collect_amount_modifier": 1460, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad005", 
+            "gestalt": "ad005", 
+            "notification": true, 
+            "price": 1820, 
+            "required_level": 12
+          }, 
+          {
+            "charge_cost_modifier": 554, 
+            "collect_amount_modifier": 1820, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad010", 
+            "gestalt": "ad010", 
+            "notification": false, 
+            "price": 1660, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 505, 
+            "collect_amount_modifier": 2190, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad023", 
+            "gestalt": "ad023", 
+            "notification": true, 
+            "price": 1250, 
+            "required_level": 18
+          }, 
+          {
+            "charge_cost_modifier": 546, 
+            "collect_amount_modifier": 2550, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad024", 
+            "gestalt": "ad024", 
+            "notification": true, 
+            "price": 1330, 
+            "required_level": 18
+          }, 
+          {
+            "charge_cost_modifier": 534, 
+            "collect_amount_modifier": 2910, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad025", 
+            "gestalt": "ad025", 
+            "notification": true, 
+            "price": 1290, 
+            "required_level": 18
+          }
+        ], 
+        "provided_teammembers": [
+          {
+            "charge_cost_modifier": 209, 
+            "collect_amount_modifier": 360, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember020", 
+            "gestalt": "teammember020", 
+            "notification": false, 
+            "price": 580, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 180, 
+            "collect_amount_modifier": 410, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember021", 
+            "gestalt": "teammember021", 
+            "notification": false, 
+            "price": 500, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 239, 
+            "collect_amount_modifier": 550, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember014", 
+            "gestalt": "teammember014", 
+            "notification": false, 
+            "price": 650, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 208, 
+            "collect_amount_modifier": 610, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember015", 
+            "gestalt": "teammember015", 
+            "notification": false, 
+            "price": 560, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 287, 
+            "collect_amount_modifier": 840, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember001", 
+            "gestalt": "teammember001", 
+            "notification": true, 
+            "price": 760, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 254, 
+            "collect_amount_modifier": 940, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember023", 
+            "gestalt": "teammember023", 
+            "notification": false, 
+            "price": 670, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 463, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -2, 
+            "full_type": "TeamMemberPowerup:teammember044", 
+            "gestalt": "teammember044", 
+            "notification": false, 
+            "price": 1390, 
+            "required_level": 6
+          }, 
+          {
+            "charge_cost_modifier": 438, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -2, 
+            "full_type": "TeamMemberPowerup:teammember043", 
+            "gestalt": "teammember043", 
+            "notification": true, 
+            "price": 1310, 
+            "required_level": 6
+          }, 
+          {
+            "charge_cost_modifier": 341, 
+            "collect_amount_modifier": 1170, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember026", 
+            "gestalt": "teammember026", 
+            "notification": false, 
+            "price": 880, 
+            "required_level": 10
+          }, 
+          {
+            "charge_cost_modifier": 304, 
+            "collect_amount_modifier": 1310, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember042", 
+            "gestalt": "teammember042", 
+            "notification": true, 
+            "price": 780, 
+            "required_level": 10
+          }, 
+          {
+            "charge_cost_modifier": 341, 
+            "collect_amount_modifier": 1170, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember005", 
+            "gestalt": "teammember005", 
+            "notification": true, 
+            "price": 880, 
+            "required_level": 13
+          }, 
+          {
+            "charge_cost_modifier": 304, 
+            "collect_amount_modifier": 1310, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember006", 
+            "gestalt": "teammember006", 
+            "notification": false, 
+            "price": 780, 
+            "required_level": 13
+          }, 
+          {
+            "charge_cost_modifier": 287, 
+            "collect_amount_modifier": 1280, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember012", 
+            "gestalt": "teammember012", 
+            "notification": false, 
+            "price": 740, 
+            "required_level": 15
+          }, 
+          {
+            "charge_cost_modifier": 257, 
+            "collect_amount_modifier": 1430, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember036", 
+            "gestalt": "teammember036", 
+            "notification": true, 
+            "price": 660, 
+            "required_level": 15
+          }, 
+          {
+            "charge_cost_modifier": 329, 
+            "collect_amount_modifier": 1090, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember035", 
+            "gestalt": "teammember035", 
+            "notification": true, 
+            "price": 860, 
+            "required_level": 19
+          }, 
+          {
+            "charge_cost_modifier": 293, 
+            "collect_amount_modifier": 1230, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember049", 
+            "gestalt": "teammember049", 
+            "notification": false, 
+            "price": 760, 
+            "required_level": 19
+          }
+        ], 
+        "provided_upgrades": [
+          {
+            "charge_cost_modifier": 210, 
+            "collect_amount_modifier": 730, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade001", 
+            "gestalt": "upgrade001", 
+            "notification": false, 
+            "price": 800, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 752, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -4, 
+            "full_type": "UpgradePowerup:upgrade008", 
+            "gestalt": "upgrade008", 
+            "notification": true, 
+            "price": 2260, 
+            "required_level": 9
+          }, 
+          {
+            "charge_cost_modifier": 277, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 2, 
+            "full_type": "UpgradePowerup:upgrade017", 
+            "gestalt": "upgrade017", 
+            "notification": false, 
+            "price": 830, 
+            "required_level": 12
+          }, 
+          {
+            "charge_cost_modifier": 305, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 4, 
+            "full_type": "UpgradePowerup:upgrade018", 
+            "gestalt": "upgrade018", 
+            "notification": true, 
+            "price": 920, 
+            "required_level": 12
+          }, 
+          {
+            "charge_cost_modifier": 293, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade015", 
+            "gestalt": "upgrade015", 
+            "notification": false, 
+            "price": 880, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 417, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade120", 
+            "gestalt": "upgrade120", 
+            "notification": false, 
+            "price": 1250, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 293, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade117", 
+            "gestalt": "upgrade117", 
+            "notification": false, 
+            "price": 880, 
+            "required_level": 8
+          }, 
+          {
+            "charge_cost_modifier": 231, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade119", 
+            "gestalt": "upgrade119", 
+            "notification": true, 
+            "price": 690, 
+            "required_level": 8
+          }, 
+          {
+            "charge_cost_modifier": 417, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade118", 
+            "gestalt": "upgrade118", 
+            "notification": false, 
+            "price": 1250, 
+            "required_level": 8
+          }, 
+          {
+            "charge_cost_modifier": 215, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 2, 
+            "full_type": "UpgradePowerup:upgrade116", 
+            "gestalt": "upgrade116", 
+            "notification": false, 
+            "price": 640, 
+            "required_level": 12
+          }, 
+          {
+            "charge_cost_modifier": 727, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade016", 
+            "gestalt": "upgrade016", 
+            "notification": false, 
+            "price": 2180, 
+            "required_level": 12
+          }, 
+          {
+            "charge_cost_modifier": 397, 
+            "collect_amount_modifier": 2550, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade109", 
+            "gestalt": "upgrade109", 
+            "notification": true, 
+            "price": 1410, 
+            "required_level": 20
+          }
+        ], 
+        "rename_ads_tab": false, 
+        "required_level": 5, 
+        "slot_cost": 80, 
+        "slot_cost_modifier": 0, 
+        "story": {
+          "text": "Good job! Hint: If you upgrade the personality test and the raffle, you\u2019ll get more profiles and maybe even additional attributes.", 
+          "trigger": "buy"
+        }, 
+        "teammember_slots": 3, 
+        "title": "Personality Tests", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token026", 
+            "gestalt": "token026"
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token007", 
+            "gestalt": "token007"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token006", 
+            "gestalt": "token006"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token029", 
+            "gestalt": "token029"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token053", 
+            "gestalt": "token053"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token120", 
+            "gestalt": "token120"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token025", 
+            "gestalt": "token025"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token081", 
+            "gestalt": "token081"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token012", 
+            "gestalt": "token012"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token008", 
+            "gestalt": "token008"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token084", 
+            "gestalt": "token084"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token132", 
+            "gestalt": "token132"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token117", 
+            "gestalt": "token117"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token022", 
+            "gestalt": "token022"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token065", 
+            "gestalt": "token065"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token085", 
+            "gestalt": "token085"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token089", 
+            "gestalt": "token089"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token103", 
+            "gestalt": "token103"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token092", 
+            "gestalt": "token092"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token090", 
+            "gestalt": "token090"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token066", 
+            "gestalt": "token066"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token021", 
+            "gestalt": "token021"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token024", 
+            "gestalt": "token024"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token083", 
+            "gestalt": "token083"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin001", 
+            "gestalt": "origin001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin003", 
+            "gestalt": "origin003"
+          }
+        ], 
+        "upgrade_slots": 3, 
+        "xp_inc": 4
+      }
+    }, 
+    "project004": {
+      "game_type": "ProjectPerp", 
+      "type_data": {
+        "ad_slots": 3, 
+        "charge_cost": 1790, 
+        "charge_time": 7200000, 
+        "collect_amount": 25900, 
+        "collect_risk": 3, 
+        "description": "Tell me what you buy, and I\u2019ll tell you who you are! Operate your loyalty card scheme for supermarkets, gas stations, furniture stores or fitness studios. Special offers for club members draw shoppers like moths, and you learn everything about their purchases.", 
+        "label": "Club Cards", 
+        "max_ad_slots": 7, 
+        "max_teammember_slots": 18, 
+        "max_upgrade_slots": 9, 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 100, 
+              "y": 700
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "price": 5400, 
+        "provided_ads": [
+          {
+            "charge_cost_modifier": 233, 
+            "collect_amount_modifier": 1380, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad008", 
+            "gestalt": "ad008", 
+            "notification": false, 
+            "price": 620, 
+            "required_level": 12
+          }, 
+          {
+            "charge_cost_modifier": 315, 
+            "collect_amount_modifier": 2070, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad005", 
+            "gestalt": "ad005", 
+            "notification": true, 
+            "price": 790, 
+            "required_level": 12
+          }, 
+          {
+            "charge_cost_modifier": 321, 
+            "collect_amount_modifier": 2760, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad010", 
+            "gestalt": "ad010", 
+            "notification": false, 
+            "price": 960, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 324, 
+            "collect_amount_modifier": 2410, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad012", 
+            "gestalt": "ad012", 
+            "notification": true, 
+            "price": 970, 
+            "required_level": 14
+          }, 
+          {
+            "charge_cost_modifier": 349, 
+            "collect_amount_modifier": 3790, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad013", 
+            "gestalt": "ad013", 
+            "notification": false, 
+            "price": 1050, 
+            "required_level": 9
+          }, 
+          {
+            "charge_cost_modifier": 368, 
+            "collect_amount_modifier": 3450, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad016", 
+            "gestalt": "ad016", 
+            "notification": true, 
+            "price": 1490, 
+            "required_level": 20
+          }
+        ], 
+        "provided_teammembers": [
+          {
+            "charge_cost_modifier": 160, 
+            "collect_amount_modifier": 690, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember020", 
+            "gestalt": "teammember020", 
+            "notification": false, 
+            "price": 440, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 138, 
+            "collect_amount_modifier": 780, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember021", 
+            "gestalt": "teammember021", 
+            "notification": false, 
+            "price": 380, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 184, 
+            "collect_amount_modifier": 1030, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember014", 
+            "gestalt": "teammember014", 
+            "notification": false, 
+            "price": 500, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 161, 
+            "collect_amount_modifier": 1160, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember015", 
+            "gestalt": "teammember015", 
+            "notification": false, 
+            "price": 430, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 234, 
+            "collect_amount_modifier": 1720, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember001", 
+            "gestalt": "teammember001", 
+            "notification": true, 
+            "price": 610, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 208, 
+            "collect_amount_modifier": 1940, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember023", 
+            "gestalt": "teammember023", 
+            "notification": false, 
+            "price": 540, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 184, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -1, 
+            "full_type": "TeamMemberPowerup:teammember044", 
+            "gestalt": "teammember044", 
+            "notification": false, 
+            "price": 550, 
+            "required_level": 6
+          }, 
+          {
+            "charge_cost_modifier": 165, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -1, 
+            "full_type": "TeamMemberPowerup:teammember043", 
+            "gestalt": "teammember043", 
+            "notification": true, 
+            "price": 500, 
+            "required_level": 6
+          }, 
+          {
+            "charge_cost_modifier": 406, 
+            "collect_amount_modifier": 3100, 
+            "collect_risk_modifier": -1, 
+            "full_type": "TeamMemberPowerup:teammember026", 
+            "gestalt": "teammember026", 
+            "notification": false, 
+            "price": 1060, 
+            "required_level": 10
+          }, 
+          {
+            "charge_cost_modifier": 300, 
+            "collect_amount_modifier": 3490, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember042", 
+            "gestalt": "teammember042", 
+            "notification": true, 
+            "price": 750, 
+            "required_level": 10
+          }, 
+          {
+            "charge_cost_modifier": 308, 
+            "collect_amount_modifier": 2760, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember005", 
+            "gestalt": "teammember005", 
+            "notification": true, 
+            "price": 780, 
+            "required_level": 13
+          }, 
+          {
+            "charge_cost_modifier": 277, 
+            "collect_amount_modifier": 3100, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember006", 
+            "gestalt": "teammember006", 
+            "notification": false, 
+            "price": 700, 
+            "required_level": 13
+          }, 
+          {
+            "charge_cost_modifier": 266, 
+            "collect_amount_modifier": 3100, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember012", 
+            "gestalt": "teammember012", 
+            "notification": false, 
+            "price": 670, 
+            "required_level": 15
+          }, 
+          {
+            "charge_cost_modifier": 240, 
+            "collect_amount_modifier": 3490, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember036", 
+            "gestalt": "teammember036", 
+            "notification": true, 
+            "price": 600, 
+            "required_level": 15
+          }
+        ], 
+        "provided_upgrades": [
+          {
+            "charge_cost_modifier": 198, 
+            "collect_amount_modifier": 2070, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade001", 
+            "gestalt": "upgrade001", 
+            "notification": false, 
+            "price": 470, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 248, 
+            "collect_amount_modifier": 2760, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade024", 
+            "gestalt": "upgrade024", 
+            "notification": false, 
+            "price": 740, 
+            "required_level": 11
+          }, 
+          {
+            "charge_cost_modifier": 202, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade146", 
+            "gestalt": "upgrade146", 
+            "notification": true, 
+            "price": 610, 
+            "required_level": 10
+          }, 
+          {
+            "charge_cost_modifier": 239, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -2, 
+            "full_type": "UpgradePowerup:upgrade008", 
+            "gestalt": "upgrade008", 
+            "notification": true, 
+            "price": 720, 
+            "required_level": 9
+          }, 
+          {
+            "charge_cost_modifier": 387, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 2, 
+            "full_type": "UpgradePowerup:upgrade021", 
+            "gestalt": "upgrade021", 
+            "notification": false, 
+            "price": 1160, 
+            "required_level": 11
+          }, 
+          {
+            "charge_cost_modifier": 295, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 2, 
+            "full_type": "UpgradePowerup:upgrade022", 
+            "gestalt": "upgrade022", 
+            "notification": false, 
+            "price": 880, 
+            "required_level": 11
+          }, 
+          {
+            "charge_cost_modifier": 272, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 2, 
+            "full_type": "UpgradePowerup:upgrade023", 
+            "gestalt": "upgrade023", 
+            "notification": false, 
+            "price": 810, 
+            "required_level": 17
+          }, 
+          {
+            "charge_cost_modifier": 180, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 2, 
+            "full_type": "UpgradePowerup:upgrade020", 
+            "gestalt": "upgrade020", 
+            "notification": true, 
+            "price": 540, 
+            "required_level": 17
+          }, 
+          {
+            "charge_cost_modifier": 262, 
+            "collect_amount_modifier": 3450, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade038", 
+            "gestalt": "upgrade038", 
+            "notification": false, 
+            "price": 720, 
+            "required_level": 11
+          }
+        ], 
+        "rename_ads_tab": false, 
+        "required_level": 11, 
+        "slot_cost": 60, 
+        "slot_cost_modifier": 0, 
+        "teammember_slots": 3, 
+        "title": "Club Cards", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token006", 
+            "gestalt": "token006"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token007", 
+            "gestalt": "token007"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token005", 
+            "gestalt": "token005"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token008", 
+            "gestalt": "token008"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token099", 
+            "gestalt": "token099"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token125", 
+            "gestalt": "token125"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token067", 
+            "gestalt": "token067"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token030", 
+            "gestalt": "token030"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token083", 
+            "gestalt": "token083"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token014", 
+            "gestalt": "token014"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token015", 
+            "gestalt": "token015"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token088", 
+            "gestalt": "token088"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token012", 
+            "gestalt": "token012"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token070", 
+            "gestalt": "token070"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token113", 
+            "gestalt": "token113"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token069", 
+            "gestalt": "token069"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token132", 
+            "gestalt": "token132"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin014", 
+            "gestalt": "origin014"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin015", 
+            "gestalt": "origin015"
+          }
+        ], 
+        "upgrade_slots": 3, 
+        "xp_inc": 13
+      }
+    }, 
+    "project005": {
+      "game_type": "ProjectPerp", 
+      "type_data": {
+        "ad_slots": 0, 
+        "charge_cost": 990, 
+        "charge_time": 3600000, 
+        "collect_amount": 16900, 
+        "collect_risk": 3, 
+        "description": "Why do things the hard way? Just call people up and get all that lucrative information directly from their mouths! Just introduce yourself as a reputable market research institute, say you just have a few discreet questions. The more specific and convincing you make your calls, the better results this kind of phone terrorizing will get you.", 
+        "label": "Telephone\r\nsurvey", 
+        "max_ad_slots": 0, 
+        "max_teammember_slots": 18, 
+        "max_upgrade_slots": 15, 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 200, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-024.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-005.png"
+        }, 
+        "price": 3000, 
+        "provided_ads": [], 
+        "provided_teammembers": [
+          {
+            "charge_cost_modifier": 162, 
+            "collect_amount_modifier": 500, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember020", 
+            "gestalt": "teammember020", 
+            "notification": false, 
+            "price": 450, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 140, 
+            "collect_amount_modifier": 560, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember021", 
+            "gestalt": "teammember021", 
+            "notification": false, 
+            "price": 390, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 186, 
+            "collect_amount_modifier": 750, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember014", 
+            "gestalt": "teammember014", 
+            "notification": false, 
+            "price": 510, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 162, 
+            "collect_amount_modifier": 850, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember015", 
+            "gestalt": "teammember015", 
+            "notification": false, 
+            "price": 440, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 224, 
+            "collect_amount_modifier": 1150, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember001", 
+            "gestalt": "teammember001", 
+            "notification": true, 
+            "price": 590, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 198, 
+            "collect_amount_modifier": 1300, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember023", 
+            "gestalt": "teammember023", 
+            "notification": false, 
+            "price": 520, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 327, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -3, 
+            "full_type": "TeamMemberPowerup:teammember044", 
+            "gestalt": "teammember044", 
+            "notification": false, 
+            "price": 980, 
+            "required_level": 6
+          }, 
+          {
+            "charge_cost_modifier": 307, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -3, 
+            "full_type": "TeamMemberPowerup:teammember043", 
+            "gestalt": "teammember043", 
+            "notification": true, 
+            "price": 920, 
+            "required_level": 6
+          }, 
+          {
+            "charge_cost_modifier": 314, 
+            "collect_amount_modifier": 2010, 
+            "collect_risk_modifier": -1, 
+            "full_type": "TeamMemberPowerup:teammember012", 
+            "gestalt": "teammember012", 
+            "notification": false, 
+            "price": 830, 
+            "required_level": 15
+          }, 
+          {
+            "charge_cost_modifier": 289, 
+            "collect_amount_modifier": 2260, 
+            "collect_risk_modifier": -1, 
+            "full_type": "TeamMemberPowerup:teammember036", 
+            "gestalt": "teammember036", 
+            "notification": true, 
+            "price": 760, 
+            "required_level": 15
+          }, 
+          {
+            "charge_cost_modifier": 281, 
+            "collect_amount_modifier": 1760, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember016", 
+            "gestalt": "teammember016", 
+            "notification": false, 
+            "price": 720, 
+            "required_level": 17
+          }, 
+          {
+            "charge_cost_modifier": 251, 
+            "collect_amount_modifier": 1980, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember017", 
+            "gestalt": "teammember017", 
+            "notification": true, 
+            "price": 640, 
+            "required_level": 17
+          }
+        ], 
+        "provided_upgrades": [
+          {
+            "charge_cost_modifier": 214, 
+            "collect_amount_modifier": 1510, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade029", 
+            "gestalt": "upgrade029", 
+            "notification": false, 
+            "price": 560, 
+            "required_level": 7
+          }, 
+          {
+            "charge_cost_modifier": 307, 
+            "collect_amount_modifier": 3010, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade028", 
+            "gestalt": "upgrade028", 
+            "notification": false, 
+            "price": 680, 
+            "required_level": 7
+          }, 
+          {
+            "charge_cost_modifier": 459, 
+            "collect_amount_modifier": 4520, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade026", 
+            "gestalt": "upgrade026", 
+            "notification": true, 
+            "price": 1650, 
+            "required_level": 13
+          }, 
+          {
+            "charge_cost_modifier": 483, 
+            "collect_amount_modifier": 5020, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade025", 
+            "gestalt": "upgrade025", 
+            "notification": false, 
+            "price": 2040, 
+            "required_level": 13
+          }, 
+          {
+            "charge_cost_modifier": 643, 
+            "collect_amount_modifier": 7530, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade027", 
+            "gestalt": "upgrade027", 
+            "notification": false, 
+            "price": 2140, 
+            "required_level": 13
+          }, 
+          {
+            "charge_cost_modifier": 378, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -4, 
+            "full_type": "UpgradePowerup:upgrade008", 
+            "gestalt": "upgrade008", 
+            "notification": true, 
+            "price": 1130, 
+            "required_level": 9
+          }, 
+          {
+            "charge_cost_modifier": 204, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade030", 
+            "gestalt": "upgrade030", 
+            "notification": false, 
+            "price": 610, 
+            "required_level": 7
+          }, 
+          {
+            "charge_cost_modifier": 252, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade033", 
+            "gestalt": "upgrade033", 
+            "notification": false, 
+            "price": 760, 
+            "required_level": 7
+          }, 
+          {
+            "charge_cost_modifier": 156, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade032", 
+            "gestalt": "upgrade032", 
+            "notification": true, 
+            "price": 470, 
+            "required_level": 13
+          }, 
+          {
+            "charge_cost_modifier": 108, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade037", 
+            "gestalt": "upgrade037", 
+            "notification": false, 
+            "price": 330, 
+            "required_level": 7
+          }, 
+          {
+            "charge_cost_modifier": 61, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade110", 
+            "gestalt": "upgrade110", 
+            "notification": false, 
+            "price": 180, 
+            "required_level": 7
+          }, 
+          {
+            "charge_cost_modifier": 204, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade031", 
+            "gestalt": "upgrade031", 
+            "notification": true, 
+            "price": 610, 
+            "required_level": 13
+          }, 
+          {
+            "charge_cost_modifier": 156, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade034", 
+            "gestalt": "upgrade034", 
+            "notification": false, 
+            "price": 470, 
+            "required_level": 13
+          }, 
+          {
+            "charge_cost_modifier": 84, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade036", 
+            "gestalt": "upgrade036", 
+            "notification": false, 
+            "price": 250, 
+            "required_level": 13
+          }
+        ], 
+        "rename_ads_tab": false, 
+        "required_level": 7, 
+        "slot_cost": 70, 
+        "slot_cost_modifier": 100, 
+        "story": {
+          "text": "Those nuisance calls do take some time, but every time you invest, you get more than 10.000 profiles, even more if you have upgrades!", 
+          "trigger": "buy"
+        }, 
+        "teammember_slots": 3, 
+        "title": "Telephone survey", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token006", 
+            "gestalt": "token006"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token007", 
+            "gestalt": "token007"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token005", 
+            "gestalt": "token005"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token008", 
+            "gestalt": "token008"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token114", 
+            "gestalt": "token114"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token012", 
+            "gestalt": "token012"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token125", 
+            "gestalt": "token125"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token047", 
+            "gestalt": "token047"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token094", 
+            "gestalt": "token094"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token064", 
+            "gestalt": "token064"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token065", 
+            "gestalt": "token065"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token030", 
+            "gestalt": "token030"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token093", 
+            "gestalt": "token093"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token098", 
+            "gestalt": "token098"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token103", 
+            "gestalt": "token103"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin001", 
+            "gestalt": "origin001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin004", 
+            "gestalt": "origin004"
+          }
+        ], 
+        "upgrade_slots": 3, 
+        "xp_inc": 7
+      }
+    }, 
+    "project006": {
+      "game_type": "ProjectPerp", 
+      "type_data": {
+        "ad_slots": 0, 
+        "charge_cost": 3440, 
+        "charge_time": 28800000, 
+        "collect_amount": 61400, 
+        "collect_risk": 5, 
+        "description": "Know those elegant cards usually enclosed with products, especially the more expensive ones? Many people dutifully fill them out and send them in, thinking this will get them special treatment if something should break. However, the manufacturer never sees those cards \u2013 they go straight to you. In turn, you\u2019re responsible for evaluation.", 
+        "label": "Warranty Cards", 
+        "max_ad_slots": 0, 
+        "max_teammember_slots": 18, 
+        "max_upgrade_slots": 12, 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 0, 
+              "y": 700
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "price": 10300, 
+        "provided_ads": [], 
+        "provided_teammembers": [
+          {
+            "charge_cost_modifier": 400, 
+            "collect_amount_modifier": 1930, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember014", 
+            "gestalt": "teammember014", 
+            "notification": false, 
+            "price": 1130, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 343, 
+            "collect_amount_modifier": 2170, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember015", 
+            "gestalt": "teammember015", 
+            "notification": false, 
+            "price": 970, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 369, 
+            "collect_amount_modifier": 1280, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember020", 
+            "gestalt": "teammember020", 
+            "notification": false, 
+            "price": 1060, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 314, 
+            "collect_amount_modifier": 1440, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember021", 
+            "gestalt": "teammember021", 
+            "notification": false, 
+            "price": 900, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 461, 
+            "collect_amount_modifier": 3210, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember001", 
+            "gestalt": "teammember001", 
+            "notification": true, 
+            "price": 1270, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 400, 
+            "collect_amount_modifier": 3610, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember023", 
+            "gestalt": "teammember023", 
+            "notification": false, 
+            "price": 1090, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 682, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -4, 
+            "full_type": "TeamMemberPowerup:teammember044", 
+            "gestalt": "teammember044", 
+            "notification": false, 
+            "price": 2050, 
+            "required_level": 6
+          }, 
+          {
+            "charge_cost_modifier": 631, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -4, 
+            "full_type": "TeamMemberPowerup:teammember043", 
+            "gestalt": "teammember043", 
+            "notification": true, 
+            "price": 1890, 
+            "required_level": 6
+          }, 
+          {
+            "charge_cost_modifier": 491, 
+            "collect_amount_modifier": 3850, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember005", 
+            "gestalt": "teammember005", 
+            "notification": true, 
+            "price": 1340, 
+            "required_level": 13
+          }, 
+          {
+            "charge_cost_modifier": 428, 
+            "collect_amount_modifier": 4330, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember006", 
+            "gestalt": "teammember006", 
+            "notification": false, 
+            "price": 1160, 
+            "required_level": 13
+          }, 
+          {
+            "charge_cost_modifier": 442, 
+            "collect_amount_modifier": 5130, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember012", 
+            "gestalt": "teammember012", 
+            "notification": false, 
+            "price": 1180, 
+            "required_level": 15
+          }, 
+          {
+            "charge_cost_modifier": 388, 
+            "collect_amount_modifier": 5780, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember036", 
+            "gestalt": "teammember036", 
+            "notification": true, 
+            "price": 1030, 
+            "required_level": 15
+          }
+        ], 
+        "provided_upgrades": [
+          {
+            "charge_cost_modifier": 278, 
+            "collect_amount_modifier": 1280, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade001", 
+            "gestalt": "upgrade001", 
+            "notification": false, 
+            "price": 780, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 429, 
+            "collect_amount_modifier": 1930, 
+            "collect_risk_modifier": -1, 
+            "full_type": "UpgradePowerup:upgrade038", 
+            "gestalt": "upgrade038", 
+            "notification": false, 
+            "price": 1200, 
+            "required_level": 11
+          }, 
+          {
+            "charge_cost_modifier": 441, 
+            "collect_amount_modifier": 3850, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade040", 
+            "gestalt": "upgrade040", 
+            "notification": false, 
+            "price": 1320, 
+            "required_level": 18
+          }, 
+          {
+            "charge_cost_modifier": 348, 
+            "collect_amount_modifier": 3850, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade029", 
+            "gestalt": "upgrade029", 
+            "notification": false, 
+            "price": 1280, 
+            "required_level": 7
+          }, 
+          {
+            "charge_cost_modifier": 450, 
+            "collect_amount_modifier": 6420, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade039", 
+            "gestalt": "upgrade039", 
+            "notification": false, 
+            "price": 630, 
+            "required_level": 20
+          }, 
+          {
+            "charge_cost_modifier": 631, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -4, 
+            "full_type": "UpgradePowerup:upgrade008", 
+            "gestalt": "upgrade008", 
+            "notification": true, 
+            "price": 1890, 
+            "required_level": 9
+          }, 
+          {
+            "charge_cost_modifier": 421, 
+            "collect_amount_modifier": 6420, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade044", 
+            "gestalt": "upgrade044", 
+            "notification": false, 
+            "price": 1010, 
+            "required_level": 18
+          }, 
+          {
+            "charge_cost_modifier": 473, 
+            "collect_amount_modifier": 6420, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade045", 
+            "gestalt": "upgrade045", 
+            "notification": false, 
+            "price": 1130, 
+            "required_level": 18
+          }, 
+          {
+            "charge_cost_modifier": 615, 
+            "collect_amount_modifier": 8980, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade147", 
+            "gestalt": "upgrade147", 
+            "notification": false, 
+            "price": 1710, 
+            "required_level": 18
+          }, 
+          {
+            "charge_cost_modifier": 258, 
+            "collect_amount_modifier": 1280, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade041", 
+            "gestalt": "upgrade041", 
+            "notification": false, 
+            "price": 630, 
+            "required_level": 20
+          }, 
+          {
+            "charge_cost_modifier": 258, 
+            "collect_amount_modifier": 1280, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade042", 
+            "gestalt": "upgrade042", 
+            "notification": false, 
+            "price": 630, 
+            "required_level": 20
+          }, 
+          {
+            "charge_cost_modifier": 214, 
+            "collect_amount_modifier": 130, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade043", 
+            "gestalt": "upgrade043", 
+            "notification": true, 
+            "price": 630, 
+            "required_level": 20
+          }
+        ], 
+        "rename_ads_tab": false, 
+        "required_level": 18, 
+        "slot_cost": 90, 
+        "slot_cost_modifier": 0, 
+        "teammember_slots": 3, 
+        "title": "Warranty Cards", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token006", 
+            "gestalt": "token006"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token007", 
+            "gestalt": "token007"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token005", 
+            "gestalt": "token005"
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token008", 
+            "gestalt": "token008"
+          }, 
+          {
+            "amount": 25, 
+            "full_type": "TokenPerp:supertoken014", 
+            "gestalt": "supertoken014"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token132", 
+            "gestalt": "token132"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token084", 
+            "gestalt": "token084"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token029", 
+            "gestalt": "token029"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token012", 
+            "gestalt": "token012"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin014", 
+            "gestalt": "origin014"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin018", 
+            "gestalt": "origin018"
+          }
+        ], 
+        "upgrade_slots": 3, 
+        "xp_inc": 31
+      }
+    }, 
+    "project007": {
+      "game_type": "ProjectPerp", 
+      "type_data": {
+        "ad_slots": 0, 
+        "charge_cost": 2480, 
+        "charge_time": 14400000, 
+        "collect_amount": 42300, 
+        "collect_risk": 4, 
+        "description": "Is there anyone who still buys CDs when MP3s are just a click away? Thankfully the music industry has found a new source of money: Anti-piracy lawsuits! Crawl those filesharing networks and you\u2019ll easily find out who downloads what \u2013 and make lots of money selling that info.", 
+        "label": "Anti-piracy\r\ncrawler", 
+        "max_ad_slots": 0, 
+        "max_teammember_slots": 18, 
+        "max_upgrade_slots": 7, 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 700, 
+              "y": 600
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "price": 7400, 
+        "provided_ads": [], 
+        "provided_teammembers": [
+          {
+            "charge_cost_modifier": 157, 
+            "collect_amount_modifier": 1970, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember020", 
+            "gestalt": "teammember020", 
+            "notification": false, 
+            "price": 440, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 136, 
+            "collect_amount_modifier": 2210, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember021", 
+            "gestalt": "teammember021", 
+            "notification": false, 
+            "price": 380, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 168, 
+            "collect_amount_modifier": 2460, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember014", 
+            "gestalt": "teammember014", 
+            "notification": false, 
+            "price": 460, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 146, 
+            "collect_amount_modifier": 2770, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember015", 
+            "gestalt": "teammember015", 
+            "notification": false, 
+            "price": 400, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 203, 
+            "collect_amount_modifier": 3940, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember001", 
+            "gestalt": "teammember001", 
+            "notification": true, 
+            "price": 540, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 179, 
+            "collect_amount_modifier": 4430, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember023", 
+            "gestalt": "teammember023", 
+            "notification": false, 
+            "price": 470, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 134, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -1, 
+            "full_type": "TeamMemberPowerup:teammember044", 
+            "gestalt": "teammember044", 
+            "notification": false, 
+            "price": 400, 
+            "required_level": 6
+          }, 
+          {
+            "charge_cost_modifier": 115, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -1, 
+            "full_type": "TeamMemberPowerup:teammember043", 
+            "gestalt": "teammember043", 
+            "notification": true, 
+            "price": 350, 
+            "required_level": 6
+          }, 
+          {
+            "charge_cost_modifier": 192, 
+            "collect_amount_modifier": 3440, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember016", 
+            "gestalt": "teammember016", 
+            "notification": false, 
+            "price": 520, 
+            "required_level": 17
+          }, 
+          {
+            "charge_cost_modifier": 168, 
+            "collect_amount_modifier": 3870, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember017", 
+            "gestalt": "teammember017", 
+            "notification": true, 
+            "price": 450, 
+            "required_level": 17
+          }, 
+          {
+            "charge_cost_modifier": 215, 
+            "collect_amount_modifier": 4430, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember035", 
+            "gestalt": "teammember035", 
+            "notification": true, 
+            "price": 570, 
+            "required_level": 19
+          }, 
+          {
+            "charge_cost_modifier": 190, 
+            "collect_amount_modifier": 4980, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember049", 
+            "gestalt": "teammember049", 
+            "notification": false, 
+            "price": 500, 
+            "required_level": 19
+          }
+        ], 
+        "provided_upgrades": [
+          {
+            "charge_cost_modifier": 173, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade069", 
+            "gestalt": "upgrade069", 
+            "notification": false, 
+            "price": 520, 
+            "required_level": 15
+          }, 
+          {
+            "charge_cost_modifier": 219, 
+            "collect_amount_modifier": 6400, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade049", 
+            "gestalt": "upgrade049", 
+            "notification": false, 
+            "price": 890, 
+            "required_level": 15
+          }, 
+          {
+            "charge_cost_modifier": 198, 
+            "collect_amount_modifier": 6890, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade064", 
+            "gestalt": "upgrade064", 
+            "notification": false, 
+            "price": 590, 
+            "required_level": 15
+          }, 
+          {
+            "charge_cost_modifier": 252, 
+            "collect_amount_modifier": 7870, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade057", 
+            "gestalt": "upgrade057", 
+            "notification": false, 
+            "price": 580, 
+            "required_level": 15
+          }
+        ], 
+        "rename_ads_tab": false, 
+        "required_level": 15, 
+        "slot_cost": 60, 
+        "slot_cost_modifier": 0, 
+        "teammember_slots": 3, 
+        "title": "Anti-piracy crawler", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token029", 
+            "gestalt": "token029"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token040", 
+            "gestalt": "token040"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token123", 
+            "gestalt": "token123"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token097", 
+            "gestalt": "token097"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token087", 
+            "gestalt": "token087"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token078", 
+            "gestalt": "token078"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token124", 
+            "gestalt": "token124"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token032", 
+            "gestalt": "token032"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token122", 
+            "gestalt": "token122"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin014", 
+            "gestalt": "origin014"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin016", 
+            "gestalt": "origin016"
+          }
+        ], 
+        "upgrade_slots": 3, 
+        "xp_inc": 20
+      }
+    }, 
+    "project009": {
+      "game_type": "ProjectPerp", 
+      "type_data": {
+        "ad_slots": 3, 
+        "charge_cost": 2100, 
+        "charge_time": 14400000, 
+        "collect_amount": 39900, 
+        "collect_risk": 4, 
+        "description": "You only have their best interests at heart, right? Offer free medical checkups and collect comprehensive data on the health status of your patients. Asking a few additional questions about their lifestyle will fill in those gaps left by what can be measured. Of course it\u2019s completely confidential.", 
+        "label": "Preventive checkup", 
+        "max_ad_slots": 8, 
+        "max_teammember_slots": 18, 
+        "max_upgrade_slots": 11, 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 700, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "price": 6300, 
+        "provided_ads": [
+          {
+            "charge_cost_modifier": 250, 
+            "collect_amount_modifier": 1180, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad006", 
+            "gestalt": "ad006", 
+            "notification": false, 
+            "price": 730, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 281, 
+            "collect_amount_modifier": 1890, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad008", 
+            "gestalt": "ad008", 
+            "notification": false, 
+            "price": 760, 
+            "required_level": 12
+          }, 
+          {
+            "charge_cost_modifier": 294, 
+            "collect_amount_modifier": 2360, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad027", 
+            "gestalt": "ad027", 
+            "notification": true, 
+            "price": 850, 
+            "required_level": 15
+          }, 
+          {
+            "charge_cost_modifier": 312, 
+            "collect_amount_modifier": 2830, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad007", 
+            "gestalt": "ad007", 
+            "notification": true, 
+            "price": 900, 
+            "required_level": 12
+          }, 
+          {
+            "charge_cost_modifier": 405, 
+            "collect_amount_modifier": 3770, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad005", 
+            "gestalt": "ad005", 
+            "notification": true, 
+            "price": 1150, 
+            "required_level": 12
+          }, 
+          {
+            "charge_cost_modifier": 312, 
+            "collect_amount_modifier": 1890, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad012", 
+            "gestalt": "ad012", 
+            "notification": true, 
+            "price": 1000, 
+            "required_level": 14
+          }, 
+          {
+            "charge_cost_modifier": 429, 
+            "collect_amount_modifier": 5180, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad010", 
+            "gestalt": "ad010", 
+            "notification": false, 
+            "price": 1290, 
+            "required_level": 2
+          }
+        ], 
+        "provided_teammembers": [
+          {
+            "charge_cost_modifier": 203, 
+            "collect_amount_modifier": 940, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember020", 
+            "gestalt": "teammember020", 
+            "notification": false, 
+            "price": 570, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 174, 
+            "collect_amount_modifier": 1060, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember021", 
+            "gestalt": "teammember021", 
+            "notification": false, 
+            "price": 490, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 227, 
+            "collect_amount_modifier": 1410, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember014", 
+            "gestalt": "teammember014", 
+            "notification": false, 
+            "price": 630, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 197, 
+            "collect_amount_modifier": 1590, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember015", 
+            "gestalt": "teammember015", 
+            "notification": false, 
+            "price": 540, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 281, 
+            "collect_amount_modifier": 2450, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember001", 
+            "gestalt": "teammember001", 
+            "notification": true, 
+            "price": 750, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 242, 
+            "collect_amount_modifier": 2650, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember023", 
+            "gestalt": "teammember023", 
+            "notification": false, 
+            "price": 640, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 335, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -2, 
+            "full_type": "TeamMemberPowerup:teammember044", 
+            "gestalt": "teammember044", 
+            "notification": false, 
+            "price": 1000, 
+            "required_level": 6
+          }, 
+          {
+            "charge_cost_modifier": 309, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -2, 
+            "full_type": "TeamMemberPowerup:teammember043", 
+            "gestalt": "teammember043", 
+            "notification": true, 
+            "price": 930, 
+            "required_level": 6
+          }, 
+          {
+            "charge_cost_modifier": 300, 
+            "collect_amount_modifier": 2830, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember005", 
+            "gestalt": "teammember005", 
+            "notification": true, 
+            "price": 790, 
+            "required_level": 13
+          }, 
+          {
+            "charge_cost_modifier": 265, 
+            "collect_amount_modifier": 3180, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember006", 
+            "gestalt": "teammember006", 
+            "notification": false, 
+            "price": 700, 
+            "required_level": 13
+          }
+        ], 
+        "provided_upgrades": [
+          {
+            "charge_cost_modifier": 117, 
+            "collect_amount_modifier": 940, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade001", 
+            "gestalt": "upgrade001", 
+            "notification": false, 
+            "price": 350, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 130, 
+            "collect_amount_modifier": 1410, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade038", 
+            "gestalt": "upgrade038", 
+            "notification": false, 
+            "price": 390, 
+            "required_level": 11
+          }, 
+          {
+            "charge_cost_modifier": 221, 
+            "collect_amount_modifier": 3770, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade049", 
+            "gestalt": "upgrade049", 
+            "notification": false, 
+            "price": 500, 
+            "required_level": 15
+          }, 
+          {
+            "charge_cost_modifier": 309, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -2, 
+            "full_type": "UpgradePowerup:upgrade008", 
+            "gestalt": "upgrade008", 
+            "notification": true, 
+            "price": 930, 
+            "required_level": 9
+          }, 
+          {
+            "charge_cost_modifier": 325, 
+            "collect_amount_modifier": 5660, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade053", 
+            "gestalt": "upgrade053", 
+            "notification": false, 
+            "price": 1430, 
+            "required_level": 15
+          }, 
+          {
+            "charge_cost_modifier": 276, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 1, 
+            "full_type": "UpgradePowerup:upgrade073", 
+            "gestalt": "upgrade073", 
+            "notification": false, 
+            "price": 830, 
+            "required_level": 15
+          }, 
+          {
+            "charge_cost_modifier": 167, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 2, 
+            "full_type": "UpgradePowerup:upgrade074", 
+            "gestalt": "upgrade074", 
+            "notification": false, 
+            "price": 500, 
+            "required_level": 15
+          }, 
+          {
+            "charge_cost_modifier": 263, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 2, 
+            "full_type": "UpgradePowerup:upgrade070", 
+            "gestalt": "upgrade070", 
+            "notification": false, 
+            "price": 790, 
+            "required_level": 15
+          }, 
+          {
+            "charge_cost_modifier": 376, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 2, 
+            "full_type": "UpgradePowerup:upgrade071", 
+            "gestalt": "upgrade071", 
+            "notification": false, 
+            "price": 1130, 
+            "required_level": 15
+          }
+        ], 
+        "rename_ads_tab": false, 
+        "required_level": 15, 
+        "slot_cost": 60, 
+        "slot_cost_modifier": 10, 
+        "teammember_slots": 3, 
+        "title": "Preventive checkup", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token006", 
+            "gestalt": "token006"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token007", 
+            "gestalt": "token007"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token005", 
+            "gestalt": "token005"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token041", 
+            "gestalt": "token041"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token015", 
+            "gestalt": "token015"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token014", 
+            "gestalt": "token014"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token017", 
+            "gestalt": "token017"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token022", 
+            "gestalt": "token022"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token098", 
+            "gestalt": "token098"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token021", 
+            "gestalt": "token021"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token058", 
+            "gestalt": "token058"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token053", 
+            "gestalt": "token053"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token018", 
+            "gestalt": "token018"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token125", 
+            "gestalt": "token125"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token109", 
+            "gestalt": "token109"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token105", 
+            "gestalt": "token105"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token114", 
+            "gestalt": "token114"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token120", 
+            "gestalt": "token120"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token054", 
+            "gestalt": "token054"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin014", 
+            "gestalt": "origin014"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin017", 
+            "gestalt": "origin017"
+          }
+        ], 
+        "upgrade_slots": 3, 
+        "xp_inc": 20
+      }
+    }, 
+    "project011": {
+      "game_type": "ProjectPerp", 
+      "type_data": {
+        "ad_slots": 3, 
+        "charge_cost": 3220, 
+        "charge_time": 28800000, 
+        "collect_amount": 61400, 
+        "collect_risk": 5, 
+        "description": "All those years of shared suffering just to lose sight of each other as soon as the gates swing open? Happens more often than you\u2019d think. But there always comes a time when nostalgia hits and people\u2019d give everything to relive the good old days. A website for locating old classmates will make them happily offer up personal details galore.", 
+        "label": "Find Classmates", 
+        "max_ad_slots": 12, 
+        "max_teammember_slots": 22, 
+        "max_upgrade_slots": 12, 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 700, 
+              "y": 200
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "price": 9700, 
+        "provided_ads": [
+          {
+            "charge_cost_modifier": 206, 
+            "collect_amount_modifier": 320, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad006", 
+            "gestalt": "ad006", 
+            "notification": false, 
+            "price": 610, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 217, 
+            "collect_amount_modifier": 640, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad007", 
+            "gestalt": "ad007", 
+            "notification": true, 
+            "price": 630, 
+            "required_level": 12
+          }, 
+          {
+            "charge_cost_modifier": 247, 
+            "collect_amount_modifier": 1600, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad005", 
+            "gestalt": "ad005", 
+            "notification": true, 
+            "price": 720, 
+            "required_level": 12
+          }, 
+          {
+            "charge_cost_modifier": 229, 
+            "collect_amount_modifier": 640, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad033", 
+            "gestalt": "ad033", 
+            "notification": true, 
+            "price": 690, 
+            "required_level": 18
+          }, 
+          {
+            "charge_cost_modifier": 240, 
+            "collect_amount_modifier": 960, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad013", 
+            "gestalt": "ad013", 
+            "notification": false, 
+            "price": 720, 
+            "required_level": 9
+          }, 
+          {
+            "charge_cost_modifier": 247, 
+            "collect_amount_modifier": 1280, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad014", 
+            "gestalt": "ad014", 
+            "notification": false, 
+            "price": 820, 
+            "required_level": 9
+          }, 
+          {
+            "charge_cost_modifier": 274, 
+            "collect_amount_modifier": 1930, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad029", 
+            "gestalt": "ad029", 
+            "notification": true, 
+            "price": 820, 
+            "required_level": 18
+          }, 
+          {
+            "charge_cost_modifier": 267, 
+            "collect_amount_modifier": 1280, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad023", 
+            "gestalt": "ad023", 
+            "notification": true, 
+            "price": 800, 
+            "required_level": 18
+          }, 
+          {
+            "charge_cost_modifier": 280, 
+            "collect_amount_modifier": 1600, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad024", 
+            "gestalt": "ad024", 
+            "notification": true, 
+            "price": 840, 
+            "required_level": 18
+          }, 
+          {
+            "charge_cost_modifier": 353, 
+            "collect_amount_modifier": 3850, 
+            "collect_risk_modifier": -1, 
+            "full_type": "AdPowerup:ad032", 
+            "gestalt": "ad032", 
+            "notification": true, 
+            "price": 1330, 
+            "required_level": 20
+          }
+        ], 
+        "provided_teammembers": [
+          {
+            "charge_cost_modifier": 194, 
+            "collect_amount_modifier": 1280, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember020", 
+            "gestalt": "teammember020", 
+            "notification": false, 
+            "price": 540, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 168, 
+            "collect_amount_modifier": 1440, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember021", 
+            "gestalt": "teammember021", 
+            "notification": false, 
+            "price": 460, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 223, 
+            "collect_amount_modifier": 1930, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember014", 
+            "gestalt": "teammember014", 
+            "notification": false, 
+            "price": 600, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 195, 
+            "collect_amount_modifier": 2170, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember015", 
+            "gestalt": "teammember015", 
+            "notification": false, 
+            "price": 520, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 281, 
+            "collect_amount_modifier": 3210, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember001", 
+            "gestalt": "teammember001", 
+            "notification": true, 
+            "price": 740, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 249, 
+            "collect_amount_modifier": 3610, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember023", 
+            "gestalt": "teammember023", 
+            "notification": false, 
+            "price": 650, 
+            "required_level": 5
+          }, 
+          {
+            "charge_cost_modifier": 229, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -1, 
+            "full_type": "TeamMemberPowerup:teammember044", 
+            "gestalt": "teammember044", 
+            "notification": false, 
+            "price": 690, 
+            "required_level": 6
+          }, 
+          {
+            "charge_cost_modifier": 206, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -1, 
+            "full_type": "TeamMemberPowerup:teammember043", 
+            "gestalt": "teammember043", 
+            "notification": true, 
+            "price": 620, 
+            "required_level": 6
+          }, 
+          {
+            "charge_cost_modifier": 402, 
+            "collect_amount_modifier": 3850, 
+            "collect_risk_modifier": -1, 
+            "full_type": "TeamMemberPowerup:teammember026", 
+            "gestalt": "teammember026", 
+            "notification": false, 
+            "price": 1080, 
+            "required_level": 10
+          }, 
+          {
+            "charge_cost_modifier": 369, 
+            "collect_amount_modifier": 4330, 
+            "collect_risk_modifier": -1, 
+            "full_type": "TeamMemberPowerup:teammember042", 
+            "gestalt": "teammember042", 
+            "notification": true, 
+            "price": 990, 
+            "required_level": 10
+          }, 
+          {
+            "charge_cost_modifier": 338, 
+            "collect_amount_modifier": 4490, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember005", 
+            "gestalt": "teammember005", 
+            "notification": true, 
+            "price": 870, 
+            "required_level": 13
+          }, 
+          {
+            "charge_cost_modifier": 303, 
+            "collect_amount_modifier": 5050, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember006", 
+            "gestalt": "teammember006", 
+            "notification": false, 
+            "price": 770, 
+            "required_level": 13
+          }, 
+          {
+            "charge_cost_modifier": 271, 
+            "collect_amount_modifier": 4490, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember012", 
+            "gestalt": "teammember012", 
+            "notification": false, 
+            "price": 690, 
+            "required_level": 15
+          }, 
+          {
+            "charge_cost_modifier": 242, 
+            "collect_amount_modifier": 5050, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember036", 
+            "gestalt": "teammember036", 
+            "notification": true, 
+            "price": 620, 
+            "required_level": 15
+          }, 
+          {
+            "charge_cost_modifier": 321, 
+            "collect_amount_modifier": 4110, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember016", 
+            "gestalt": "teammember016", 
+            "notification": false, 
+            "price": 830, 
+            "required_level": 17
+          }, 
+          {
+            "charge_cost_modifier": 287, 
+            "collect_amount_modifier": 4620, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember017", 
+            "gestalt": "teammember017", 
+            "notification": true, 
+            "price": 730, 
+            "required_level": 17
+          }, 
+          {
+            "charge_cost_modifier": 367, 
+            "collect_amount_modifier": 5130, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember035", 
+            "gestalt": "teammember035", 
+            "notification": true, 
+            "price": 930, 
+            "required_level": 19
+          }, 
+          {
+            "charge_cost_modifier": 330, 
+            "collect_amount_modifier": 5780, 
+            "collect_risk_modifier": 0, 
+            "full_type": "TeamMemberPowerup:teammember049", 
+            "gestalt": "teammember049", 
+            "notification": false, 
+            "price": 830, 
+            "required_level": 19
+          }
+        ], 
+        "provided_upgrades": [
+          {
+            "charge_cost_modifier": 147, 
+            "collect_amount_modifier": 1280, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade001", 
+            "gestalt": "upgrade001", 
+            "notification": false, 
+            "price": 390, 
+            "required_level": 2
+          }, 
+          {
+            "charge_cost_modifier": 216, 
+            "collect_amount_modifier": 1930, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade038", 
+            "gestalt": "upgrade038", 
+            "notification": false, 
+            "price": 680, 
+            "required_level": 11
+          }, 
+          {
+            "charge_cost_modifier": 192, 
+            "collect_amount_modifier": 2570, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade057", 
+            "gestalt": "upgrade057", 
+            "notification": false, 
+            "price": 480, 
+            "required_level": 15
+          }, 
+          {
+            "charge_cost_modifier": 200, 
+            "collect_amount_modifier": 3210, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade049", 
+            "gestalt": "upgrade049", 
+            "notification": false, 
+            "price": 680, 
+            "required_level": 15
+          }, 
+          {
+            "charge_cost_modifier": 206, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": -1, 
+            "full_type": "UpgradePowerup:upgrade008", 
+            "gestalt": "upgrade008", 
+            "notification": true, 
+            "price": 620, 
+            "required_level": 9
+          }, 
+          {
+            "charge_cost_modifier": 213, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 2, 
+            "full_type": "UpgradePowerup:upgrade103", 
+            "gestalt": "upgrade103", 
+            "notification": false, 
+            "price": 640, 
+            "required_level": 18
+          }, 
+          {
+            "charge_cost_modifier": 250, 
+            "collect_amount_modifier": 3850, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade104", 
+            "gestalt": "upgrade104", 
+            "notification": false, 
+            "price": 750, 
+            "required_level": 18
+          }, 
+          {
+            "charge_cost_modifier": 31, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 3, 
+            "full_type": "UpgradePowerup:upgrade105", 
+            "gestalt": "upgrade105", 
+            "notification": false, 
+            "price": 90, 
+            "required_level": 18
+          }, 
+          {
+            "charge_cost_modifier": 427, 
+            "collect_amount_modifier": 0, 
+            "collect_risk_modifier": 3, 
+            "full_type": "UpgradePowerup:upgrade107", 
+            "gestalt": "upgrade107", 
+            "notification": false, 
+            "price": 1280, 
+            "required_level": 18
+          }, 
+          {
+            "charge_cost_modifier": 312, 
+            "collect_amount_modifier": 5130, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade109", 
+            "gestalt": "upgrade109", 
+            "notification": true, 
+            "price": 1160, 
+            "required_level": 20
+          }, 
+          {
+            "charge_cost_modifier": 300, 
+            "collect_amount_modifier": 4490, 
+            "collect_risk_modifier": 0, 
+            "full_type": "UpgradePowerup:upgrade108", 
+            "gestalt": "upgrade108", 
+            "notification": false, 
+            "price": 900, 
+            "required_level": 20
+          }
+        ], 
+        "rename_ads_tab": false, 
+        "required_level": 18, 
+        "slot_cost": 40, 
+        "slot_cost_modifier": 0, 
+        "teammember_slots": 3, 
+        "title": "Find Classmates", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token006", 
+            "gestalt": "token006"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token007", 
+            "gestalt": "token007"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token008", 
+            "gestalt": "token008"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token011", 
+            "gestalt": "token011"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token061", 
+            "gestalt": "token061"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token005", 
+            "gestalt": "token005"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token064", 
+            "gestalt": "token064"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token045", 
+            "gestalt": "token045"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token036", 
+            "gestalt": "token036"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003"
+          }, 
+          {
+            "amount": 0, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin014", 
+            "gestalt": "origin014"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:origin019", 
+            "gestalt": "origin019"
+          }
+        ], 
+        "upgrade_slots": 3, 
+        "xp_inc": 31
+      }
+    }, 
+    "proxy001": {
+      "game_type": "ProxyPerp", 
+      "type_data": {
+        "description": "You run raffles, dating sites and possibly even your own Smoogle and Tracebook? And then feed the collected data to your database? That\u2019s not without a certain risk. It might be better if these projects and companies didn\u2019t officially belong to YOU, but to a bogus company. And who that belongs to is really nobody\u2019s business.", 
+        "label": "Bogus Company", 
+        "max_instances": 1, 
+        "max_slots": 3, 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 320, 
+              "y": 760
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "price": 100, 
+        "provided_perps": [
+          "project001", 
+          "project003", 
+          "project005", 
+          "project002"
+        ], 
+        "required_level": 2, 
+        "title": "Bogus Company"
+      }
+    }, 
+    "proxy002": {
+      "game_type": "ProxyPerp", 
+      "type_data": {
+        "description": "You run raffles, dating sites and possibly even your own Smoogle and Tracebook? And then feed the collected data to your database? That\u2019s not without a certain risk. It might be better if these projects and companies didn\u2019t officially belong to YOU, but to a bogus company. And who that belongs to is really nobody\u2019s business.", 
+        "label": "Bogus Company", 
+        "max_instances": 1, 
+        "max_slots": 3, 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 240, 
+              "y": 760
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "price": 2000, 
+        "provided_perps": [
+          "project004", 
+          "project009", 
+          "project007", 
+          "project011", 
+          "project006"
+        ], 
+        "required_level": 11, 
+        "title": "Bogus Company"
+      }
+    }, 
+    "proxy003": {
+      "game_type": "ProxyPerp", 
+      "type_data": {
+        "description": "You run raffles, dating sites and possibly even your own Smoogle and Tracebook? And then feed the collected data to your database? That\u2019s not without a certain risk. It might be better if these projects and companies didn\u2019t officially belong to YOU, but to a bogus company. And who that belongs to is really nobody\u2019s business.", 
+        "label": "Bogus Company", 
+        "max_instances": 1, 
+        "max_slots": 5, 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 160, 
+              "y": 760
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "price": 10000, 
+        "provided_perps": [
+          "project004", 
+          "project009", 
+          "project007", 
+          "project011", 
+          "project006"
+        ], 
+        "required_level": 18, 
+        "title": "Bogus Company"
+      }
+    }, 
+    "proxy004": {
+      "game_type": "ProxyPerp", 
+      "type_data": {
+        "description": "You run raffles, dating sites and possibly even your own Smoogle and Tracebook? And then feed the collected data to your database? That\u2019s not without a certain risk. It might be better if these projects and companies didn\u2019t officially belong to YOU, but to a bogus company. And who that belongs to is really nobody\u2019s business.", 
+        "label": "Bogus Company", 
+        "max_instances": 1, 
+        "max_slots": 4, 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 80, 
+              "y": 760
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "price": 4000, 
+        "provided_perps": [
+          "project001", 
+          "project003", 
+          "project005", 
+          "project002"
+        ], 
+        "required_level": 9, 
+        "story": {
+          "text": "With a properly set-up bogus company, media and authorities will have a hard time getting a proper overview of your empire. Click on it and check it out!", 
+          "trigger": "buy"
+        }, 
+        "title": "Bogus Company"
+      }
+    }, 
+    "pusher001": {
+      "game_type": "PusherPerp", 
+      "type_data": {
+        "description": "Scotty used to be head of a huge data collection agency and knows exactly how to best make money from your database. He\u2019s an old hand, a real pro. He\u2019ll get you in contact with some very special clients, so you can gather the money you need to expand your empire even further.", 
+        "label": "Scotty", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 0, 
+              "y": 760
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-001.png"
+        }, 
+        "price": 1800, 
+        "provided_perps": [
+          "client014", 
+          "client011", 
+          "client019"
+        ], 
+        "required_level": 1, 
+        "required_providers": [
+          "project007", 
+          "contact004", 
+          "project006"
+        ], 
+        "subtitle": "procures new clients for you", 
+        "title": "Scotty"
+      }
+    }, 
+    "pusher003": {
+      "game_type": "PusherPerp", 
+      "type_data": {
+        "description": "Alfonso is young, dynamic, and a sales pro. Give him 10 minutes and he\u2019ll charm you into buying things you had no idea you needed 11 minutes ago. His speciality? City councils, schools and public authorities \u2013 all of them lucrative clientele for your data sets.", 
+        "label": "Alfonso", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 600, 
+              "y": 560
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-001.png"
+        }, 
+        "price": 900, 
+        "provided_perps": [
+          "client005", 
+          "client008"
+        ], 
+        "required_level": 1, 
+        "required_providers": [
+          "contact026", 
+          "contact008"
+        ], 
+        "story": {
+          "text": "Alfonso is the bomb! Click on him and check whether he has procured a profitable data source for you.", 
+          "trigger": "buy"
+        }, 
+        "subtitle": "procures new clients for you", 
+        "title": "Alfonso"
+      }
+    }, 
+    "pusher004": {
+      "game_type": "PusherPerp", 
+      "type_data": {
+        "description": "Denise is a pro and has been instrumental in clinching the really big deals for years. Car company, supermarket or insurance agency \u2013 she\u2019ll always find new clients interested in your data sets. Ones who pay well! Her services don\u2019t come cheap, but will definitely pay off in the long run.", 
+        "label": "Denise", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 500, 
+              "y": 460
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-001.png"
+        }, 
+        "price": 50, 
+        "provided_perps": [
+          "client007", 
+          "client002", 
+          "client006", 
+          "client010"
+        ], 
+        "required_level": 1, 
+        "required_providers": [
+          "project002", 
+          "contact035", 
+          "project003", 
+          "contact001"
+        ], 
+        "subtitle": "procures new clients for you", 
+        "title": "Denise"
+      }
+    }
+  }, 
+  "powerups": {
+    "ad001": {
+      "game_type": "AdPowerup", 
+      "type_data": {
+        "description": "Hire some cute, silver-tongued sales talents and deploy them at the city\u2019s subway stations.", 
+        "label": "Distribute at subway stations", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-027.png"
+        }, 
+        "required_level": 2, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 760, 
+              "y": 600
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "title": "Distribute at subway stations", 
+        "tokens": []
+      }
+    }, 
+    "ad002": {
+      "game_type": "AdPowerup", 
+      "type_data": {
+        "description": "Hire some cute, silver-tongued sales talents and send them to the country\u2019s biggest malls.", 
+        "label": "Distribute in malls", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-025.png"
+        }, 
+        "required_level": 2, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 760, 
+              "y": 500
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "title": "Distribute in malls", 
+        "tokens": []
+      }
+    }, 
+    "ad003": {
+      "game_type": "AdPowerup", 
+      "type_data": {
+        "description": "Hire some cute, silver-tongued sales talents and send them to the city\u2019s most popular restaurants.", 
+        "label": "Distribute in restaurants", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-025.png"
+        }, 
+        "required_level": 2, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 760, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "title": "Distribute in restaurants", 
+        "tokens": []
+      }
+    }, 
+    "ad004": {
+      "game_type": "AdPowerup", 
+      "type_data": {
+        "description": "Create a shiny mini mag filled with interesting stories and a handful of cute pictures, all masquerading the fact this is just one big ad for your products\u2013 and enclose it with a popular newspaper. ", 
+        "label": "Newspaper Supplement", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-025.png"
+        }, 
+        "required_level": 2, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 760, 
+              "y": 300
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "title": "Newspaper Supplement", 
+        "tokens": []
+      }
+    }, 
+    "ad005": {
+      "game_type": "AdPowerup", 
+      "type_data": {
+        "description": "TV Ads aren\u00b4t cheap, but boy, are they worth it. Just make sure it\u2019s got a stupid punchline and you\u2019re on.", 
+        "label": "TV Ad", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-025.png"
+        }, 
+        "required_level": 12, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 760, 
+              "y": 200
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "title": "TV Ad", 
+        "tokens": []
+      }
+    }, 
+    "ad006": {
+      "game_type": "AdPowerup", 
+      "type_data": {
+        "description": "It\u2019s a classic \u2013 and it\u2019s still going strong. Just combine an attention-grabbing picture with a so-so slogan, and you\u2019re done!", 
+        "label": "Newspaper Ad", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-026.png"
+        }, 
+        "required_level": 5, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 760, 
+              "y": 100
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "title": "Newspaper Ad", 
+        "tokens": []
+      }
+    }, 
+    "ad007": {
+      "game_type": "AdPowerup", 
+      "type_data": {
+        "description": "Ah, good old radio! Still useful to ensure your ad reaches its target audience: folk or classical music, disco or news, whatever they put on. And if you think they might not listen, just make your spot a little louder to get their attention.", 
+        "label": "Radio Spot", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-026.png"
+        }, 
+        "required_level": 12, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 760, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "title": "Radio Spot", 
+        "tokens": []
+      }
+    }, 
+    "ad008": {
+      "game_type": "AdPowerup", 
+      "type_data": {
+        "description": "Have someone design a convincing poster and plaster the streets with it. Make it provocative so the message really sticks.", 
+        "label": "Poster ads", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-026.png"
+        }, 
+        "required_level": 12, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 600, 
+              "y": 658
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "title": "Poster ads", 
+        "tokens": []
+      }
+    }, 
+    "ad009": {
+      "game_type": "AdPowerup", 
+      "type_data": {
+        "description": "Put a seemingly independent product test online. Of course your product comes in first, even if only by a small margin.", 
+        "label": "Comparative Test", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-026.png"
+        }, 
+        "required_level": 9, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 500, 
+              "y": 658
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "title": "Comparative Test", 
+        "tokens": []
+      }
+    }, 
+    "ad010": {
+      "game_type": "AdPowerup", 
+      "type_data": {
+        "description": "Buy yourself a celeb to promote your business. Ex-athletes are a much better choice than ex-politicians \u2013 their status as darlings of the nation means they\u2019re especially well-suited for your purposes.", 
+        "label": "Ex-Athlete", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-025.png"
+        }, 
+        "required_level": 2, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 400, 
+              "y": 658
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "title": "Ex-Athlete", 
+        "tokens": []
+      }
+    }, 
+    "ad012": {
+      "game_type": "AdPowerup", 
+      "type_data": {
+        "description": "Buy yourself a celebrity and put them in your ads. TV presenters are really popular with the masses, which makes them perfect for your objectives.", 
+        "label": "TV Presenter", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-025.png"
+        }, 
+        "required_level": 14, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 200, 
+              "y": 658
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "title": "TV Presenter", 
+        "tokens": []
+      }
+    }, 
+    "ad013": {
+      "game_type": "AdPowerup", 
+      "type_data": {
+        "description": "Spring break in Cancun is no day on the beach for your team, but it does provide the perfect environment for scoring thousands of judgement-impaired profiles.", 
+        "label": "Spring Break Trip", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-025.png"
+        }, 
+        "required_level": 9, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 100, 
+              "y": 658
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "title": "Spring Break Trip", 
+        "tokens": []
+      }
+    }, 
+    "ad014": {
+      "game_type": "AdPowerup", 
+      "type_data": {
+        "description": "Regular singles parties provide some social warmth for your users and are a must-have for every dating agency.", 
+        "label": "Singles Parties", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-026.png"
+        }, 
+        "required_level": 9, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 0, 
+              "y": 658
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "title": "Singles Parties", 
+        "tokens": []
+      }
+    }, 
+    "ad015": {
+      "game_type": "AdPowerup", 
+      "type_data": {
+        "description": "Become main sponsor of a huge rock festival! Thousands of people waiting to be entertained, and your logo plastered all over the main stage. Rock on!", 
+        "label": "Rock Festival", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-025.png"
+        }, 
+        "required_level": 9, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 660, 
+              "y": 500
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "title": "Rock Festival", 
+        "tokens": []
+      }
+    }, 
+    "ad016": {
+      "game_type": "AdPowerup", 
+      "type_data": {
+        "description": "Become the main sponsor of ski jumping! You\u2019ll soon rise to fame, and the hearts and profiles of every extreme armchair athlete will be yours.", 
+        "label": "Ski Jumping", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-025.png"
+        }, 
+        "required_level": 20, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 660, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "title": "Ski Jumping", 
+        "tokens": []
+      }
+    }, 
+    "ad023": {
+      "game_type": "AdPowerup", 
+      "type_data": {
+        "description": "Not enough people liking your page? That can easily be fixed: Get some students or other cheap labour and pay them to make your online popularity soar.", 
+        "label": "Paid Likes", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-026.png"
+        }, 
+        "required_level": 18, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 300, 
+              "y": 558
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "title": "Paid Likes", 
+        "tokens": []
+      }
+    }, 
+    "ad024": {
+      "game_type": "AdPowerup", 
+      "type_data": {
+        "description": "Get yourself some net slaves who anonymously hail your product. Just have them add a little criticism now and then and nobody will ever guess...", 
+        "label": "Paid Online Postings", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-026.png"
+        }, 
+        "required_level": 18, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 200, 
+              "y": 558
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "title": "Paid Online Postings", 
+        "tokens": []
+      }
+    }, 
+    "ad025": {
+      "game_type": "AdPowerup", 
+      "type_data": {
+        "description": "Create an amateurish-looking website which deals with your range of products. These things are easily found by search engines and come across as quite trustworthy.", 
+        "label": "Amateur Website", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-026.png"
+        }, 
+        "required_level": 18, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 100, 
+              "y": 558
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "title": "Amateur Website", 
+        "tokens": []
+      }
+    }, 
+    "ad027": {
+      "game_type": "AdPowerup", 
+      "type_data": {
+        "description": "Create a citywide mailbox blockage with your new exciting brochure! There\u2019s always someone who actually reads those things. Make good use of all your usual tricks \u2013 covering it in \"Bargain!\" and \"Low price!\" in huge bright letters should help bring in the profiles.", 
+        "label": "Junk mail", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-026.png"
+        }, 
+        "required_level": 15, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 560, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "title": "Junk mail", 
+        "tokens": []
+      }
+    }, 
+    "ad029": {
+      "game_type": "AdPowerup", 
+      "type_data": {
+        "description": "Convince some enthusiastic fans to invite their friends and advertise your products. Then some of those friends invite their friends\u2026and on and on it goes. Genius!", 
+        "label": "Tupperware Parties", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-026.png"
+        }, 
+        "required_level": 18, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 560, 
+              "y": 200
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "title": "Tupperware Parties", 
+        "tokens": []
+      }
+    }, 
+    "ad032": {
+      "game_type": "AdPowerup", 
+      "type_data": {
+        "description": "Sudden singing, coordinated dancing, heart-wrenching proposals, all in public locations \u2013 whatever it is, make sure you get it on film and put it online. These things go viral within seconds! Important: Get as many shots of astonished bystanders as you can.", 
+        "label": "Flash mob video", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-025.png"
+        }, 
+        "required_level": 20, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 400, 
+              "y": 458
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "title": "Flash mob video", 
+        "tokens": []
+      }
+    }, 
+    "ad033": {
+      "game_type": "AdPowerup", 
+      "type_data": {
+        "description": "Buy yourself a celebrity and put them in your ads! Well-known real estate moguls with regular TV appearances are especially useful. Careful though: Not suitable for every occasion!", 
+        "label": "Real estate mogul", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-026.png"
+        }, 
+        "required_level": 18, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 300, 
+              "y": 458
+            }
+          }, 
+          "frameSrc": "sprite-020.png"
+        }, 
+        "title": "Real estate mogul", 
+        "tokens": []
+      }
+    }, 
+    "teammember001": {
+      "game_type": "TeamMemberPowerup", 
+      "type_data": {
+        "description": "Burning the midnight oil? Hire a manager to do the dirty work for you and get your team\u2019s ass in gear! ", 
+        "label": "Manager", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-017.png"
+        }, 
+        "required_level": 5, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 840, 
+              "y": 600
+            }
+          }, 
+          "frameSrc": "sprite-001.png"
+        }, 
+        "title": "Manager", 
+        "tokens": []
+      }
+    }, 
+    "teammember005": {
+      "game_type": "TeamMemberPowerup", 
+      "type_data": {
+        "description": "Style your project from top to bottom to ensure a smashing success. You just need one of those graphic whiz kids who knows what people want to see.", 
+        "label": "Graphic designer", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-017.png"
+        }, 
+        "required_level": 13, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 840, 
+              "y": 200
+            }
+          }, 
+          "frameSrc": "sprite-001.png"
+        }, 
+        "title": "Graphic designer", 
+        "tokens": []
+      }
+    }, 
+    "teammember006": {
+      "game_type": "TeamMemberPowerup", 
+      "type_data": {
+        "description": "Style your project from top to bottom to ensure a smashing success. You just need one of those graphic whiz kids who knows what people want to see.", 
+        "label": "Graphic designer", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-018.png"
+        }, 
+        "required_level": 13, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 840, 
+              "y": 100
+            }
+          }, 
+          "frameSrc": "sprite-001.png"
+        }, 
+        "title": "Graphic designer", 
+        "tokens": []
+      }
+    }, 
+    "teammember012": {
+      "game_type": "TeamMemberPowerup", 
+      "type_data": {
+        "description": "Not everyone willingly hands over their data. Insights from behavioral research might come in handy. And a little manipulation never hurts.", 
+        "label": "Psychologist", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-018.png"
+        }, 
+        "required_level": 15, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 300, 
+              "y": 710
+            }
+          }, 
+          "frameSrc": "sprite-001.png"
+        }, 
+        "title": "Psychologist", 
+        "tokens": []
+      }
+    }, 
+    "teammember014": {
+      "game_type": "TeamMemberPowerup", 
+      "type_data": {
+        "description": "Trainees are highly qualified and still cheaper by the dozen. Put them to good use and they\u2019ll raise your general performance.", 
+        "label": "Trainee", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-017.png"
+        }, 
+        "required_level": 2, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 100, 
+              "y": 710
+            }
+          }, 
+          "frameSrc": "sprite-001.png"
+        }, 
+        "title": "Trainee", 
+        "tokens": []
+      }
+    }, 
+    "teammember015": {
+      "game_type": "TeamMemberPowerup", 
+      "type_data": {
+        "description": "Trainees are highly qualified and still cheaper by the dozen. Put them to good use and they\u2019ll raise your general performance.", 
+        "label": "Trainee", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-018.png"
+        }, 
+        "required_level": 2, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 0, 
+              "y": 710
+            }
+          }, 
+          "frameSrc": "sprite-001.png"
+        }, 
+        "title": "Trainee", 
+        "tokens": []
+      }
+    }, 
+    "teammember016": {
+      "game_type": "TeamMemberPowerup", 
+      "type_data": {
+        "description": "Whenever there\u2019s a screw lose or something misbehaves \u2013 your technician is sure to fix things. Very helpful indeed!", 
+        "label": "Technician", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-017.png"
+        }, 
+        "required_level": 17, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 740, 
+              "y": 600
+            }
+          }, 
+          "frameSrc": "sprite-001.png"
+        }, 
+        "title": "Technician", 
+        "tokens": []
+      }
+    }, 
+    "teammember017": {
+      "game_type": "TeamMemberPowerup", 
+      "type_data": {
+        "description": "Whenever there\u2019s a screw lose or something misbehaves \u2013 your technician is sure to fix things. Very helpful indeed!", 
+        "label": "Technician", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-018.png"
+        }, 
+        "required_level": 17, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 740, 
+              "y": 500
+            }
+          }, 
+          "frameSrc": "sprite-001.png"
+        }, 
+        "title": "Technician", 
+        "tokens": []
+      }
+    }, 
+    "teammember020": {
+      "game_type": "TeamMemberPowerup", 
+      "type_data": {
+        "description": "Students may not be as good as trainees, but they have one advantage: They\u2019ll do whatever you want.", 
+        "label": "Student", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-017.png"
+        }, 
+        "required_level": 2, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 740, 
+              "y": 200
+            }
+          }, 
+          "frameSrc": "sprite-001.png"
+        }, 
+        "title": "Student", 
+        "tokens": []
+      }
+    }, 
+    "teammember021": {
+      "game_type": "TeamMemberPowerup", 
+      "type_data": {
+        "description": "Students may not be as good as trainees, but they have one advantage: They\u2019ll do whatever you want.", 
+        "label": "Student", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-018.png"
+        }, 
+        "required_level": 2, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 740, 
+              "y": 100
+            }
+          }, 
+          "frameSrc": "sprite-001.png"
+        }, 
+        "title": "Student", 
+        "tokens": []
+      }
+    }, 
+    "teammember023": {
+      "game_type": "TeamMemberPowerup", 
+      "type_data": {
+        "description": "You can\u2019t do it all by yourself! It\u2019s good to have someone in charge while you do the really important things like counting all the money you\u2019re making.", 
+        "label": "Manager", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-017.png"
+        }, 
+        "required_level": 5, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 600, 
+              "y": 610
+            }
+          }, 
+          "frameSrc": "sprite-001.png"
+        }, 
+        "title": "Manager", 
+        "tokens": []
+      }
+    }, 
+    "teammember026": {
+      "game_type": "TeamMemberPowerup", 
+      "type_data": {
+        "description": "Your business runs on advertising, so you better hire some professionals. They\u2019ll melt people\u2019s brains without them even noticing.", 
+        "label": "Ad hottie", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-018.png"
+        }, 
+        "required_level": 10, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 300, 
+              "y": 610
+            }
+          }, 
+          "frameSrc": "sprite-001.png"
+        }, 
+        "title": "Ad hottie", 
+        "tokens": []
+      }
+    }, 
+    "teammember035": {
+      "game_type": "TeamMemberPowerup", 
+      "type_data": {
+        "description": "When you\u2019re out gathering data, technology is your friend. You need a good programmer to ensure that no profile is lost or corrupted, and your machine keeps on running smoothly.", 
+        "label": "Programmer", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-018.png"
+        }, 
+        "required_level": 19, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 640, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-001.png"
+        }, 
+        "title": "Programmer", 
+        "tokens": []
+      }
+    }, 
+    "teammember036": {
+      "game_type": "TeamMemberPowerup", 
+      "type_data": {
+        "description": "Not everyone willingly hands over their data. Insights from behavioral research might come in handy. And a little manipulation never hurts.", 
+        "label": "Psychologist", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-018.png"
+        }, 
+        "required_level": 15, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 500, 
+              "y": 510
+            }
+          }, 
+          "frameSrc": "sprite-001.png"
+        }, 
+        "title": "Psychologist", 
+        "tokens": []
+      }
+    }, 
+    "teammember042": {
+      "game_type": "TeamMemberPowerup", 
+      "type_data": {
+        "description": "Your business runs on advertising, so you better hire some professionals. They\u2019ll melt people\u2019s brains without them even noticing.", 
+        "label": "Junior Art director", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-017.png"
+        }, 
+        "required_level": 10, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 540, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-001.png"
+        }, 
+        "title": "Junior Art director", 
+        "tokens": []
+      }
+    }, 
+    "teammember043": {
+      "game_type": "TeamMemberPowerup", 
+      "type_data": {
+        "description": "Just to be on the safe side during your data gathering, you should get yourself a good lawyer. Just someone to check your tricky phrasing and sue the pants off your critics...", 
+        "label": "Lawyer", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-017.png"
+        }, 
+        "required_level": 6, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 540, 
+              "y": 300
+            }
+          }, 
+          "frameSrc": "sprite-001.png"
+        }, 
+        "title": "Lawyer", 
+        "tokens": []
+      }
+    }, 
+    "teammember044": {
+      "game_type": "TeamMemberPowerup", 
+      "type_data": {
+        "description": "Just to be on the safe side during your data gathering, you should get yourself a good lawyer. Just someone to check your tricky phrasing and sue the pants off your critics...", 
+        "label": "Lawyer", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-018.png"
+        }, 
+        "required_level": 6, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 540, 
+              "y": 200
+            }
+          }, 
+          "frameSrc": "sprite-001.png"
+        }, 
+        "title": "Lawyer", 
+        "tokens": []
+      }
+    }, 
+    "teammember049": {
+      "game_type": "TeamMemberPowerup", 
+      "type_data": {
+        "description": "When you\u2019re out gathering data, technology is your friend. You need a good programmer to ensure that no profile is lost or corrupted, and your machine keeps on running smoothly.", 
+        "label": "Programmer", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-017.png"
+        }, 
+        "required_level": 19, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 240, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-001.png"
+        }, 
+        "title": "Programmer", 
+        "tokens": []
+      }
+    }, 
+    "upgrade001": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Make it shine! Pimping your venture is the way to go. A slick company design will make it even easier to get customers to part with their data.", 
+        "label": "Logo & Design", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-015.png"
+        }, 
+        "required_level": 2, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 600, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "title": "Logo & Design", 
+        "tokens": []
+      }
+    }, 
+    "upgrade002": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Offer some shiny Aye-Pods as prizes in your sweepstakes. You might get better prizes later on, but it\u2019s not shabby for a start.", 
+        "label": "Win an Aye-Pod!", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-014.png"
+        }, 
+        "required_level": 2, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 500, 
+              "y": 700
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "Win an Aye-Pod!", 
+        "tokens": []
+      }
+    }, 
+    "upgrade003": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Offer three amazing mystery cruises in your next sweepstakes! No need to tell the participants what kind of trip is waiting for them. That\u2019s why it\u2019s called \"mystery,\" right?", 
+        "label": "Win a Mystery Cruise!", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-015.png"
+        }, 
+        "required_level": 10, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 600, 
+              "y": 300
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "title": "Win a Mystery Cruise!", 
+        "tokens": []
+      }
+    }, 
+    "upgrade004": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Offer a fancy sports car in your next sweepstakes. Cars always draw in the crowds - the sexier the better!", 
+        "label": "Win a Sports Car!", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-015.png"
+        }, 
+        "required_level": 2, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 600, 
+              "y": 200
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "title": "Win a Sports Car!", 
+        "tokens": []
+      }
+    }, 
+    "upgrade005": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Try to sneak a question about household income into your entry form\u2013 and make it compulsory for winning the grand prize!", 
+        "label": "Extra Question: Income", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-011.png"
+        }, 
+        "required_level": 8, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 860, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "Extra Question: Income", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token012", 
+            "gestalt": "token012"
+          }
+        ]
+      }
+    }, 
+    "upgrade006": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Try to sneak a question about education into your entry form \u2013 and make it compulsory for winning the grand prize!", 
+        "label": "Extra question: Education", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-014.png"
+        }, 
+        "required_level": 8, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 600, 
+              "y": 100
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "title": "Extra question: Education", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token130", 
+            "gestalt": "token130"
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token011", 
+            "gestalt": "token011"
+          }
+        ]
+      }
+    }, 
+    "upgrade007": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Try to sneak a question about children into your entry form \u2013 and make it compulsory for winning the grand prize!", 
+        "label": "Extra question: Children", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-012.png"
+        }, 
+        "required_level": 8, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 400, 
+              "y": 700
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "Extra question: Children", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token064", 
+            "gestalt": "token064"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token065", 
+            "gestalt": "token065"
+          }
+        ]
+      }
+    }, 
+    "upgrade008": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "The longer, more complicated and more trustworthy your Privacy Policy sounds, the faster and more willingly people will open their hearts to you. Who cares whether your \u201cstatement of privacy\u201d actually states there is none? Who even reads these things?", 
+        "label": "Privacy Policy", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-015.png"
+        }, 
+        "required_level": 9, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 600, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "title": "Privacy Policy", 
+        "tokens": []
+      }
+    }, 
+    "upgrade009": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Keep your users entertained \u2013 offer some new toys and tricks to stave off boredom.", 
+        "label": "Technology", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-013.png"
+        }, 
+        "required_level": 9, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 300, 
+              "y": 700
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "Technology", 
+        "tokens": []
+      }
+    }, 
+    "upgrade010": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Online dating is especially hot when there\u2019s lots of mega-attractive people on the site. Ideally just as mega-attractive as those photoshopped models people see in all the ads. Sadly, reality\u2019s far from that. Better help things along a little...", 
+        "label": "Fake Profiles", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-015.png"
+        }, 
+        "required_level": 12, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 500, 
+              "y": 500
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "title": "Fake Profiles", 
+        "tokens": []
+      }
+    }, 
+    "upgrade012": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Once you\u2019ve collected enough profiles, you can start making big money on membership fees. The additional info you get from people\u2019s payment details, like reliable names and addresses, is really just the icing on the cake.", 
+        "label": "Premium Membership", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-013.png"
+        }, 
+        "required_level": 14, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 200, 
+              "y": 700
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "Premium Membership", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004"
+          }
+        ]
+      }
+    }, 
+    "upgrade013": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Why do all the work yourself when there\u2019s hundreds of enthusiastic people out there willing to put in endless hours for the right to call themselves \"moderator\"? They\u2019ll take care of your community 24/7, solve dicey problems and make your service even more attractive! Total win!", 
+        "label": "Community Moderators", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-014.png"
+        }, 
+        "required_level": 12, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 400, 
+              "y": 500
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "title": "Community Moderators", 
+        "tokens": []
+      }
+    }, 
+    "upgrade015": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Use this test to determine the confidentiality, reliability, and loyalty of your users. Of course those results only apply in romantic situations...", 
+        "label": "How faithful are you?", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-011.png"
+        }, 
+        "required_level": 5, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 600, 
+              "y": 760
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "How faithful are you?", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token024", 
+            "gestalt": "token024"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token066", 
+            "gestalt": "token066"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token021", 
+            "gestalt": "token021"
+          }
+        ]
+      }
+    }, 
+    "upgrade016": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Happy and content or frustrated and depressed? Genuine depression is no joke, but you\u2019ll definitely find some takers for your test results.", 
+        "label": "Are you depressed?", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-010.png"
+        }, 
+        "required_level": 12, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 500, 
+              "y": 760
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "Are you depressed?", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token025", 
+            "gestalt": "token025"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token053", 
+            "gestalt": "token053"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token120", 
+            "gestalt": "token120"
+          }
+        ]
+      }
+    }, 
+    "upgrade017": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Of course your tests are completely anonymous! However, the extensive, reputable premium analysis is available only via email. Just ask them for their email addresses.", 
+        "label": "Results via email", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-013.png"
+        }, 
+        "required_level": 12, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 0, 
+              "y": 700
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "Results via email", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token008", 
+            "gestalt": "token008"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token132", 
+            "gestalt": "token132"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token084", 
+            "gestalt": "token084"
+          }
+        ]
+      }
+    }, 
+    "upgrade018": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Of course your tests are completely anonymous! However, the extensive, reputable premium analysis is only available via postal mail. Just ask them for their real name and street address.", 
+        "label": "Results via mail", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-012.png"
+        }, 
+        "required_level": 12, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 400, 
+              "y": 760
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "Results via mail", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004"
+          }
+        ]
+      }
+    }, 
+    "upgrade020": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Increase your reach by cooperating with a chain of furniture stores. The fancy family club cards will be used for every shopping trip, and by analyzing buying patterns over a longer period of time you can make some pretty good assumptions about household income.", 
+        "label": "Partnership with furniture chain", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-011.png"
+        }, 
+        "required_level": 17, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 300, 
+              "y": 760
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "Partnership with furniture chain", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token069", 
+            "gestalt": "token069"
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token012", 
+            "gestalt": "token012"
+          }
+        ]
+      }
+    }, 
+    "upgrade021": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Increase your reach by cooperating with a chain of bookstores. If you analyze buying patterns over a longer period of time, you\u2019ll be able to infer political attitudes and more.", 
+        "label": "Partnership with bookstore chain", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-013.png"
+        }, 
+        "required_level": 11, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 700, 
+              "y": 600
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "Partnership with bookstore chain", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token067", 
+            "gestalt": "token067"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token030", 
+            "gestalt": "token030"
+          }
+        ]
+      }
+    }, 
+    "upgrade022": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Increase your reach by partnering up with a fitness chain. Long-term analysis of attendance can help you deduce whether they\u2019re slackers or sports nuts.", 
+        "label": "Partnership with fitness chain", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-012.png"
+        }, 
+        "required_level": 11, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 200, 
+              "y": 760
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "Partnership with fitness chain", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token088", 
+            "gestalt": "token088"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token015", 
+            "gestalt": "token015"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token014", 
+            "gestalt": "token014"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token083", 
+            "gestalt": "token083"
+          }
+        ]
+      }
+    }, 
+    "upgrade023": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Increase your coverage by partnering up with a fashion chain. Their fancy club card goes with them every time they shop, and by analyzing their buying habits over a longer period of time, you can easily guess at their income level and brand fetishism. ", 
+        "label": "Partnership with fashion chain", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-011.png"
+        }, 
+        "required_level": 17, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 100, 
+              "y": 760
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "Partnership with fashion chain", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token070", 
+            "gestalt": "token070"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token113", 
+            "gestalt": "token113"
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token012", 
+            "gestalt": "token012"
+          }
+        ]
+      }
+    }, 
+    "upgrade024": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Your customers will receive yummy bonus offers for filling out just one little questionnaire. Naturally the answers will only be used to improve quality of service!", 
+        "label": "Bonus Program", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-013.png"
+        }, 
+        "required_level": 11, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 700, 
+              "y": 500
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "Bonus Program", 
+        "tokens": []
+      }
+    }, 
+    "upgrade025": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "A call center is cheap, efficient and saves space. Incredible, how many employees you can fit into such  a tiny space! Bonus: With so little privacy, they basically supervise each other \u2013 how convenient! And should it turn out to be too expensive after all, you can always outsource it to some cheaper nation.", 
+        "label": "Call center", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-015.png"
+        }, 
+        "required_level": 13, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 200, 
+              "y": 500
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "title": "Call center", 
+        "tokens": []
+      }
+    }, 
+    "upgrade026": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "You get the feeling your team isn\u2019t working as efficiently as it should? Maybe they surf the net, have extended coffee breaks... you may be right! Trust is good, but control is way better. You need not even need to watch what you record \u2013 just placing a few cameras here and there usually works wonders all by itself.", 
+        "label": "Employee monitoring", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-010.png"
+        }, 
+        "required_level": 13, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 0, 
+              "y": 760
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "Employee monitoring", 
+        "tokens": []
+      }
+    }, 
+    "upgrade027": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Have your team work from home! This has lots of advantages: Less office rent to pay, cheaper wages, and a lower risk of workers organizing into unions or silly stuff like that. Thanks to today's advanced technology, you can even keep tabs on their tasks from afar. All in all: Same cost, more profiles!", 
+        "label": "Telework", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-010.png"
+        }, 
+        "required_level": 13, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 760, 
+              "y": 600
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "Telework", 
+        "tokens": []
+      }
+    }, 
+    "upgrade028": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "The basis for those nuisance calls? The so-called interview guide, better known as THE MANUAL. It contains tips and tricks galore; for example: How do I react when someone wants to hang up? How do I prevent them from doing so? ", 
+        "label": "Interview Guide", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-012.png"
+        }, 
+        "required_level": 7, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 760, 
+              "y": 500
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "Interview Guide", 
+        "tokens": []
+      }
+    }, 
+    "upgrade029": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Better statistical evaluation methods means more data gained from the same amount of information, plus you minimise the danger of ending up with something that\u2019s useless or just plain wrong. Put simply: More profiles for you!", 
+        "label": "Improved evaluation", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-011.png"
+        }, 
+        "required_level": 7, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 760, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "Improved evaluation", 
+        "tokens": []
+      }
+    }, 
+    "upgrade030": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "You\u2019ve already got them on the line \u2013 why not ask a few more questions? Just develop a questionnaire on personal income. A little psychology and some control questions should ensure they spill the truth.", 
+        "label": "Extra questions: Income", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-014.png"
+        }, 
+        "required_level": 7, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 100, 
+              "y": 500
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "title": "Extra questions: Income", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token012", 
+            "gestalt": "token012"
+          }
+        ]
+      }
+    }, 
+    "upgrade031": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "You\u2019ve already got them on the line \u2013 why not ask a few more questions? Just develop a questionnaire on their political attitude. A little psychology and some control questions should ensure they spill the truth.", 
+        "label": "Extra Questions: Politics", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-013.png"
+        }, 
+        "required_level": 13, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 700, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "Extra Questions: Politics", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token030", 
+            "gestalt": "token030"
+          }
+        ]
+      }
+    }, 
+    "upgrade032": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "You\u2019ve already got them on the line \u2013 why not ask a few more questions? Just develop a questionnaire on personal diet. A little psychology and some control questions should ensure they spill the truth.", 
+        "label": "Extra Questions: Diet", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-014.png"
+        }, 
+        "required_level": 13, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 0, 
+              "y": 500
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "title": "Extra Questions: Diet", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token125", 
+            "gestalt": "token125"
+          }
+        ]
+      }
+    }, 
+    "upgrade033": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "You\u2019ve already got them on the line \u2013 why not ask a few more questions? Just develop a survey with questions about children. A little psychology and some control questions should ensure they spill the truth.", 
+        "label": "Extra Questions: Children", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-013.png"
+        }, 
+        "required_level": 7, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 700, 
+              "y": 300
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "Extra Questions: Children", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token064", 
+            "gestalt": "token064"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token065", 
+            "gestalt": "token065"
+          }
+        ]
+      }
+    }, 
+    "upgrade034": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "You\u2019ve already got them on the line \u2013 why not ask a few more questions? Just develop a questionnaire on  their travel and holidays. A little psychology and some control questions should ensure they spill the truth.", 
+        "label": "Extra Questions: Travel", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-014.png"
+        }, 
+        "required_level": 13, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 500, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "title": "Extra Questions: Travel", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token093", 
+            "gestalt": "token093"
+          }
+        ]
+      }
+    }, 
+    "upgrade036": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "You\u2019ve already got them on the line \u2013 why not ask a few more questions? Just develop a questionnaire on their religious beliefs. A little psychology and some control questions should ensure they spill the truth.", 
+        "label": "Extra Questions: Religion", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-014.png"
+        }, 
+        "required_level": 13, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 500, 
+              "y": 300
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "title": "Extra Questions: Religion", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token098", 
+            "gestalt": "token098"
+          }
+        ]
+      }
+    }, 
+    "upgrade037": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "You\u2019ve already got them on the line \u2013 why not ask a few more questions? Try a questionnaire about the high-risk sports they enjoy. A little psychology and some control questions should ensure they spill the truth.", 
+        "label": "Extra Questions: High-risk sport", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-013.png"
+        }, 
+        "required_level": 7, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 700, 
+              "y": 100
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "Extra Questions: High-risk sport", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token103", 
+            "gestalt": "token103"
+          }
+        ]
+      }
+    }, 
+    "upgrade038": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Text and text aren\u2019t necessarily the same. Some fine-tuning here and there is invaluable. The more elegant, manipulative and convincing your texts, the more people will fall for them.", 
+        "label": "Persuasive Text", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-011.png"
+        }, 
+        "required_level": 11, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 760, 
+              "y": 300
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "Persuasive Text", 
+        "tokens": []
+      }
+    }, 
+    "upgrade039": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Still think buyers are going to send in their warranty cards by mail? A little old-fashioned, are we? High time you get yourself an online form as a service for your customers. Result: More profiles, and loads of email and IP addresses.", 
+        "label": "Online form", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-011.png"
+        }, 
+        "required_level": 20, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 760, 
+              "y": 200
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "Online form", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token008", 
+            "gestalt": "token008"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token029", 
+            "gestalt": "token029"
+          }
+        ]
+      }
+    }, 
+    "upgrade040": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "You don\u2019t really want to waste valuable time by manually typing in the information from all those warranty cards, right? Get yourself an intelligent automatic text recognition system and a scanner, and watch as it does the job for you in seconds.", 
+        "label": "Automatic Text Recognition", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-013.png"
+        }, 
+        "required_level": 18, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 700, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "Automatic Text Recognition", 
+        "tokens": []
+      }
+    }, 
+    "upgrade041": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Increase your reach by partnering up with a luxury watch maker. Know just how quickly such a fancy watch can get damaged? Better make sure your customers are extra-aware. Practically guarantees that you get data on a particularly solvent target group.", 
+        "label": "Partnership with luxury watch maker", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-015.png"
+        }, 
+        "required_level": 20, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 500, 
+              "y": 200
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "title": "Partnership with luxury watch maker", 
+        "tokens": [
+          {
+            "amount": 25, 
+            "full_type": "TokenPerp:token012", 
+            "gestalt": "token012"
+          }
+        ]
+      }
+    }, 
+    "upgrade042": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Increase your coverage by partnering up with a car maker. SUVs with four-wheel drive are increasingly popular for city driving, but aren\u2019t exactly cheap. Know what this means? Yes, more lucrative data!", 
+        "label": "Partnership with SUV manufacturer", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-014.png"
+        }, 
+        "required_level": 20, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 600, 
+              "y": 600
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "Partnership with SUV manufacturer", 
+        "tokens": [
+          {
+            "amount": 25, 
+            "full_type": "TokenPerp:token012", 
+            "gestalt": "token012"
+          }
+        ]
+      }
+    }, 
+    "upgrade043": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Increase your coverage by partnering up with a yacht manufacturer. Whether they have acquired a motor boat or a fancy sailing yacht \u2013 this kind of person will surely be extra careful in filling out their warranty cards.", 
+        "label": "Partnership with yacht manufacturer", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-011.png"
+        }, 
+        "required_level": 20, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 760, 
+              "y": 100
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "Partnership with yacht manufacturer", 
+        "tokens": [
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token012", 
+            "gestalt": "token012"
+          }
+        ]
+      }
+    }, 
+    "upgrade044": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Increase your reach by partnering up with a drill manufacturer. DIY types seem to love good customer service and take special care to fill in their warranty cards.", 
+        "label": "Partnership with drill manufacturer", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-015.png"
+        }, 
+        "required_level": 18, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 500, 
+              "y": 100
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "title": "Partnership with drill manufacturer", 
+        "tokens": [
+          {
+            "amount": 25, 
+            "full_type": "TokenPerp:supertoken014", 
+            "gestalt": "supertoken014"
+          }
+        ]
+      }
+    }, 
+    "upgrade045": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Increase your coverage by partnering up with a TV manufacturer. Whether it\u2019s cheap plasma TV or prestigious cinema-size LCD screens, there\u2019ll surely be a lot of warranty cards coming your way.", 
+        "label": "Partnership with TV manufacturer", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-014.png"
+        }, 
+        "required_level": 18, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 500, 
+              "y": 600
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "Partnership with TV manufacturer", 
+        "tokens": [
+          {
+            "amount": 25, 
+            "full_type": "TokenPerp:supertoken014", 
+            "gestalt": "supertoken014"
+          }
+        ]
+      }
+    }, 
+    "upgrade049": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Better statistical evaluation methods means more data gained from the same amount of information, plus you minimise the danger of ending up with something that\u2019s useless or just plain wrong. Put simply: More profiles for you!", 
+        "label": "Improved evaluation", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-010.png"
+        }, 
+        "required_level": 15, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 760, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "Improved evaluation", 
+        "tokens": []
+      }
+    }, 
+    "upgrade053": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Gluten sensitive, or allergic to dust? Offer an allergy test \u2013 you won\u2019t even need medical personnel. Cheap, easy to do, and instantly increases the appeal of your service. Let\u2019s face it \u2013 who doesn\u2019t suffer from one, these days?", 
+        "label": "Allergy test", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-015.png"
+        }, 
+        "required_level": 15, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 200, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "title": "Allergy test", 
+        "tokens": []
+      }
+    }, 
+    "upgrade057": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Business thriving so much that your server is buckling under the load? Better take care of that ASAP. Outages are the last thing you need. Invest now to ensure your future success.", 
+        "label": "Better Server", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-013.png"
+        }, 
+        "required_level": 15, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 200, 
+              "y": 600
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "Better Server", 
+        "tokens": []
+      }
+    }, 
+    "upgrade064": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Your software is at the heart of your operation. If it doesn\u2019t work perfectly, you miss out on 50% of those pirating masses. Also, BitTorrent alone won\u2019t cut it \u2013 you\u2019ll need to access even more P2P networks to increase your success rate.", 
+        "label": "Improved crawler", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-011.png"
+        }, 
+        "required_level": 15, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 0, 
+              "y": 660
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "Improved crawler", 
+        "tokens": []
+      }
+    }, 
+    "upgrade069": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "You only have the IP addresses of your clueless victims? High time you partnered up with a major internet provider. They\u2019ll know exactly which IP goes with which person. And once you\u2019ve got their names and addresses, those label bosses will have a much easier time suing those online pirates \u2013 and will pay you more for your services.", 
+        "label": "Partnership with an ISP", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-011.png"
+        }, 
+        "required_level": 15, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 660, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "Partnership with an ISP", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token002", 
+            "gestalt": "token002"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004"
+          }
+        ]
+      }
+    }, 
+    "upgrade070": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Compile a questionnaire about medical background information. And use it! There\u2019s always some people who think answering those questions truthfully is in their best interest. So go for it \u2013 just ask them straight out about their aches and pains, conditions, and what meds they live on.", 
+        "label": "Medical Questionnaire", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-011.png"
+        }, 
+        "required_level": 15, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 660, 
+              "y": 300
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "Medical Questionnaire", 
+        "tokens": [
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token018", 
+            "gestalt": "token018"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token114", 
+            "gestalt": "token114"
+          }
+        ]
+      }
+    }, 
+    "upgrade071": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Compile a questionnaire about addictive behavior. There\u2019s always some people who think answering those questions truthfully is in their best interest. Go for it \u2013 just ask them straight out about their use of drugs like nicotine, alcohol and more. ", 
+        "label": "Drug use Questionnaire", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-011.png"
+        }, 
+        "required_level": 15, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 660, 
+              "y": 200
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "Drug use Questionnaire", 
+        "tokens": [
+          {
+            "amount": 75, 
+            "full_type": "TokenPerp:token053", 
+            "gestalt": "token053"
+          }, 
+          {
+            "amount": 75, 
+            "full_type": "TokenPerp:token054", 
+            "gestalt": "token054"
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token120", 
+            "gestalt": "token120"
+          }
+        ]
+      }
+    }, 
+    "upgrade073": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Offer a blood test plus evaluation. People just love having their blood analyzed so they can compare their blood type. As for you \u2013 you don\u2019t just learn about possible illnesses, but about people\u2019s nutritional deficiencies as well.", 
+        "label": "Blood test", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-015.png"
+        }, 
+        "required_level": 15, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 400, 
+              "y": 200
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "title": "Blood test", 
+        "tokens": [
+          {
+            "amount": 25, 
+            "full_type": "TokenPerp:token018", 
+            "gestalt": "token018"
+          }, 
+          {
+            "amount": 25, 
+            "full_type": "TokenPerp:token053", 
+            "gestalt": "token053"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token125", 
+            "gestalt": "token125"
+          }
+        ]
+      }
+    }, 
+    "upgrade074": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "You really should include urine tests in your services. More popular than blood tests (no pricking!), and even more exciting data: You won\u2019t just get information on possible illnesses \u2013 you might even find proof of drug abuse. You don\u2019t even need to do the analysis yourself \u2013 that\u2019s what you pay that lab for.", 
+        "label": "Urine test", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-012.png"
+        }, 
+        "required_level": 15, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 600, 
+              "y": 200
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "Urine test", 
+        "tokens": [
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token018", 
+            "gestalt": "token018"
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token120", 
+            "gestalt": "token120"
+          }
+        ]
+      }
+    }, 
+    "upgrade103": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Age knows no mercy \u2013 people don\u2019t just look older, but more well-behaved and settled. How are they supposed to recognise each other when there\u2019s no option to upload their photos? ", 
+        "label": "Photo Upload", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-014.png"
+        }, 
+        "required_level": 18, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 500, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "Photo Upload", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token036", 
+            "gestalt": "token036"
+          }
+        ]
+      }
+    }, 
+    "upgrade104": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "This is sure to be a hit: Offer your users the option to upload their old school photos. Someone is sure to have kept them all, and they have an almost magical attraction for your sentimental target audience.", 
+        "label": "School photos", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-010.png"
+        }, 
+        "required_level": 18, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 560, 
+              "y": 100
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "School photos", 
+        "tokens": []
+      }
+    }, 
+    "upgrade105": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Just chatting online gets boring after a while. Offer your users some options for organising their real-life reunions. This would also be the perfect time to ask about their adress and home town \u2013 it's strictly confidential of course.", 
+        "label": "Organise class reunion", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-011.png"
+        }, 
+        "required_level": 18, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 560, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "Organise class reunion", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token003", 
+            "gestalt": "token003"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004"
+          }
+        ]
+      }
+    }, 
+    "upgrade107": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "High school\u2026it\u2019s been a while, right? Is rehashing those old stories really such a good idea? The option of anonymous phone contact helps to lower the risk of embarassing yourself \u2013 especially in the case of that secret crush you still have on your classmate.", 
+        "label": "Anonymous phone contact", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-012.png"
+        }, 
+        "required_level": 18, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 400, 
+              "y": 460
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "Anonymous phone contact", 
+        "tokens": [
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token005", 
+            "gestalt": "token005"
+          }
+        ]
+      }
+    }, 
+    "upgrade108": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Expand your target audience through a partnership with the online version of a national newspaper. They can offer more diverse services on their website, and you get: more data! ", 
+        "label": "Partner with online newspaper", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-012.png"
+        }, 
+        "required_level": 20, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 300, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "Partner with online newspaper", 
+        "tokens": []
+      }
+    }, 
+    "upgrade109": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Give them a forum! A place for discussion, creating friendships, heated arguments, but mostly: A place to return to. An active forum increases the popularity of your project without your editors having to come up with new content all the time.", 
+        "label": "Forum", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-012.png"
+        }, 
+        "required_level": 20, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 200, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "Forum", 
+        "tokens": []
+      }
+    }, 
+    "upgrade110": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "You\u2019ve already got them on the line \u2013 why not ask a few more questions? Just develop a questionnaire on union membership. A little psychology and some control questions should they ensure spill the truth.", 
+        "label": "Extra Questions: Unions", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-012.png"
+        }, 
+        "required_level": 7, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 300, 
+              "y": 460
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "Extra Questions: Unions", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token047", 
+            "gestalt": "token047"
+          }
+        ]
+      }
+    }, 
+    "upgrade112": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Try to sneak a question about pets into your entry form \u2013 and make it compulsory for winning the grand prize!", 
+        "label": "Extra Question: Pets", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-013.png"
+        }, 
+        "required_level": 10, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 100, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "Extra Question: Pets", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token129", 
+            "gestalt": "token129"
+          }
+        ]
+      }
+    }, 
+    "upgrade113": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Online dating sites ask their users to answer hundreds of questions about their character - resulting in the so-called match factor. Who\u2019s a good match? With 90% in common, you know you found the One! Include a match test about sexual proclivities.", 
+        "label": "Match Test: Sex", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-013.png"
+        }, 
+        "required_level": 14, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 0, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "Match Test: Sex", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token066", 
+            "gestalt": "token066"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token020", 
+            "gestalt": "token020"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token024", 
+            "gestalt": "token024"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token025", 
+            "gestalt": "token025"
+          }
+        ]
+      }
+    }, 
+    "upgrade114": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Online dating sites ask their users to answer hundreds of questions about their character - resulting in the so-called match factor. Who\u2019s a good match? With 90% in common, you know you found the One! Include a match test about lifestyle choices.", 
+        "label": "Match-Test:\r\nLifestyle", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-012.png"
+        }, 
+        "required_level": 9, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 400, 
+              "y": 300
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "Match-Test: Lifestyle", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token097", 
+            "gestalt": "token097"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token030", 
+            "gestalt": "token030"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token129", 
+            "gestalt": "token129"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token081", 
+            "gestalt": "token081"
+          }
+        ]
+      }
+    }, 
+    "upgrade116": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Ready to blow or calm and collected? Master of Multitasking or getting nervous at the sight of two open tabs? Find our how stressed out your users are \u2013 that kind of information is sure to come in handy.", 
+        "label": "How well do I cope?", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-015.png"
+        }, 
+        "required_level": 12, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 300, 
+              "y": 200
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "title": "How well do I cope?", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token083", 
+            "gestalt": "token083"
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token092", 
+            "gestalt": "token092"
+          }
+        ]
+      }
+    }, 
+    "upgrade117": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Calculating or impulsive? Guarded or bossy? Hold back or go for the throat? The way people act in fights should give you lots of ideas of how they act in other situations as well. ", 
+        "label": "Test your self-control!", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-015.png"
+        }, 
+        "required_level": 8, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 300, 
+              "y": 100
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "title": "Test your self-control!", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token089", 
+            "gestalt": "token089"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token103", 
+            "gestalt": "token103"
+          }
+        ]
+      }
+    }, 
+    "upgrade118": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Busy bee or sleepy sloth? Career-driven or placid and laid-back? Are you curious how ambitious your users are? This test is sure to deliver some very interesting results.", 
+        "label": "Test your determination!", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-015.png"
+        }, 
+        "required_level": 8, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 300, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-023.png"
+        }, 
+        "title": "Test your determination!", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token081", 
+            "gestalt": "token081"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token012", 
+            "gestalt": "token012"
+          }
+        ]
+      }
+    }, 
+    "upgrade119": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Stage hog or shy as a deer? Arrogant jerk or quiet wallflower? The way your users judge their own confidence should give you lots of ideas of how they generally act in life \u2013 which has lots of lucrative implications on many issues.", 
+        "label": "How self-confident are you?", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-012.png"
+        }, 
+        "required_level": 8, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 400, 
+              "y": 200
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "How self-confident are you?", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token090", 
+            "gestalt": "token090"
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token092", 
+            "gestalt": "token092"
+          }
+        ]
+      }
+    }, 
+    "upgrade120": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Clingy or freedom-loving? Big circle of friends or big TV screen? What sort of relationships do your users have? The results should give you lots if interesting insights concerning their personality profiles. ", 
+        "label": "Relationship Test", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-012.png"
+        }, 
+        "required_level": 5, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 400, 
+              "y": 100
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "Relationship Test", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token085", 
+            "gestalt": "token085"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token022", 
+            "gestalt": "token022"
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token065", 
+            "gestalt": "token065"
+          }
+        ]
+      }
+    }, 
+    "upgrade146": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Who falls for your tricks and who slips through your fingers? Analyzing the numbers will really help in fine-tuning your ventures for your various target groups, and you\u2019ll also find out who reacts best to your ads.", 
+        "label": "Response Tracking", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-012.png"
+        }, 
+        "required_level": 10, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 200, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-022.png"
+        }, 
+        "title": "Response Tracking", 
+        "tokens": [
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token132", 
+            "gestalt": "token132"
+          }
+        ]
+      }
+    }, 
+    "upgrade147": {
+      "game_type": "UpgradePowerup", 
+      "type_data": {
+        "description": "Increase your reach by partnering up with a phone manufacturer. Just one picture of a shiny smartphone, its display ruined by spiderweb cracks, will surely convince them to buy protection \u2013 even though the small print clearly says that display damage is excluded from warranty.", 
+        "label": "Partnership with mobile phone maker", 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-010.png"
+        }, 
+        "required_level": 18, 
+        "slot_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 0, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-021.png"
+        }, 
+        "title": "Partnership with mobile phone maker", 
+        "tokens": [
+          {
+            "amount": 25, 
+            "full_type": "TokenPerp:supertoken014", 
+            "gestalt": "supertoken014"
+          }
+        ]
+      }
+    }
+  }, 
+  "tokens": {
+    "origin001": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "label": "Little Rock City", 
+        "origin_full_type": "CityPerp:city002", 
+        "origin_gestalt": "city002", 
+        "title": "Little Rock City"
+      }
+    }, 
+    "origin002": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "label": "Gewinnspiel", 
+        "origin_full_type": "ProjectPerp:project001", 
+        "origin_gestalt": "project001", 
+        "title": "Gewinnspiel"
+      }
+    }, 
+    "origin003": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "label": "Psychotest", 
+        "origin_full_type": "ProjectPerp:project003", 
+        "origin_gestalt": "project003", 
+        "title": "Psychotest"
+      }
+    }, 
+    "origin004": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "label": "Telefon-\r\numfrage", 
+        "origin_full_type": "ProjectPerp:project005", 
+        "origin_gestalt": "project005", 
+        "title": "Telefon-\r\numfrage"
+      }
+    }, 
+    "origin005": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "label": "Partnerb\u00f6rse", 
+        "origin_full_type": "ProjectPerp:project002", 
+        "origin_gestalt": "project002", 
+        "title": "Partnerb\u00f6rse"
+      }
+    }, 
+    "origin006": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "label": "Elly DeTelly ", 
+        "origin_full_type": "ContactPerp:contact026", 
+        "origin_gestalt": "contact026", 
+        "title": "Elly DeTelly "
+      }
+    }, 
+    "origin007": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "label": "Hana Blum", 
+        "origin_full_type": "ContactPerp:contact033", 
+        "origin_gestalt": "contact033", 
+        "title": "Hana Blum"
+      }
+    }, 
+    "origin008": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "label": "Lennon Che\r\nWurlitschek", 
+        "origin_full_type": "ContactPerp:contact008", 
+        "origin_gestalt": "contact008", 
+        "title": "Lennon Che\r\nWurlitschek"
+      }
+    }, 
+    "origin009": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "label": "Sadik Konetschnig", 
+        "origin_full_type": "ContactPerp:contact007", 
+        "origin_gestalt": "contact007", 
+        "title": "Sadik Konetschnig"
+      }
+    }, 
+    "origin010": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "label": "Alexa C. Tivia", 
+        "origin_full_type": "ContactPerp:contact019", 
+        "origin_gestalt": "contact019", 
+        "title": "Alexa C. Tivia"
+      }
+    }, 
+    "origin011": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "label": "Jessica Seno", 
+        "origin_full_type": "ContactPerp:contact035", 
+        "origin_gestalt": "contact035", 
+        "title": "Jessica Seno"
+      }
+    }, 
+    "origin012": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "label": "Schwester\r\nElfriede", 
+        "origin_full_type": "ContactPerp:contact001", 
+        "origin_gestalt": "contact001", 
+        "title": "Schwester\r\nElfriede"
+      }
+    }, 
+    "origin013": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "label": "Ulli Stenzer", 
+        "origin_full_type": "ContactPerp:contact022", 
+        "origin_gestalt": "contact022", 
+        "title": "Ulli Stenzer"
+      }
+    }, 
+    "origin014": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "label": "New York City", 
+        "origin_full_type": "CityPerp:city004", 
+        "origin_gestalt": "city004", 
+        "title": "New York City"
+      }
+    }, 
+    "origin015": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "label": "Vorteilsclub", 
+        "origin_full_type": "ProjectPerp:project004", 
+        "origin_gestalt": "project004", 
+        "title": "Vorteilsclub"
+      }
+    }, 
+    "origin016": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "label": "Raubkopierer\r\nSpinne", 
+        "origin_full_type": "ProjectPerp:project007", 
+        "origin_gestalt": "project007", 
+        "title": "Raubkopierer\r\nSpinne"
+      }
+    }, 
+    "origin017": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "label": "Vorsorge-\r\nUntersuchung", 
+        "origin_full_type": "ProjectPerp:project009", 
+        "origin_gestalt": "project009", 
+        "title": "Vorsorge-\r\nUntersuchung"
+      }
+    }, 
+    "origin018": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "label": "Garantiekarten", 
+        "origin_full_type": "ProjectPerp:project006", 
+        "origin_gestalt": "project006", 
+        "title": "Garantiekarten"
+      }
+    }, 
+    "origin019": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "label": "Virtuelles Klassentreffen", 
+        "origin_full_type": "ProjectPerp:project011", 
+        "origin_gestalt": "project011", 
+        "title": "Virtuelles Klassentreffen"
+      }
+    }, 
+    "origin020": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "label": "Franz Sauerzapf", 
+        "origin_full_type": "ContactPerp:contact004", 
+        "origin_gestalt": "contact004", 
+        "title": "Franz Sauerzapf"
+      }
+    }, 
+    "origin021": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "label": "Sieglinde\r\nBayer-Wurz", 
+        "origin_full_type": "ContactPerp:contact005", 
+        "origin_gestalt": "contact005", 
+        "title": "Sieglinde\r\nBayer-Wurz"
+      }
+    }, 
+    "origin022": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "label": "Onkel Enzo", 
+        "origin_full_type": "ContactPerp:contact003", 
+        "origin_gestalt": "contact003", 
+        "title": "Onkel Enzo"
+      }
+    }, 
+    "supertoken002": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 14400000, 
+        "contained_tokens": [
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token125", 
+            "gestalt": "token125", 
+            "is_required": true, 
+            "position": 2
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token018", 
+            "gestalt": "token018", 
+            "is_required": true, 
+            "position": 4
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token092", 
+            "gestalt": "token092", 
+            "is_required": false, 
+            "position": 7
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token088", 
+            "gestalt": "token088", 
+            "is_required": false, 
+            "position": 6
+          }, 
+          {
+            "amount": 100, 
+            "full_type": "TokenPerp:token114", 
+            "gestalt": "token114", 
+            "is_required": false, 
+            "position": 8
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token120", 
+            "gestalt": "token120", 
+            "is_required": false, 
+            "position": 11
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token103", 
+            "gestalt": "token103", 
+            "is_required": false, 
+            "position": 5
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token054", 
+            "gestalt": "token054", 
+            "is_required": false, 
+            "position": 10
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token055", 
+            "gestalt": "token055", 
+            "is_required": true, 
+            "position": 1
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token017", 
+            "gestalt": "token017", 
+            "is_required": true, 
+            "position": 3
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token053", 
+            "gestalt": "token053", 
+            "is_required": false, 
+            "position": 9
+          }
+        ], 
+        "description": "So, how\u2019s your profile\u2019s general health? What\u2019s the prognosis? Fit and healthy or soon-to-be nursing case? Pile up all your data and calculate a value for every single person that summarises their physical and psychological risks. Your customers will go crazy for it! Help them make their decisions more easily. Bad score \u2013 tough luck! The more new info you collect for your calculation, the more money you\u2019ll make.", 
+        "findings_text": "You get a health prognosis for %s people.", 
+        "is_buyable": true, 
+        "is_supertoken": true, 
+        "knowledge_text": "You have a health prognosis for %s people.", 
+        "label": "Health Prognosis", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 580, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-005.png"
+        }, 
+        "price": 5000, 
+        "required_level": 17, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Health Prognosis", 
+        "xp_inc": 30
+      }
+    }, 
+    "supertoken014": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 7200000, 
+        "contained_tokens": [
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token097", 
+            "gestalt": "token097", 
+            "is_required": false, 
+            "position": 8
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token093", 
+            "gestalt": "token093", 
+            "is_required": false, 
+            "position": 9
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token032", 
+            "gestalt": "token032", 
+            "is_required": false, 
+            "position": 10
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token067", 
+            "gestalt": "token067", 
+            "is_required": false, 
+            "position": 1
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token070", 
+            "gestalt": "token070", 
+            "is_required": false, 
+            "position": 2
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token069", 
+            "gestalt": "token069", 
+            "is_required": false, 
+            "position": 3
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token113", 
+            "gestalt": "token113", 
+            "is_required": false, 
+            "position": 4
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token125", 
+            "gestalt": "token125", 
+            "is_required": false, 
+            "position": 5
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token099", 
+            "gestalt": "token099", 
+            "is_required": false, 
+            "position": 6
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token128", 
+            "gestalt": "token128", 
+            "is_required": false, 
+            "position": 7
+          }
+        ], 
+        "description": "Food, drinks, cosmetics, clothes? Electronics, music, videos, books or cars? Looking at a list of personal purchases over several months, you\u2019ll learn quite a lot about the person concerned. Just from supermarket purchases alone you\u2019ll be able to make a good guess whether someone is rich or poor, educated or not, and maybe even their sexual orientation. The more you know about other people\u2019s buys, the easier it will be to sell \u2013 not just for targeted advertising.", 
+        "findings_text": "You learn the buying habits of %s people", 
+        "is_buyable": true, 
+        "is_supertoken": true, 
+        "knowledge_text": "You know the buying habits of %s people", 
+        "label": "Buying Habits", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 100, 
+              "width": 100, 
+              "x": 100, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-005.png"
+        }, 
+        "price": 2000, 
+        "required_level": 12, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Buying Habits", 
+        "xp_inc": 11
+      }
+    }, 
+    "token001": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Whether cool or dumb, common or unique, old-fashioned or trendy \u2013 the first name is essential for the definite identification of a person and thus one of the most important attributes for your business. The name can help you settle the question of gender as well. With a list of popular first names for several birth years you might even be able to guess the age of a person. Someone called Gertrude or Bob is most likely not younger than 40, on the other hand you probably won\u2019t find a Kevin or Jennifer older than 50.", 
+        "findings_text": "You get the first name of %s people", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the first names of %s people", 
+        "label": "First name", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 800, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 900
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "First name", 
+        "xp_inc": 1
+      }
+    }, 
+    "token002": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "The last name is essential for the identification of a person. Combined with first name and date of birth, it\u2019s pretty much a done deal. It\u2019s not exactly a walk in the park, though, what with all those Smiths, Browns and Joneses.\r\nFirst name, last name and date of birth are among the key attributes in your database. Whenever you gain new profiles, your database might be able to use these attributes to connect them to existing profiles.", 
+        "findings_text": "You get the last names of %s people", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the last names of %s people", 
+        "label": "Last name", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 720, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 900
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Last name", 
+        "xp_inc": 1
+      }
+    }, 
+    "token003": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Knowing the address is perfect not only for spamming people with junk mail, but tells you lots of other things about them as well. Fancy neighborhood or ghetto? City slicker or country bumpkin? This information will prove essential in filing and pigeonholing. And just imagine the marketing possibilities!", 
+        "findings_text": "You get the street and house numbers of %s people", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the street and house numbers of %s people", 
+        "label": "Address", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 640, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 900
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Address", 
+        "xp_inc": 1
+      }
+    }, 
+    "token004": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Essential for precise identification, these codes created by the postal service will also tell you much, much more. Fancy neighborhood or ghetto? City slicker or country bumpkin? This information will prove essential in filing and pigeonholing. And just imagine the marketing possibilities!", 
+        "findings_text": "You get the zip codes of %s people", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the zip codes of %s people", 
+        "label": "Zip Code", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 560, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 900
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Zip Code", 
+        "xp_inc": 1
+      }
+    }, 
+    "token005": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "The phone is one of the most important personal communication tools. Marketing agencies pay good money for profiles that include phone numbers.\r\nEver since the dawn of the age of smartphones, more and more personal information has been collected inside these constant companions. All that stored data can be made into near-perfect personality profiles. So extra-nasty data collectors plant funny apps on people\u2019s phones which then sneakily tap the phones\u2019 memory.", 
+        "findings_text": "You get one or more phone numbers of %s people", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know one or more phone numbers of %s people", 
+        "label": "Phone number", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 480, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 900
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Phone number", 
+        "xp_inc": 1
+      }
+    }, 
+    "token006": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "The combination of name and date of birth makes identifying a person a pretty safe bet. You can also learn someone\u2019s age, and that in turn leads to lots of interesting conclusions. For example, concerning wealth, income, interests, problems, buying habits or state of health.", 
+        "findings_text": "You get the date of birth for %s people", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the date of birth of %s people", 
+        "label": "Date of birth", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 400, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 900
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Date of birth", 
+        "xp_inc": 1
+      }
+    }, 
+    "token007": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 30000, 
+        "contained_tokens": [
+          {
+            "amount": 75, 
+            "full_type": "TokenPerp:token001", 
+            "gestalt": "token001", 
+            "is_required": false, 
+            "position": 1
+          }
+        ], 
+        "description": "The entry \u201csex\u201d on birth certificates and in passports is thankfully less decisive in people\u2019s lives than it used to be. However, girls and boys are still fully under the thumb of their designated gender roles. Unequal incomes, interests, risk factors, medical needs, buying habits, life expectancy \u2013 knowing a person\u2019s sex offers you countless opportunities. Hint: Once you\u2019ve collected enough first names, you can use them to calculate the sex of previously unclassified profiles.", 
+        "findings_text": "You get info about the sex of %s people", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the sex of %s people", 
+        "label": "Sex", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 320, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Sex", 
+        "xp_inc": 1
+      }
+    }, 
+    "token008": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Nowadays email addresses have become more important than postal addresses. They\u2019re the key to a net data gold mine. Countless online services utilize their users\u2019 email address for registration instead of their name. And once you know someone\u2019s email address, you can pinpoint them anywhere, no matter which nickname or pseudonym they use. In addition, email addresses can be sold quite profitably for marketing purposes.", 
+        "findings_text": "You get one or more email addresses of %s people", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know one or more email addresses of %s people", 
+        "label": "Email", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 240, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Email", 
+        "xp_inc": 1
+      }
+    }, 
+    "token009": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Always late? Prone to calling in \u201csick\u201d? Whistle blower? Other red flags? Lots of companies keep fat files on their employees, including all their strengths, weaknesses and little lapses. Legal? More or less. But very interesting indeed for future employers.", 
+        "findings_text": "You get the personnel records of %s people", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the personnel records of %s people", 
+        "label": "Personnel\r\nRecords", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 160, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 900
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Personnel Records", 
+        "xp_inc": 1
+      }
+    }, 
+    "token011": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Some celebs show off their bad report cards and dazzle the media with their youthful dropout antics. For those who are stars, a slacker past shouldn\u2019t be too much of a problem. But cold, hard reality is somewhat different for most people. It\u2019s especially important for young adults who want to get their foot in the door by boasting of their diligent careers at prestigious schools. Let\u2019s hope none of them flunked \u201cHonesty in Application Writing\u201d...", 
+        "findings_text": "You get information about the educations of %s people", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know about the educations of %s people", 
+        "label": "Education", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 0, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 900
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Education", 
+        "xp_inc": 1
+      }
+    }, 
+    "token012": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 1800000, 
+        "contained_tokens": [
+          {
+            "amount": 3, 
+            "full_type": "TokenPerp:token004", 
+            "gestalt": "token004", 
+            "is_required": true, 
+            "position": 1
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token067", 
+            "gestalt": "token067", 
+            "is_required": true, 
+            "position": 3
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token070", 
+            "gestalt": "token070", 
+            "is_required": false, 
+            "position": 4
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token069", 
+            "gestalt": "token069", 
+            "is_required": false, 
+            "position": 5
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token128", 
+            "gestalt": "token128", 
+            "is_required": false, 
+            "position": 2
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token093", 
+            "gestalt": "token093", 
+            "is_required": false, 
+            "position": 6
+          }
+        ], 
+        "description": "Maximum wage earner, middle class or barely scraping by? Who cares whether it\u2019s fair or not. There\u2019s no question that there\u2019s a huge difference in what people earn. It shapes their whole lives and the lives of their children too. Whether they earn a manager\u2019s wage, are on the dole or live off a pension \u2013 many institutions are interested in people\u2019s financial situation. Hint: Using statistics you can estimate people\u2019s income just from knowing where they live. Geo-Scoring! You can use other attributes as well to calculate people\u2019s income.", 
+        "findings_text": "You learn the income of %s people", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the incomes of %s people", 
+        "label": "Income", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 720, 
+              "y": 640
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Income", 
+        "xp_inc": 3
+      }
+    }, 
+    "token013": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Student loans, monthly payments for a swanky TV, leasing a car or a taking on a huge mortgage: a lot of people are in debt. Especially delicate if one loan only serves to pay off another. While this may be fine for governments and companies, for private persons it\u2019s a real no-go.\r\nIf your debts are out-of-control compared to income and purchases, you're blacklisted and no one wants to do business with you. That\u2019s especially interesting to banks, mail-order companies, online shops and mobile phone providers.", 
+        "findings_text": "You learn the debt status of %s people", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the debt status of %s people", 
+        "label": "Debts", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 720, 
+              "y": 560
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 900
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Debts", 
+        "xp_inc": 1
+      }
+    }, 
+    "token014": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Anorexic, obese or just right? Sorry folks: those who deviate from the norm often find themselves unwanted as customers. Weight is lucrative information for every client dealing in health. Some employers are also not averse to knowing it, either. And let\u2019s not even get started on advertising targeted for weight loss!", 
+        "findings_text": "You get the current weights of %s people", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the current weights of %s people", 
+        "label": "Weight", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 720, 
+              "y": 480
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Weight", 
+        "xp_inc": 1
+      }
+    }, 
+    "token015": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Mainly useful when combined with weight. Once you have both, you can calculate the body mass index, or BMI for short. This is much more useful than weight alone and can be sold for even more money. Fat people have no chance at certain jobs and health insurance can also do without potential high-risk patients.", 
+        "findings_text": "You get the heights of %s people", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the heights of %s people", 
+        "label": "Height", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 720, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Height", 
+        "xp_inc": 1
+      }
+    }, 
+    "token017": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Past and current ailments, treatments and operations, examination results and their exact date: the medical records produced in doctors\u2019 offices and hospitals offer important clues for future prognoses. The health industry pays good money for information like this.", 
+        "findings_text": "You get the detailed medical records of %s people", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You have the detailed medical records of %s people", 
+        "label": "Medical records", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 720, 
+              "y": 240
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Medical records", 
+        "xp_inc": 1
+      }
+    }, 
+    "token018": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Asthma, migraines, allergies, eczema or chronic back problems? Drug addiction, depression, hepatitis or the heavy stuff like multiple sclerosis or cancer? Insurance companies are dying to know about these things, and certain employers wouldn\u2019t be averse to getting this info either.", 
+        "findings_text": "You get information about the chronic ailments (or their absence) of %s people", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know about the chronic ailments (or their absence) of %s people", 
+        "label": "Chronic\r\nillnesses", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 80, 
+              "y": 800
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Chronic illnesses", 
+        "xp_inc": 1
+      }
+    }, 
+    "token019": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "A weekly dose of twenty minutes of artificial sun inside the strongest ray gun available? Just don\u2019t tell your dermatologist! Making a habit of this can\u2019t be good \u2013 some day one of those moles might take action and grow up to be a gnarly melanoma. Those concerned will find out sooner or later, but there\u2019s many more people interested in the casual handling of UV radiation. After all, to the health industry the world is nothing but a long list of risk factors.", 
+        "findings_text": "You get information about the UV exposure of %s people", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the UV exposure of %s people", 
+        "label": "Tanning booth\r\nvisits", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 0, 
+              "y": 800
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Tanning booth visits", 
+        "xp_inc": 1
+      }
+    }, 
+    "token020": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Now isn\u2019t this a juicy little detail? And quite useful for your personality profiles. Lost their virginity too early? Probably prone to rash decisions and easily manipulated! Much too late? Weirdo! From the \u201creliable psychological matching test\u201c offered at your online dating portal you learn even more than that. Isn\u2019t it great how people don\u2019t bother to read your privacy policy?", 
+        "findings_text": "You learn the age they were when they fucked the first time for %s people", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the age they were when they fucked the first time for %s people", 
+        "label": "Age at first\r\nsexual encounter", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 720, 
+              "y": 160
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Age at first sexual encounter", 
+        "xp_inc": 1
+      }
+    }, 
+    "token021": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Life\u2019s not as hard as it used to be if you\u2019re gay. However, there\u2019s still plenty of Neanderthals out there who can\u2019t deal with certain sexual orientations. For this reason, some people hide their orientation from their family or their employer. But not from you! Sexual orientation can be used for target group specific advertising \u2013 and, in the end, no profile is complete without it.", 
+        "findings_text": "You learn the sexual orientation of %s people", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the sexual orientation of %s people", 
+        "label": "Sexual\r\norientation", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 720, 
+              "y": 80
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Sexual orientation", 
+        "xp_inc": 1
+      }
+    }, 
+    "token022": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Single, shacked up, married, divorced, widowed, other? Singles are generally more flexible, couples more stable. Nowadays this can change pretty fast, but it can still be made use of \u2013 for advertising and for creating comprehensive personality profiles.", 
+        "findings_text": "You learn how complicated things are for %s people", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know how complicated things are for %s people", 
+        "label": "Relationship\r\nstatus", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 800, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Relationship status", 
+        "xp_inc": 1
+      }
+    }, 
+    "token023": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "People are so cute. Especially teenagers. Just look how much they enjoy taking strange pictures and putting them out there for anyone to see. Each and every funny pic is immediately put online, and if the posers are not doing it themselves, their esteemed friends or the party photo portal\u2019s photographer will take care of it. Of course not every employer is bothered by pictures of their half-naked, screaming alcohol-infused employee from that party last month. But they definitely want to take a look.", 
+        "findings_text": "You get funny party pictures of %s people", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You have funny party pictures of %s people", 
+        "label": "Party photos", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 720, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Party photos", 
+        "xp_inc": 1
+      }
+    }, 
+    "token024": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Can this person be relied upon or are we dealing with a real flake? It\u2019s a question countless employers undoubtedly ask themselves during job interviews. There\u2019s only so much time for those talks, and a more reliable assessment would be great. Little tricks like online personality tests can help out. There might be a considerable margin of error, but better than nothing, right?", 
+        "findings_text": "You get information about the loyalty and reliability of %s people", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the loyalty and reliability of %s people", 
+        "label": "Trustworthy/\r\nunreliable?", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 800, 
+              "y": 640
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Trustworthy or unreliable?", 
+        "xp_inc": 1
+      }
+    }, 
+    "token025": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Generally quite happy? Or discontent and frustrated? There are many ways to scan a person\u2019s psychological wiring. Just don\u2019t spring it on them or you will learn nothing. If you go at it with a little more finesse and trickery, people will happily let you into their confidence. Character assessments like these are a great basis for an informed analysis of a person.", 
+        "findings_text": "You get information about the happiness level of %s people", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the happiness level of %s people", 
+        "label": "Happy/\r\nfrustrated?", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 640, 
+              "y": 640
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Happy or frustrated?", 
+        "xp_inc": 1
+      }
+    }, 
+    "token026": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Should IQ really be used to measure intelligence? Psychologists have been debating the issue for decades now. Despite all that, people still love those IQ tests with undamped fervor, and no employer would turn down test results of this sort. Just to make sure...", 
+        "findings_text": "You get the so-called IQ of %s people", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the so-called IQ of %s people", 
+        "label": "IQ", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 800, 
+              "y": 560
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "IQ\r\n", 
+        "xp_inc": 1
+      }
+    }, 
+    "token027": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Other people\u2019s passwords in your database? Getting into sketchy territory, aren\u2019t we? But who knows, you might be able to use them someday. Let\u2019s hang on to them, \u201cjust in case\u201c. You might just be able to recognize users of certain web portals even though they use a pseudonym or an anonymous email address.\r\nAnd should you ever be really desperate for cash, there are always certain dark corners of the data market with some interest in delicate matters like this...", 
+        "findings_text": "You learn one or more passwords of %s people", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know one or more passwords of %s people", 
+        "label": "Passwords", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 560, 
+              "y": 640
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Passwords", 
+        "xp_inc": 1
+      }
+    }, 
+    "token028": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Credit cards are GREAT. As soon as this beloved online payment method enters the game, you\u2019ve won. You\u2019ll find some pretty reliable personal data, never mind the flourishing illegal trade in credit card numbers. However, you should think thrice before you get involved in this...", 
+        "findings_text": "You learn the credit card numbers of %s people", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the credit card numbers of %s people", 
+        "label": "Credit card\r\nnumber", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 480, 
+              "y": 640
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Credit card number", 
+        "xp_inc": 1
+      }
+    }, 
+    "token029": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Computer, game console or smartphone \u2013 every device connected to the web has its own IP address. Users leave their tracks everywhere, even when surfing the net without being logged in anywhere.\r\nIP addresses might be shared among several members of a household, but a decent collection still constitutes an important foundation for your database \u2013 using these, you\u2019ll be able to make some intelligent connections and links between several data sets.", 
+        "findings_text": "You get one or more IP addresses of %s people", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know one or more IP addresses of %s people", 
+        "label": "IP address", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 400, 
+              "y": 640
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "IP address", 
+        "xp_inc": 1
+      }
+    }, 
+    "token030": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Liberal or conservative? Left or right? Indifferent or dedicated? Political attitude is key for many people and an essential part of a balanced personality profile.\r\nEven though really nasty governmental snooping \u00e0 la KGB is a thing of the past in these parts (we hope!) \u2013 any security agency would surely appreciate a list of bothersome, critical or even \u201cradical\u201d names.", 
+        "findings_text": "You get clues to the political attitudes of %s people", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You have clues to the political attitudes of %s people", 
+        "label": "Political\r\nattitude", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 800, 
+              "y": 480
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Political attitude", 
+        "xp_inc": 1
+      }
+    }, 
+    "token032": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Casual game, strategy, online role-playing game or blood-drenched shooter? Some people claim that the kind of games people prefer tells you something about their character. While the truth of the matter is still up for discussion, we\u2019ll just let them believe what they want and give them what they need \u2013 in exchange for cold, hard cash.", 
+        "findings_text": "You get information about the favorite computer games of %s people", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the favorite computer games of %s people", 
+        "label": "Preferred\r\ncomputer games", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 240, 
+              "y": 640
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Preferred computer games", 
+        "xp_inc": 1
+      }
+    }, 
+    "token033": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Platinum blonde, redhead or brunette? Whether it is their original hair color is often hard to say. Green, blue and pink are a little more obvious. In the end, hair color isn\u2019t the best feature for identifying someone; eye color is much better. \r\n\r\nBut who knows, it might just come in handy to know who keeps changing their hair color, or goes for the crazy shades.", 
+        "findings_text": "You learn the hair color of %s people.", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the hair color of %s people.", 
+        "label": "Hair color", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 160, 
+              "y": 640
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Hair color", 
+        "xp_inc": 1
+      }
+    }, 
+    "token034": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "90% of all people have brown eyes \u2013 the rest is divided between green, blue and gray. Red eyes only occur in pictures and after weepy movies. Seriously though \u2013 eye color is quite important for identification. Even though those colored lenses keep getting more popular, you can\u2019t change their real hue. It\u2019s permanent, unique, and part of every ID card in the world. So \u2013 essential information to include in your database.", 
+        "findings_text": "You learn the eye color of %s people.", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the eye color of %s people.", 
+        "label": "Eye color", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 80, 
+              "y": 640
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Eye color", 
+        "xp_inc": 1
+      }
+    }, 
+    "token035": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 35 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 35 (%s)", 
+        "label": "Token 35", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 0, 
+              "y": 640
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Token 35", 
+        "xp_inc": 1
+      }
+    }, 
+    "token036": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Photos are pretty amazing, especially when they\u2019re connected to specific individuals. Make sure to grab everything you can get \u2013 which might not be that hard, considering how much people love taking (and sharing!) pictures. Face recognition technology develops at a rapid pace, and will soon offer you lots of potential options. Once you can automatically identify people with the help of their pictures, there\u2019s no longer any need to laboriously extract their email addresses or names. Honestly \u2013 gather every picture you can get your hands on!", 
+        "findings_text": "You get photos of %s people", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You have photos of %s people", 
+        "label": "Photo", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 640, 
+              "y": 560
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Photo", 
+        "xp_inc": 1
+      }
+    }, 
+    "token038": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 38 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 38 (%s)", 
+        "label": "Token 38", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 640, 
+              "y": 480
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Token 38", 
+        "xp_inc": 1
+      }
+    }, 
+    "token039": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 39 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 39 (%s)", 
+        "label": "Token 39", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 640, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Token 39", 
+        "xp_inc": 1
+      }
+    }, 
+    "token040": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Wouldn\u2019t it be lovely if people just used their real names online? But no, pseudonyms everywhere you look, which means much more work for you. But never fear: Once you stored enough nicknames, you can easily align them with your collection of names, phone numbers, and email and IP addresses. Problem solved!\r\n\r\nIn other news: Some major companies have by now simply prohibited the use of pseudonyms. Commendable!", 
+        "findings_text": "You learn the online nicknames of %s people.", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the online nicknames of %s people.", 
+        "label": "Nicknames", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 640, 
+              "y": 320
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Nicknames", 
+        "xp_inc": 1
+      }
+    }, 
+    "token041": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Almost every country has some form of social security number. Names might differ, acronyms might look different, and they don\u2019t always perform the same function. But there\u2019s one trait they all share: They\u2019re an incredibly powerful piece of data. Several people sharing the same name? Knowing their SSN will help you identify specific individuals. Odd how people just throw them around like that, but you\u2019re not one to complain. By the way: Once you got someone\u2019s SSN, it\u2019s really easy to impersonate them.", 
+        "findings_text": "You learn the SSN of %s people.", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the SSN of %s people.", 
+        "label": "Social Security\r\nNumber", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 640, 
+              "y": 240
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 900, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Social Security Number", 
+        "xp_inc": 1
+      }
+    }, 
+    "token042": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 42 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 42 (%s)", 
+        "label": "Token 42", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 640, 
+              "y": 160
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Token 42", 
+        "xp_inc": 1
+      }
+    }, 
+    "token043": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 43 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 43 (%s)", 
+        "label": "Citizenship", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 640, 
+              "y": 80
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Citizenship", 
+        "xp_inc": 1
+      }
+    }, 
+    "token044": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 44 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 44 (%s)", 
+        "label": "Token 44", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 800, 
+              "y": 320
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Token 44", 
+        "xp_inc": 1
+      }
+    }, 
+    "token045": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 45 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 45 (%s)", 
+        "label": "Profession", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 800, 
+              "y": 240
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Profession", 
+        "xp_inc": 1
+      }
+    }, 
+    "token046": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 46 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 46 (%s)", 
+        "label": "Token 46", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 640, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Token 46", 
+        "xp_inc": 1
+      }
+    }, 
+    "token047": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Unions! Most company bosses would get rid of them in a flash. How are they supposed to rake in the profits when those pesky unions keep on demanding fair wages and better working conditions? And that\u2019s not all! They unite workers against their superiors, they cause disturbances, or organise strikes! Disaster! Which is why companies tend to prefer hiring people who are most definitely not part of any union. But how are they to find out?", 
+        "findings_text": "You learn the union membership of %s people.", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the union membership of %s people.", 
+        "label": "Union member", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 560, 
+              "y": 560
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Union member", 
+        "xp_inc": 1
+      }
+    }, 
+    "token048": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Complete loser at math? Really bad at languages? Or straight-A student? Report cards \u2013 some people break out in a cold sweat just thinking about them. But they catch up with everyone when they enter the workforce. Most bosses tend to be pretty nosy and want to know every little detail about their employees. Bad grades? Off you go!\r\n\r\nWho cares whether some bad scores are due to incompetent teachers or should really be blamed on the school system as a whole: Knowing people\u2019s grades will definitely help you.", 
+        "findings_text": "You learn about the school grades of %s people.", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know about the school grades of %s people.", 
+        "label": "School grades", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 480, 
+              "y": 560
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "School grades", 
+        "xp_inc": 1
+      }
+    }, 
+    "token049": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 49 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 49 (%s)", 
+        "label": "Token 49", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 800, 
+              "y": 160
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Token 49", 
+        "xp_inc": 1
+      }
+    }, 
+    "token050": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 50 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 50 (%s)", 
+        "label": "Token 50", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 400, 
+              "y": 560
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Token 50", 
+        "xp_inc": 1
+      }
+    }, 
+    "token051": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 51 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 51 (%s)", 
+        "label": "Token 51", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 800, 
+              "y": 80
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Token 51", 
+        "xp_inc": 1
+      }
+    }, 
+    "token052": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 52 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 52 (%s)", 
+        "label": "Token 52", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 800, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Token 52", 
+        "xp_inc": 1
+      }
+    }, 
+    "token053": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Teetotaler, or binge drinker every weekend? Enjoys a glass of wine with dinner now and then, or terminal alcoholic? Once you know whether, how often, how much and what kind of alcohol someone drinks, you can make all sorts of predictions \u2013 and not just concerning the future of their liver. This can be especially interesting when you\u2019re dealing with people who think they\u2019re just light drinkers. But the really serious cases can also be useful \u2013 those types do tend to be rather secretive, after all.", 
+        "findings_text": "You know the alcohol consumption of %s people.", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You learn the alcohol consumption of %s people.", 
+        "label": "Alcohol\r\nconsumption", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 720, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Alcohol consumption", 
+        "xp_inc": 1
+      }
+    }, 
+    "token054": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Smoking kills. And costs money. Once you start, it\u2019s really hard to stop. Despite all that, there\u2019s still scores of smokers out there. Knowing if and how much someone smokes is getting more and more important. Smokers are increasingly being shunned \u2013 by public authorities, landlords, HR departments and insurance companies.", 
+        "findings_text": "You learn the smoking habits of %s people.", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the smoking habits of %s people.", 
+        "label": "Tobacco use", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 320, 
+              "y": 560
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Tobacco use", 
+        "xp_inc": 1
+      }
+    }, 
+    "token055": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 120000, 
+        "contained_tokens": [
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token014", 
+            "gestalt": "token014", 
+            "is_required": true, 
+            "position": 1
+          }, 
+          {
+            "amount": 50, 
+            "full_type": "TokenPerp:token015", 
+            "gestalt": "token015", 
+            "is_required": true, 
+            "position": 2
+          }
+        ], 
+        "description": "BMI is a popular measure for evaluating whether someone is under-, over- or normal weight \u2013 whatever that means.  Now, some may doubt the significance of this value, but who cares - you\u2019ll still make a mint with it! Upgrade your database to include the BMI, and just calculate it from the height and weight values you\u2019ve already got. Gain more data sets in those two, and you can easily increase your BMI collection as well.", 
+        "findings_text": "You learn the BMI of %s people.", 
+        "is_buyable": true, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the BMI of %s people.", 
+        "label": "Body Mass Index", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 640, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 300, 
+        "required_level": 7, 
+        "requirements_text": "Von %s Personen erf\u00e4hrst du den Body Mass Index", 
+        "story": {
+          "text": "Click on Body Mass Index and start the calculation. The more new profiles including Height and Weight you have, the better results you\u2019ll get!", 
+          "trigger": "buy"
+        }, 
+        "title": "Body Mass Index", 
+        "xp_inc": 1
+      }
+    }, 
+    "token056": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 56 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 56 (%s)", 
+        "label": "Token 56", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 240, 
+              "y": 560
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Token 56", 
+        "xp_inc": 1
+      }
+    }, 
+    "token057": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 57 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 57 (%s)", 
+        "label": "Token 57", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 160, 
+              "y": 560
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Token 57", 
+        "xp_inc": 1
+      }
+    }, 
+    "token058": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 58 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 58 (%s)", 
+        "label": "Relatives", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 80, 
+              "y": 560
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Relatives", 
+        "xp_inc": 1
+      }
+    }, 
+    "token059": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 59 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 59 (%s)", 
+        "label": "Token 59", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 0, 
+              "y": 560
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Token 59", 
+        "xp_inc": 1
+      }
+    }, 
+    "token060": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 60 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 60 (%s)", 
+        "label": "Token 60", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 560, 
+              "y": 480
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Token 60", 
+        "xp_inc": 1
+      }
+    }, 
+    "token061": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Who knows who? And how do they relate to each other? Even though some might lose sight of each other over the years \u2013 classmates are an important part of your profiles\u2019 personal environment.\r\n\r\nThe more you know about the personal environment of a profile, the more you can find out about them in the long run. Which is immensely helpful, because \u2013 you\u2019ll get info on people you haven\u2019t got any data on yet!", 
+        "findings_text": "You learn about the classmates of %s people.", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know about the classmates of %s people.", 
+        "label": "Classmates", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 560, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Classmates", 
+        "xp_inc": 1
+      }
+    }, 
+    "token062": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 62 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 62 (%s)", 
+        "label": "Token 62", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 560, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Token 62", 
+        "xp_inc": 1
+      }
+    }, 
+    "token064": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "None or maybe one, that\u2019s how things mostly are. And apparently there\u2019s a few households with a staggering three or even four. In this time of patchwork families, things aren\u2019t that clear-cut anyway. And for the time being it doesn\u2019t really matter whether these kids share any genes or not. What matters is where they live. People with kids need more money, larger flats, need to look after them and are less flexible. Plus, the noise those brats make could really bother the neighbours.", 
+        "findings_text": "You learn the number of children of %s people.", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the number of children of %s people.", 
+        "label": "Number of children", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 560, 
+              "y": 320
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Number of children", 
+        "xp_inc": 1
+      }
+    }, 
+    "token065": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 1800000, 
+        "contained_tokens": [
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token071", 
+            "gestalt": "token071", 
+            "is_required": false, 
+            "position": 5
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token072", 
+            "gestalt": "token072", 
+            "is_required": false, 
+            "position": 6
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token125", 
+            "gestalt": "token125", 
+            "is_required": true, 
+            "position": 2
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token006", 
+            "gestalt": "token006", 
+            "is_required": true, 
+            "position": 1
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token068", 
+            "gestalt": "token068", 
+            "is_required": false, 
+            "position": 7
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token067", 
+            "gestalt": "token067", 
+            "is_required": false, 
+            "position": 3
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token128", 
+            "gestalt": "token128", 
+            "is_required": false, 
+            "position": 4
+          }
+        ], 
+        "description": "Let\u2019s assume you\u2019re head of HR. After going through 400 applications, you found 10 that fulfill all your requirements, 3 of them women. In interviews, your favorite candidate claims she won\u2019t be interested in having children anytime soon. Legally, you shouldn\u2019t have asked \u2013 but all that expensive training just to have her go on maternity leave? No way. Now what if I told you that her book purchases, online searches and dietary habits actually point to a pregnancy? What then?", 
+        "findings_text": "You learn the child-bearing intentions of %s people.", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the child-bearing intentions of %s people.", 
+        "label": "Desire to\r\nhave children", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 400, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Desire to have children", 
+        "xp_inc": 3
+      }
+    }, 
+    "token066": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Womanizer, or 30-year-old virgin? Wild child, or or more of a True Love Waits type? If someone is getting more action, does that make them unreliable and disloyal? Or are they curious and prepared to take risks to get what they want? Just leave that decision to your clients.", 
+        "findings_text": "You learn the number of sexual partners of %s people.", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the number of sexual partners of %s people.", 
+        "label": "Number of\r\nsexual partners", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 320, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Number of sexual partners", 
+        "xp_inc": 1
+      }
+    }, 
+    "token067": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Comics or demanding novels? Critical non-fiction or shallow pulp stories? Knitting, crafts, new age or Koran? Pets, hacking or inconvenient political topics? Or, who knows, maybe even self-help literature on a serious illness or other life crisis? Tell me what you read and I\u2019ll tell you who you are. A look at someone\u2019s book purchases will not only tell you their political views, but many, many other things besides.", 
+        "findings_text": "You learn the book buying habits of %s people.", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the book buying habits of %s people.", 
+        "label": "Books bought", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 240, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 0, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Books bought", 
+        "xp_inc": 1
+      }
+    }, 
+    "token068": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 68 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 68 (%s)", 
+        "label": "Online Postings", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 560, 
+              "y": 240
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Online Postings", 
+        "xp_inc": 1
+      }
+    }, 
+    "token069": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Once you know what kind of furniture someone buys over a longer period, it will tell you all kinds of things. Cheapest shelf available, once a year? Designer kitchen and expensive sofa in one go? No matter whether we\u2019re talking sets of cutlery or a whole bedroom: Do they always go for the cheapest option or the most exclusive pieces?", 
+        "findings_text": "You learn the furiture buying habits of %s people.", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the furniture buying habits of %s people.", 
+        "label": "Furniture bought", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 560, 
+              "y": 160
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 0, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Furniture bought", 
+        "xp_inc": 1
+      }
+    }, 
+    "token070": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Nowadays, most of our clothes are produced in low-wage countries, by people who earn close to zilch for sitting at their sewing machines 12 hours a day, seven days a week. Nevertheless the clothes industry comes right after supermarkets in term of economic factor. Because \u2013 you guessed it \u2013 people buy buy buy like mad. And you, you really want to know just what it is they\u2019re buying. All that data will give you a pretty good basis for creating consumer and character profiles \u2013 and will even tell you whether someone's rich or poor. ", 
+        "findings_text": "You learn the clothes buying habits of %s people.", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the clothes buying habits of %s people.", 
+        "label": "Clothes purchased", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 560, 
+              "y": 80
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 0, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Clothes purchased", 
+        "xp_inc": 1
+      }
+    }, 
+    "token071": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 71 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 71 (%s)", 
+        "label": "Web searches", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 780, 
+              "y": 560
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-005.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Web searches", 
+        "xp_inc": 1
+      }
+    }, 
+    "token072": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 72 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 72 (%s)", 
+        "label": "Regularly visited websites", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 160, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Regularly visited websites", 
+        "xp_inc": 1
+      }
+    }, 
+    "token073": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 73 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 73 (%s)", 
+        "label": "Token 73", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 560, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Token 73", 
+        "xp_inc": 1
+      }
+    }, 
+    "token074": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 74 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 74 (%s)", 
+        "label": "Token 74", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 480, 
+              "y": 480
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Token 74", 
+        "xp_inc": 1
+      }
+    }, 
+    "token075": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 75 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 75 (%s)", 
+        "label": "Token 75", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 400, 
+              "y": 480
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Token 75", 
+        "xp_inc": 1
+      }
+    }, 
+    "token076": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 76 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 76 (%s)", 
+        "label": "Token 76", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 320, 
+              "y": 480
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 720, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Token 76", 
+        "xp_inc": 1
+      }
+    }, 
+    "token077": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 77 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 77 (%s)", 
+        "label": "Token 77", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 240, 
+              "y": 480
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Token 77", 
+        "xp_inc": 1
+      }
+    }, 
+    "token078": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 78 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 78 (%s)", 
+        "label": "Pirated Movies", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 80, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Pirated Movies", 
+        "xp_inc": 1
+      }
+    }, 
+    "token079": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 79 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 79 (%s)", 
+        "label": "Token 79", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 160, 
+              "y": 480
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Token 79", 
+        "xp_inc": 1
+      }
+    }, 
+    "token080": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 80 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 80 (%s)", 
+        "label": "Token 80", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 80, 
+              "y": 480
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Token 80", 
+        "xp_inc": 1
+      }
+    }, 
+    "token081": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Busy bee or sleepy sloth? Career-driven or placid and laid-back? If you manage to get that kind of information on as many people as possible, there must be something you can do with it. Highly detailed questionnaires on dating sites and online personality tests are good sources for these attributes. Labels like these might be too simplistic - but if they sell well, who cares?", 
+        "findings_text": "You learn the ambitiousness of %s people.", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the ambitiousness of %s people.", 
+        "label": "Ambitious or lazy?", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 0, 
+              "y": 720
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Ambitious or lazy?", 
+        "xp_inc": 1
+      }
+    }, 
+    "token082": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 82 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 82 (%s)", 
+        "label": "Token 82", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 0, 
+              "y": 480
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Token 82", 
+        "xp_inc": 1
+      }
+    }, 
+    "token083": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Jobs these days: Firms are understaffed and nothing goes as planned. Ten things to finish at once, everything is URGENT and should have been done yesterday. Who can keep calm in situations like this?\r\nCool, calm and collected, or about to blow? Master of multitasking, or gets nervous at the sight of two opened browser tabs? Try to find out \u2013 resilience and flexibility are in high demand! So are assessments of who might fall apart under pressure.", 
+        "findings_text": "You learn about the resilience and flexibility of %s people.", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know about the resilience and flexibility of %s people.", 
+        "label": "Resilience", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 720, 
+              "y": 640
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Resilience", 
+        "xp_inc": 1
+      }
+    }, 
+    "token084": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Some people will believe anything. Be it a one-off sale, impossible election pledges or the chance to win the jackpot, they\u2019ll act as any good lemming would and completely go for it without thinking. \r\nWho fits this pattern perfectly and who doesn\u2019t? Knowing this will not only come in useful for advertising.", 
+        "findings_text": "You learn the credulity of %s people.", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the credulity of %s people.", 
+        "label": "Naive or critical?", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 480, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Naive or critical?", 
+        "xp_inc": 1
+      }
+    }, 
+    "token085": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Team player or not, that is the question. It\u2019s important the company runs like a well-oiled machine, after all. There are some who are simply perfect \u2013 and then there are those lone wolves and other difficult characters that no one really cares for. They\u2019re like a spanner in the works of this clockwork of human cogs. Find out about the teamwork abilities of your profiles \u2013 it\u2019s precious information, especially in combination with other attributes. ", 
+        "findings_text": "You learn the teamworking abilities of %s people.", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the teamworking abilities of %s people.", 
+        "label": "Capacity\r\nfor teamwork", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 720, 
+              "y": 560
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Capacity for teamwork", 
+        "xp_inc": 1
+      }
+    }, 
+    "token086": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 86 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 86 (%s)", 
+        "label": "Attractiveness", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 480, 
+              "y": 320
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Attractiveness", 
+        "xp_inc": 1
+      }
+    }, 
+    "token087": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 87 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 87 (%s)", 
+        "label": "Favourite movies", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 480, 
+              "y": 240
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Favourite movies", 
+        "xp_inc": 1
+      }
+    }, 
+    "token088": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Swimming, cycling, skateboarding, fitness center? Or slobby couch potato? Active people stay fit in both body and mind, at least that\u2019s what they say \u2013 and demand! All those lazy bums will just get older, frailer, sicker much earlier. Just think of the cost! Better get some data on the activity level of your profiles, just to be on the safe side.", 
+        "findings_text": "You learn the activity level of %s people.", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the activity level of %s people.", 
+        "label": "Sports nut or\r\ncouch potato?", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 480, 
+              "y": 160
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Sports nut or couch potato?", 
+        "xp_inc": 1
+      }
+    }, 
+    "token089": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Some people are no fun. One little thing, and they explode like a ticking time bomb. It would really be preferable to avoid these types completely \u2013 at work, at home, or in relationships. \r\n\r\nSo try to categorize people. Do they belong with the good guys or not? Just remember that it\u2019s not necessary to be absolutely right about these things. How could you be? As long as it\u2019s right some of the time!", 
+        "findings_text": "You learn the temper of %s people.", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the temper of %s people.", 
+        "label": "Short-fused or\r\ncool cucumber?", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 480, 
+              "y": 80
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Short-fused or cool cucumber?", 
+        "xp_inc": 1
+      }
+    }, 
+    "token090": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Clammy hands, palpitations, stuttering and suddenly red-faced? Lots of people experience this as soon as they have to deal with a group larger than one. \r\n\r\nPersuasive or uptight? Silver-tongued or insecure? Find out how eloquent or bashful your profiles are.", 
+        "findings_text": "You learn the eloquence of %s people.", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the eloquence of %s people.", 
+        "label": "Eloquence or\r\nstage fright?", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 480, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Eloquence or stage fright?", 
+        "xp_inc": 1
+      }
+    }, 
+    "token091": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 91 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 91 (%s)", 
+        "label": "Token 91", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 400, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Token 91", 
+        "xp_inc": 1
+      }
+    }, 
+    "token092": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Psychos! And I don\u2019t just mean total nutjobs \u2013 there\u2019s all kinds of crazies out there. You know, suffering from ADHS, depression, burnout, borderline and more. But really, it applies to everyone who isn\u2019t \"normal,\" who doesn\u2019t fit in, who just doesn\u2019t function perfectly. You know, those people who just don\u2019t manage school, work or everyday life as efficiently as is expected. Or at all. So, almost everyone, right? When you get this kind of information on someone, it won\u2019t just be their employer lining up to take it off your hands.", 
+        "findings_text": "You learn about the mental problems of %s people.", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know about the mental problems of %s people.", 
+        "label": "Mental problems?", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 320, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Mental problems?", 
+        "xp_inc": 1
+      }
+    }, 
+    "token093": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "A century ago travel was only for the rich \u2013 nowadays everyone takes to the skies whenever they want. City trip, holiday by the sea or jungle adventure? Luxury cruise or Lonely Planet? Once you know which countries people tend to visit and by which means, you can add that to your profiles \u2013 and it won\u2019t just help with advertising! Public authorities are also quite keen on knowing about travels to politically suspect countries.", 
+        "findings_text": "You learn the travel habits of %s people.", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the travel habits of %s people.", 
+        "label": "Travel habits", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 240, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Travel habits", 
+        "xp_inc": 1
+      }
+    }, 
+    "token094": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [
+          {
+            "amount": 25, 
+            "full_type": "TokenPerp:token128", 
+            "gestalt": "token128", 
+            "is_required": false, 
+            "position": 2
+          }, 
+          {
+            "amount": 25, 
+            "full_type": "TokenPerp:token072", 
+            "gestalt": "token072", 
+            "is_required": true, 
+            "position": 1
+          }
+        ], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 94 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 94 (%s)", 
+        "label": "Hobbies", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 160, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 540
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Hobbies", 
+        "xp_inc": 1
+      }
+    }, 
+    "token095": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 95 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 95 (%s)", 
+        "label": "Token 95", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 80, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Token 95", 
+        "xp_inc": 1
+      }
+    }, 
+    "token096": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 96 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 96 (%s)", 
+        "label": "GPS Location", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 0, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "GPS Location", 
+        "xp_inc": 1
+      }
+    }, 
+    "token097": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Annoying bongo beats, lofty classical music or hardcore techno beats? Christian Death Metal or soppy crooning from Greenland?  There\u2019s no accounting for taste in music \u2013 or is there? Find out what sound people dig. Which bands and artists they love and which they could live without. This is important lifestyle information which will be immensely useful in sorting and classifying your profiles.", 
+        "findings_text": "You learn the musical preferences of %s people.", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the musical preferences of %s people.", 
+        "label": "Music Preferences", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 400, 
+              "y": 320
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Music Preferences", 
+        "xp_inc": 1
+      }
+    }, 
+    "token098": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 3600000, 
+        "contained_tokens": [
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token067", 
+            "gestalt": "token067", 
+            "is_required": true, 
+            "position": 1
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token128", 
+            "gestalt": "token128", 
+            "is_required": false, 
+            "position": 2
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token072", 
+            "gestalt": "token072", 
+            "is_required": false, 
+            "position": 3
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token071", 
+            "gestalt": "token071", 
+            "is_required": false, 
+            "position": 4
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token068", 
+            "gestalt": "token068", 
+            "is_required": false, 
+            "position": 5
+          }
+        ], 
+        "description": "God is dead? Far from it. Take your pick: One of the world religions or some dubious sect? Feel-good esotericism or consequent atheism? And then there\u2019s some who believe in the Flying Spaghetti Monster. It takes all kinds, right?  \r\nThe religion of your profiles is attractive info for several reasons. First off you can use it for marketing, second it\u2019s a central attribute for your character profile, and third there\u2019s rumors that some public authorities have a dislike towards certain religions.", 
+        "findings_text": "You learn the beliefs of %s people.", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the beliefs of %s people.", 
+        "label": "Religion", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 780, 
+              "y": 480
+            }
+          }, 
+          "frameSrc": "sprite-002.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-005.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Religion", 
+        "xp_inc": 7
+      }
+    }, 
+    "token099": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Always hunting for bargains. Scrutinizing all those high-gloss sales-promoting flyers that end up in their mailbox everyday, so they don\u2019t miss the chance to fight for their place in line for a reduced-price flatscreen. Or they go overboard with the rest of their shopping. They take those bulk offers\u2026\"yes I only need one, but if I take three I save more!\" These people are the best!", 
+        "findings_text": "You learn the attraction to bargains of %s people.", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the attraction to bargains of %s people.", 
+        "label": "Bargain hunter", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 400, 
+              "y": 240
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Bargain hunter", 
+        "xp_inc": 1
+      }
+    }, 
+    "token100": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 100 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 100 (%s)", 
+        "label": "Mobile ID", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 400, 
+              "y": 160
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 0, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Mobile ID", 
+        "xp_inc": 1
+      }
+    }, 
+    "token102": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Who wouldn\u2019t love to win the lottery? The less money people have, the more they long for winning the jackpot. But gamblers come from all walks of life \u2013 and with the array of raffles, casinos and online betting at your fingertips, you can make money off all of them. It\u2019s not just the gambling industry that is interested in data on who\u2019s particularly susceptible to its charms. That kind of knowledge will also help with other things, for example advertising \u2013 gullible people are a lot easier to trick.", 
+        "findings_text": "You learn the gambling habits of %s people.", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the gambling habits of %s people.", 
+        "label": "Gambling Addict?", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 400, 
+              "y": 80
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 540, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Gambling Addict?", 
+        "xp_inc": 1
+      }
+    }, 
+    "token103": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Do sports! There\u2019s jogging, swimming and table tennis, sure, but what about adventure sports? No need to go straight for stratosphere jumps, canyoning, diving, ice climbing or paragliding. Skateboarding, skiing or simple cycling also carry a certain risk. What is this to you? Find out what sort of risks people take and sell that info to insurance companies. Or use it for marketing. Some of these sports use rather expensive equipment, so getting hold of that particular target group will really pay off.", 
+        "findings_text": "You learn the risk-taking tendency of %s people.", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the risk-taking tendency of %s people.", 
+        "label": "High-risk sports", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 400, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "High-risk sports", 
+        "xp_inc": 1
+      }
+    }, 
+    "token104": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 104 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 104 (%s)", 
+        "label": "Sleeping pattern", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 320, 
+              "y": 320
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Sleeping pattern", 
+        "xp_inc": 1
+      }
+    }, 
+    "token105": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 105 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 105 (%s)", 
+        "label": "Heart rate", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 720, 
+              "y": 400
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Heart rate", 
+        "xp_inc": 1
+      }
+    }, 
+    "token106": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 106 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 106 (%s)", 
+        "label": "Activity", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 240, 
+              "y": 320
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Activity", 
+        "xp_inc": 1
+      }
+    }, 
+    "token107": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 107 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 107 (%s)", 
+        "label": "Token 107", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 160, 
+              "y": 320
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Token 107", 
+        "xp_inc": 1
+      }
+    }, 
+    "token108": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 108 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 108 (%s)", 
+        "label": "Hormone level", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 80, 
+              "y": 320
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 360
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Hormone level", 
+        "xp_inc": 1
+      }
+    }, 
+    "token109": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 109 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 109 (%s)", 
+        "label": "Blood pressure", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 0, 
+              "y": 320
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Blood pressure", 
+        "xp_inc": 1
+      }
+    }, 
+    "token111": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 111 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 111 (%s)", 
+        "label": "Internet junkie?", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 720, 
+              "y": 320
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Internet junkie?", 
+        "xp_inc": 1
+      }
+    }, 
+    "token113": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "People staying loyal to their favorite brands are real cash cows. What do they pay for? Nothing? And how much? Lots more! First of all, they\u2019ll happily pay ten times a similar product without the shiny logo would cost. And second, they keep on buying the same brand. This especially applies to teenagers \u2013 perfect!\r\n\r\nFor this reason, a whole slew of companies nowadays sell one thing, and one thing only: Their logo. Not much else they have to offer, really. And what do they need? The suckers' names and addresses. So give them what they ask for \u2013 just do it!", 
+        "findings_text": "You learn the brand loyalty of %s people.", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the brand loyalty of %s people.", 
+        "label": "Brand fetishism", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 320, 
+              "y": 80
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Brand fetishism", 
+        "xp_inc": 1
+      }
+    }, 
+    "token114": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Insulin, heart meds or antidepressants? Some aspirin for breakfast, a couple of anxiety meds during the day and Viagra every night? Whether people carelessly misuse their pills or use them sensibly to fight severe illnesses \u2013 you\u2019re interested in all of it!\r\n\r\nThe pharmaceutical and health industries are quite affluent and eager to get that kind of data. And knowing the meds people use allows for some other interesting inferences as well.", 
+        "findings_text": "You learn the meds taken by %s people.", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the meds taken by %s people.", 
+        "label": "Medication", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 320, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 360, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Medication", 
+        "xp_inc": 1
+      }
+    }, 
+    "token115": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Comics or demanding novels? Critical non-fiction or shallow pulp stories? Knitting, crafts, new age or Koran? Pets, hacking or inconvenient political topics? Or, who knows, maybe even self-help literature on a serious illness or other life crisis? Tell me what you read and I\u2019ll tell you who you are. A look at someone\u2019s library loans will not only tell you their political views, but many, many other things as well.", 
+        "findings_text": "You learn the reading habits of %s people.", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the reading habits of %s people.", 
+        "label": "Library Loans", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 240, 
+              "y": 240
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Library Loans", 
+        "xp_inc": 1
+      }
+    }, 
+    "token116": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 116 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 116 (%s)", 
+        "label": "Token 116", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 160, 
+              "y": 240
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Token 116", 
+        "xp_inc": 1
+      }
+    }, 
+    "token117": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 117 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 117 (%s)", 
+        "label": "Handwriting", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 720, 
+              "y": 240
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Handwriting", 
+        "xp_inc": 1
+      }
+    }, 
+    "token119": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 119 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 119 (%s)", 
+        "label": "Token 119", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 720, 
+              "y": 160
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Token 119", 
+        "xp_inc": 1
+      }
+    }, 
+    "token120": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Drugs, man! Like whoa. Coffee, cigarettes, alcohol and prescription meds are definitely top of the list. But where does use end and abuse start? We all know the dosage makes the poison\u2026but it\u2019s a fine line to tread. And then, of course, there\u2019s all those illegal drugs. Though there\u2019s some discussion whether alcohol abuse might be a more pressing problem \u2013 information that someone\u2019s been in contact with illegal stuff is difficult to obtain and incredibly valuable. Public authorities, potential employers, landlords \u2013 they\u2019d all love to hear about this.", 
+        "findings_text": "You learn about the drug habits of %s people.", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know about the drug habits of %s people.", 
+        "label": "Drug use", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 80, 
+              "y": 240
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Drug use", 
+        "xp_inc": 1
+      }
+    }, 
+    "token121": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 121 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 121 (%s)", 
+        "label": "Token 121", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 0, 
+              "y": 240
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-005.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Token 121", 
+        "xp_inc": 1
+      }
+    }, 
+    "token122": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 122 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 122 (%s)", 
+        "label": "Pirated Games", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 240, 
+              "y": 160
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Pirated Games", 
+        "xp_inc": 1
+      }
+    }, 
+    "token123": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Everyone\u2019s doing it. Over the past decade, pirating songs or software has become a national sport. Our kids and teens have turned into everyday copyright infringers. Guess the whole music industry has been a little slow on the uptake.\r\nThankfully the big labels have found an even better method to make money: Anti-piracy lawsuits! If you manage to find out who downloads what you\u2019ll be able to sell that info for a tidy sum.", 
+        "findings_text": "You learn the filesharing habits of %s people.", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the filesharing habits of %s people.", 
+        "label": "Pirated songs", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 240, 
+              "y": 80
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Pirated songs", 
+        "xp_inc": 1
+      }
+    }, 
+    "token124": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 124 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 124 (%s)", 
+        "label": "Pirated Software", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 240, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 180
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Pirated Software", 
+        "xp_inc": 1
+      }
+    }, 
+    "token125": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Mounds of meat or mainly vegetarian? Chips, coke and a daily dose of frozen food, or organic, light and lots of veggies? Using a list of purchases, you can create nice diet profiles, and from those you can in turn conclude something about people\u2019s health status, even make some predictions for the future. The time period covered doesn\u2019t even have to be that long - a few weeks will usually suffice.", 
+        "findings_text": "You get the daily diet of %s people", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the daily diet of %s people", 
+        "label": "Diet", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 160, 
+              "y": 160
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 7, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Diet", 
+        "xp_inc": 1
+      }
+    }, 
+    "token127": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 127 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 127 (%s)", 
+        "label": "Token 127", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 0, 
+              "y": 160
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Token 127", 
+        "xp_inc": 1
+      }
+    }, 
+    "token128": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Broadsheet or tabloid? Conservative rag, critical left-wing paper or management weekly? Glossies about pets, environment, science, celebs, guns, porn, or the local church distribution? Maybe even all of that?\r\nTell me what you read and I\u2019ll tell you who you are. There\u2019s all sorts of things you can deduce from someone\u2019s subscriptions, much more than just their political views.", 
+        "findings_text": "You learn about the subscriptions of %s people.", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know about the subscriptions of %s people.", 
+        "label": "Subscriptions", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 160, 
+              "y": 80
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-006.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Subscriptions", 
+        "xp_inc": 1
+      }
+    }, 
+    "token129": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 1800000, 
+        "contained_tokens": [
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token128", 
+            "gestalt": "token128", 
+            "is_required": false, 
+            "position": 2
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token071", 
+            "gestalt": "token071", 
+            "is_required": false, 
+            "position": 3
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token072", 
+            "gestalt": "token072", 
+            "is_required": false, 
+            "position": 4
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token068", 
+            "gestalt": "token068", 
+            "is_required": false, 
+            "position": 5
+          }, 
+          {
+            "amount": 10, 
+            "full_type": "TokenPerp:token067", 
+            "gestalt": "token067", 
+            "is_required": false, 
+            "position": 1
+          }
+        ], 
+        "description": "Dog or cat? Vital question! And then there\u2019s the more exotic variants as well. Pets are definitely big business. Things like high-class cat food and dog homeopathy help whole commercial sectors thrive. Hint: No need to ask your profiles directly whether they have pets and/or what kind. Your database can easily calculate that from other info you collected.", 
+        "findings_text": "You learn about the pets of %s people.", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know about the pets of %s people.", 
+        "label": "Pets", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 160, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-007.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Pets", 
+        "xp_inc": 3
+      }
+    }, 
+    "token130": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Multiple university degrees or high-school dropout? Even though there are some people who make it big without finishing school, most fields still place a heavy emphasis on so-called formal education. And it\u2019s not just employers who are interested in this. The level of education is also a factor in classifying a person, and for the creation of targeted consumer profiles.", 
+        "findings_text": "You learn the level of education of %s people.", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the level of education of %s people.", 
+        "label": "Educational level", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 720, 
+              "y": 80
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 180, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Educational level", 
+        "xp_inc": 1
+      }
+    }, 
+    "token131": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "findings_text": "Token 131 (%s)", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "Token 131 (%s)", 
+        "label": "Token 131", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 720, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-004.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-009.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "title": "Token 131", 
+        "xp_inc": 1
+      }
+    }, 
+    "token132": {
+      "game_type": "TokenPerp", 
+      "type_data": {
+        "charge_time": 0, 
+        "contained_tokens": [], 
+        "description": "Say you need to advertise some stupid product or another,  either with ads, posters, radio, TV or online. You need to convince viewers they\u2019re passing up a one-in-a-million chance, by being as original, attractive, dramatic and funny as possible. That will cost you some. Turns out there\u2019s two kind of people: Those on whom this ad strategy works really well, and those where it doesn\u2019t. You can actually measure it. Some people are more likely to buy stuff after you run a campaign. There\u2019s even a few who think they\u2019ll never let themselves be manipulated \u2013 cute, right?", 
+        "findings_text": "You learn the responsiveness to advertising of %s people.", 
+        "is_buyable": false, 
+        "is_supertoken": false, 
+        "knowledge_text": "You know the responsiveness to advertising of %s people.", 
+        "label": "Responsive to\r\nadvertising", 
+        "perp_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 80, 
+              "width": 80, 
+              "x": 80, 
+              "y": 80
+            }
+          }, 
+          "frameSrc": "sprite-003.png"
+        }, 
+        "popup_sprite": {
+          "frameMap": {
+            "normal": {
+              "height": 180, 
+              "width": 180, 
+              "x": 0, 
+              "y": 0
+            }
+          }, 
+          "frameSrc": "sprite-008.png"
+        }, 
+        "price": 0, 
+        "required_level": 1, 
+        "requirements_text": "This text part of this beautiful game item is currently being reviewed by our amazing editorial team. It will become available here shortly. Thanks for your understanding.", 
+        "title": "Responsive to advertising", 
+        "xp_inc": 1
+      }
+    }
+  }, 
+  "version": 1
+}


### PR DESCRIPTION
Closes #1.

Foundation work for the webxdc port. No JavaScript is touched in this PR — `dd_auth` and other server-coupled bits are left intact for sibling threads to handle.

## Changes

**README**
- New "About this fork" section at the top: framing of the port (dd_js + dd_rules + ported dd_app), upstream repo links, the framing quote from the issue (verbatim), and a note that planning was done with Claude.
- Original dd_js README content kept below for reference.

**License files at repo root**
- `LICENSE-CODE.txt` — Artistic License 2.0, scoped to the dd_js fork and any code ported from dd_app.
- `LICENSE-ASSETS.txt` — CC-BY-SA 3.0 Austria, scoped to `data/`, `img/`, `i18n/` and the CC-licensed font material. Third-party SIL-licensed webfonts under `font/` keep their existing notices in `font/LICENSE/`.
- `CREDITS.txt` — original team (Ivan Averintsev, Wolfie Christl, Pascale Osterwalder, Tobi Schäfer, Ralf Traunsteiner), upstream repo links, third-party font copyrights, and a "Modifications in this fork" section.
- The original `LICENSE.txt` is left in place for historical reference (referenced from `CREDITS.txt`).

**Vendored game data**
- `data/default_game.json`, `data/ruleset_3.de.json`, `data/ruleset_3.en.json` copied verbatim from [`datadealer/dd_rules`](https://github.com/datadealer/dd_rules) at commit `9290ab97a9ab7623d85290541cb44173b7a908d9`.
- `data/UPSTREAM.txt` records the source SHA and provides a one-liner for diffing future upstream changes.

**Pre-pivot tag**
- Tag `pre-pivot/dd_js` created locally on `da6a034` ("v0.2.0 release"), the dd_js HEAD before any port work.
- Pushing the tag to `origin` was rejected by the git proxy (HTTP 403) on every attempt; the branch push for this PR went through fine, so it appears tag pushes are blocked from this environment. The tag exists in the local repo and can be pushed by a maintainer with:
  ```
  git fetch origin && git tag -a pre-pivot/dd_js -m "Pre-pivot snapshot: original dd_js HEAD before webxdc port begins" da6a034 && git push origin pre-pivot/dd_js
  ```
  Happy to retry from a different environment if there's a preferred way to land the tag.

## Acceptance check (against #1)

- [x] README renders with quote, framing, and upstream links.
- [x] Both license files present, `CREDITS.txt` lists all original authors.
- [x] `data/` directory contains the three JSON files + `UPSTREAM.txt`.
- [~] Tag `pre-pivot/dd_js` exists locally; push blocked — see note above.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SBxZEWNsiLp8NKL19aimte)_