### PR TITLE
Phase 3: port setDisplayName, setPerpCoordinates (#13)

### DIFF
--- a/scripts/LocalEngine.js
+++ b/scripts/LocalEngine.js
@@ -2,8 +2,9 @@
 // ESM exports — consumed by Remote.js via the AMD bridge in esm-bundle.js.
 // No DOM globals in handler bodies; safe to import from Node for tests.
 //
-// Handlers implemented here: getToken, ping, getSessionLocale, loadGame (#12), resetGame (#20).
-// Remaining handlers (#13–#21) are stubs that return a rejected Promise.
+// Handlers implemented here: getToken, ping, getSessionLocale, loadGame (#12),
+// resetGame (#20), getRanking, setDisplayName, setPerpCoordinates (#13).
+// Remaining handlers are stubs that return a rejected Promise.
 
 import { getState, setState } from './boot.js';
 import { applyDelta } from './state.js';
@@ -201,13 +202,131 @@ export function getRanking(_token, type) {
 }
 
 // ---------------------------------------------------------------------------
+// Delta helpers
+// ---------------------------------------------------------------------------
+
+function _selfAddr() {
+  var state = getState();
+  return (state && state.addr) || '';
+}
+
+// Persist a delta to the webxdc update history (no-op when webxdc is absent,
+// e.g. in Node/vitest).  The reducer in state.js applies the same mutation on
+// replay so state survives a reload.
+function _sendDelta(op, args, result) {
+  // eslint-disable-next-line no-undef
+  if (typeof webxdc !== 'undefined') {
+    // eslint-disable-next-line no-undef
+    webxdc.sendUpdate({
+      payload: {
+        kind: 'delta',
+        addr: _selfAddr(),
+        op: op,
+        args: args,
+        result: result,
+        ts: clockNow()
+      }
+    }, '');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Validation helpers (mirrors dd_app helpers.validateDisplayName)
+// ---------------------------------------------------------------------------
+
+var DISPLAY_NAME_MAX = 30;
+// Printable Unicode except ASCII control chars (< 0x20) and DEL (0x7f).
+var DISPLAY_NAME_RE = /^[^\x00-\x1f\x7f]{1,30}$/;
+
+function validateDisplayName(name) {
+  if (typeof name !== 'string') return false;
+  var trimmed = name.trim();
+  if (trimmed.length === 0) return false;
+  return DISPLAY_NAME_RE.test(name) && name.length <= DISPLAY_NAME_MAX;
+}
+
+// ---------------------------------------------------------------------------
+// setDisplayName / setPerpCoordinates (#13)
+// ---------------------------------------------------------------------------
+
+/**
+ * setDisplayName(token, dname) → Promise<{result: {}|{error:0|1}}>
+ *
+ * Validates dname (length cap, charset), writes state.user.display_name, and
+ * emits a delta so the change survives a reload.
+ * Returns {} on success or {error: 0} on bad input / {error: 1} on internal fault.
+ */
+export function setDisplayName(/* token, */ _, dname) {
+  if (!validateDisplayName(dname)) {
+    return Promise.resolve({ result: { error: 0 } });
+  }
+
+  var state = getState();
+  if (!state) {
+    return Promise.resolve({ result: { error: 1 } });
+  }
+
+  var newState = Object.assign({}, state, { display_name: dname });
+  setState(newState);
+  _sendDelta('setDisplayName', [dname], {});
+
+  return Promise.resolve({ result: {} });
+}
+
+/**
+ * setPerpCoordinates(token, updates) → Promise<{result: 1}>
+ *
+ * updates = [[full_path, {x, y}], ...]
+ * Matches nodes by full_path and $sets instance_data.x / instance_data.y.
+ * Emits one delta covering all entries.  Always returns {result: 1} even when
+ * some paths are not found (matches original server behaviour: Game.js:981).
+ */
+export function setPerpCoordinates(/* token, */ _, updates) {
+  if (!Array.isArray(updates) || updates.length === 0) {
+    return Promise.resolve({ result: 1 });
+  }
+
+  var state = getState();
+  if (!state || !Array.isArray(state.nodes)) {
+    return Promise.resolve({ result: 1 });
+  }
+
+  // Build a lookup map: full_path → {x, y}
+  var coordMap = {};
+  for (var i = 0; i < updates.length; i++) {
+    var entry = updates[i];
+    if (!Array.isArray(entry) || entry.length < 2) continue;
+    var path = entry[0];
+    var pos  = entry[1];
+    if (typeof path !== 'string' || !pos || typeof pos !== 'object') continue;
+    coordMap[path] = pos;
+  }
+
+  var nodes = state.nodes.map(function (node) {
+    var pos = coordMap[node.full_path];
+    if (!pos) return node;
+    return Object.assign({}, node, {
+      instance_data: Object.assign({}, node.instance_data, {
+        x: pos.x,
+        y: pos.y
+      })
+    });
+  });
+
+  var newState = Object.assign({}, state, { nodes: nodes });
+  setState(newState);
+  _sendDelta('setPerpCoordinates', [updates], {});
+
+  return Promise.resolve({ result: 1 });
+}
+
+// ---------------------------------------------------------------------------
 // Stub handlers — Wave 4+ issues fill these in.
 // ---------------------------------------------------------------------------
 var _STUBS = [
   'buyPowerup', 'chargePerp', 'collectPerp', 'integrateCollected',
   'getPowerups', 'getProvidedPerps', 'buyKarma', 'buyPerp', 'buySlots',
-  'setDisplayName', 'sellPowerup',
-  'setPerpCoordinates', 'checkUsername'
+  'sellPowerup', 'checkUsername'
 ];
 
 var _stubHandlers = {};
@@ -228,6 +347,8 @@ var LocalEngine = Object.assign({
   loadGame: loadGame,
   getRanking: getRanking,
   resetGame: resetGame,
+  setDisplayName: setDisplayName,
+  setPerpCoordinates: setPerpCoordinates,
   setEmitter: setEmitter
 }, _stubHandlers);
 

--- a/scripts/LocalEngine.js
+++ b/scripts/LocalEngine.js
@@ -205,22 +205,17 @@ export function getRanking(_token, type) {
 // Delta helpers
 // ---------------------------------------------------------------------------
 
-function _selfAddr() {
-  var state = getState();
-  return (state && state.addr) || '';
-}
-
 // Persist a delta to the webxdc update history (no-op when webxdc is absent,
 // e.g. in Node/vitest).  The reducer in state.js applies the same mutation on
 // replay so state survives a reload.
-function _sendDelta(op, args, result) {
+function _sendDelta(addr, op, args, result) {
   // eslint-disable-next-line no-undef
   if (typeof webxdc !== 'undefined') {
     // eslint-disable-next-line no-undef
     webxdc.sendUpdate({
       payload: {
         kind: 'delta',
-        addr: _selfAddr(),
+        addr: addr,
         op: op,
         args: args,
         result: result,
@@ -234,15 +229,12 @@ function _sendDelta(op, args, result) {
 // Validation helpers (mirrors dd_app helpers.validateDisplayName)
 // ---------------------------------------------------------------------------
 
-var DISPLAY_NAME_MAX = 30;
-// Printable Unicode except ASCII control chars (< 0x20) and DEL (0x7f).
+// Printable Unicode, 1–30 chars; no ASCII control chars (< 0x20) or DEL (0x7f).
 var DISPLAY_NAME_RE = /^[^\x00-\x1f\x7f]{1,30}$/;
 
 function validateDisplayName(name) {
   if (typeof name !== 'string') return false;
-  var trimmed = name.trim();
-  if (trimmed.length === 0) return false;
-  return DISPLAY_NAME_RE.test(name) && name.length <= DISPLAY_NAME_MAX;
+  return name.trim().length > 0 && DISPLAY_NAME_RE.test(name);
 }
 
 // ---------------------------------------------------------------------------
@@ -268,7 +260,7 @@ export function setDisplayName(/* token, */ _, dname) {
 
   var newState = Object.assign({}, state, { display_name: dname });
   setState(newState);
-  _sendDelta('setDisplayName', [dname], {});
+  _sendDelta(state.addr, 'setDisplayName', [dname], {});
 
   return Promise.resolve({ result: {} });
 }
@@ -315,7 +307,7 @@ export function setPerpCoordinates(/* token, */ _, updates) {
 
   var newState = Object.assign({}, state, { nodes: nodes });
   setState(newState);
-  _sendDelta('setPerpCoordinates', [updates], {});
+  _sendDelta(state.addr, 'setPerpCoordinates', [updates], {});
 
   return Promise.resolve({ result: 1 });
 }

--- a/scripts/state.js
+++ b/scripts/state.js
@@ -109,7 +109,39 @@ reducers.reset = function resetReducer(state) {
   return freshState(state.addr);
 };
 
-// Stubs — return state unchanged until Wave 3 fills them in.
+reducers.setDisplayName = function setDisplayNameReducer(state, delta) {
+  var args = delta.args || [];
+  var dname = args[0];
+  if (typeof dname !== 'string' || dname.length === 0) return state;
+  return Object.assign({}, state, { display_name: dname });
+};
+
+reducers.setPerpCoordinates = function setPerpCoordinatesReducer(state, delta) {
+  var args = delta.args || [];
+  var updates = args[0];
+  if (!Array.isArray(updates) || !Array.isArray(state.nodes)) return state;
+
+  var coordMap = {};
+  for (var i = 0; i < updates.length; i++) {
+    var entry = updates[i];
+    if (Array.isArray(entry) && entry.length >= 2 &&
+        typeof entry[0] === 'string' && entry[1] && typeof entry[1] === 'object') {
+      coordMap[entry[0]] = entry[1];
+    }
+  }
+
+  var nodes = state.nodes.map(function (node) {
+    var pos = coordMap[node.full_path];
+    if (!pos) return node;
+    return Object.assign({}, node, {
+      instance_data: Object.assign({}, node.instance_data, { x: pos.x, y: pos.y })
+    });
+  });
+
+  return Object.assign({}, state, { nodes: nodes });
+};
+
+// Stubs — return state unchanged until Wave 4+ fills them in.
 OP_NAMES.forEach(function (op) {
   if (!reducers[op]) {
     reducers[op] = function stubReducer(state) {

--- a/scripts/state.js
+++ b/scripts/state.js
@@ -124,10 +124,11 @@ reducers.setPerpCoordinates = function setPerpCoordinatesReducer(state, delta) {
   var coordMap = {};
   for (var i = 0; i < updates.length; i++) {
     var entry = updates[i];
-    if (Array.isArray(entry) && entry.length >= 2 &&
-        typeof entry[0] === 'string' && entry[1] && typeof entry[1] === 'object') {
-      coordMap[entry[0]] = entry[1];
-    }
+    if (!Array.isArray(entry) || entry.length < 2) continue;
+    var path = entry[0];
+    var pos  = entry[1];
+    if (typeof path !== 'string' || !pos || typeof pos !== 'object') continue;
+    coordMap[path] = pos;
   }
 
   var nodes = state.nodes.map(function (node) {

--- a/tests/handlers/handlers.test.js
+++ b/tests/handlers/handlers.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
-  getToken, ping, getSessionLocale, loadGame, getRanking, resetGame, setEmitter
+  getToken, ping, getSessionLocale, loadGame, getRanking, resetGame, setEmitter,
+  setDisplayName, setPerpCoordinates
 } from '../../scripts/LocalEngine.js';
 import { getState, setState } from '../../scripts/boot.js';
 import { freshState, applyDelta } from '../../scripts/state.js';
@@ -381,5 +382,135 @@ describe('resetGame', () => {
     const { result } = await loadGame('tok');
     expect(result.is_new_game).toBe(true);
     expect(result.nodes).toHaveLength(0);
+  });
+});
+
+// ── setDisplayName ────────────────────────────────────────────────────────────
+
+describe('setDisplayName — happy path', () => {
+  beforeEach(() => setState(mkState()));
+
+  it('returns {} (no error field) on a valid name', async () => {
+    const data = await setDisplayName('tok', 'Alice');
+    expect(data).toEqual({ result: {} });
+    expect(data.result.error).toBeUndefined();
+  });
+
+  it('persists display_name in in-memory state', async () => {
+    await setDisplayName('tok', 'Alice');
+    expect(getState().display_name).toBe('Alice');
+  });
+
+  it('accepts names up to 30 characters', async () => {
+    const name30 = 'A'.repeat(30);
+    const data = await setDisplayName('tok', name30);
+    expect(data.result.error).toBeUndefined();
+    expect(getState().display_name).toBe(name30);
+  });
+});
+
+describe('setDisplayName — failure modes', () => {
+  beforeEach(() => setState(mkState()));
+
+  it('returns {error: 0} for an empty string', async () => {
+    const data = await setDisplayName('tok', '');
+    expect(data.result.error).toBe(0);
+  });
+
+  it('returns {error: 0} for a whitespace-only string', async () => {
+    const data = await setDisplayName('tok', '   ');
+    expect(data.result.error).toBe(0);
+  });
+
+  it('returns {error: 0} for a name exceeding 30 characters', async () => {
+    const data = await setDisplayName('tok', 'A'.repeat(31));
+    expect(data.result.error).toBe(0);
+  });
+
+  it('does not mutate state on invalid input', async () => {
+    const before = getState().display_name;
+    await setDisplayName('tok', '');
+    expect(getState().display_name).toBe(before);
+  });
+});
+
+// ── setPerpCoordinates ────────────────────────────────────────────────────────
+
+function mkStateWithNodes() {
+  return mkState({
+    nodes: [
+      {
+        game_id: 'n1', game_type: 'ContactPerp',
+        full_path: 'Imperium.City.Agent0',
+        full_type: 'ContactPerp:Agent0',
+        instance_data: { x: 0, y: 0 }
+      },
+      {
+        game_id: 'n2', game_type: 'ProjectPerp',
+        full_path: 'Imperium.City.Project1',
+        full_type: 'ProjectPerp:Project1',
+        instance_data: { x: 10, y: 20 }
+      }
+    ]
+  });
+}
+
+describe('setPerpCoordinates — happy path', () => {
+  beforeEach(() => setState(mkStateWithNodes()));
+
+  it('returns {result: 1}', async () => {
+    const data = await setPerpCoordinates('tok', [
+      ['Imperium.City.Agent0', { x: 5, y: 7 }]
+    ]);
+    expect(data).toEqual({ result: 1 });
+  });
+
+  it('updates x/y on matched node', async () => {
+    await setPerpCoordinates('tok', [
+      ['Imperium.City.Agent0', { x: 42, y: 99 }]
+    ]);
+    const node = getState().nodes.find(n => n.full_path === 'Imperium.City.Agent0');
+    expect(node.instance_data.x).toBe(42);
+    expect(node.instance_data.y).toBe(99);
+  });
+
+  it('updates multiple nodes in a single call', async () => {
+    await setPerpCoordinates('tok', [
+      ['Imperium.City.Agent0',   { x: 1, y: 2 }],
+      ['Imperium.City.Project1', { x: 3, y: 4 }]
+    ]);
+    const nodes = getState().nodes;
+    const a = nodes.find(n => n.full_path === 'Imperium.City.Agent0');
+    const p = nodes.find(n => n.full_path === 'Imperium.City.Project1');
+    expect(a.instance_data).toMatchObject({ x: 1, y: 2 });
+    expect(p.instance_data).toMatchObject({ x: 3, y: 4 });
+  });
+});
+
+describe('setPerpCoordinates — failure modes', () => {
+  beforeEach(() => setState(mkStateWithNodes()));
+
+  it('returns {result: 1} (not an error) for an empty updates array', async () => {
+    const data = await setPerpCoordinates('tok', []);
+    expect(data).toEqual({ result: 1 });
+  });
+
+  it('silently skips a malformed entry (non-array element)', async () => {
+    const data = await setPerpCoordinates('tok', [
+      'not-an-array',
+      ['Imperium.City.Agent0', { x: 7, y: 8 }]
+    ]);
+    expect(data).toEqual({ result: 1 });
+    const node = getState().nodes.find(n => n.full_path === 'Imperium.City.Agent0');
+    expect(node.instance_data.x).toBe(7);
+  });
+
+  it('leaves unmatched nodes unchanged', async () => {
+    await setPerpCoordinates('tok', [
+      ['Imperium.City.NoSuchNode', { x: 99, y: 99 }]
+    ]);
+    const node = getState().nodes.find(n => n.full_path === 'Imperium.City.Agent0');
+    expect(node.instance_data.x).toBe(0);
+    expect(node.instance_data.y).toBe(0);
   });
 });


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `setDisplayName(token, dname)`: validates charset/length cap (≤30 chars, no control characters — mirrors `dd_app helpers.validateDisplayName`), writes `state.display_name`, emits a delta. Returns `{}` on success or `{error: 0}` on invalid input.
- `setPerpCoordinates(token, updates)`: matches nodes by `full_path`, `$set`s `instance_data.x/y` for all entries in one pass, emits one delta. Always returns `{result: 1}` (per `response-shapes.md` — client discards the value).
- Adds `setDisplayName` and `setPerpCoordinates` reducers to `state.js` so replayed deltas converge to the same state.
- No `logAction` calls per #60 recommended-drop policy.

## Test plan

- [x] `setDisplayName` happy path: valid name → `{}`, state mutated
- [x] `setDisplayName` accepts max-length (30 char) names
- [x] `setDisplayName` failure: empty string → `{error: 0}`, state unchanged
- [x] `setDisplayName` failure: whitespace-only → `{error: 0}`
- [x] `setDisplayName` failure: name > 30 chars → `{error: 0}`
- [x] `setPerpCoordinates` happy path: single entry updates x/y on matched node
- [x] `setPerpCoordinates` happy path: multiple entries in one call
- [x] `setPerpCoordinates` returns `{result: 1}` for empty updates array
- [x] `setPerpCoordinates` silently skips malformed (non-array) entry
- [x] `setPerpCoordinates` leaves unmatched nodes unchanged
- [x] All 129 tests pass (`vitest run`)

Closes #13.

https://claude.ai/code/session_01DNF3hJ4rtR6X7ikyF3mgQC
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DNF3hJ4rtR6X7ikyF3mgQC)_