### PR TITLE
Clarify buyKarma response format in handler documentation

### DIFF
--- a/docs/handler-map.md
+++ b/docs/handler-map.md
@@ -44,14 +44,12 @@ Method `userData` (`views.py:164`), `logout` (`views.py:1464`), and
 list. They're real RPC endpoints; flagged here for completeness but not
 detailed below.
 
-> **Phase 3 implementer note — `buyKarma` missions discrepancy:**
-> `docs/response-shapes.md` lists `missions: MissionsPayload` as part of the
-> `buyKarma` response. This is incorrect. `views.py:939-1000` shows that
-> `buyKarma` never instantiates `MissionHandler` and never includes a
-> `missions` key in its response — it only returns `{game_values, [levelup]}`.
-> `response-shapes.md` appears to have over-specified this by analogy with
-> `buyPerp`. The LocalEngine implementation must **not** return a missions
-> payload for `buyKarma`. Fix `response-shapes.md` before Phase 3 begins.
+> **`buyKarma` missions discrepancy — resolved (issue #59):**
+> `views.py:939-1000` confirms `buyKarma` never instantiates `MissionHandler`
+> and returns only `{game_values, [levelup]}` — no `missions` key. The earlier
+> draft of `docs/response-shapes.md` over-specified this by analogy with
+> `buyPerp`; that error has been corrected. LocalEngine must **not** return a
+> missions payload for `buyKarma`.
 
 ---
 


### PR DESCRIPTION
## Summary
Updated the `buyKarma` handler documentation to clarify the correct response format and remove outdated implementation notes.

## Changes
- Removed Phase 3 implementer note that contained incorrect specifications about the `buyKarma` response
- Clarified that `buyKarma` returns only `{game_values, [levelup]}` without a `missions` key
- Updated documentation to reference the corrected `response-shapes.md` and resolved issue #59
- Simplified the note to reflect the current, correct behavior rather than prescriptive guidance

## Details
The documentation previously contained a warning about a discrepancy between the spec and implementation. This has been resolved by correcting the spec in `response-shapes.md`. The updated note now confirms the actual behavior: `buyKarma` does not instantiate `MissionHandler` and does not include a missions payload in its response, unlike `buyPerp`.

https://claude.ai/code/session_01Fr6GErCBdyaXdMT6c8p2CK