### PR TITLE
Implement getRanking handler for leaderboard queries

### DIFF
--- a/scripts/LocalEngine.js
+++ b/scripts/LocalEngine.js
@@ -150,12 +150,35 @@ function _buildLoadGameResponse(state, now) {
 }
 
 // ---------------------------------------------------------------------------
+// getRanking
+// ---------------------------------------------------------------------------
+
+// TODO(#29): Replace with multi-peer aggregation in Phase 6.
+export function getRanking(_token, type) {
+  var state = getState();
+  var gv = (state && state.game_values) || {};
+  var fieldMap = {
+    cash:     gv.cash_value,
+    profiles: gv.profiles_value,
+    xp:       gv.xp_value,
+    spent:    gv.cash_spent
+  };
+  var value = fieldMap[type] !== undefined ? fieldMap[type] : 0;
+  return Promise.resolve({
+    result: {
+      top: [{ display_name: (state && state.display_name) || '', value: value, self: true }],
+      user_rank: 1
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Stub handlers — Wave 4+ issues fill these in.
 // ---------------------------------------------------------------------------
 var _STUBS = [
   'buyPowerup', 'chargePerp', 'collectPerp', 'integrateCollected',
   'getPowerups', 'getProvidedPerps', 'buyKarma', 'buyPerp', 'buySlots',
-  'setDisplayName', 'getRanking', 'resetGame', 'sellPowerup',
+  'setDisplayName', 'resetGame', 'sellPowerup',
   'setPerpCoordinates', 'checkUsername'
 ];
 
@@ -175,6 +198,7 @@ var LocalEngine = Object.assign({
   ping: ping,
   getSessionLocale: getSessionLocale,
   loadGame: loadGame,
+  getRanking: getRanking,
   setEmitter: setEmitter
 }, _stubHandlers);
 

--- a/tests/handlers/handlers.test.js
+++ b/tests/handlers/handlers.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
-  getToken, ping, getSessionLocale, loadGame, setEmitter
+  getToken, ping, getSessionLocale, loadGame, getRanking, setEmitter
 } from '../../scripts/LocalEngine.js';
 import { setState } from '../../scripts/boot.js';
 import { freshState, applyDelta } from '../../scripts/state.js';
@@ -11,6 +11,53 @@ import { setOverride, clearOverride } from '../../scripts/clock.js';
 function mkState(overrides) {
   return Object.assign(freshState('test@local'), overrides || {});
 }
+
+// ── getRanking ───────────────────────────────────────────────────────────────
+
+function mkRankingState() {
+  var base = mkState();
+  return Object.assign({}, base, {
+    display_name: 'TestUser',
+    game_values: Object.assign({}, base.game_values, {
+      xp_value: 77,
+      cash_value: 200,
+      profiles_value: 3,
+      cash_spent: 50
+    })
+  });
+}
+
+describe('getRanking', () => {
+  beforeEach(() => setState(mkRankingState()));
+
+  it('returns the single-row shape with user_rank 1', async () => {
+    const { result } = await getRanking('tok', 'xp');
+    expect(result).toHaveProperty('top');
+    expect(result).toHaveProperty('user_rank', 1);
+    expect(result.top).toHaveLength(1);
+    expect(result.top[0]).toMatchObject({ display_name: 'TestUser', self: true });
+  });
+
+  it('xp type returns game_values.xp_value', async () => {
+    const { result } = await getRanking('tok', 'xp');
+    expect(result.top[0].value).toBe(77);
+  });
+
+  it('cash type returns game_values.cash_value', async () => {
+    const { result } = await getRanking('tok', 'cash');
+    expect(result.top[0].value).toBe(200);
+  });
+
+  it('profiles type returns game_values.profiles_value', async () => {
+    const { result } = await getRanking('tok', 'profiles');
+    expect(result.top[0].value).toBe(3);
+  });
+
+  it('spent type returns game_values.cash_spent', async () => {
+    const { result } = await getRanking('tok', 'spent');
+    expect(result.top[0].value).toBe(50);
+  });
+});
 
 // ── getToken ─────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
Implement the `getRanking` handler to support leaderboard functionality, allowing clients to query ranking data for different metric types (xp, cash, profiles, spent).

## Changes
- **Added `getRanking` function** in `LocalEngine.js` that:
  - Accepts a token and ranking type parameter
  - Maps ranking types (xp, cash, profiles, spent) to corresponding game_values fields
  - Returns a single-row result with the current user's rank and metric value
  - Includes a TODO comment noting this is a placeholder for Phase 6 multi-peer aggregation
  
- **Removed `getRanking` from stub handlers** list since it now has a full implementation

- **Added comprehensive test suite** in `handlers.test.js` covering:
  - Basic response shape validation (top array, user_rank property)
  - Correct value mapping for each ranking type (xp, cash, profiles, spent)
  - User identification with `self: true` flag

## Implementation Details
The current implementation returns a single-row ranking containing only the current user with rank 1. This is a placeholder that will be replaced with actual multi-peer aggregation in a future phase. The function properly handles missing game_values by defaulting to 0 for any requested metric type.

https://claude.ai/code/session_018ZLcoZ7stDf2pneZEhZmmz