### PR TITLE
Phase 3: idle-progression materializer (#11)

### DIFF
--- a/scripts/esm-entry.js
+++ b/scripts/esm-entry.js
@@ -6,3 +6,4 @@
 
 export const __placeholder = true;
 export * as state from './state.js';
+export { materialize } from './materializer.js';

--- a/scripts/materializer.js
+++ b/scripts/materializer.js
@@ -1,0 +1,145 @@
+// Idle-progression materializer for the webxdc port of Data Dealer.
+//
+// Timers don't survive app close; state stores immutable timestamps and
+// progress is a pure function of (state, now) materialized lazily on read.
+//
+// Source authority for each rule: docs/async-map.md.
+
+// ── materialize ────────────────────────────────────────────────────────────
+/**
+ * Apply all time-based progression rules to `state` up to clock value `now`.
+ *
+ * @param {object} state  - Immutable game-state snapshot.
+ *   Relevant fields (all optional; missing fields are treated as empty/absent):
+ *     nodes_charging: Array<{
+ *       path: string,
+ *       result: object,
+ *       charge_start: number,   // epoch-ms
+ *       charge_end: number,     // epoch-ms — gate for collection
+ *       game_id: string,        // needed for node_ready event id field
+ *       game_type: string       // needed for node_ready event type field
+ *     }>
+ *     nodes_collect:  Array<{ path: string, result: object }>
+ *     game_values: {
+ *       ap_snapshot:    number,  // AP at time of last snapshot
+ *       ap_update:      number,  // epoch-ms of last snapshot
+ *       ap_inc_value:   number,  // AP gained per regen tick
+ *       ap_inc_interval:number,  // ms between regen ticks
+ *       ap_max:         number   // AP ceiling
+ *     }
+ *   NOTE: nodes_charging entries in the port must carry game_id and game_type
+ *   (not in the original Mongo schema) so the materializer can build the
+ *   node_ready payload without a second nodes lookup.
+ *
+ * @param {number} now  - Current wall-clock epoch-ms supplied by the caller.
+ *                        Never call Date.now() inside this function.
+ *
+ * @returns {{ state: object, events: Array }}
+ *   state  — New state object (shallow-cloned; input is never mutated).
+ *             Completed charges are moved from nodes_charging to nodes_collect.
+ *             AP snapshot is advanced to `now`.
+ *   events — Synthetic socket events in temporal order (earliest charge_end
+ *             first).  Each entry: { ev: 'node_ready', pl: { id, type, path,
+ *             result } }.  Shape matches docs/socket-events.md §node_ready.
+ *             Events represent transitions that occurred in *this* call only;
+ *             a second call with the same `now` emits no events (idempotent
+ *             state, empty event array).
+ */
+function materialize(state, now) {
+  var events = [];
+
+  // ── Rule 1: chargePerpReady (docs/async-map.md §1) ──────────────────────
+  // For every nodes_charging entry where now >= charge_end:
+  //   • remove from nodes_charging
+  //   • append to nodes_collect (deduplicated by path)
+  //   • push a node_ready event
+  //
+  // Bounded accumulation: each charge is discrete and never auto-restarts,
+  // so no cap is needed — we just move every completed entry.
+  var charging = state.nodes_charging || [];
+  var collect = (state.nodes_collect || []).slice();
+
+  // Build a path-set for O(1) duplicate detection.
+  var inCollect = Object.create(null);
+  for (var i = 0; i < collect.length; i++) {
+    inCollect[collect[i].path] = true;
+  }
+
+  var stillCharging = [];
+  var newlyReady = [];
+  for (var j = 0; j < charging.length; j++) {
+    var c = charging[j];
+    if (now >= c.charge_end) {
+      newlyReady.push(c);
+    } else {
+      stillCharging.push(c);
+    }
+  }
+
+  // Emit events in temporal order (earliest charge_end first) so Game.js
+  // handlers light up the UI as if the player had been watching live.
+  newlyReady.sort(function(a, b) { return a.charge_end - b.charge_end; });
+
+  for (var k = 0; k < newlyReady.length; k++) {
+    var entry = newlyReady[k];
+    // Guard against a path being present in both arrays simultaneously.
+    if (!inCollect[entry.path]) {
+      collect.push({ path: entry.path, result: entry.result });
+      inCollect[entry.path] = true;
+    }
+    events.push({
+      ev: 'node_ready',
+      pl: {
+        id:     entry.game_id,
+        type:   entry.game_type,
+        path:   entry.path,
+        result: entry.result
+      }
+    });
+  }
+
+  // ── Rule 2: AP regeneration (docs/async-map.md §cross-cutting) ──────────
+  // Advance the ap_snapshot to `now` so that every downstream read gets the
+  // current AP without re-running the calculation.
+  // Mirrors dd_app/helpers.py::calculateAP.
+  var gv = state.game_values || {};
+  var newGv = Object.assign({}, gv);
+  if (
+    typeof gv.ap_snapshot    === 'number' &&
+    typeof gv.ap_update      === 'number' &&
+    typeof gv.ap_inc_value   === 'number' &&
+    gv.ap_inc_interval > 0                &&
+    typeof gv.ap_max         === 'number'
+  ) {
+    var elapsed = Math.max(0, now - gv.ap_update);
+    var ticks   = Math.floor(elapsed / gv.ap_inc_interval);
+    newGv = Object.assign({}, gv, {
+      ap_snapshot: Math.min(gv.ap_max, gv.ap_snapshot + ticks * gv.ap_inc_value),
+      // Advance ap_update only to the last full-tick boundary so that the
+      // fractional remainder is preserved across stepwise materializations.
+      // Setting ap_update = now would silently discard sub-interval progress
+      // and violate the composability invariant.
+      ap_update: gv.ap_update + ticks * gv.ap_inc_interval,
+    });
+  }
+
+  // ── notifyLevelupItems / notifyBuyperpItems (docs/async-map.md §2–3) ────
+  // Both tasks are purely cosmetic (2 s delay so animation completes) with no
+  // DB write and no persistent duration.  In the port they run synchronously
+  // inside the RPC handler at the moment the level-up or buyPerp is
+  // processed.  No materialization rule is needed here.
+
+  // ── logAction (docs/async-map.md §4) ────────────────────────────────────
+  // Analytics-only sink; no gameplay state; drop on port (v1).
+
+  return {
+    state: Object.assign({}, state, {
+      nodes_charging: stillCharging,
+      nodes_collect:  collect,
+      game_values:    newGv
+    }),
+    events: events
+  };
+}
+
+export { materialize };

--- a/tests/materializer/materializer.test.js
+++ b/tests/materializer/materializer.test.js
@@ -1,8 +1,346 @@
 import { describe, it, expect } from 'vitest';
+import { materialize } from '../../scripts/materializer.js';
 
-// Placeholder — real materializer tests land with #11 (materializer).
-describe('materializer (placeholder)', () => {
-  it('test runner is operational in Node context', () => {
-    expect(true).toBe(true);
+// ── test fixtures ────────────────────────────────────────────────────────────
+
+function baseState(overrides) {
+  return Object.assign({
+    nodes_charging: [],
+    nodes_collect:  [],
+    game_values: {
+      ap_snapshot:     10,
+      ap_update:        0,
+      ap_inc_value:     1,
+      ap_inc_interval:  60000,  // 1 AP per minute
+      ap_max:          20,
+    }
+  }, overrides);
+}
+
+function charge(path, charge_end, game_id, game_type) {
+  return {
+    path:         path      || 'Imperium.City.Agent0',
+    result:       { value: 10 },
+    charge_start: 0,
+    charge_end:   charge_end != null ? charge_end : 5000,
+    game_id:      game_id   || 'abc123',
+    game_type:    game_type || 'ContactPerp',
+  };
+}
+
+// ── charge-cycle rule ────────────────────────────────────────────────────────
+
+describe('chargePerpReady rule', () => {
+  it('leaves a charging entry alone before charge_end', () => {
+    const s = baseState({ nodes_charging: [charge('p.a', 5000)] });
+    const r = materialize(s, 4999);
+    expect(r.state.nodes_charging).toHaveLength(1);
+    expect(r.state.nodes_collect).toHaveLength(0);
+    expect(r.events).toHaveLength(0);
+  });
+
+  it('moves the entry at exactly charge_end', () => {
+    const s = baseState({ nodes_charging: [charge('p.a', 5000)] });
+    const r = materialize(s, 5000);
+    expect(r.state.nodes_charging).toHaveLength(0);
+    expect(r.state.nodes_collect).toHaveLength(1);
+    expect(r.state.nodes_collect[0].path).toBe('p.a');
+  });
+
+  it('does not mutate the input state', () => {
+    const s = baseState({ nodes_charging: [charge('p.a', 5000)] });
+    const original_len = s.nodes_charging.length;
+    materialize(s, 9999);
+    expect(s.nodes_charging).toHaveLength(original_len);
+  });
+
+  it('emits a node_ready event with correct payload shape', () => {
+    const c = charge('p.a', 5000, 'id1', 'ContactPerp');
+    const s = baseState({ nodes_charging: [c] });
+    const r = materialize(s, 5000);
+    expect(r.events).toHaveLength(1);
+    expect(r.events[0]).toEqual({
+      ev: 'node_ready',
+      pl: { id: 'id1', type: 'ContactPerp', path: 'p.a', result: c.result }
+    });
+  });
+
+  it('emits multiple events in temporal order (earliest charge_end first)', () => {
+    const s = baseState({
+      nodes_charging: [
+        charge('p.b', 8000, 'id2', 'T'),
+        charge('p.a', 5000, 'id1', 'T'),
+        charge('p.c', 3000, 'id3', 'T'),
+      ]
+    });
+    const r = materialize(s, 10000);
+    expect(r.events.map(e => e.pl.path)).toEqual(['p.c', 'p.a', 'p.b']);
+  });
+
+  it('preserves pre-existing nodes_collect entries', () => {
+    const existing = { path: 'p.x', result: { value: 5 } };
+    const s = baseState({
+      nodes_charging: [charge('p.a', 5000)],
+      nodes_collect:  [existing],
+    });
+    const r = materialize(s, 5000);
+    expect(r.state.nodes_collect).toHaveLength(2);
+    expect(r.state.nodes_collect[0]).toEqual(existing);
+  });
+
+  it('deduplicates a path already present in nodes_collect', () => {
+    // Guard: if somehow both arrays contain the same path, don't double-add.
+    const s = baseState({
+      nodes_charging: [charge('p.a', 5000)],
+      nodes_collect:  [{ path: 'p.a', result: { value: 10 } }],
+    });
+    const r = materialize(s, 5000);
+    expect(r.state.nodes_collect).toHaveLength(1);
+    // Event is still emitted (the transition did occur).
+    expect(r.events).toHaveLength(1);
+  });
+
+  it('keeps still-charging entries in nodes_charging', () => {
+    const s = baseState({
+      nodes_charging: [
+        charge('p.done',  1000),
+        charge('p.later', 9000),
+      ]
+    });
+    const r = materialize(s, 5000);
+    expect(r.state.nodes_charging).toHaveLength(1);
+    expect(r.state.nodes_charging[0].path).toBe('p.later');
+    expect(r.state.nodes_collect).toHaveLength(1);
+    expect(r.state.nodes_collect[0].path).toBe('p.done');
+  });
+});
+
+// ── AP regen rule ────────────────────────────────────────────────────────────
+
+describe('AP regen rule', () => {
+  it('advances AP by the correct number of ticks', () => {
+    const s = baseState({
+      game_values: { ap_snapshot: 5, ap_update: 0,
+                     ap_inc_value: 2, ap_inc_interval: 1000, ap_max: 100 }
+    });
+    const r = materialize(s, 3000);  // 3 ticks × 2 = 6
+    expect(r.state.game_values.ap_snapshot).toBe(11);
+    expect(r.state.game_values.ap_update).toBe(3000);
+  });
+
+  it('caps AP at ap_max', () => {
+    const s = baseState({
+      game_values: { ap_snapshot: 18, ap_update: 0,
+                     ap_inc_value: 5, ap_inc_interval: 1000, ap_max: 20 }
+    });
+    expect(materialize(s, 5000).state.game_values.ap_snapshot).toBe(20);
+  });
+
+  it('does not advance AP before a full interval elapses', () => {
+    const s = baseState({
+      game_values: { ap_snapshot: 5, ap_update: 0,
+                     ap_inc_value: 1, ap_inc_interval: 1000, ap_max: 20 }
+    });
+    expect(materialize(s, 999).state.game_values.ap_snapshot).toBe(5);
+  });
+
+  it('does not alter game_values when AP fields are absent', () => {
+    const s = baseState({ game_values: { xp_value: 42 } });
+    const r = materialize(s, 9999);
+    expect(r.state.game_values).toEqual({ xp_value: 42 });
+  });
+
+  it('does not regress AP when now < ap_update', () => {
+    const s = baseState({
+      game_values: { ap_snapshot: 10, ap_update: 5000,
+                     ap_inc_value: 1, ap_inc_interval: 1000, ap_max: 20 }
+    });
+    expect(materialize(s, 3000).state.game_values.ap_snapshot).toBe(10);
+  });
+});
+
+// ── idempotence ──────────────────────────────────────────────────────────────
+//
+// materialize(materialize(s, t).state, t).state  ≡  materialize(s, t).state
+//
+// Applying the same timestamp twice arrives at the same state — no further
+// transitions occur, no duplicate entries accumulate.
+
+describe('idempotence', () => {
+  it('state is unchanged on a second call with the same t', () => {
+    const s = baseState({
+      nodes_charging: [charge('p.a', 5000), charge('p.b', 3000)],
+    });
+    const r1 = materialize(s, 6000);
+    const r2 = materialize(r1.state, 6000);
+    expect(r2.state).toEqual(r1.state);
+  });
+
+  it('no events are emitted on the second call with the same t', () => {
+    const s = baseState({ nodes_charging: [charge('p.a', 5000)] });
+    const r1 = materialize(s, 6000);
+    expect(materialize(r1.state, 6000).events).toHaveLength(0);
+  });
+
+  it('AP snapshot does not drift on repeated same-t calls', () => {
+    const s = baseState({
+      game_values: { ap_snapshot: 0, ap_update: 0,
+                     ap_inc_value: 1, ap_inc_interval: 1000, ap_max: 50 }
+    });
+    const t = 5000;
+    const r1 = materialize(s, t);
+    const r2 = materialize(r1.state, t);
+    expect(r2.state.game_values.ap_snapshot)
+      .toBe(r1.state.game_values.ap_snapshot);
+  });
+});
+
+// ── monotonicity ─────────────────────────────────────────────────────────────
+//
+// Increasing `now` never loses progress: nodes_collect count is non-decreasing
+// and AP is non-decreasing (up to cap).
+
+describe('monotonicity', () => {
+  it('nodes_collect count is non-decreasing as t increases', () => {
+    const s = baseState({
+      nodes_charging: [
+        charge('p.a', 1000),
+        charge('p.b', 3000),
+        charge('p.c', 5000),
+      ]
+    });
+    const times = [0, 500, 1000, 2000, 3000, 4000, 5000, 10000];
+    let prev = 0;
+    for (const t of times) {
+      const len = materialize(s, t).state.nodes_collect.length;
+      expect(len).toBeGreaterThanOrEqual(prev);
+      prev = len;
+    }
+  });
+
+  it('AP is non-decreasing as t increases', () => {
+    const s = baseState({
+      game_values: { ap_snapshot: 0, ap_update: 0,
+                     ap_inc_value: 1, ap_inc_interval: 1000, ap_max: 10 }
+    });
+    const times = [0, 1000, 2000, 5000, 9000, 10000, 20000];
+    let prev = 0;
+    for (const t of times) {
+      const ap = materialize(s, t).state.game_values.ap_snapshot;
+      expect(ap).toBeGreaterThanOrEqual(prev);
+      prev = ap;
+    }
+  });
+});
+
+// ── composability ────────────────────────────────────────────────────────────
+//
+// N stepwise materializations t0→t1→…→tN arrive at the same state as one
+// big-step materialization t0→tN.
+// For events: accumulated stepwise events equal the big-step events array.
+
+describe('composability', () => {
+  it('two-step state equals big-step state', () => {
+    const s = baseState({
+      nodes_charging: [charge('p.a', 2000), charge('p.b', 7000)],
+      game_values: { ap_snapshot: 0, ap_update: 0,
+                     ap_inc_value: 1, ap_inc_interval: 1000, ap_max: 50 }
+    });
+    const r1 = materialize(s, 3000);
+    const r2 = materialize(r1.state, 9000);
+    expect(r2.state).toEqual(materialize(s, 9000).state);
+  });
+
+  it('accumulated two-step events equal big-step events', () => {
+    const s = baseState({
+      nodes_charging: [
+        charge('p.a', 2000, 'id1', 'T'),
+        charge('p.b', 7000, 'id2', 'T'),
+      ]
+    });
+    const r1 = materialize(s, 3000);
+    const r2 = materialize(r1.state, 9000);
+    expect([...r1.events, ...r2.events]).toEqual(materialize(s, 9000).events);
+  });
+
+  it('five-step state equals big-step state', () => {
+    const s = baseState({
+      nodes_charging: [
+        charge('p.a', 1500),
+        charge('p.b', 3500),
+        charge('p.c', 7000),
+      ],
+      game_values: { ap_snapshot: 3, ap_update: 0,
+                     ap_inc_value: 2, ap_inc_interval: 1000, ap_max: 100 }
+    });
+    let cur = s;
+    for (const t of [1000, 2000, 4000, 6000, 8000]) {
+      cur = materialize(cur, t).state;
+    }
+    expect(cur).toEqual(materialize(s, 8000).state);
+  });
+});
+
+// ── property: random delta sequences ────────────────────────────────────────
+//
+// For any sequence of non-decreasing timestamps t0 ≤ t1 ≤ … ≤ tN,
+// stepwise materialization to tN must equal a single big-step to tN.
+// Verified over 50 random trials using a seeded LCG so failures are
+// reproducible.
+
+describe('property — random delta sequences', () => {
+  // Minimal seeded LCG PRNG (same algorithm across all JS engines).
+  function prng(seed) {
+    let s = seed >>> 0;
+    return function rand() {
+      s = (Math.imul(1664525, s) + 1013904223) >>> 0;
+      return s / 0xFFFFFFFF;
+    };
+  }
+
+  it('N random stepwise advances produce the same final state as one big jump', () => {
+    const rand = prng(0xDEADBEEF);
+
+    for (let trial = 0; trial < 50; trial++) {
+      // Random charge entries (1–5) with charge_ends in 0–100 s
+      const numCharges = Math.floor(rand() * 5) + 1;
+      const charges = [];
+      for (let i = 0; i < numCharges; i++) {
+        charges.push(charge('p.' + i, Math.floor(rand() * 100000), 'id' + i, 'T'));
+      }
+
+      const s = baseState({
+        nodes_charging: charges,
+        game_values: {
+          ap_snapshot:     0,
+          ap_update:       0,
+          ap_inc_value:    Math.floor(rand() * 3) + 1,
+          ap_inc_interval: Math.floor(rand() * 5000) + 1000,
+          ap_max:          Math.floor(rand() * 50) + 10,
+        }
+      });
+
+      const tFinal = Math.floor(rand() * 150000);
+
+      // Random monotonically-increasing intermediate timestamps
+      const numSteps = Math.floor(rand() * 6) + 1;
+      const steps = [];
+      for (let i = 0; i < numSteps; i++) {
+        steps.push(Math.floor(rand() * tFinal));
+      }
+      steps.sort((a, b) => a - b);
+      steps.push(tFinal);   // always end exactly at tFinal
+
+      // Stepwise path
+      let cur = s;
+      for (const t of steps) {
+        cur = materialize(cur, t).state;
+      }
+
+      // Big-step path
+      const big = materialize(s, tFinal).state;
+
+      expect(cur).toEqual(big);
+    }
   });
 });


### PR DESCRIPTION
## Summary

Closes #11.

Implements the lazy idle-game materializer for the webxdc port. webxdc apps can be closed for hours/days — wall-clock timers (`setTimeout`) don't survive. This module formalises the solution: state stores immutable timestamps; progress is a pure function of `(state, now)` evaluated on read.

## Changed files

| File | Change |
|---|---|
| `scripts/materializer.js` | New — pure materializer function |
| `tests/materializer/materializer.test.js` | Replaces placeholder with 22 real tests |
| `scripts/esm-entry.js` | Adds `export { materialize }` alongside PR #56's state export |

## `scripts/materializer.js`

Exports a single function:

```js
materialize(state, now) → { state, events }
```

- **Pure** — no `Date.now()` calls, no side effects, no DOM, no jQuery, no RequireJS. Importable from Node.
- **Rules implemented** (source authority: `docs/async-map.md`):
  - **chargePerpReady** (`async-map §1`): for each `nodes_charging` entry where `now ≥ charge_end`, moves it to `nodes_collect` and pushes a `node_ready` event in temporal order. Payload shape matches `docs/socket-events.md §node_ready`.
  - **AP regeneration** (`async-map §cross-cutting`): advances `ap_snapshot` by whole ticks; `ap_update` is pinned to the **last full-tick boundary** (not `now`) so the fractional remainder is preserved across stepwise materializations — setting `ap_update = now` silently violates composability.
  - **notifyLevelupItems / notifyBuyperpItems** (`async-map §2–3`): cosmetic 2 s delay only, no DB write, no persistent duration. Runs synchronously inside the RPC handler in Wave 3 — no materializer rule needed.
  - **logAction** (`async-map §4`): analytics sink — dropped per policy decision in `docs/async-map.md`.

## `nodes_charging` shape note for Wave 3 handler work

The port's `nodes_charging` entries must include `game_id` and `game_type` (absent from the original Mongo schema). The materializer needs them to build the `node_ready` payload `{ id, type, path, result }` without a second lookup into `nodes`. The `chargePerp` handler should populate these when writing the entry.

## Tests (22, vitest)

| Suite | What it checks |
|---|---|
| `chargePerpReady rule` | 8 unit cases — boundary timing, mutation safety, payload shape, temporal ordering, deduplication |
| `AP regen rule` | 5 unit cases — tick math, cap, partial-interval, missing fields, backward clock |
| `idempotence` | `materialize(materialize(s,t).state, t).state ≡ materialize(s,t).state`; second call emits no events |
| `monotonicity` | `nodes_collect` count and AP are non-decreasing as `t` increases |
| `composability` | 2-step and N-step state equals big-step state; accumulated stepwise events equal big-step events |
| `property` | 50 seeded-random trials: arbitrary non-decreasing clock-advance sequences reach the same final state as a single jump |

## Test plan

- [x] `npm test` → 22 materializer tests pass (63 total across all suites)
- [x] Rebased onto master after PR #56 (state model) merged — `esm-entry.js` conflict resolved by keeping both export lines

https://claude.ai/code/session_014c4r5pvVcEjUFFzCZJEmV9