### PR TITLE
Implement resetGame handler to wipe game state while preserving identity

### DIFF
--- a/scripts/LocalEngine.js
+++ b/scripts/LocalEngine.js
@@ -2,10 +2,11 @@
 // ESM exports — consumed by Remote.js via the AMD bridge in esm-bundle.js.
 // No DOM globals in handler bodies; safe to import from Node for tests.
 //
-// Handlers implemented here: getToken, ping, getSessionLocale, loadGame (#12).
+// Handlers implemented here: getToken, ping, getSessionLocale, loadGame (#12), resetGame (#20).
 // Remaining handlers (#13–#21) are stubs that return a rejected Promise.
 
 import { getState, setState } from './boot.js';
+import { applyDelta } from './state.js';
 import { materialize } from './materializer.js';
 import { now as clockNow } from './clock.js';
 import defaultRuleset from '../data/ruleset_3.de.json' with { type: 'json' };
@@ -88,6 +89,33 @@ export function loadGame(/* token */) {
   });
 
   return Promise.resolve({ result: gameData });
+}
+
+/**
+ * resetGame(token) → Promise<{result: true}>
+ *
+ * Emits a 'reset' delta that wipes all game state while preserving the
+ * player's identity (addr).  Game.js calls location.reload() after this
+ * resolves, so the payload is ignored — any 200-truthy value suffices.
+ *
+ * Cold-start replay note: webxdc update history is append-only, so prior
+ * deltas remain in the log.  applyDelta's 'reset' reducer turns them into a
+ * no-op prefix.  Compaction is deferred to Phase 7 (#35).
+ */
+export function resetGame(/* token */) {
+  var state = getState();
+  var delta = { kind: 'delta', op: 'reset', addr: state.addr, ts: clockNow() };
+
+  // Apply locally so in-memory state is consistent before the page reload.
+  setState(applyDelta(state, delta));
+
+  // Broadcast to webxdc update history for durable replay on cold start.
+  // eslint-disable-next-line no-undef
+  if (typeof webxdc !== 'undefined') {
+    webxdc.sendUpdate({ payload: delta }, ''); // eslint-disable-line no-undef
+  }
+
+  return Promise.resolve({ result: true });
 }
 
 // ---------------------------------------------------------------------------
@@ -178,7 +206,7 @@ export function getRanking(_token, type) {
 var _STUBS = [
   'buyPowerup', 'chargePerp', 'collectPerp', 'integrateCollected',
   'getPowerups', 'getProvidedPerps', 'buyKarma', 'buyPerp', 'buySlots',
-  'setDisplayName', 'resetGame', 'sellPowerup',
+  'setDisplayName', 'sellPowerup',
   'setPerpCoordinates', 'checkUsername'
 ];
 
@@ -199,6 +227,7 @@ var LocalEngine = Object.assign({
   getSessionLocale: getSessionLocale,
   loadGame: loadGame,
   getRanking: getRanking,
+  resetGame: resetGame,
   setEmitter: setEmitter
 }, _stubHandlers);
 

--- a/tests/handlers/handlers.test.js
+++ b/tests/handlers/handlers.test.js
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
-  getToken, ping, getSessionLocale, loadGame, getRanking, setEmitter
+  getToken, ping, getSessionLocale, loadGame, getRanking, resetGame, setEmitter
 } from '../../scripts/LocalEngine.js';
-import { setState } from '../../scripts/boot.js';
+import { getState, setState } from '../../scripts/boot.js';
 import { freshState, applyDelta } from '../../scripts/state.js';
 import { setOverride, clearOverride } from '../../scripts/clock.js';
 
@@ -331,5 +331,55 @@ describe('materialization on boot', () => {
     await Promise.resolve();
 
     expect(emitted).toHaveLength(0);
+  });
+});
+
+// ── resetGame ─────────────────────────────────────────────────────────────────
+
+describe('resetGame', () => {
+  it('resolves to a truthy result', async () => {
+    setState(mkState());
+    const data = await resetGame('tok');
+    expect(data).toHaveProperty('result');
+    expect(data.result).toBeTruthy();
+  });
+
+  it('wipes nodes after reset', async () => {
+    setState(mkState({
+      nodes: [{ game_id: 'n1', game_type: 'ContactPerp', full_path: 'Imperium.n1',
+                full_type: 'ContactPerp:contact001', instance_data: {} }]
+    }));
+    await resetGame('tok');
+    expect(getState().nodes).toEqual([]);
+  });
+
+  it('wipes active_missions after reset', async () => {
+    setState(mkState({ active_missions: ['m1', 'm2'] }));
+    await resetGame('tok');
+    expect(getState().active_missions).toEqual([]);
+  });
+
+  it('restores game_values to seed defaults after reset', async () => {
+    setState(mkState({ game_values: { cash_value: 99999, xp_level: 10 } }));
+    await resetGame('tok');
+    expect(getState().game_values.cash_value).toBe(300);
+    expect(getState().game_values.xp_level).toBe(1);
+  });
+
+  it('preserves addr (identity must survive reset)', async () => {
+    setState(mkState());
+    await resetGame('tok');
+    expect(getState().addr).toBe('test@local');
+  });
+
+  it('reset followed by loadGame reflects a new game', async () => {
+    setState(mkState({
+      nodes: [{ game_id: 'n1', game_type: 'ContactPerp', full_path: 'Imperium.n1',
+                full_type: 'ContactPerp:contact001', instance_data: {} }]
+    }));
+    await resetGame('tok');
+    const { result } = await loadGame('tok');
+    expect(result.is_new_game).toBe(true);
+    expect(result.nodes).toHaveLength(0);
   });
 });

--- a/tests/state/state.test.js
+++ b/tests/state/state.test.js
@@ -209,6 +209,44 @@ describe('applyDelta — malformed delta guard', () => {
   });
 });
 
+describe('applyDelta — reset replay semantics (issue #20)', () => {
+  const addr = 'alice@example.com';
+
+  it('reset + ops produces same game state as a fresh start + same ops', () => {
+    // Pre-reset ops (stubs): their effect on state is wiped by reset.
+    const preOps = [
+      makeDelta(addr, 'buyKarma', 1000),
+      makeDelta(addr, 'chargePerp', 2000),
+    ];
+    const postOp = makeDelta(addr, 'buyPerp', 4000);
+
+    const viaReset = replay([...preOps, makeDelta(addr, 'reset', 3000), postOp], addr);
+    const viaFresh  = replay([postOp], addr);
+
+    // Game-meaningful fields must be identical; last_seen_ts may differ.
+    expect(viaReset.nodes).toEqual(viaFresh.nodes);
+    expect(viaReset.game_values).toEqual(viaFresh.game_values);
+    expect(viaReset.active_missions).toEqual(viaFresh.active_missions);
+    expect(viaReset.addr).toBe(viaFresh.addr);
+  });
+
+  it('replay-through-reset discards prior history', () => {
+    // Any ops before the reset delta must not survive into post-reset state.
+    const withHistory = replay([
+      makeDelta(addr, 'buyKarma', 1000),
+      makeDelta(addr, 'collectPerp', 2000),
+      makeDelta(addr, 'reset', 3000),
+    ], addr);
+
+    expect(withHistory.nodes).toEqual([]);
+    expect(withHistory.mission_goals).toEqual([]);
+    expect(withHistory.active_missions).toEqual([]);
+    // game_values restored to seed defaults
+    expect(withHistory.game_values.cash_value).toBe(300);
+    expect(withHistory.game_values.xp_level).toBe(1);
+  });
+});
+
 describe('applyDelta — clock-skew guard', () => {
   it('last_seen_ts never decreases', () => {
     const addr = 'alice@example.com';


### PR DESCRIPTION
## Summary
Implements the `resetGame` handler (issue #20) that allows players to reset their game state while preserving their player identity. The reset operation emits a delta that is replayed during cold starts, ensuring consistent state across page reloads.

## Key Changes
- **New `resetGame` handler** in `LocalEngine.js`: Emits a 'reset' delta that clears nodes, active_missions, and game_values while preserving the player's addr (identity). Broadcasts the delta to webxdc update history for durable replay on cold start.
- **New 'reset' delta reducer** in `state.js`: Implements reset replay semantics where any operations before a reset delta are discarded, and game_values are restored to seed defaults (cash_value: 300, xp_level: 1).
- **Updated exports**: Added `resetGame` to LocalEngine exports and `getState` to boot.js exports for test access.
- **Comprehensive test coverage**: 
  - Handler tests verify reset wipes nodes/missions, restores game_values, preserves addr, and that reset+loadGame reflects a new game
  - State tests verify reset replay semantics: reset+ops produces same state as fresh start+same ops, and pre-reset history is discarded

## Implementation Details
- The reset delta is applied locally before page reload to keep in-memory state consistent
- Webxdc update history remains append-only; prior deltas are turned into no-ops by the reset reducer
- State compaction is deferred to Phase 7 (#35)
- Removed `resetGame` from the stubs list since it's now fully implemented

https://claude.ai/code/session_01DNYjYmv3gqLv7YrLjB9ab6