### PR TITLE
Phase 2: boot-to-broken integration + architecture.md (#9)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,141 @@
+# Network-layer architecture (post-Wave-1 stubs)
+
+## Overview
+
+Wave 1 replaced the original JSON-RPC + SockJS network layer with an
+in-process stub stack that keeps every existing `.done()` / `.fail()` call
+site intact.  The three new modules are:
+
+| Module | Role |
+|---|---|
+| `scripts/Remote.js` | Thin shim; delegates `remote.method()` calls to LocalEngine |
+| `scripts/LocalEngine.js` | Stub engine; every handler rejects with `"NotImplemented: <name>"` |
+| `scripts/Socket.js` | In-process event bus backed by `$(document)` jQuery events |
+
+---
+
+## Boot sequence
+
+```
+index.html
+  └─ require.js  (data-main: scripts/require.config)
+       └─ require(['bootstrap'])
+            └─ bootstrap.js
+                 1. new Remote(...)          # endPoint arg is ignored by the stub
+                 2. remote.addMethod('getToken')
+                 3. routie('load')
+                      └─ remote.getToken()
+                           └─ LocalEngine.getToken()
+                                └─ $.Deferred().reject('NotImplemented: getToken')
+                           └─ .fail() handler fires
+                                ├─ console.error('Error: NotImplemented: getToken')
+                                └─ routie('downtime')  →  downtime view rendered
+```
+
+`app.start()` (in `app.js`) is never reached in this baseline because the
+`remote.getToken()` in the `routie('load')` handler rejects before the asset
+loader runs.  Socket initialisation (`app.initSocket`) is therefore also
+skipped.
+
+---
+
+## RPC call path: Game.js → Remote → LocalEngine → Deferred
+
+When the game eventually runs (Wave 3+), every RPC call follows the same
+path:
+
+```
+// e.g. inside Game.js
+app.remote.buyPerp(app.token, path, gestalt)
+  │
+  ├─ Remote.addMethod registered remote['buyPerp'] as:
+  │     function() {
+  │       var fn = LocalEngine['buyPerp'];
+  │       if (typeof fn === 'function') return fn.apply(LocalEngine, arguments);
+  │       return $.Deferred().reject('NotImplemented: buyPerp').promise();
+  │     }
+  │
+  └─ LocalEngine.buyPerp(token, path, gestalt)
+       └─ returns $.Deferred().reject('NotImplemented: buyPerp').promise()
+            │
+            ├─ .done() chain → skipped
+            └─ .fail() chain → error handled at call site
+```
+
+`Remote` accepts (and silently ignores) a second `endpointOverride` argument
+to `addMethod` and the `Remote.NEEDS_QUEUE` sentinel passed by legacy call
+sites in `app.js`.  No HTTP request is ever issued.
+
+---
+
+## Event flow: LocalEngine → Socket → app.js handlers
+
+When LocalEngine handlers are implemented (Wave 3+) they will push server-
+side state changes back to the UI by emitting events through the Socket:
+
+```
+LocalEngine.someHandler(...)
+  └─ socket.emit('node_ready', { id: ..., result: ... })
+       └─ $(document).trigger('node_ready', data)
+            └─ listener registered by app.js via socket.on('node_ready', ...)
+                 └─ app.game.getById(data.id).trigger('node_ready', [data.result])
+```
+
+`Socket.emit(eventName, data)` calls `$(document).trigger(eventName, data)`.
+`Socket.on(eventName, handler)` wraps the handler in a `$(document).on()`
+listener.  There is no WebSocket, no SockJS, and no server involved.
+
+On construction `Socket` fires `connect` then `established` synchronously
+(via `setTimeout(0)`) so that `app.initSocket`'s handshake Deferred resolves
+without needing a real server connection.
+
+---
+
+## Where LocalEngine plugs into the boot sequence
+
+`Remote.js` requires `LocalEngine` at module load time:
+
+```javascript
+// Remote.js top-level
+var LocalEngine = require('LocalEngine');
+```
+
+`LocalEngine` is therefore available to every `remote.addMethod(name)` call.
+No explicit wiring is needed in `bootstrap.js` or `app.js`.
+
+When a Wave 3 handler is ready, replace the stub in `LocalEngine.js`:
+
+```javascript
+// before
+LocalEngine['buyPerp'] = function() {
+  return $.Deferred().reject('NotImplemented: buyPerp').promise();
+};
+
+// after
+LocalEngine['buyPerp'] = function(token, path, gestalt) {
+  // … real implementation …
+  return $.Deferred().resolve({ result: … }).promise();
+};
+```
+
+No changes to Remote.js, Socket.js, app.js, or bootstrap.js are required.
+
+---
+
+## "Boots-to-broken" baseline
+
+The state after Wave 1 is intentionally broken at the game-start level:
+
+* The app loads, renders no game, and shows the **downtime** view.
+* DevTools **Network** tab shows **zero non-localhost requests** during boot.
+* DevTools **Console** shows the expected rejection:
+
+  ```
+  Error:  NotImplemented: getToken
+  Backend made a  bubu, do something!
+  ```
+
+This is the correct baseline.  Wave 1's goal was to eliminate all external
+network calls while keeping every existing call site in Game.js, app.js, and
+bootstrap.js syntactically intact.  Wave 3 issues will replace the stubs one
+by one with real client-side handlers.

--- a/scripts/bootstrap.js
+++ b/scripts/bootstrap.js
@@ -116,11 +116,6 @@ require([
   // -----------------------------------------------------------------------------------
   // ^- desperately slashing at the spaghetti, trying to kill it, but all to no avail.
 
-  // register some backend calls
-
-  remote.addMethod('logout',setup.jsonRpcUrl);
-  remote.addMethod('getToken',setup.jsonRpcUrl);
-
   // finally do it:
 
   // routie endpoint, so reassign route handlers


### PR DESCRIPTION
## Summary

Closes #9. Integration verification for the three Wave 1 strips, plus post-stub control-flow documentation.

- **Conflict fix (`bootstrap.js`):** PR #6 stripped the dd_auth login flow but left two orphan lines — `remote.addMethod('logout', ...)` (dead code; `logout` is never called) and a duplicate `remote.addMethod('getToken', ...)` (already registered four lines above). Both are removed.
- **No changes to `Socket.js` or `Remote.js`** — the three Wave 1 stubs integrate cleanly; no further conflicts found.
- **`docs/architecture.md`** (~1 page): documents the post-stub control flow — RPC call path through Remote → LocalEngine → Deferred, event return path through Socket's `$(document)` bus, where LocalEngine plugs into the boot sequence, and a note that this is the "boots-to-broken" baseline.

## Integration verification (manual)

Boot sequence with all three stubs in place:

1. `bootstrap.js` constructs `Remote` (endpoint arg silently ignored) and calls `remote.getToken()`.
2. `Remote.addMethod` dispatch → `LocalEngine.getToken()` → `$.Deferred().reject('NotImplemented: getToken')`.
3. `.fail()` handler fires: `console.error('Error: NotImplemented: getToken')` then `routie('downtime')`.
4. Downtime view renders. `app.start()` and `app.initSocket()` are never reached.

**Expected DevTools results:**
- Network tab: zero non-localhost requests during boot.
- Console: `Error:  NotImplemented: getToken` / `Backend made a  bubu, do something!`

This is the correct boots-to-broken baseline. No new handler logic is added here — that is Wave 3.

## Test plan

- [ ] Serve repo root with `python3 -m http.server` and open `index.html`
- [ ] Confirm DevTools Network shows no non-localhost requests
- [ ] Confirm DevTools Console shows `NotImplemented: getToken` rejection
- [ ] Confirm downtime view is rendered (not a blank page or JS error)
- [ ] Read `docs/architecture.md` for accuracy

https://claude.ai/code/session_01TyDtXMXgEnzojUzxik75qw

---
_Generated by [Claude Code](https://claude.ai/code/session_01TyDtXMXgEnzojUzxik75qw)_