### PR TITLE
Implement buyKarma handler for purchasing karma points

### DIFF
--- a/scripts/LocalEngine.js
+++ b/scripts/LocalEngine.js
@@ -4,7 +4,7 @@
 //
 // Handlers implemented here: getToken, ping, getSessionLocale, loadGame (#12),
 // resetGame (#20), getRanking, setDisplayName, setPerpCoordinates (#13),
-//   getProvidedPerps, getPowerups (#14).
+//   getProvidedPerps, getPowerups (#14), buyKarma (#19).
 // Remaining handlers are stubs that return a rejected Promise.
 
 import { getState, setState } from './boot.js';
@@ -412,12 +412,89 @@ export function setPerpCoordinates(/* token, */ _, updates) {
 }
 
 // ---------------------------------------------------------------------------
+// buyKarma handler
+// ---------------------------------------------------------------------------
+
+function _getLevelNumber(levels, xp) {
+  for (var i = 0; i < levels.length; i++) {
+    if (xp >= levels[i].xp_min && xp <= levels[i].xp_max) {
+      return levels[i].number;
+    }
+  }
+  return levels[levels.length - 1].number;
+}
+
+function _getLevel(levels, number) {
+  for (var i = 0; i < levels.length; i++) {
+    if (levels[i].number === number) return levels[i];
+  }
+  return null;
+}
+
+/**
+ * buyKarma(token, karmalauterGestalt) → Promise<{result}>
+ *
+ * Looks up the karmalauter in the ruleset, validates cash, applies increments,
+ * and returns {game_values, [levelup]}.  No missions payload (handler-map.md).
+ */
+export function buyKarma(_token, karmalauterGestalt) {
+  var state = getState();
+  var ruleset = _getRuleset();
+
+  var karmalauter = null;
+  for (var i = 0; i < ruleset.karmalauters.length; i++) {
+    if (ruleset.karmalauters[i].type_data.gestalt === karmalauterGestalt) {
+      karmalauter = ruleset.karmalauters[i];
+      break;
+    }
+  }
+  if (!karmalauter) {
+    return Promise.resolve({ result: { error: 1 } });
+  }
+
+  var td = karmalauter.type_data;
+  var gv = state.game_values;
+
+  if (gv.cash_value < td.price) {
+    return Promise.resolve({ result: { error: 2 } });
+  }
+
+  var newXp = (gv.xp_value || 0) + td.karma_points;
+  var newKarma = Math.min(100, Math.max(-100, (gv.karma_value || 0) + td.karma_points));
+  var newCash = gv.cash_value - td.price;
+  var newCashSpent = (gv.cash_spent || 0) + td.price;
+
+  var oldLevelNum = gv.xp_level || 1;
+  var newLevelNum = _getLevelNumber(ruleset.levels, newXp);
+  var levelup = newLevelNum > oldLevelNum;
+
+  var newGv = Object.assign({}, gv, {
+    xp_value: newXp,
+    karma_value: newKarma,
+    cash_value: newCash,
+    cash_spent: newCashSpent,
+    xp_level: newLevelNum
+  });
+
+  if (levelup) {
+    var newLevel = _getLevel(ruleset.levels, newLevelNum);
+    if (newLevel) newGv.ap_snapshot = newLevel.ap_max;
+  }
+
+  setState(Object.assign({}, state, { game_values: newGv }));
+  _sendDelta(state.addr, 'buyKarma', [karmalauterGestalt], { game_values: newGv });
+
+  var response = { game_values: newGv };
+  if (levelup) response.levelup = true;
+  return Promise.resolve({ result: response });
+}
+
+// ---------------------------------------------------------------------------
 // Stub handlers — Wave 4+ issues fill these in.
 // ---------------------------------------------------------------------------
 var _STUBS = [
   'buyPowerup', 'chargePerp', 'collectPerp', 'integrateCollected',
-  'buyKarma', 'buyPerp', 'buySlots',
-  'sellPowerup', 'checkUsername'
+  'buyPerp', 'buySlots', 'sellPowerup', 'checkUsername'
 ];
 
 var _stubHandlers = {};
@@ -442,6 +519,7 @@ var LocalEngine = Object.assign({
   setPerpCoordinates: setPerpCoordinates,
   getProvidedPerps: getProvidedPerps,
   getPowerups: getPowerups,
+  buyKarma: buyKarma,
   setEmitter: setEmitter
 }, _stubHandlers);
 

--- a/scripts/LocalEngine.js
+++ b/scripts/LocalEngine.js
@@ -415,20 +415,14 @@ export function setPerpCoordinates(/* token, */ _, updates) {
 // buyKarma handler
 // ---------------------------------------------------------------------------
 
-function _getLevelNumber(levels, xp) {
+// Returns the matching level entry (or the last level for XP beyond the cap).
+function _findLevelByXP(levels, xp) {
   for (var i = 0; i < levels.length; i++) {
     if (xp >= levels[i].xp_min && xp <= levels[i].xp_max) {
-      return levels[i].number;
+      return levels[i];
     }
   }
-  return levels[levels.length - 1].number;
-}
-
-function _getLevel(levels, number) {
-  for (var i = 0; i < levels.length; i++) {
-    if (levels[i].number === number) return levels[i];
-  }
-  return null;
+  return levels[levels.length - 1];
 }
 
 /**
@@ -465,21 +459,18 @@ export function buyKarma(_token, karmalauterGestalt) {
   var newCashSpent = (gv.cash_spent || 0) + td.price;
 
   var oldLevelNum = gv.xp_level || 1;
-  var newLevelNum = _getLevelNumber(ruleset.levels, newXp);
-  var levelup = newLevelNum > oldLevelNum;
+  var newLevel = _findLevelByXP(ruleset.levels, newXp);
+  var levelup = newLevel.number > oldLevelNum;
 
   var newGv = Object.assign({}, gv, {
     xp_value: newXp,
     karma_value: newKarma,
     cash_value: newCash,
     cash_spent: newCashSpent,
-    xp_level: newLevelNum
+    xp_level: newLevel.number
   });
 
-  if (levelup) {
-    var newLevel = _getLevel(ruleset.levels, newLevelNum);
-    if (newLevel) newGv.ap_snapshot = newLevel.ap_max;
-  }
+  if (levelup) newGv.ap_snapshot = newLevel.ap_max;
 
   setState(Object.assign({}, state, { game_values: newGv }));
   _sendDelta(state.addr, 'buyKarma', [karmalauterGestalt], { game_values: newGv });

--- a/scripts/state.js
+++ b/scripts/state.js
@@ -142,6 +142,14 @@ reducers.setPerpCoordinates = function setPerpCoordinatesReducer(state, delta) {
   return Object.assign({}, state, { nodes: nodes });
 };
 
+reducers.buyKarma = function buyKarmaReducer(state, delta) {
+  var gv = delta.result && delta.result.game_values;
+  if (!gv) return state;
+  return Object.assign({}, state, {
+    game_values: Object.assign({}, state.game_values, gv)
+  });
+};
+
 // Stubs — return state unchanged until Wave 4+ fills them in.
 OP_NAMES.forEach(function (op) {
   if (!reducers[op]) {

--- a/tests/handlers/handlers.test.js
+++ b/tests/handlers/handlers.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   getToken, ping, getSessionLocale, loadGame, getRanking, resetGame, setEmitter,
-  setDisplayName, setPerpCoordinates
+  setDisplayName, setPerpCoordinates, buyKarma
 } from '../../scripts/LocalEngine.js';
 import { getState, setState } from '../../scripts/boot.js';
 import { freshState, applyDelta } from '../../scripts/state.js';
@@ -252,6 +252,120 @@ describe('loadGame — replayed state', () => {
     const { result } = await loadGame('tok');
     expect(result.is_new_game).toBe(false);
     expect(result.nodes).toHaveLength(1);
+  });
+});
+
+// ── buyKarma ─────────────────────────────────────────────────────────────────
+
+// karma001: price=250, karma_points=5, required_level=5
+const KARMA_GESTALT = 'karma001';
+const KARMA_PRICE   = 250;
+const KARMA_POINTS  = 5;
+
+describe('buyKarma — happy path', () => {
+  beforeEach(() => {
+    setState(mkState({
+      game_values: {
+        xp_value: 1, xp_level: 1, cash_value: 1000, cash_spent: 0,
+        karma_value: 50, profiles_value: 0, profiles_max: 1,
+        ap_snapshot: 6, ap_update: null
+      }
+    }));
+  });
+
+  it('resolves to an object with a result property', async () => {
+    const data = await buyKarma('tok', KARMA_GESTALT);
+    expect(data).toHaveProperty('result');
+  });
+
+  it('result has game_values but no error', async () => {
+    const { result } = await buyKarma('tok', KARMA_GESTALT);
+    expect(result.error).toBeUndefined();
+    expect(result.game_values).toBeDefined();
+  });
+
+  it('deducts the price from cash_value', async () => {
+    const { result } = await buyKarma('tok', KARMA_GESTALT);
+    expect(result.game_values.cash_value).toBe(1000 - KARMA_PRICE);
+  });
+
+  it('adds the price to cash_spent', async () => {
+    const { result } = await buyKarma('tok', KARMA_GESTALT);
+    expect(result.game_values.cash_spent).toBe(KARMA_PRICE);
+  });
+
+  it('increments karma_value by karma_points', async () => {
+    const { result } = await buyKarma('tok', KARMA_GESTALT);
+    expect(result.game_values.karma_value).toBe(50 + KARMA_POINTS);
+  });
+
+  it('increments xp_value by karma_points', async () => {
+    const { result } = await buyKarma('tok', KARMA_GESTALT);
+    expect(result.game_values.xp_value).toBe(1 + KARMA_POINTS);
+  });
+
+  it('does not include a missions field', async () => {
+    const { result } = await buyKarma('tok', KARMA_GESTALT);
+    expect(result.missions).toBeUndefined();
+  });
+
+  it('persists game_values into state', async () => {
+    await buyKarma('tok', KARMA_GESTALT);
+    expect(getState().game_values.cash_value).toBe(1000 - KARMA_PRICE);
+    expect(getState().game_values.karma_value).toBe(50 + KARMA_POINTS);
+  });
+
+  it('clamps karma_value at 100 when already near the cap', async () => {
+    setState(mkState({
+      game_values: {
+        xp_value: 1, xp_level: 1, cash_value: 9999, cash_spent: 0,
+        karma_value: 98, profiles_value: 0, profiles_max: 1,
+        ap_snapshot: 6, ap_update: null
+      }
+    }));
+    // karma001 karma_points=5; 98+5=103 → clamped to 100
+    const { result } = await buyKarma('tok', KARMA_GESTALT);
+    expect(result.game_values.karma_value).toBe(100);
+  });
+});
+
+describe('buyKarma — failure: insufficient cash', () => {
+  beforeEach(() => {
+    setState(mkState({
+      game_values: {
+        xp_value: 1, xp_level: 1, cash_value: 10, cash_spent: 0,
+        karma_value: 0, profiles_value: 0, profiles_max: 1,
+        ap_snapshot: 6, ap_update: null
+      }
+    }));
+  });
+
+  it('resolves with error when cash is below price', async () => {
+    const { result } = await buyKarma('tok', KARMA_GESTALT);
+    expect(result.error).toBeDefined();
+  });
+
+  it('does not mutate state on cash failure', async () => {
+    const before = getState().game_values.cash_value;
+    await buyKarma('tok', KARMA_GESTALT);
+    expect(getState().game_values.cash_value).toBe(before);
+  });
+});
+
+describe('buyKarma — failure: unknown karmalauter', () => {
+  beforeEach(() => {
+    setState(mkState({
+      game_values: {
+        xp_value: 1, xp_level: 1, cash_value: 9999, cash_spent: 0,
+        karma_value: 0, profiles_value: 0, profiles_max: 1,
+        ap_snapshot: 6, ap_update: null
+      }
+    }));
+  });
+
+  it('resolves with error for an unknown gestalt', async () => {
+    const { result } = await buyKarma('tok', 'karma_does_not_exist');
+    expect(result.error).toBeDefined();
   });
 });
 


### PR DESCRIPTION
## Summary
Implements the `buyKarma` handler to allow players to purchase karma points using in-game currency. This includes validation, state management, and level-up detection.

## Key Changes
- **LocalEngine.js**: Added `buyKarma` handler that:
  - Looks up karmalauter items by gestalt identifier from the ruleset
  - Validates player has sufficient cash before allowing purchase
  - Deducts price from `cash_value` and adds to `cash_spent`
  - Increments both `karma_value` and `xp_value` by the karmalauter's `karma_points`
  - Clamps karma value between -100 and 100
  - Detects level-ups and updates `ap_snapshot` when leveling occurs
  - Sends delta updates via webxdc or updates local state
  - Returns error codes for unknown karmalauters (error: 1) or insufficient cash (error: 2)

- **state.js**: Added `buyKarmaReducer` to merge returned `game_values` snapshot into state when processing delta updates

- **handlers.test.js**: Added comprehensive test suite covering:
  - Happy path: successful purchase with proper state mutations
  - Karma clamping at 100 when exceeding cap
  - Failure case: insufficient cash (state remains unchanged)
  - Failure case: unknown karmalauter gestalt

## Implementation Details
- Uses helper functions `_getLevelNumber()` and `_getLevel()` to determine current and new player levels based on XP
- Removed `buyKarma` from stub handlers list since it's now fully implemented
- Follows existing patterns for delta creation and webxdc integration

https://claude.ai/code/session_01Lh8jGJ3a3jYUuRqRrV2eET