### PR TITLE
Remove logout button and handler (not needed in webxdc)

### DIFF
--- a/scripts/Render.js
+++ b/scripts/Render.js
@@ -4089,12 +4089,6 @@ define(function(require) {
         e.preventDefault();
         GameRoot.trigger('user_data');
       });
-      this.jdomelem.on('click touchend','#Logout',function(e){
-        e.stopPropagation();
-        e.preventDefault();
-        GameRoot.lock();
-        routie('sign_out');
-      });
       this.jdomelem.on('click touchend','.MainMenuButton:not(.disabled)',function(e){
         e.stopPropagation();
         e.preventDefault();
@@ -4116,7 +4110,7 @@ define(function(require) {
     MainMenu.prototype.lock = function() {
       var node = this;
       node.jdomelem.addClass('locked');
-      node.jdomelem.find('.UserButton:not(#Logout), .MainMenuButton').addClass('disabled');
+      node.jdomelem.find('.UserButton, .MainMenuButton').addClass('disabled');
     };
 
     MainMenu.prototype.unlock = function() {

--- a/views/mainmenu.html
+++ b/views/mainmenu.html
@@ -5,7 +5,6 @@
   <div class="RenderSprite MainMenuLogo <%= logoclass %>"></div>
   <div class="UserActions">
     <div id="UserData" class="UserButton"><%= D.userdata.display_name %></div>
-    <div id="Logout" class="UserButton"><% print(_._('Log Out')); %></div>
   </div>
   <div id="MainMenuButtons" class="MainMenuButtons">
     <% _.each(D.buttons, function(button) { %> <div class="MainMenuButton<% if (button.states.active) { print(' active') }; %>" data-button-id="<%= button.id %>"><%= button.label %></div> <% }); %>


### PR DESCRIPTION
## Summary

- Removes the `#Logout` button from `views/mainmenu.html`
- Removes the `#Logout` click handler and `routie('sign_out')` call from `scripts/Render.js`
- Simplifies the `lock()` selector now that `#Logout` no longer needs to be excluded from the disabled state

## Reason

webxdc apps run inside Delta Chat and have no server session to sign out of, so the Log Out button is meaningless in this context.

## Test plan

- [ ] Launch the app as a webxdc and confirm the main menu renders without a Log Out button
- [ ] Confirm the `#UserData` button and main menu buttons still work normally
- [ ] Confirm `lock()` / `unlock()` still disables/enables all `.UserButton` elements correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKzUV8L4shPwdUP5z9eAfq)_