### PR TITLE
Phase 3: injectable clock for testing (#46)

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,84 @@
+# Testing guide
+
+## Injectable clock
+
+All game-logic modules obtain the current time from `scripts/clock.js` rather
+than calling `Date.now()` directly.  This lets unit and Playwright tests advance
+time by hours or days in **O(1)** without `setTimeout` or fake-timer libraries.
+
+### API
+
+```js
+import { now, setOverride, clearOverride, advance } from './scripts/clock.js';
+```
+
+| Function | Description |
+|---|---|
+| `now()` | Current epoch-ms. Returns the override if one is set, else `Date.now()`. |
+| `setOverride(t)` | Pin the clock to epoch-ms value `t`. |
+| `clearOverride()` | Remove the override; `now()` reverts to `Date.now()`. |
+| `advance(deltaMs)` | Advance the clock by `deltaMs` ms relative to the current `now()`. |
+
+### Using the clock in vitest unit tests
+
+Always restore the real clock in `afterEach` so tests don't bleed into each
+other:
+
+```js
+import { afterEach } from 'vitest';
+import { now, setOverride, clearOverride, advance } from '../../scripts/clock.js';
+
+afterEach(() => clearOverride());
+
+it('charges complete after 1 day', () => {
+  setOverride(0);                  // pin to epoch 0
+  advance(86_400_000);             // jump forward 1 day in O(1)
+  const r = materialize(state, now());
+  expect(r.state.nodes_collect).toHaveLength(1);
+});
+```
+
+### Clock-skew guard
+
+`scripts/state.js` applies `Math.max(clockNow(), state.last_seen_ts)` before
+every reducer call.  This means:
+
+- Setting the override **forward** in time works as expected — charges fire,
+  AP accumulates.
+- Setting the override **behind** the highest previously-recorded `last_seen_ts`
+  does **not** rewind stored progress; the guard clamps to the recorded floor.
+
+This mirrors the production clock-skew guard that protects against devices with
+misconfigured system clocks.
+
+### Using the clock from a browser devtools session
+
+When the app URL contains `?devtools=1`, the page exposes `window.__dd`:
+
+```js
+window.__dd.setNow(Date.now() + 86_400_000);   // jump 1 day
+window.__dd.advanceNow(3_600_000);              // advance 1 hour
+window.__dd.clearNowOverride();                 // revert to wall clock
+```
+
+**Production builds do not set `?devtools=1`**, so `window.__dd` is `undefined`
+and there is no debug surface exposed to end users.
+
+### Using the clock from Playwright e2e tests
+
+In Playwright, evaluate the `window.__dd` helpers after navigating to the app
+with the devtools flag:
+
+```js
+await page.goto('http://localhost:5173/?devtools=1');
+await page.evaluate(() => window.__dd.advanceNow(86_400_000));
+// now trigger UI actions that depend on charged nodes being ready …
+```
+
+Alternatively, import `clock.js` directly in the Node-side test if you prefer
+to avoid browser-side evaluation:
+
+```js
+import { setOverride, clearOverride } from '../scripts/clock.js';
+// (works because clock.js has no DOM globals)
+```

--- a/scripts/clock.js
+++ b/scripts/clock.js
@@ -1,0 +1,49 @@
+// Injectable clock for the webxdc port of Data Dealer.
+//
+// clock.now() is the single authoritative time source for all game logic.
+// Tests advance time in O(1) via setOverride / advance; production never sets
+// an override so window.__dd is never defined (see scripts/devtools.js).
+//
+// Clock-skew guard: state.js still applies Math.max(clockNow(), last_seen_ts)
+// so that a skewed system clock or a stale override never rewinds stored
+// progress.  That guard lives in applyDelta, not here, to keep this module
+// free of state imports.
+//
+// No DOM globals — safe to import from Node test environments.
+
+var _override = null;
+
+/**
+ * Returns the current time in epoch-ms.
+ *
+ * If an override is set (via setOverride or advance), that value is returned
+ * until clearOverride() is called; otherwise returns Date.now().
+ */
+export function now() {
+  return _override !== null ? _override : Date.now();
+}
+
+/**
+ * Pin the clock to a fixed epoch-ms value.  All subsequent calls to now()
+ * return this value until clearOverride() is called.
+ *
+ * Useful in tests to jump forward by hours or days in O(1).
+ */
+export function setOverride(t) {
+  _override = t;
+}
+
+/** Remove the override; now() reverts to Date.now(). */
+export function clearOverride() {
+  _override = null;
+}
+
+/**
+ * Advance the clock by deltaMs milliseconds relative to the current now().
+ *
+ * Equivalent to setOverride(now() + deltaMs).  If no override is currently
+ * active, the base is the real Date.now() at the moment advance() is called.
+ */
+export function advance(deltaMs) {
+  _override = now() + deltaMs;
+}

--- a/scripts/devtools.js
+++ b/scripts/devtools.js
@@ -1,0 +1,24 @@
+// Browser-only devtools surface for the injectable clock.
+//
+// Loaded only when the page URL contains ?devtools=1.
+// In production (no flag) this module is a no-op and window.__dd is never
+// defined, so there is zero debug surface exposed to end users.
+//
+// Usage from a browser console or Playwright test:
+//   window.__dd.setNow(Date.now() + 86_400_000);  // jump 1 day forward
+//   window.__dd.advanceNow(3_600_000);             // advance by 1 hour
+//   window.__dd.clearNowOverride();                // revert to real wall clock
+
+import { setOverride, clearOverride, advance } from './clock.js';
+
+if (
+  typeof window !== 'undefined' &&
+  typeof window.location !== 'undefined' &&
+  new URLSearchParams(window.location.search).get('devtools') === '1'
+) {
+  window.__dd = {
+    setNow:          setOverride,
+    advanceNow:      advance,
+    clearNowOverride: clearOverride,
+  };
+}

--- a/scripts/esm-entry.js
+++ b/scripts/esm-entry.js
@@ -8,3 +8,5 @@ export { default as webxdcIdentity } from './webxdc-identity.js';
 export const __placeholder = true;
 export * as state from './state.js';
 export { materialize } from './materializer.js';
+export * as clock from './clock.js';
+import './devtools.js';

--- a/scripts/state.js
+++ b/scripts/state.js
@@ -6,6 +6,7 @@
 // docs/handler-map.md. Wave 3 issues (#12–#21) fill in the reducer stubs.
 
 import defaultGameData from '../data/default_game.json';
+import { now as clockNow } from './clock.js';
 
 export var SCHEMA_VERSION = 1;
 
@@ -149,8 +150,9 @@ export function applyDelta(state, delta) {
     return state;
   }
 
-  // Guard 4: monotonic clock — wrong system clock never rewinds progress
-  var now = Math.max(Date.now(), state.last_seen_ts);
+  // Guard 4: monotonic clock — wrong system clock (or stale test override)
+  // never rewinds stored progress; clockNow() is injectable from clock.js.
+  var now = Math.max(clockNow(), state.last_seen_ts);
   var next = Object.assign({}, state, { last_seen_ts: now });
 
   // Guard 5: dispatch

--- a/tests/clock/clock.test.js
+++ b/tests/clock/clock.test.js
@@ -1,0 +1,178 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { now, setOverride, clearOverride, advance } from '../../scripts/clock.js';
+import { freshState, applyDelta } from '../../scripts/state.js';
+import { materialize } from '../../scripts/materializer.js';
+
+// Always restore real clock after each test to prevent cross-test pollution.
+afterEach(() => {
+  clearOverride();
+});
+
+// ── basic override behaviour ─────────────────────────────────────────────────
+
+describe('now() — override lifecycle', () => {
+  it('returns the override value when one is set', () => {
+    setOverride(1_000_000);
+    expect(now()).toBe(1_000_000);
+  });
+
+  it('returns different overrides as they are set', () => {
+    setOverride(111);
+    expect(now()).toBe(111);
+    setOverride(999);
+    expect(now()).toBe(999);
+  });
+
+  it('returns Date.now() once the override is cleared', () => {
+    setOverride(1_000_000);
+    clearOverride();
+    const before = Date.now();
+    const result = now();
+    const after  = Date.now();
+    expect(result).toBeGreaterThanOrEqual(before);
+    expect(result).toBeLessThanOrEqual(after);
+  });
+
+  it('allows override = 0', () => {
+    setOverride(0);
+    expect(now()).toBe(0);
+  });
+});
+
+// ── advance() ────────────────────────────────────────────────────────────────
+
+describe('advance()', () => {
+  it('moves the clock forward by deltaMs from a set override', () => {
+    setOverride(1_000_000);
+    advance(86_400_000); // + 1 day
+    expect(now()).toBe(1_000_000 + 86_400_000);
+  });
+
+  it('can be called multiple times cumulatively', () => {
+    setOverride(0);
+    advance(1_000);
+    advance(2_000);
+    expect(now()).toBe(3_000);
+  });
+
+  it('starts from real Date.now() when no override is active', () => {
+    const before = Date.now();
+    advance(86_400_000);
+    const result = now();
+    expect(result).toBeGreaterThanOrEqual(before + 86_400_000);
+    // Should not be astronomically large (within a second of our advance)
+    expect(result).toBeLessThan(before + 86_400_000 + 1_000);
+  });
+
+  it('tests can advance a day in O(1) without setTimeout', () => {
+    setOverride(1_000_000_000);
+    advance(86_400_000);
+    expect(now()).toBe(1_000_000_000 + 86_400_000);
+  });
+});
+
+// ── clock-skew guard (state.js integration) ──────────────────────────────────
+//
+// Setting override below the current last_seen_ts must NOT rewind stored
+// progress.  The guard Math.max(clockNow(), last_seen_ts) in applyDelta
+// ensures this even when the clock override is stale or set backwards.
+
+describe('clock-skew guard survives a backwards override', () => {
+  function makeDelta(addr, op) {
+    return { kind: 'delta', addr, op, args: [], result: {}, ts: Date.now() };
+  }
+
+  it('last_seen_ts does not decrease when override < last_seen_ts', () => {
+    const addr = 'alice@example.com';
+    const highTs = Date.now() + 1_000_000; // 1000 s into the future
+    const s = { ...freshState(addr), last_seen_ts: highTs };
+
+    // Set override well below the recorded last_seen_ts
+    setOverride(highTs - 500_000);
+
+    const result = applyDelta(s, makeDelta(addr, 'ping'));
+    expect(result.last_seen_ts).toBeGreaterThanOrEqual(highTs);
+  });
+
+  it('last_seen_ts advances when override > last_seen_ts', () => {
+    const addr = 'alice@example.com';
+    const base = Date.now();
+    const s = { ...freshState(addr), last_seen_ts: base };
+
+    setOverride(base + 1_000_000);
+
+    const result = applyDelta(s, makeDelta(addr, 'ping'));
+    expect(result.last_seen_ts).toBe(base + 1_000_000);
+  });
+});
+
+// ── materializer integration ─────────────────────────────────────────────────
+//
+// Verify that clock.now() can drive materialize() and that idempotence and
+// monotonicity hold when the clock module is in the loop.
+
+describe('materializer integration with clock', () => {
+  function baseState(overrides) {
+    return Object.assign({
+      nodes_charging: [],
+      nodes_collect:  [],
+      game_values: {
+        ap_snapshot:      0,
+        ap_update:        0,
+        ap_inc_value:     1,
+        ap_inc_interval:  1_000,
+        ap_max:           50,
+      }
+    }, overrides);
+  }
+
+  function makeCharge(path, charge_end) {
+    return { path, result: {}, charge_start: 0, charge_end, game_id: 'g1', game_type: 'T' };
+  }
+
+  it('materialize driven by clock.now() fires charges correctly', () => {
+    const s = baseState({ nodes_charging: [makeCharge('p.a', 5_000)] });
+    setOverride(5_000);
+    const r = materialize(s, now());
+    expect(r.state.nodes_collect).toHaveLength(1);
+    expect(r.events).toHaveLength(1);
+  });
+
+  it('idempotence: second call with same clock value produces no new events', () => {
+    const s = baseState({ nodes_charging: [makeCharge('p.a', 5_000)] });
+    setOverride(6_000);
+    const r1 = materialize(s, now());
+    const r2 = materialize(r1.state, now());
+    expect(r2.events).toHaveLength(0);
+    expect(r2.state).toEqual(r1.state);
+  });
+
+  it('monotonicity: advancing the clock never loses collected nodes', () => {
+    const s = baseState({
+      nodes_charging: [makeCharge('p.a', 2_000), makeCharge('p.b', 6_000)],
+    });
+
+    setOverride(0);
+    const steps = [1_000, 2_000, 4_000, 6_000, 10_000];
+    let cur = s;
+    let prevCollected = 0;
+    for (const t of steps) {
+      setOverride(t);
+      const r = materialize(cur, now());
+      cur = r.state;
+      expect(cur.nodes_collect.length).toBeGreaterThanOrEqual(prevCollected);
+      prevCollected = cur.nodes_collect.length;
+    }
+  });
+
+  it('advance(1 day) in O(1) triggers charges without setTimeout', () => {
+    const oneDayMs = 86_400_000;
+    const s = baseState({
+      nodes_charging: [makeCharge('future.charge', oneDayMs - 1)],
+    });
+    setOverride(0);
+    advance(oneDayMs);
+    const r = materialize(s, now());
+    expect(r.state.nodes_collect).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `scripts/clock.js` — side-effect-free ESM module (`now()`, `setOverride(t)`, `clearOverride()`, `advance(deltaMs)`) that is the single time source for all game logic. No DOM globals; safe to import from Node test environments.
- Updates `scripts/state.js` Guard 4 to call `clockNow()` instead of `Date.now()` directly. The `Math.max(clockNow(), last_seen_ts)` skew-guard remains in place, so a stale or backwards override never rewinds stored progress.
- Adds `scripts/devtools.js` — wires `window.__dd.{setNow, advanceNow, clearNowOverride}` behind the `?devtools=1` URL flag. Production builds never set the flag so `window.__dd` stays undefined.
- Adds `tests/clock/clock.test.js` — 14 tests covering override lifecycle, `advance()`, clock-skew guard integration with `state.applyDelta`, and materializer idempotence/monotonicity driven by `clock.now()`.
- Adds `docs/testing.md` documenting the hook for unit tests, Playwright e2e, and browser devtools; notes that production has no debug surface.

All 92 tests pass (78 pre-existing + 14 new).

## Test plan

- [ ] `pnpm test` → all 92 tests green
- [ ] Clock override: `setOverride(t)` → `now()` returns `t`; `clearOverride()` → `now()` returns real `Date.now()`
- [ ] `advance(86_400_000)` jumps 1 day in O(1), no `setTimeout` needed
- [ ] Setting override below `last_seen_ts` does not rewind stored progress (skew-guard still clamps)
- [ ] Existing materializer idempotence + monotonicity tests unchanged
- [ ] `?devtools=1` in URL → `window.__dd` is defined; without flag → undefined

Closes #46. Unblocks Thread S (#16 chargePerp) and Thread TC (#17 collectPerp).

https://claude.ai/code/session_0114neTX131Ev7j3b1DoNrBR
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_0114neTX131Ev7j3b1DoNrBR)_