### PR TITLE
Replace JSON-RPC backend with local engine stub

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,8 +7,6 @@
     "EaselJS": "release_v0.6.1",
     "jquery": "2.0.3",
     "jquery.cookie": "1.3.1",
-    "jquery-jsonrpcjs": "https://raw.github.com/datagraph/jquery-jsonrpc/6f6af4120d8417a55610b30d9ab108ef34772028/jquery.jsonrpc.js",
-    "jquery-message-queuing": "https://raw.githubusercontent.com/cowboy/jquery-message-queuing/514f091e0fad742ed3d96c909dc3217951e530b3/jquery.ba-jqmq.min.js",
     "jquery-migrate": "1.2.1",
     "jquery-mobile": "1.3.2",
     "json2": "https://raw.github.com/douglascrockford/JSON-js/e39db4b7e6249f04a195e7dd0840e610cc9e941e/json2.js",

--- a/scripts/LocalEngine.js
+++ b/scripts/LocalEngine.js
@@ -1,0 +1,42 @@
+// Local replacement for the back-end JSON-RPC service.
+// Phase 2 only provides stubs: every method rejects with "NotImplemented".
+// Phase 3 issues will fill these in with real client-side handlers.
+
+define(function(require) {
+
+  var $ = require('jquery');
+
+  // RPC names registered in app.js:140-159.
+  var names = [
+    'buyPowerup',
+    'chargePerp',
+    'collectPerp',
+    'integrateCollected',
+    'getPowerups',
+    'getProvidedPerps',
+    'getSessionLocale',
+    'buyKarma',
+    'buyPerp',
+    'buySlots',
+    'getToken',
+    'loadGame',
+    'setDisplayName',
+    'getRanking',
+    'ping',
+    'resetGame',
+    'sellPowerup',
+    'setPerpCoordinates',
+    'checkUsername'
+  ];
+
+  var LocalEngine = {};
+
+  names.forEach(function(name) {
+    LocalEngine[name] = function() {
+      return $.Deferred().reject('NotImplemented: ' + name).promise();
+    };
+  });
+
+  return LocalEngine;
+
+});

--- a/scripts/Remote.js
+++ b/scripts/Remote.js
@@ -1,158 +1,47 @@
-// Wrapper for back-end calls using the $.jsonRPC plugin.
+// Thin shim that delegates remote-method calls to LocalEngine.
+// Each registered method returns a jQuery Deferred promise so existing
+// .done()/.fail() chains in Game.js and bootstrap.js keep working.
 
-// The object is defined as RequireJS module, using the classy CommonJS-like style.
 define(function(require) {
 
-  // The local variable Remote is going to contain the resulting return value.
+  var $ = require('jquery');
+  var LocalEngine = require('LocalEngine');
+
   var Remote = function(options) {
-    var _ = require('underscore');
-    var $ = require('jquery');
-
-    require('jquery-jsonrpc');
-    require('jquery-message-queuing');
-
-    var setup = require('setup');
-    var util = require('util');
-
     var remote = this;
     options = options || {};
 
-    if (options.queue) {
-      remote.queue = $.jqmq(options.queue);
-    }
-  
-    remote.addMethod = function(name, endPoint, needsQueue) {
-      if (!_.isString(endPoint)) {
-        endPoint = options.endPoint;
-      }
-      if (!name || !endPoint) {
-        console.error('Insufficient arguments.');
+    // `endpointOverride` and any additional arguments are accepted for
+    // backwards compatibility with callers like app.js and bootstrap.js
+    // that still pass an endpoint URL or Remote.NEEDS_QUEUE, but they are
+    // no longer used now that calls are dispatched locally.
+    remote.addMethod = function(name /*, endpointOverride */) {
+      if (!name) {
+        console.error('Remote.addMethod: method name is required.');
         return remote;
       }
-      if (name in Remote.RESERVED_METHODNAMES) {
-        console.error('Cannot add remote method, method name ‘%s’ is reserved for internal use.', name);
+      if (Remote.RESERVED_METHODNAMES.hasOwnProperty(name)) {
+        console.error('Cannot add remote method, name "%s" is reserved.', name);
         return remote;
       }
-      // Define handler function.
-      var handler = function(name) {
-        return function() {
-          return request(name, endPoint, needsQueue, arguments);
+      remote[name] = function() {
+        var fn = LocalEngine[name];
+        if (typeof fn === 'function') {
+          return fn.apply(LocalEngine, arguments);
         }
-      }
-      remote[name] = (function(name) {
-        return handler(name);
-      }(name));
+        return $.Deferred().reject('NotImplemented: ' + name).promise();
+      };
       return remote;
     };
 
-    // The setup for the JSON-RPC plugin is straighforward. The endpoint is defined in setup.js. As we are using the `$.jsonRPC.withOptions` method this is done for every request at a later time, and we do not need a global setup right now.
-    /*
-    $.jsonRPC.setup({
-      endPoint: setup.jsonRpcUrl,
-      namespace: ''
-    });
-    */
-  
-    // The core method needs at least the method name and the RPC endpoint. Optionally, the method call can be queued by setting the value of the `needsQueue` argument to `Remote.NEEDS_QUEUE`. Queuing calls decreases the risk of race conditions at the back-end as there is never more than one remote call sent from each client simultaneously. Further arbitrary parameters can be provided as array in a third argument. As we will see below, the latter is very useful for function wrappers or using the `apply` and `call` methods of the Function prototype.
-    function request(method, endPoint, needsQueue, args) {
-      // Fail silently if no method is given.
-      if (!method) {
-        return;
-      }
-      // We support `jQuery.Deferred`.
-      var deferred = new $.Deferred();
-
-      var handler = (function(method, endPoint, args, deferred) {
-        return function() {
-          // Initialising some local variables.
-          var param = [];
-          var arg;
-          // We loop indefinitely, thus we need to break somewhere inside the loop body.
-          while (true) {
-            // Shift (ie. pop the first item of) the `args` array by calling the prototype methods of Array. This keeps us safe if `args` is in fact an `arguments` array which does not inherit the Array methods, unfortunatley.
-            arg = Array.prototype.shift.call(args, 0);
-            // _Caveat:_ It is assumed that a parameter is never a function! Thus, every item in the 
-            // args array is viewed as JSON-RPC parameter until we hit the first function.
-            if (typeof arg === 'undefined' || (arg !== null && arg.constructor === Function)) {
-              // Here comes the break from the loop!
-              break;
-            }
-            // At this point we can safely add the argument as option.
-            param.push(arg);
-          }
-          // arg is now either a function or nullsy. Anyway, let’s use it for the success callback handler.
-          var onSuccess = arg;
-          // Same with the remaining item in the args array. This is used for the error callback handler.
-          var onError = args[0];
-          // Calling the `$.jsonRPC.withOptions` method with our endPoint and options.
-          $.jsonRPC.withOptions({
-            endPoint: endPoint,
-            namespace: ''
-          }, function() {
-            var jsonrpc = this;
-            jsonrpc.request(method, {
-              params: param,
-              // The JSON-RPC success handler.
-              success: function() {
-                var args = arguments;
-                // Apply the onSuccess callback if it is given as argument.
-                if (_.isFunction(onSuccess)) {
-                  onSuccess.apply(jsonrpc, arguments);
-                }
-                // Apply a delay to simulate network latency when defined and in debug mode.
-                if (setup.debug && setup.latency) {
-                  return util.wait(setup.latency).then(function() {
-                    return deferred.resolve.apply(jsonrpc, args);
-                  });
-                }
-                // Finally apply the $.Deferred.resolve() method.
-                return deferred.resolve.apply(jsonrpc, args);
-              }, 
-              // The JSON-RPC error handler.
-              error: function() {
-                // Apply the onError callback if it is given as argument.
-                if (_.isFunction(onError)) {
-                  onError.apply(jsonrpc, arguments);
-                }
-                // Finally apply the $.Deferred.reject() method.
-                return deferred.reject.apply(jsonrpc, arguments);
-              }
-            });
-          });
-          // The promise is returned from the handler, too.
-          return deferred.promise();
-        }
-      }(method, endPoint, args, deferred));
-
-      // Add the method call to the queue if desired.
-      if (needsQueue === Remote.NEEDS_QUEUE) {
-        // Do a last check whether we have a functional queue.
-        if (remote.queue && _.isFunction(remote.queue.add)) {
-          needsQueue = false; // We only want to be queued once!
-          remote.queue.add({
-            context: remote, 
-            handler: handler, 
-            'arguments': arguments        
-          });
-        } else {
-          console.error('Cannot queue remote method call, no queue defined.')
-        }
-      } else {
-        return handler();
-      }
-
-      // Return the promise of the $.Deferred object for chaining.
-      return deferred.promise();
-    }
-  
     return this;
   };
-  
-  // Use this constant for the `needsQueue` argument.
+
+  // Preserved so app.js can still pass `Remote.NEEDS_QUEUE` as it does today.
   Remote.NEEDS_QUEUE = true;
-  
+
   Remote.RESERVED_METHODNAMES = {addMethod: true, queue: true};
-  
+
   return Remote;
-  
+
 });

--- a/scripts/require.config.js
+++ b/scripts/require.config.js
@@ -13,8 +13,6 @@ require.config({
     'createjs-tween': '../components/TweenJS/lib/tweenjs-0.4.1.min',
     'createjs-sound': '../components/SoundJS/lib/soundjs-0.4.1.min',
     jquery: '../components/jquery/jquery',
-    'jquery-jsonrpc': '../components/jquery-jsonrpcjs/index',
-    'jquery-message-queuing': '../components/jquery-message-queuing/index',
     'jquery-migrate': '../components/jquery-migrate/jquery-migrate',
     'jquery-mobile': '../components/jquery-mobile/index',
     json2: '../components/json2/index',
@@ -44,14 +42,6 @@ require.config({
     'createjs-tween': {
       deps: ['createjs-easel'],
       exports: 'createjs.Tween'
-    },
-    'jquery-jsonrpc': {
-      deps: ['jquery'],
-      exports: 'jQuery.jsonRPC'
-    },
-    'jquery-message-queuing': {
-      deps: ['jquery'],
-      exports: 'jQuery.jqmq'
     },
     'jquery-migrate': ['jquery'],
     'jquery-mobile': ['jquery'],


### PR DESCRIPTION
## Summary
Refactored the Remote module to delegate method calls to a new LocalEngine module instead of making JSON-RPC calls to a backend service. This is Phase 2 of a migration to client-side game logic, with LocalEngine providing stub implementations that reject with "NotImplemented" errors.

## Key Changes
- **Remote.js**: Simplified from 158 lines to 47 lines
  - Removed all JSON-RPC plugin integration and network request logic
  - Removed message queue handling
  - Removed endpoint configuration and parameter parsing
  - Now acts as a thin shim that delegates to LocalEngine methods
  - Maintains backward compatibility by accepting (but ignoring) `endpointOverride` and `Remote.NEEDS_QUEUE` arguments
  - Methods still return jQuery Deferred promises to preserve existing `.done()/.fail()` chains in Game.js and bootstrap.js

- **LocalEngine.js**: New module created
  - Defines 19 RPC method stubs (buyPowerup, chargePerp, collectPerp, etc.)
  - Each method returns a rejected promise with "NotImplemented" error message
  - Serves as placeholder for Phase 3 implementation of actual client-side handlers

## Implementation Details
- Remote.addMethod() now validates only the method name and reserved names, delegating actual execution to LocalEngine
- Error handling simplified: methods that don't exist in LocalEngine return a rejected promise
- Backward compatibility preserved for callers in app.js and bootstrap.js that still pass endpoint URLs or Remote.NEEDS_QUEUE
- All 19 game RPC methods are pre-registered in LocalEngine to match the current app.js registration list

https://claude.ai/code/session_01J714SKZ5r2VeCAwBydWC5H