### PR TITLE
Wave 3 follow-ups: integrate flow, timers, briefing/NEW persistence, centering, About, level-up

### DIFF
--- a/css/Render.css
+++ b/css/Render.css
@@ -584,6 +584,17 @@
   background-position: -315px -703px;
 }
 
+.ZoomControls div.disabled {
+  opacity: 0.35;
+  pointer-events: none;
+  cursor: default;
+}
+.ZoomControls div.disabled:hover {
+  -webkit-transform: none;
+  -moz-transform: none;
+  transform: none;
+}
+
 .ZoomControls div:hover {
   -webkit-transform: scale(1.1,1.1);
   -moz-transform: scale(1.1,1.1);

--- a/css/Render.css
+++ b/css/Render.css
@@ -2005,6 +2005,17 @@
   text-align: left;
 }
 
+/* About dialog: long text body would otherwise scroll under the absolute
+   PopupButtons strip at bottom:-10px. Make the tab content scroll inside
+   .PopupContent and reserve room for the buttons. */
+.PopupBody.User .PopupContent {
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+.PopupBody.User .PopupTab {
+  padding-bottom: 56px;
+}
+
 .SubpopContainer {
   position: absolute;
   visibility:hidden;

--- a/data/default_game.json
+++ b/data/default_game.json
@@ -18,6 +18,9 @@
   "active_missions": ["mission001"],
   "game_values": {
     "ap_snapshot": 6,
+    "ap_max": 6,
+    "ap_inc_value": 1,
+    "ap_inc_interval": 120000,
     "cash_value": 270,
     "karma_value": 50,
     "profiles_max": 1,

--- a/data/default_game.json
+++ b/data/default_game.json
@@ -18,7 +18,7 @@
   "active_missions": ["mission001"],
   "game_values": {
     "ap_snapshot": 6,
-    "cash_value": 300,
+    "cash_value": 270,
     "karma_value": 50,
     "profiles_max": 1,
     "profiles_value": 0,

--- a/i18n/de_AT.json
+++ b/i18n/de_AT.json
@@ -685,6 +685,10 @@
     null,
     "Schliessen"
   ],
+  "About": [
+    null,
+    "Über"
+  ],
   "agent_popup selector title": [
     null,
     "Kontakte anwerben"

--- a/i18n/de_AT.po
+++ b/i18n/de_AT.po
@@ -890,6 +890,10 @@ msgstr "Ok"
 msgid "Close"
 msgstr "Schliessen"
 
+#: views/mainmenu.html:8
+msgid "About"
+msgstr "Über"
+
 #: views/popup_agent.html:31
 msgid "agent_popup selector title"
 msgstr "Kontakte anwerben"

--- a/i18n/en_US.json
+++ b/i18n/en_US.json
@@ -685,6 +685,10 @@
     null,
     "Close"
   ],
+  "About": [
+    null,
+    "About"
+  ],
   "agent_popup selector title": [
     null,
     "Acquire contact"

--- a/i18n/en_US.po
+++ b/i18n/en_US.po
@@ -869,6 +869,10 @@ msgstr "OK"
 msgid "Close"
 msgstr "Close"
 
+#: views/mainmenu.html:8
+msgid "About"
+msgstr "About"
+
 #: views/popup_agent.html:31
 msgid "agent_popup selector title"
 msgstr "Acquire contact"

--- a/scripts/Game.js
+++ b/scripts/Game.js
@@ -1199,9 +1199,6 @@ define(function(require) {
         // The seen-flag is persisted via the dismissMissionBriefing op so it
         // survives webxdc replay across reloads.
         var seenBriefings = (groot.raw_data && groot.raw_data.mission_briefings_seen) || {};
-        console.log('[briefing] mission_active check:', data.mission_active,
-          'seenBriefings=', seenBriefings,
-          'isSeen=', !!seenBriefings[data.mission_active]);
         if (!seenBriefings[data.mission_active]) {
           var mission = groot.Missions.getMission(data.mission_active);
           n = mergeData({},mission.data);
@@ -3005,9 +3002,6 @@ define(function(require) {
 
       popup.on('popup_close',function(e) {
         e.stopPropagation();
-        console.log('[briefing] popup_close fired; notificationMission=',
-          popup.notificationMission,
-          'hasRemoteFn=', !!(app.remote && app.remote.dismissMissionBriefing));
         if (popup.notificationMission) {
           var gestalt = popup.notificationMission;
           popup.notificationMission = null;
@@ -3016,17 +3010,7 @@ define(function(require) {
             groot.raw_data.mission_briefings_seen[gestalt] = true;
           }
           if (app.remote && app.remote.dismissMissionBriefing) {
-            console.log('[briefing] dispatching dismissMissionBriefing for', gestalt);
-            var r = app.remote.dismissMissionBriefing(app.token, gestalt);
-            if (r && typeof r.then === 'function') {
-              r.then(function (resp) {
-                console.log('[briefing] dismiss response:', resp);
-              }, function (err) {
-                console.log('[briefing] dismiss error:', err);
-              });
-            } else if (r && typeof r.done === 'function') {
-              r.done(function (resp) { console.log('[briefing] dismiss done:', resp); });
-            }
+            app.remote.dismissMissionBriefing(app.token, gestalt);
           }
         }
         if (gnode.highlightTabs) {

--- a/scripts/Game.js
+++ b/scripts/Game.js
@@ -1024,6 +1024,15 @@ define(function(require) {
         });
         gnode.activeView = getById(view_id);
         gnode.activeView.setState('active',true);
+        // Refresh the new view's scroller dimensions against the current
+        // stage (it may have been resized while a different tab was active),
+        // then recentre on its content. Without this, switching to Database
+        // leaves the camera wherever the previous view was scrolled.
+        var vm = gnode.activeView && gnode.activeView.renderNode;
+        if (vm && typeof vm.updateScroller === 'function') {
+          vm.updateScroller();
+        }
+        gnode._centerActiveView(true);
       });
 
       gnode.on('toggle_locale',function(e) {
@@ -1637,6 +1646,12 @@ define(function(require) {
       config.popupContainer = this;
 
       var popup = gnode.notificationPopup = new Render.Popup(config);
+      // Tag the popup with the mission gestalt so the popup_close handler in
+      // initPopupEvents can persist the dismissal directly. Persisting in
+      // popup.callback (which only fires via popup.close(cb)) was unreliable
+      // — popup_close fires the moment the user clicks X, before the close
+      // animation/timeout chain that triggers the callback.
+      popup.notificationMission = notification.mission_active_gestalt;
       //gnode.lock();
 
       window.setTimeout(function(){
@@ -1651,17 +1666,8 @@ define(function(require) {
         gnode.renderNode.addPopup(popup);
         gnode.initPopupEvents(popup);
       }, config.delay || 0);
-      
+
       popup.callback = function(){
-        if (notification.mission_active_gestalt) {
-          // Mark this mission's briefing as seen so it doesn't reopen on reload.
-          var gestalt = notification.mission_active_gestalt;
-          groot.raw_data.mission_briefings_seen = groot.raw_data.mission_briefings_seen || {};
-          groot.raw_data.mission_briefings_seen[gestalt] = true;
-          if (app.remote && app.remote.dismissMissionBriefing) {
-            app.remote.dismissMissionBriefing(app.token, gestalt);
-          }
-        }
         groot.uncueNotification(notification);
         delete groot.notificationPopup;
         if (groot.NotificationQueue.length) {
@@ -1685,10 +1691,11 @@ define(function(require) {
       var vm = this.activeView && this.activeView.renderNode;
       if (!vm || !vm.scroller || typeof vm.scroller.zoomTo !== 'function') return;
       if (typeof vm.updateScroller === 'function') vm.updateScroller();
-      vm.scroller.options.animating = true;
+      // Don't toggle options.animating — the zynga-scroller animation reads
+      // the flag every frame, so flipping it back to false synchronously
+      // cancels the zoom mid-animation.
       vm.scroller.zoomTo(1, true);
       this._centerActiveView(true);
-      vm.scroller.options.animating = false;
     };
 
     // Re-centers the active ViewMap so the design home point sits in the
@@ -1881,7 +1888,7 @@ define(function(require) {
       var clipap = (this.ap_value < 0) ? 0 : this.ap_value
       sb.AP.val = (this.ap_value < 0) ? 0 : this.ap_value;
       sb.AP.max = this.xp_level.ap_max;
-      sb.AP.barsize = Math.round((sb.AP.val/this.xp_level.ap_max)*120);
+      sb.AP.barsize = Math.min(120, Math.max(0, Math.round((sb.AP.val/this.xp_level.ap_max)*120)));
       if (this.renderStatusbar && !silent) { this.renderStatusbar.FXUpdateAP(); }
     };
 
@@ -1891,7 +1898,7 @@ define(function(require) {
       }
       sb = this.data.status_bar;
       sb.cash.val = this.cash_value;
-      sb.cash.barsize = Math.round((this.cash_value/this.cash_max)*120);
+      sb.cash.barsize = Math.min(120, Math.max(0, Math.round((this.cash_value/this.cash_max)*120)));
       if (this.renderStatusbar && !silent) { this.renderStatusbar.FXUpdateCash(); }
     };
 
@@ -1905,7 +1912,7 @@ define(function(require) {
       sb = this.data.status_bar;
       sb.profiles.val = this.profiles_value;
       sb.profiles.max = this.profiles_max;
-      sb.profiles.barsize = Math.round((this.profiles_value/this.profiles_max)*120);
+      sb.profiles.barsize = Math.min(120, Math.max(0, Math.round((this.profiles_value/this.profiles_max)*120)));
       sb.profiles.crosssum = this.getDBTokensCrossSum();
       this.getDBTokensLength();
       sb.profiles.tokenslength = this.DBTokensLength;
@@ -1931,7 +1938,7 @@ define(function(require) {
       sb.karma.max = this.karma_max || 100;
       //var val_center = 50 - this.karma_value;
       //FIXME: set to correct level not 50;
-      sb.karma.barsize = Math.round((this.karma_value/this.karma_max)*59);
+      sb.karma.barsize = Math.min(59, Math.max(-59, Math.round((this.karma_value/this.karma_max)*59)));
       if (this.renderStatusbar && !silent) { this.renderStatusbar.FXUpdateKarma(); }
     };
 
@@ -1950,7 +1957,7 @@ define(function(require) {
       sb = this.data.status_bar;
       sb.XP.val = this.xp_value;
       sb.XP.level = this.xp_level.number;
-      sb.XP.barsize = Math.round(((this.xp_value - this.xp_level.xp_min) / (this.xp_level.xp_max - this.xp_level.xp_min)) * 96);
+      sb.XP.barsize = Math.min(96, Math.max(0, Math.round(((this.xp_value - this.xp_level.xp_min) / (this.xp_level.xp_max - this.xp_level.xp_min)) * 96)));
       if (this.renderStatusbar && !silent) { this.renderStatusbar.FXUpdateXP(); }
     };
 
@@ -2599,10 +2606,13 @@ define(function(require) {
             return;
           }
           if (gnode.renderPopup) { gnode.renderPopup.trigger('popup_close'); }
-          // TODO game_values
           var gv = data.result.game_values;
-          //groot.updateGameValues(data.result.game_values,data.result.levelup,data.result.missions,true);
           groot.setProfiles(data.result.game_values.profiles_value,true);
+          // Recompute game values + mission goals so integrate_profiles
+          // missions tick over right after DBTokensAbsolute is populated.
+          // setProfiles above already set profiles_value, so the inner
+          // setProfiles in updateGameValues is a no-op (guard by !== current).
+          groot.updateGameValues(data.result.game_values,data.result.levelup,data.result.missions,true);
           var profiles_increment = data.result.result.increment;
           var profiles_dup = data.result.result.dup;
           
@@ -2987,6 +2997,20 @@ define(function(require) {
 
       popup.on('popup_close',function(e) {
         e.stopPropagation();
+        // Persist mission-briefing dismissal synchronously here, not in
+        // popup.callback. Callback runs only when popup.close(cb) chains
+        // through; popup_close fires the moment the user clicks X.
+        if (popup.notificationMission) {
+          var gestalt = popup.notificationMission;
+          popup.notificationMission = null;
+          if (groot.raw_data) {
+            groot.raw_data.mission_briefings_seen = groot.raw_data.mission_briefings_seen || {};
+            groot.raw_data.mission_briefings_seen[gestalt] = true;
+          }
+          if (app.remote && app.remote.dismissMissionBriefing) {
+            app.remote.dismissMissionBriefing(app.token, gestalt);
+          }
+        }
         if (gnode.highlightTabs) {
           gnode.highlightTabs = [];
         }

--- a/scripts/Game.js
+++ b/scripts/Game.js
@@ -1199,6 +1199,9 @@ define(function(require) {
         // The seen-flag is persisted via the dismissMissionBriefing op so it
         // survives webxdc replay across reloads.
         var seenBriefings = (groot.raw_data && groot.raw_data.mission_briefings_seen) || {};
+        console.log('[briefing] mission_active check:', data.mission_active,
+          'seenBriefings=', seenBriefings,
+          'isSeen=', !!seenBriefings[data.mission_active]);
         if (!seenBriefings[data.mission_active]) {
           var mission = groot.Missions.getMission(data.mission_active);
           n = mergeData({},mission.data);
@@ -2987,10 +2990,6 @@ define(function(require) {
 
       popup.on('button_click.MainButton',function(e) {
         e.stopPropagation();
-        // Distinguish "user clicked Accept" from "user X'd out" so we don't
-        // mark a mission briefing as seen when the player aborted the
-        // conversation midway. Read by the popup_close handler below.
-        popup.accepted = true;
         popup.trigger('popup_close');
       });
 
@@ -3006,11 +3005,10 @@ define(function(require) {
 
       popup.on('popup_close',function(e) {
         e.stopPropagation();
-        // Mark a mission briefing as seen only when the user clicked the
-        // Accept button (popup.accepted) — not when they X'd out or clicked
-        // outside. If they aborted midway, the briefing should re-appear on
-        // next reload so they can re-read the conversation.
-        if (popup.notificationMission && popup.accepted) {
+        console.log('[briefing] popup_close fired; notificationMission=',
+          popup.notificationMission,
+          'hasRemoteFn=', !!(app.remote && app.remote.dismissMissionBriefing));
+        if (popup.notificationMission) {
           var gestalt = popup.notificationMission;
           popup.notificationMission = null;
           if (groot.raw_data) {
@@ -3018,7 +3016,17 @@ define(function(require) {
             groot.raw_data.mission_briefings_seen[gestalt] = true;
           }
           if (app.remote && app.remote.dismissMissionBriefing) {
-            app.remote.dismissMissionBriefing(app.token, gestalt);
+            console.log('[briefing] dispatching dismissMissionBriefing for', gestalt);
+            var r = app.remote.dismissMissionBriefing(app.token, gestalt);
+            if (r && typeof r.then === 'function') {
+              r.then(function (resp) {
+                console.log('[briefing] dismiss response:', resp);
+              }, function (err) {
+                console.log('[briefing] dismiss error:', err);
+              });
+            } else if (r && typeof r.done === 'function') {
+              r.done(function (resp) { console.log('[briefing] dismiss done:', resp); });
+            }
           }
         }
         if (gnode.highlightTabs) {

--- a/scripts/Game.js
+++ b/scripts/Game.js
@@ -2987,6 +2987,10 @@ define(function(require) {
 
       popup.on('button_click.MainButton',function(e) {
         e.stopPropagation();
+        // Distinguish "user clicked Accept" from "user X'd out" so we don't
+        // mark a mission briefing as seen when the player aborted the
+        // conversation midway. Read by the popup_close handler below.
+        popup.accepted = true;
         popup.trigger('popup_close');
       });
 
@@ -3002,10 +3006,11 @@ define(function(require) {
 
       popup.on('popup_close',function(e) {
         e.stopPropagation();
-        // Persist mission-briefing dismissal synchronously here, not in
-        // popup.callback. Callback runs only when popup.close(cb) chains
-        // through; popup_close fires the moment the user clicks X.
-        if (popup.notificationMission) {
+        // Mark a mission briefing as seen only when the user clicked the
+        // Accept button (popup.accepted) — not when they X'd out or clicked
+        // outside. If they aborted midway, the briefing should re-appear on
+        // next reload so they can re-read the conversation.
+        if (popup.notificationMission && popup.accepted) {
           var gestalt = popup.notificationMission;
           popup.notificationMission = null;
           if (groot.raw_data) {

--- a/scripts/Game.js
+++ b/scripts/Game.js
@@ -1827,6 +1827,11 @@ define(function(require) {
       this.profiles_value = gv.profiles_value;
       this.profiles_max = gv.profiles_max;
       this.cash_value = gv.cash_value;
+      // cash_max was never initialised in the legacy code, so the cash-bar
+      // barsize divided by undefined → NaN. Pin to a sane large default so
+      // the bar fills meaningfully without overflowing once the player
+      // accumulates cash from client collections.
+      this.cash_max = gv.cash_max || 10000;
       this.karma_value = gv.karma_value;
       this.karma_max = 100;
       this.xp_value = gv.xp_value;

--- a/scripts/Game.js
+++ b/scripts/Game.js
@@ -1033,12 +1033,10 @@ define(function(require) {
 
       gnode.on('user_data',function(e) {
         e.stopPropagation();
-        var user = gnode.data.user;
-        var text = _._('user description');
         gnode.openGenericPopup({
           data: {
-            title: user.display_name,
-            description: text
+            title: 'About',
+            description: 'Data Dealer &mdash; webxdc port'
           },
           template:'popup_user_data.html'
         });
@@ -1188,23 +1186,24 @@ define(function(require) {
         gnode.cueNotification(n);
       }
       if (data.mission_active) {
-        var mission = groot.Missions.getMission(data.mission_active);
-        n = mergeData({},mission.data);
-        n.game_type = "MissionNew";
-        n.states = mission.states;
-        n.mission_decorator = _._('New Mission!');
-        n.mission = mission;
-        n.config = {
-          template: 'popup_mission.html',
-          extendClass: 'Mission'
-        };
-        /*
-        n.scriptedEvents = [];
-        n.scriptedEvents.push(function(){
-          groot.renderNode.FXLevelUpBling(data.levelup);
-        });
-        */
-        gnode.cueNotification(n);
+        // Only show the briefing if the player hasn't already dismissed it.
+        // The seen-flag is persisted via the dismissMissionBriefing op so it
+        // survives webxdc replay across reloads.
+        var seenBriefings = (groot.raw_data && groot.raw_data.mission_briefings_seen) || {};
+        if (!seenBriefings[data.mission_active]) {
+          var mission = groot.Missions.getMission(data.mission_active);
+          n = mergeData({},mission.data);
+          n.game_type = "MissionNew";
+          n.states = mission.states;
+          n.mission_decorator = _._('New Mission!');
+          n.mission = mission;
+          n.mission_active_gestalt = data.mission_active;
+          n.config = {
+            template: 'popup_mission.html',
+            extendClass: 'Mission'
+          };
+          gnode.cueNotification(n);
+        }
       }
       if (data.levelup) {
         var n = {};
@@ -1654,6 +1653,15 @@ define(function(require) {
       }, config.delay || 0);
       
       popup.callback = function(){
+        if (notification.mission_active_gestalt) {
+          // Mark this mission's briefing as seen so it doesn't reopen on reload.
+          var gestalt = notification.mission_active_gestalt;
+          groot.raw_data.mission_briefings_seen = groot.raw_data.mission_briefings_seen || {};
+          groot.raw_data.mission_briefings_seen[gestalt] = true;
+          if (app.remote && app.remote.dismissMissionBriefing) {
+            app.remote.dismissMissionBriefing(app.token, gestalt);
+          }
+        }
         groot.uncueNotification(notification);
         delete groot.notificationPopup;
         if (groot.NotificationQueue.length) {
@@ -1676,6 +1684,7 @@ define(function(require) {
     GameRoot.prototype.resetZoom = function() {
       var vm = this.activeView && this.activeView.renderNode;
       if (!vm || !vm.scroller || typeof vm.scroller.zoomTo !== 'function') return;
+      if (typeof vm.updateScroller === 'function') vm.updateScroller();
       vm.scroller.options.animating = true;
       vm.scroller.zoomTo(1, true);
       this._centerActiveView(true);
@@ -1694,21 +1703,17 @@ define(function(require) {
       var vm = view && view.renderNode;
       if (!vm || !vm.scroller || !vm.parentNode) return;
 
-      // Design home = where the legacy 960×600 stage would have centred:
-      // scroll-offset (-data.x, -data.y) plus half the legacy stage size.
-      var d = (view.data || {});
-      var rootData = (this.data || {});
-      var designStageW = rootData.width  || 960;
-      var designStageH = rootData.height || 600;
-      var homeX = -(d.x || 0) + designStageW / 2;
-      var homeY = -(d.y || 0) + designStageH / 2;
-
+      // Centre on the middle of the ViewMap. The legacy "design home" math
+      // (-data.x + designStageW/2) resolved to the design-stage centre, not
+      // the content area, so on Imperium it parked the camera in the empty
+      // top-left quadrant. Centring on vm.width/2 always shows the seeded
+      // content (e.g. database001 at 1024,800 in a 2920×2200 ViewMap).
       var vw = vm.parentNode.width;
       var vh = vm.parentNode.height;
       var maxX = Math.max(0, vm.width  - vw);
       var maxY = Math.max(0, vm.height - vh);
-      var sx = Math.max(0, Math.min(maxX, homeX - vw / 2));
-      var sy = Math.max(0, Math.min(maxY, homeY - vh / 2));
+      var sx = Math.max(0, Math.min(maxX, vm.width  / 2 - vw / 2));
+      var sy = Math.max(0, Math.min(maxY, vm.height / 2 - vh / 2));
       vm.scroller.scrollTo(sx, sy, !!animate);
     };
 
@@ -1716,11 +1721,15 @@ define(function(require) {
     // load and on window resize so the game fills the available space by
     // default rather than sitting in a 960×600 letterbox.
     GameRoot.prototype.fitToWindow = function() {
-      var width = $(window).width();
-      var height = $(window).height();
-      this.setSize(width - 32, height - 64);
-      // After resizing, snap the active ViewMap back to its home point so
-      // the seed neighbourhood stays visually centred.
+      this.setSize($(window).width() - 32, $(window).height() - 64);
+      // Refresh the scroller's viewport dimensions so the new stage size is
+      // reflected in clamping/zoom math. Without this, scrollTo and the
+      // +/- zoom buttons clamp against the previous viewport.
+      var view = this.activeView || (this.getImperium && this.getImperium());
+      var vm = view && view.renderNode;
+      if (vm && typeof vm.updateScroller === 'function') {
+        vm.updateScroller();
+      }
       this._centerActiveView(false);
     };
 
@@ -2101,7 +2110,8 @@ define(function(require) {
         var timerconf = {
           serverTime: game.raw_data.server_time.$date,
           duration: gnode.data.charge_time,
-          serverStart: gnode.data.charge_start.$date
+          // chargeEntry.charge_start is a plain epoch-ms number — no $date wrapper.
+          serverStart: v.charge_start
         };
         gnode.setAttrs({_loadTimer: timerconf});
       });
@@ -2226,10 +2236,11 @@ define(function(require) {
           t.database_absoluteAmount = groot.DBTokensAbsolute[token.gestalt] || 0;
         }
         if (gnode.markNew) {
-          if (!groot.DBTokens.hasOwnProperty(token.gestalt)) {
+          var seenMap = (groot.raw_data && groot.raw_data.tokens_seen) || {};
+          if (!groot.DBTokens.hasOwnProperty(token.gestalt) && !seenMap[token.gestalt]) {
             t.new = true;
           }
-        } 
+        }
         if (gnode.lockAmountZero && token.amount === 0) {
           t.locked = true;
         }
@@ -2293,8 +2304,9 @@ define(function(require) {
     ProfileSet.prototype.updateNewMarker = function(){
       var ps = this;
       var groot = this.GameRoot;
+      var seenMap = (groot.raw_data && groot.raw_data.tokens_seen) || {};
       _.each(ps.tokens_set,function(token){
-        if (!groot.DBTokens.hasOwnProperty(token.gestalt)) {
+        if (!groot.DBTokens.hasOwnProperty(token.gestalt) && !seenMap[token.gestalt]) {
           token.new = true;
         } else {
           token.new = false;
@@ -3005,6 +3017,17 @@ define(function(require) {
       popup.on('button_click.PowerupSellButton',function(e,bgestalt,bslot) {
          e.stopPropagation();
          gnode.SellPowerup(bgestalt,bslot);
+      });
+
+      popup.on('popup_token_seen',function(e,gestalt) {
+        e.stopPropagation();
+        if (!gestalt) { return; }
+        groot.raw_data.tokens_seen = groot.raw_data.tokens_seen || {};
+        if (groot.raw_data.tokens_seen[gestalt]) { return; }
+        groot.raw_data.tokens_seen[gestalt] = true;
+        if (app.remote && app.remote.markTokenSeen) {
+          app.remote.markTokenSeen(app.token, gestalt);
+        }
       });
 
       popup.on('button_click.PerpBuyButton',function(e,bgestalt) {
@@ -4157,27 +4180,28 @@ define(function(require) {
         var type_data = groot.getTypeData(p);
         perp.data = type_data;
         perp.gestalt = p;
+        // Already-owned perps shouldn't appear in the buy dialog at all —
+        // backend `provided_perps` is a static list per-provider, so the
+        // UI is the only place that knows about ownership.
+        if (groot.IPerps.hasOwnProperty(perp.gestalt)) {
+          return;
+        }
         perp.locked = _.find(gnode.data.buyablePerps,function(v){ return perp.gestalt === v }) === undefined;
-        if (perp.locked && perp.data.required_level && !perp.data.required_providers && perp.data.required_level <= groot.xp_level.number && !groot.IPerps.hasOwnProperty(perp.gestalt)) {
+        if (perp.locked && perp.data.required_level && !perp.data.required_providers && perp.data.required_level <= groot.xp_level.number) {
           perp.locked = false;
         }
-        // FIXME: When Project only check for project in city
-        if ( perp.locked && groot.IPerps.hasOwnProperty(perp.gestalt) ) {
-          perp.bought = true;
-        } else {
-          if (perp.locked) {
-            if (perp.data.required_providers && perp.data.required_providers.length) {
-              perp.data.requiredProviders = [];
-              _.each(perp.data.required_providers,function(v,k){
-                var tdata = groot.getTypeData(v);
-                if (tdata && tdata.title) {
-                  perp.data.requiredProviders.push(tdata.title);
-                }
-              });
-            }
+        if (perp.locked) {
+          if (perp.data.required_providers && perp.data.required_providers.length) {
+            perp.data.requiredProviders = [];
+            _.each(perp.data.required_providers,function(v,k){
+              var tdata = groot.getTypeData(v);
+              if (tdata && tdata.title) {
+                perp.data.requiredProviders.push(tdata.title);
+              }
+            });
           }
-          gnode.data.providedPerps.push(perp);
         }
+        gnode.data.providedPerps.push(perp);
       });
       var sorted = _.sortBy(gnode.data.providedPerps, function(v){ return v.data.required_level; });
       var grouped = _.groupBy(sorted,function(v){

--- a/scripts/LocalEngine.js
+++ b/scripts/LocalEngine.js
@@ -960,6 +960,7 @@ export function buyPerp(_token, parentPath, gestalt) {
   }
 
   var missionResult = _advanceBuyPerpMissions(state, gestalt);
+  newGv = _applyRewardsToGv(newGv, missionResult.rewards);
 
   // profile_set for project*/contact*/city* gestalts:
   // initial data batch pushed to db_queue; city-buy path also read by Game.js:3816.
@@ -1166,9 +1167,42 @@ function _completeMissionsIfReady(updatedGoals, activeMissions) {
         mission_goals: updatedGoals
       }
     },
+    rewards: _collectMissionRewards(ruleset, completed),
     mission_goals: updatedGoals,
     active_missions: newActive
   };
+}
+
+// Sums up cash / xp / karma rewards across the just-completed missions so
+// the caller can fold them into the new game_values. Without this, mission
+// completion notifications fire but the player never sees the payout.
+function _collectMissionRewards(ruleset, completedGestalts) {
+  var totals = { cash_value: 0, xp_value: 0, karma_value: 0, profiles_max: 0 };
+  if (!completedGestalts.length || !ruleset || !ruleset.missions) return totals;
+  completedGestalts.forEach(function (mGestalt) {
+    var def = _findMissionDef(ruleset, mGestalt);
+    var rewards = (def && def.type_data && def.type_data.rewards) || [];
+    rewards.forEach(function (r) {
+      if (!r || typeof r.amount !== 'number') return;
+      if (Object.prototype.hasOwnProperty.call(totals, r.target)) {
+        totals[r.target] += r.amount;
+      }
+    });
+  });
+  return totals;
+}
+
+// Folds reward totals into a fresh game_values object, clamping karma to
+// [-100, 100] to match the integrate/karmalizer math.
+function _applyRewardsToGv(gv, rewards) {
+  if (!rewards) return gv;
+  return Object.assign({}, gv, {
+    cash_value:   (gv.cash_value   || 0) + (rewards.cash_value   || 0),
+    xp_value:     (gv.xp_value     || 0) + (rewards.xp_value     || 0),
+    karma_value:  Math.max(-100, Math.min(100,
+                  (gv.karma_value  || 0) + (rewards.karma_value || 0))),
+    profiles_max: (gv.profiles_max || 0) + (rewards.profiles_max || 0)
+  });
 }
 
 /**
@@ -1196,33 +1230,7 @@ function _advanceBuyPerpMissions(state, gestalt) {
     return { missions: null, mission_goals: missionGoals, active_missions: activeMissions };
   }
 
-  var updatedMissionIds = [];
-  var completedMissionIds = [];
-  activeMissions.forEach(function (mGestalt) {
-    var goals = updatedGoals.filter(function (g) { return g.mission === mGestalt; });
-    if (!goals.length) { return; }
-    updatedMissionIds.push(mGestalt);
-    if (goals.every(function (g) { return g.complete; })) {
-      completedMissionIds.push(mGestalt);
-    }
-  });
-
-  var newActiveMissions = activeMissions.filter(function (m) {
-    return completedMissionIds.indexOf(m) === -1;
-  });
-
-  return {
-    missions: {
-      complete_missions: completedMissionIds,
-      updated_missions: updatedMissionIds,
-      mission_data: {
-        active_missions: newActiveMissions,
-        mission_goals: updatedGoals
-      }
-    },
-    mission_goals: updatedGoals,
-    active_missions: newActiveMissions
-  };
+  return _completeMissionsIfReady(updatedGoals, activeMissions);
 }
 
 // ---------------------------------------------------------------------------
@@ -1557,7 +1565,9 @@ export function collectPerp(_token, gperpPath) {
     ? _advanceCollectProfilesMissions(preMissionState, gestalt, cr.amount || 0)
     : { missions: null, mission_goals: preMissionState.mission_goals,
         active_missions: preMissionState.active_missions };
+  newGv = _applyRewardsToGv(newGv, collectMissionResult.rewards);
   var newState = Object.assign({}, preMissionState, {
+    game_values: newGv,
     mission_goals: collectMissionResult.mission_goals,
     active_missions: collectMissionResult.active_missions
   });
@@ -1716,7 +1726,9 @@ export function integrateCollected(_token, collectId) {
   var missionResult = _advanceIntegrateProfilesMissions(
     preMissionState, newGv.profiles_value || 0, newNodes
   );
+  newGv = _applyRewardsToGv(newGv, missionResult.rewards);
   var newState = Object.assign({}, preMissionState, {
+    game_values: newGv,
     mission_goals: missionResult.mission_goals,
     active_missions: missionResult.active_missions
   });

--- a/scripts/LocalEngine.js
+++ b/scripts/LocalEngine.js
@@ -940,7 +940,12 @@ export function buyPerp(_token, parentPath, gestalt) {
       newGv = Object.assign({}, newGv, {
         ap_inc_value: levelInfo.ap_inc_value,
         ap_inc_interval: levelInfo.ap_inc_interval,
-        ap_max: levelInfo.ap_max
+        ap_max: levelInfo.ap_max,
+        // Refill AP on levelup so the player gets a fresh batch of actions —
+        // matches buyKarma/chargePerp behaviour. Without this, ap_snapshot
+        // stayed at the previous level's value while ap_max grew, so the AP
+        // bar visibly under-filled after a buyPerp-triggered level.
+        ap_snapshot: levelInfo.ap_max
       });
     }
   }
@@ -1358,7 +1363,14 @@ export function collectPerp(_token, gperpPath) {
   var oldLevel = (ms.game_values && ms.game_values.xp_level) || 1;
   var newLevel = _getLevelByXP(newGv.xp_value);
   var levelup  = newLevel > oldLevel;
-  if (levelup) newGv = Object.assign({}, newGv, { xp_level: newLevel });
+  if (levelup) {
+    var collectLevels = _getRuleset().levels;
+    var collectLevelInfo = collectLevels[newLevel - 1] || collectLevels[collectLevels.length - 1];
+    newGv = Object.assign({}, newGv, {
+      xp_level: newLevel,
+      ap_snapshot: collectLevelInfo.ap_max
+    });
+  }
 
   var newState = Object.assign({}, ms, {
     nodes:         newNodes,
@@ -1498,7 +1510,14 @@ export function integrateCollected(_token, collectId) {
   var oldLevel = (state.game_values && state.game_values.xp_level) || 1;
   var newLevel = _getLevelByXP(newGv.xp_value);
   var levelup  = newLevel > oldLevel;
-  if (levelup) newGv = Object.assign({}, newGv, { xp_level: newLevel });
+  if (levelup) {
+    var integrateLevels = _getRuleset().levels;
+    var integrateLevelInfo = integrateLevels[newLevel - 1] || integrateLevels[integrateLevels.length - 1];
+    newGv = Object.assign({}, newGv, {
+      xp_level: newLevel,
+      ap_snapshot: integrateLevelInfo.ap_max
+    });
+  }
 
   var newState = Object.assign({}, state, {
     db_queue:       newQueue,

--- a/scripts/LocalEngine.js
+++ b/scripts/LocalEngine.js
@@ -1238,9 +1238,16 @@ function _advanceBuyPerpMissions(state, gestalt) {
 // ---------------------------------------------------------------------------
 
 export function chargePerp(token, path) { // eslint-disable-line no-unused-vars
-  var state   = getState();
-  var now     = clockNow();
-  var ruleset = _getRuleset();
+  var rawState = getState();
+  var now      = clockNow();
+  var ruleset  = _getRuleset();
+
+  // Materialize before reading game_values so AP regen ticks accumulated
+  // since the last handler call are visible. Without this, the UI's
+  // APTicker can show 1 AP while state.ap_snapshot still says 0, and
+  // chargePerp would refuse the action despite the visible bar.
+  var mat   = materialize(rawState, now);
+  var state = mat.state;
 
   var nodes   = state.nodes || [];
   var nodeIdx = -1;
@@ -1621,8 +1628,11 @@ export function collectPerp(_token, gperpPath) {
  *   0 — collect_id not in db_queue (already integrated or never collected)
  */
 export function integrateCollected(_token, collectId) {
-  var state = getState();
+  var rawState = getState();
   var now = clockNow();
+  // Materialize so the AP regen ticks accumulated since the last call are
+  // visible — same contract as collectPerp / chargePerp.
+  var state = materialize(rawState, now).state;
 
   // $pull db_queue entry.
   var entry = null;

--- a/scripts/LocalEngine.js
+++ b/scripts/LocalEngine.js
@@ -1250,7 +1250,20 @@ export function collectPerp(_token, gperpPath) {
 
   if (gameType === 'ContactPerp' || gameType === 'ProjectPerp') {
     var collectId = _generateId();
-    var profileSet = { profiles_value: cr.amount || 0, tokens_map: {} };
+    // Profile-set token contributions come from the perp's contained_tokens —
+    // each entry's `amount` is the percentage of profiles that carry that
+    // token type. Without this, tokens_map stays empty, integrateCollected
+    // never creates TokenPerp nodes, DBTokensAbsolute never populates, and
+    // missions whose workflow is "integrate_profiles" never advance past 0.
+    var tokensMap = {};
+    var contained = (typeData && typeData.contained_tokens) || [];
+    for (var ct = 0; ct < contained.length; ct++) {
+      var ctEntry = contained[ct];
+      if (ctEntry && ctEntry.gestalt) {
+        tokensMap[ctEntry.gestalt] = { amount: ctEntry.amount || 0 };
+      }
+    }
+    var profileSet = { profiles_value: cr.amount || 0, tokens_map: tokensMap };
     dbEntry = {
       origin:      gperpPath,
       collect_id:  collectId,
@@ -1379,11 +1392,14 @@ export function integrateCollected(_token, collectId) {
     profiles_value: (state.game_values.profiles_value || 0) + increment
   });
 
+  var ruleset = _getRuleset();
   var tokensMap = ps.tokens_map || {};
   var updatedNodes = [];
+  var seenGestalts = {};
   var newNodes = (state.nodes || []).map(function (n) {
     var tok = tokensMap[n.gestalt];
     if (!tok) return n;
+    seenGestalts[n.gestalt] = true;
     var newAmount = ((n.instance_data && n.instance_data.amount) || 0) + (tok.amount || 0);
     var updated = Object.assign({}, n, {
       instance_data: Object.assign({}, n.instance_data, { amount: newAmount })
@@ -1391,10 +1407,38 @@ export function integrateCollected(_token, collectId) {
     updatedNodes.push({
       game_id:       updated.game_id,
       gestalt:       updated.gestalt,
+      game_type:     updated.game_type,
+      full_type:     updated.full_type,
       full_path:     updated.full_path,
       instance_data: updated.instance_data
     });
     return updated;
+  });
+
+  // First-time integration of a token type: append a new TokenPerp node
+  // under Database.<gestalt>. Without this, DBTokens stays empty, the
+  // Database tab stays blank, and integrate_profiles missions never tick.
+  Object.keys(tokensMap).forEach(function (gestalt) {
+    if (seenGestalts[gestalt]) return;
+    if (!ruleset.tokens || !ruleset.tokens[gestalt]) return;
+    var tok = tokensMap[gestalt];
+    var newNode = {
+      game_id:    gestalt,
+      gestalt:    gestalt,
+      game_type:  'TokenPerp',
+      full_type:  'TokenPerp:' + gestalt,
+      full_path:  'Database.' + gestalt,
+      instance_data: { amount: tok.amount || 0 }
+    };
+    newNodes = newNodes.concat([newNode]);
+    updatedNodes.push({
+      game_id:       newNode.game_id,
+      gestalt:       newNode.gestalt,
+      game_type:     newNode.game_type,
+      full_type:     newNode.full_type,
+      full_path:     newNode.full_path,
+      instance_data: newNode.instance_data
+    });
   });
 
   var oldLevel = (state.game_values && state.game_values.xp_level) || 1;

--- a/scripts/LocalEngine.js
+++ b/scripts/LocalEngine.js
@@ -212,6 +212,9 @@ export function loadGame(/* token */) {
   }
 
   var gameData = _buildLoadGameResponse(mat.state, now, isNewGame);
+  console.log('[LE] loadGame response: mission_briefings_seen=',
+    gameData.mission_briefings_seen,
+    'state.mission_briefings_seen=', mat.state.mission_briefings_seen);
 
   // Schedule socket event emission via queueMicrotask so it runs after the
   // microtask that resolves the Deferred in Remote.js (result.then → d.resolve
@@ -635,6 +638,9 @@ function _commitDelta(computedNewState, addr, op, args, result) {
   };
   // eslint-disable-next-line no-undef
   if (typeof webxdc !== 'undefined') {
+    if (op === 'dismissMissionBriefing' || op === 'markTokenSeen') {
+      console.log('[LE] _commitDelta → webxdc.sendUpdate', op, args);
+    }
     webxdc.sendUpdate({ payload: delta }, '');  // eslint-disable-line no-undef
   } else {
     setState(computedNewState);
@@ -1570,16 +1576,19 @@ export function markTokenSeen(_token, gestalt) {
 }
 
 export function dismissMissionBriefing(_token, gestalt) {
+  console.log('[LE] dismissMissionBriefing(', gestalt, ') type=', typeof gestalt);
   if (typeof gestalt !== 'string' || !gestalt) {
     return Promise.resolve({ result: { error: 0 } });
   }
   var state = getState();
   var seen = state.mission_briefings_seen || {};
   if (seen[gestalt]) {
+    console.log('[LE] already seen, skipping commit');
     return Promise.resolve({ result: { ok: true } });
   }
   var newSeen = Object.assign({}, seen, { [gestalt]: true });
   var newState = Object.assign({}, state, { mission_briefings_seen: newSeen });
+  console.log('[LE] committing delta; new seen=', newSeen);
   _commitDelta(newState, state.addr, 'dismissMissionBriefing', [gestalt], { gestalt: gestalt });
   return Promise.resolve({ result: { ok: true } });
 }

--- a/scripts/LocalEngine.js
+++ b/scripts/LocalEngine.js
@@ -1633,7 +1633,8 @@ export function integrateCollected(_token, collectId) {
     xp_value:       (state.game_values.xp_value    || 0) + xpGain,
     karma_value: Math.max(-100, Math.min(100,
       (state.game_values.karma_value || 0) + karmaGain)),
-    profiles_value: (state.game_values.profiles_value || 0) + increment
+    profiles_value: (state.game_values.profiles_value || 0) + increment,
+    ap_snapshot:    Math.max(0, (state.game_values.ap_snapshot || 0) - 1)
   });
 
   var ruleset = _getRuleset();

--- a/scripts/LocalEngine.js
+++ b/scripts/LocalEngine.js
@@ -1305,17 +1305,24 @@ export function collectPerp(_token, gperpPath) {
 
   if (gameType === 'ContactPerp' || gameType === 'ProjectPerp') {
     var collectId = _generateId();
-    // Profile-set token contributions come from the perp's contained_tokens —
-    // each entry's `amount` is the percentage of profiles that carry that
-    // token type. Without this, tokens_map stays empty, integrateCollected
-    // never creates TokenPerp nodes, DBTokensAbsolute never populates, and
-    // missions whose workflow is "integrate_profiles" never advance past 0.
+    // Profile-set token contributions come from the perp's `tokens` list in
+    // the ruleset — each entry's `amount` is the percentage of profiles that
+    // carry that token type. Without this, tokens_map stays empty,
+    // integrateCollected never creates TokenPerp nodes, DBTokensAbsolute
+    // never populates, and missions whose workflow is "integrate_profiles"
+    // (e.g. mission002 = 900 of token008) never advance past 0.
+    // (TokenPerps use `contained_tokens` for super-token decomposition; we
+    // accept either field so future ProjectPerps with that shape still work.)
     var tokensMap = {};
-    var contained = (typeData && typeData.contained_tokens) || [];
+    var profilesValue = cr.amount || 0;
+    var contained = (typeData && (typeData.tokens || typeData.contained_tokens)) || [];
     for (var ct = 0; ct < contained.length; ct++) {
       var ctEntry = contained[ct];
       if (ctEntry && ctEntry.gestalt) {
-        tokensMap[ctEntry.gestalt] = { amount: ctEntry.amount || 0 };
+        var pct = ctEntry.amount || 0;
+        tokensMap[ctEntry.gestalt] = {
+          amount: Math.floor((pct * profilesValue) / 100)
+        };
       }
     }
     var profileSet = { profiles_value: cr.amount || 0, tokens_map: tokensMap };

--- a/scripts/LocalEngine.js
+++ b/scripts/LocalEngine.js
@@ -207,12 +207,14 @@ export function loadGame(/* token */) {
   var seededState = _seedMissionGoals(mat.state);
   setState(seededState);
 
-  // Re-arm one-shot materializers for any charges still in flight — without
-  // this, charges that cross a page reload would never fire node_ready.
+  // Re-arm one-shot materializers for any charges still in flight. Clear
+  // any prior handles first so calling loadGame twice doesn't queue
+  // duplicate node_ready emissions for the same charge.
+  _clearAllChargeReady();
   var stillCharging = (seededState && seededState.nodes_charging) || [];
   for (var i = 0; i < stillCharging.length; i++) {
     if (typeof stillCharging[i].charge_end === 'number') {
-      _scheduleChargeReady(stillCharging[i].charge_end);
+      _scheduleChargeReady(stillCharging[i].charge_end, stillCharging[i].path);
     }
   }
 
@@ -1081,12 +1083,14 @@ function _advanceIntegrateProfilesMissions(state, profilesValue, nodes) {
     if (activeMissions.indexOf(goal.mission) === -1) return goal;
     var pct = amountByGestalt[goal.target] || 0;
     var absoluteAmount = Math.floor((profilesValue * pct) / 100);
-    var capped = Math.min(absoluteAmount, goal.amount);
-    if (capped === goal.current_amount) return goal;
+    // Monotonic — never let a later integrate roll back progress (e.g. if
+    // profiles_value drops or coverage decays, mission progress sticks).
+    var newAmount = Math.max(goal.current_amount || 0, Math.min(absoluteAmount, goal.amount));
+    if (newAmount === goal.current_amount) return goal;
     changed = true;
     return Object.assign({}, goal, {
-      current_amount: capped,
-      complete: capped >= goal.amount
+      current_amount: newAmount,
+      complete: newAmount >= goal.amount
     });
   });
 
@@ -1352,23 +1356,49 @@ export function chargePerp(token, path) { // eslint-disable-line no-unused-vars
   // without this the charge ripens silently — the perp's UI blinks at zero
   // but no node_ready fires until the player reloads (which runs materialize
   // on cold-start). Schedule a one-shot materialize at exactly charge_end.
-  _scheduleChargeReady(chargeEntry.charge_end);
+  _scheduleChargeReady(chargeEntry.charge_end, chargeEntry.path);
 
   return Promise.resolve({
     result: { game_values: newGv, duration: durationMs, levelup: levelup, missions: {} },
   });
 }
 
+// Active charge-ready timers, keyed by path. Tracking lets us clear stale
+// handles before re-scheduling — e.g. when loadGame replays history we
+// re-arm every in-flight charge, and without cleanup duplicate timers fire
+// duplicate node_ready events for the same charge.
+var _chargeReadyTimers = {};
+
+function _clearChargeReady(path) {
+  if (!path || !_chargeReadyTimers[path]) return;
+  clearTimeout(_chargeReadyTimers[path]);
+  delete _chargeReadyTimers[path];
+}
+
+function _clearAllChargeReady() {
+  Object.keys(_chargeReadyTimers).forEach(function (p) {
+    clearTimeout(_chargeReadyTimers[p]);
+  });
+  _chargeReadyTimers = {};
+}
+
 // One-shot per charge: at charge_end, run materialize() to transition the
 // charging entry into nodes_collect and emit node_ready. Tests stub
 // setTimeout via the override clock; we use the host setTimeout directly so
 // production play actually fires.
-function _scheduleChargeReady(chargeEnd) {
+function _scheduleChargeReady(chargeEnd, path) {
   if (typeof setTimeout !== 'function') return;
+  _clearChargeReady(path);
   var msUntil = Math.max(0, chargeEnd - clockNow());
-  setTimeout(function () {
+  var handle = setTimeout(function () {
+    if (path) delete _chargeReadyTimers[path];
     var s = getState();
     if (!s) return;
+    // Skip if the charge no longer exists (cancelled / already collected).
+    if (path) {
+      var stillCharging = (s.nodes_charging || []).some(function (c) { return c.path === path; });
+      if (!stillCharging) return;
+    }
     var mat = materialize(s, clockNow());
     setState(mat.state);
     var events = mat.events || [];
@@ -1376,6 +1406,7 @@ function _scheduleChargeReady(chargeEnd) {
       _emit(events[i].ev, events[i].pl);
     }
   }, msUntil);
+  if (path) _chargeReadyTimers[path] = handle;
 }
 
 // ---------------------------------------------------------------------------
@@ -1626,6 +1657,7 @@ export function collectPerp(_token, gperpPath) {
  *
  * Error codes:
  *   0 — collect_id not in db_queue (already integrated or never collected)
+ *   1 — insufficient AP (parity with chargePerp)
  */
 export function integrateCollected(_token, collectId) {
   var rawState = getState();
@@ -1633,6 +1665,10 @@ export function integrateCollected(_token, collectId) {
   // Materialize so the AP regen ticks accumulated since the last call are
   // visible — same contract as collectPerp / chargePerp.
   var state = materialize(rawState, now).state;
+
+  if ((state.game_values && state.game_values.ap_snapshot || 0) < 1) {
+    return Promise.resolve({ result: { error: 1 } });
+  }
 
   // $pull db_queue entry.
   var entry = null;

--- a/scripts/LocalEngine.js
+++ b/scripts/LocalEngine.js
@@ -1305,27 +1305,21 @@ export function collectPerp(_token, gperpPath) {
 
   if (gameType === 'ContactPerp' || gameType === 'ProjectPerp') {
     var collectId = _generateId();
-    // Profile-set token contributions come from the perp's `tokens` list in
-    // the ruleset — each entry's `amount` is the percentage of profiles that
-    // carry that token type. Without this, tokens_map stays empty,
-    // integrateCollected never creates TokenPerp nodes, DBTokensAbsolute
-    // never populates, and missions whose workflow is "integrate_profiles"
-    // (e.g. mission002 = 900 of token008) never advance past 0.
-    // (TokenPerps use `contained_tokens` for super-token decomposition; we
-    // accept either field so future ProjectPerps with that shape still work.)
+    // Each `tokens` entry's `amount` is a percentage of profiles_value that
+    // carry that token type. ContactPerps use `tokens`, TokenPerps use
+    // `contained_tokens` (super-token decomposition); accept either.
     var tokensMap = {};
     var profilesValue = cr.amount || 0;
     var contained = (typeData && (typeData.tokens || typeData.contained_tokens)) || [];
     for (var ct = 0; ct < contained.length; ct++) {
       var ctEntry = contained[ct];
       if (ctEntry && ctEntry.gestalt) {
-        var pct = ctEntry.amount || 0;
         tokensMap[ctEntry.gestalt] = {
-          amount: Math.floor((pct * profilesValue) / 100)
+          amount: Math.floor(((ctEntry.amount || 0) * profilesValue) / 100)
         };
       }
     }
-    var profileSet = { profiles_value: cr.amount || 0, tokens_map: tokensMap };
+    var profileSet = { profiles_value: profilesValue, tokens_map: tokensMap };
     dbEntry = {
       origin:      gperpPath,
       collect_id:  collectId,

--- a/scripts/LocalEngine.js
+++ b/scripts/LocalEngine.js
@@ -200,21 +200,23 @@ export function loadGame(/* token */) {
   var isNewGame = !state.node_counter;
 
   var mat = materialize(state, now);
-  setState(mat.state);
+  // Lazy-seed mission_goals from ruleset for any active mission that hasn't
+  // had its goals populated yet (e.g. fresh game, or a mission activated by
+  // legacy code that didn't seed goals). This is the prerequisite for
+  // mission progression: empty goals → progression handlers no-op.
+  var seededState = _seedMissionGoals(mat.state);
+  setState(seededState);
 
   // Re-arm one-shot materializers for any charges still in flight — without
   // this, charges that cross a page reload would never fire node_ready.
-  var stillCharging = (mat.state && mat.state.nodes_charging) || [];
+  var stillCharging = (seededState && seededState.nodes_charging) || [];
   for (var i = 0; i < stillCharging.length; i++) {
     if (typeof stillCharging[i].charge_end === 'number') {
       _scheduleChargeReady(stillCharging[i].charge_end);
     }
   }
 
-  var gameData = _buildLoadGameResponse(mat.state, now, isNewGame);
-  console.log('[LE] loadGame response: mission_briefings_seen=',
-    gameData.mission_briefings_seen,
-    'state.mission_briefings_seen=', mat.state.mission_briefings_seen);
+  var gameData = _buildLoadGameResponse(seededState, now, isNewGame);
 
   // Schedule socket event emission via queueMicrotask so it runs after the
   // microtask that resolves the Deferred in Remote.js (result.then → d.resolve
@@ -289,8 +291,12 @@ function _buildLoadGameResponse(state, now, isNewGame) {
     missions: ruleset.missions,
     mission_goals: state.mission_goals || [],
     active_missions: state.active_missions || [],
-    mission_briefings_seen: state.mission_briefings_seen || {},
-    tokens_seen: state.tokens_seen || {}
+    // Clone the seen-maps so Game.js mutating raw_data.* doesn't poison
+    // state.* via shared object reference (which would make
+    // dismissMissionBriefing / markTokenSeen think the gestalt is already
+    // seen and skip the delta commit, so the dismissal never persists).
+    mission_briefings_seen: Object.assign({}, state.mission_briefings_seen || {}),
+    tokens_seen: Object.assign({}, state.tokens_seen || {})
   };
 }
 
@@ -638,9 +644,6 @@ function _commitDelta(computedNewState, addr, op, args, result) {
   };
   // eslint-disable-next-line no-undef
   if (typeof webxdc !== 'undefined') {
-    if (op === 'dismissMissionBriefing' || op === 'markTokenSeen') {
-      console.log('[LE] _commitDelta → webxdc.sendUpdate', op, args);
-    }
     webxdc.sendUpdate({ payload: delta }, '');  // eslint-disable-line no-undef
   } else {
     setState(computedNewState);
@@ -1001,6 +1004,183 @@ export function buyPerp(_token, parentPath, gestalt) {
   }
 
   return Promise.resolve({ result: payload });
+}
+
+// Build mission_goals rows for any active mission that has none yet, by
+// pulling its ruleset goals (workflow / target / amount / position). Idempotent
+// — won't duplicate goals that already exist for a given mission. Without this
+// the mission_goals array stays empty, so progression handlers find nothing to
+// advance and integrate_profiles missions never tick.
+function _findMissionDef(ruleset, gestalt) {
+  if (!ruleset || !ruleset.missions || !gestalt) return null;
+  for (var i = 0; i < ruleset.missions.length; i++) {
+    var def = ruleset.missions[i];
+    if (def && def.type_data && def.type_data.gestalt === gestalt) return def;
+  }
+  return null;
+}
+
+function _seedMissionGoals(state) {
+  var activeMissions = state.active_missions || [];
+  if (!activeMissions.length) return state;
+  var ruleset = _getRuleset();
+  if (!ruleset || !ruleset.missions) return state;
+
+  var existingGoals = state.mission_goals || [];
+  var existingByMission = {};
+  existingGoals.forEach(function (g) {
+    existingByMission[g.mission] = true;
+  });
+
+  var newGoals = existingGoals.slice();
+  var added = false;
+  activeMissions.forEach(function (mGestalt) {
+    if (existingByMission[mGestalt]) return;
+    var mDef = _findMissionDef(ruleset, mGestalt);
+    if (!mDef || !mDef.type_data || !mDef.type_data.goals) return;
+    mDef.type_data.goals.forEach(function (g) {
+      newGoals.push({
+        mission: mGestalt,
+        workflow: g.workflow,
+        target: g.target,
+        amount: g.amount,
+        position: g.position,
+        current_amount: 0,
+        complete: false
+      });
+      added = true;
+    });
+  });
+
+  if (!added) return state;
+  return Object.assign({}, state, { mission_goals: newGoals });
+}
+
+// Advance integrate_profiles goals after an integrate. current_amount =
+// profiles_value * (instance_data.amount of TokenPerp[gestalt]) / 100,
+// matching the UI's groot.DBTokensAbsolute math (Game.js:5439).
+function _advanceIntegrateProfilesMissions(state, profilesValue, nodes) {
+  var goals = state.mission_goals || [];
+  var activeMissions = state.active_missions || [];
+  if (!goals.length || !activeMissions.length) {
+    return { missions: null, mission_goals: goals, active_missions: activeMissions };
+  }
+
+  var amountByGestalt = {};
+  (nodes || []).forEach(function (n) {
+    if (n.game_type === 'TokenPerp' && n.gestalt && n.instance_data) {
+      amountByGestalt[n.gestalt] = n.instance_data.amount || 0;
+    }
+  });
+
+  var changed = false;
+  var updatedGoals = goals.map(function (goal) {
+    if (goal.workflow !== 'integrate_profiles' || goal.complete) return goal;
+    if (activeMissions.indexOf(goal.mission) === -1) return goal;
+    var pct = amountByGestalt[goal.target] || 0;
+    var absoluteAmount = Math.floor((profilesValue * pct) / 100);
+    var capped = Math.min(absoluteAmount, goal.amount);
+    if (capped === goal.current_amount) return goal;
+    changed = true;
+    return Object.assign({}, goal, {
+      current_amount: capped,
+      complete: capped >= goal.amount
+    });
+  });
+
+  if (!changed) {
+    return { missions: null, mission_goals: goals, active_missions: activeMissions };
+  }
+
+  return _completeMissionsIfReady(updatedGoals, activeMissions);
+}
+
+// Advance collect_profiles goals after a collect. current_amount accumulates
+// profiles collected from a specific contact gestalt.
+function _advanceCollectProfilesMissions(state, contactGestalt, profilesCollected) {
+  var goals = state.mission_goals || [];
+  var activeMissions = state.active_missions || [];
+  if (!goals.length || !activeMissions.length || !profilesCollected) {
+    return { missions: null, mission_goals: goals, active_missions: activeMissions };
+  }
+
+  var changed = false;
+  var updatedGoals = goals.map(function (goal) {
+    if (goal.workflow !== 'collect_profiles' || goal.complete) return goal;
+    if (goal.target !== contactGestalt) return goal;
+    if (activeMissions.indexOf(goal.mission) === -1) return goal;
+    var newAmount = Math.min((goal.current_amount || 0) + profilesCollected, goal.amount);
+    if (newAmount === goal.current_amount) return goal;
+    changed = true;
+    return Object.assign({}, goal, {
+      current_amount: newAmount,
+      complete: newAmount >= goal.amount
+    });
+  });
+
+  if (!changed) {
+    return { missions: null, mission_goals: goals, active_missions: activeMissions };
+  }
+
+  return _completeMissionsIfReady(updatedGoals, activeMissions);
+}
+
+// Shared completion bookkeeping: any active mission whose goals are all
+// complete moves out of active_missions, and the next mission whose
+// required_mission matches it activates (with its goals seeded from ruleset).
+function _completeMissionsIfReady(updatedGoals, activeMissions) {
+  var ruleset = _getRuleset();
+  var completed = [];
+  var stillActive = activeMissions.filter(function (mGestalt) {
+    var goals = updatedGoals.filter(function (g) { return g.mission === mGestalt; });
+    if (!goals.length) return true;
+    if (goals.every(function (g) { return g.complete; })) {
+      completed.push(mGestalt);
+      return false;
+    }
+    return true;
+  });
+
+  var newActive = stillActive.slice();
+  if (ruleset && ruleset.missions && completed.length) {
+    ruleset.missions.forEach(function (def) {
+      if (!def || !def.type_data) return;
+      var req = def.type_data.required_mission;
+      var gestalt = def.type_data.gestalt;
+      if (!req || !gestalt || newActive.indexOf(gestalt) !== -1) return;
+      if (completed.indexOf(req) === -1) return;
+      newActive.push(gestalt);
+      (def.type_data.goals || []).forEach(function (g) {
+        updatedGoals = updatedGoals.concat([{
+          mission: gestalt,
+          workflow: g.workflow,
+          target: g.target,
+          amount: g.amount,
+          position: g.position,
+          current_amount: 0,
+          complete: false
+        }]);
+      });
+    });
+  }
+
+  var updatedMissions = activeMissions.filter(function (m) {
+    var goals = updatedGoals.filter(function (g) { return g.mission === m; });
+    return goals.some(function (g) { return g.current_amount > 0 || g.complete; });
+  });
+
+  return {
+    missions: {
+      complete_missions: completed,
+      updated_missions: updatedMissions,
+      mission_data: {
+        active_missions: newActive,
+        mission_goals: updatedGoals
+      }
+    },
+    mission_goals: updatedGoals,
+    active_missions: newActive
+  };
 }
 
 /**
@@ -1378,7 +1558,7 @@ export function collectPerp(_token, gperpPath) {
     });
   }
 
-  var newState = Object.assign({}, ms, {
+  var preMissionState = Object.assign({}, ms, {
     nodes:         newNodes,
     nodes_collect: newCollect,
     db_queue:      newQueue,
@@ -1386,14 +1566,26 @@ export function collectPerp(_token, gperpPath) {
     last_seen_ts:  Math.max(now, ms.last_seen_ts || 0)
   });
 
-  var deltaResult = { game_values: newGv, path: gperpPath };
+  // Advance collect_profiles goals against the contact gestalt this collect
+  // was sourced from. Only ContactPerp collects feed mission progress.
+  var collectMissionResult = _advanceCollectProfilesMissions(
+    preMissionState,
+    (gameType === 'ContactPerp') ? gestalt : null,
+    (gameType === 'ContactPerp') ? (cr.amount || 0) : 0
+  );
+  var newState = Object.assign({}, preMissionState, {
+    mission_goals: collectMissionResult.mission_goals,
+    active_missions: collectMissionResult.active_missions
+  });
+
+  var deltaResult = { game_values: newGv, path: gperpPath, missions: collectMissionResult.missions };
   if (dbEntry)     deltaResult.db_entry     = dbEntry;
   if (tokenUpdate) deltaResult.token_update = tokenUpdate;
   _commitDelta(newState, state.addr, 'collectPerp', [gperpPath], deltaResult);
 
   var response = Object.assign(
     { result: innerResult, game_values: newGv, levelup: levelup,
-      missions: { complete_missions: [], updated_missions: [] } },
+      missions: collectMissionResult.missions || { complete_missions: [], updated_missions: [] } },
     incident ? { karma_incident: incident.gestalt } : {}
   );
 
@@ -1527,7 +1719,7 @@ export function integrateCollected(_token, collectId) {
     });
   }
 
-  var newState = Object.assign({}, state, {
+  var preMissionState = Object.assign({}, state, {
     db_queue:       newQueue,
     nodes:          newNodes,
     game_values:    newGv,
@@ -1535,15 +1727,25 @@ export function integrateCollected(_token, collectId) {
     last_seen_ts:   Math.max(now, state.last_seen_ts || 0)
   });
 
+  // Advance integrate_profiles goals against the new TokenPerp amounts.
+  var missionResult = _advanceIntegrateProfilesMissions(
+    preMissionState, newGv.profiles_value || 0, newNodes
+  );
+  var newState = Object.assign({}, preMissionState, {
+    mission_goals: missionResult.mission_goals,
+    active_missions: missionResult.active_missions
+  });
+
   // Persist delta for webxdc replay; result carries full state for the reducer.
   _commitDelta(newState, state.addr, 'integrateCollected', [collectId],
-    { increment: increment, dup: dup, game_values: newGv, nodes: updatedNodes });
+    { increment: increment, dup: dup, game_values: newGv, nodes: updatedNodes,
+      missions: missionResult.missions });
 
   var response = {
     result: { nodes: updatedNodes, increment: increment, dup: dup },
     game_values: newGv,
     levelup: levelup,
-    missions: { complete_missions: [], updated_missions: [] }
+    missions: missionResult.missions || { complete_missions: [], updated_missions: [] }
   };
 
   if (levelup) {
@@ -1576,19 +1778,16 @@ export function markTokenSeen(_token, gestalt) {
 }
 
 export function dismissMissionBriefing(_token, gestalt) {
-  console.log('[LE] dismissMissionBriefing(', gestalt, ') type=', typeof gestalt);
   if (typeof gestalt !== 'string' || !gestalt) {
     return Promise.resolve({ result: { error: 0 } });
   }
   var state = getState();
   var seen = state.mission_briefings_seen || {};
   if (seen[gestalt]) {
-    console.log('[LE] already seen, skipping commit');
     return Promise.resolve({ result: { ok: true } });
   }
   var newSeen = Object.assign({}, seen, { [gestalt]: true });
   var newState = Object.assign({}, state, { mission_briefings_seen: newSeen });
-  console.log('[LE] committing delta; new seen=', newSeen);
   _commitDelta(newState, state.addr, 'dismissMissionBriefing', [gestalt], { gestalt: gestalt });
   return Promise.resolve({ result: { ok: true } });
 }

--- a/scripts/LocalEngine.js
+++ b/scripts/LocalEngine.js
@@ -1006,11 +1006,6 @@ export function buyPerp(_token, parentPath, gestalt) {
   return Promise.resolve({ result: payload });
 }
 
-// Build mission_goals rows for any active mission that has none yet, by
-// pulling its ruleset goals (workflow / target / amount / position). Idempotent
-// — won't duplicate goals that already exist for a given mission. Without this
-// the mission_goals array stays empty, so progression handlers find nothing to
-// advance and integrate_profiles missions never tick.
 function _findMissionDef(ruleset, gestalt) {
   if (!ruleset || !ruleset.missions || !gestalt) return null;
   for (var i = 0; i < ruleset.missions.length; i++) {
@@ -1020,6 +1015,21 @@ function _findMissionDef(ruleset, gestalt) {
   return null;
 }
 
+// Canonical mission-goal row shape. One source so adding a field touches one place.
+function _seedGoalRow(missionGestalt, g) {
+  return {
+    mission: missionGestalt,
+    workflow: g.workflow,
+    target: g.target,
+    amount: g.amount,
+    position: g.position,
+    current_amount: 0,
+    complete: false
+  };
+}
+
+// Without this, fresh games (or saves activated by legacy code) have empty
+// mission_goals and progression handlers find nothing to advance.
 function _seedMissionGoals(state) {
   var activeMissions = state.active_missions || [];
   if (!activeMissions.length) return state;
@@ -1039,15 +1049,7 @@ function _seedMissionGoals(state) {
     var mDef = _findMissionDef(ruleset, mGestalt);
     if (!mDef || !mDef.type_data || !mDef.type_data.goals) return;
     mDef.type_data.goals.forEach(function (g) {
-      newGoals.push({
-        mission: mGestalt,
-        workflow: g.workflow,
-        target: g.target,
-        amount: g.amount,
-        position: g.position,
-        current_amount: 0,
-        complete: false
-      });
+      newGoals.push(_seedGoalRow(mGestalt, g));
       added = true;
     });
   });
@@ -1056,9 +1058,8 @@ function _seedMissionGoals(state) {
   return Object.assign({}, state, { mission_goals: newGoals });
 }
 
-// Advance integrate_profiles goals after an integrate. current_amount =
-// profiles_value * (instance_data.amount of TokenPerp[gestalt]) / 100,
-// matching the UI's groot.DBTokensAbsolute math (Game.js:5439).
+// current_amount math mirrors TokenPerp.setAmount → DBTokensAbsolute
+// (Game.js:5439) so the LocalEngine and UI agree on completion.
 function _advanceIntegrateProfilesMissions(state, profilesValue, nodes) {
   var goals = state.mission_goals || [];
   var activeMissions = state.active_missions || [];
@@ -1095,12 +1096,10 @@ function _advanceIntegrateProfilesMissions(state, profilesValue, nodes) {
   return _completeMissionsIfReady(updatedGoals, activeMissions);
 }
 
-// Advance collect_profiles goals after a collect. current_amount accumulates
-// profiles collected from a specific contact gestalt.
 function _advanceCollectProfilesMissions(state, contactGestalt, profilesCollected) {
   var goals = state.mission_goals || [];
   var activeMissions = state.active_missions || [];
-  if (!goals.length || !activeMissions.length || !profilesCollected) {
+  if (!goals.length || !activeMissions.length || !profilesCollected || !contactGestalt) {
     return { missions: null, mission_goals: goals, active_missions: activeMissions };
   }
 
@@ -1125,9 +1124,6 @@ function _advanceCollectProfilesMissions(state, contactGestalt, profilesCollecte
   return _completeMissionsIfReady(updatedGoals, activeMissions);
 }
 
-// Shared completion bookkeeping: any active mission whose goals are all
-// complete moves out of active_missions, and the next mission whose
-// required_mission matches it activates (with its goals seeded from ruleset).
 function _completeMissionsIfReady(updatedGoals, activeMissions) {
   var ruleset = _getRuleset();
   var completed = [];
@@ -1151,15 +1147,7 @@ function _completeMissionsIfReady(updatedGoals, activeMissions) {
       if (completed.indexOf(req) === -1) return;
       newActive.push(gestalt);
       (def.type_data.goals || []).forEach(function (g) {
-        updatedGoals = updatedGoals.concat([{
-          mission: gestalt,
-          workflow: g.workflow,
-          target: g.target,
-          amount: g.amount,
-          position: g.position,
-          current_amount: 0,
-          complete: false
-        }]);
+        updatedGoals = updatedGoals.concat([_seedGoalRow(gestalt, g)]);
       });
     });
   }
@@ -1491,11 +1479,8 @@ export function collectPerp(_token, gperpPath) {
 
   if (gameType === 'ContactPerp' || gameType === 'ProjectPerp') {
     var collectId = _generateId();
-    // Each `tokens` entry's `amount` is a percentage of profiles carrying
-    // that token type. We pass it through unchanged — TokenPerp.setAmount
-    // computes absoluteAmount = profiles_value * amount / 100 downstream.
-    // ContactPerps use `tokens`; TokenPerps use `contained_tokens` for
-    // super-token decomposition; accept either.
+    // ContactPerps store yielded token-types under `tokens`; TokenPerps
+    // (super-token decomposition) under `contained_tokens` — accept either.
     var tokensMap = {};
     var contained = (typeData && (typeData.tokens || typeData.contained_tokens)) || [];
     for (var ct = 0; ct < contained.length; ct++) {
@@ -1566,13 +1551,12 @@ export function collectPerp(_token, gperpPath) {
     last_seen_ts:  Math.max(now, ms.last_seen_ts || 0)
   });
 
-  // Advance collect_profiles goals against the contact gestalt this collect
-  // was sourced from. Only ContactPerp collects feed mission progress.
-  var collectMissionResult = _advanceCollectProfilesMissions(
-    preMissionState,
-    (gameType === 'ContactPerp') ? gestalt : null,
-    (gameType === 'ContactPerp') ? (cr.amount || 0) : 0
-  );
+  // Only ContactPerp collects feed collect_profiles goals; ProjectPerp /
+  // ClientPerp / TokenPerp paths skip mission progression.
+  var collectMissionResult = (gameType === 'ContactPerp')
+    ? _advanceCollectProfilesMissions(preMissionState, gestalt, cr.amount || 0)
+    : { missions: null, mission_goals: preMissionState.mission_goals,
+        active_missions: preMissionState.active_missions };
   var newState = Object.assign({}, preMissionState, {
     mission_goals: collectMissionResult.mission_goals,
     active_missions: collectMissionResult.active_missions

--- a/scripts/LocalEngine.js
+++ b/scripts/LocalEngine.js
@@ -1272,9 +1272,14 @@ export function chargePerp(token, path) { // eslint-disable-line no-unused-vars
   if ((gv.ap_snapshot || 0) < 1)           return Promise.resolve({ result: { error: 1 } });
   if ((gv.cash_value  || 0) < chargeCost)  return Promise.resolve({ result: { error: 1 } });
 
+  // ClientPerps don't carry collect_amount in the ruleset — they ship
+  // income_base / income_factor instead. Fall back so charging the car
+  // company actually pays out when collected. (Income_factor / consumed-
+  // tokens scaling is a separate enhancement; this gives the base payout.)
   var baseAmount = typeof instanceData.collect_amount === 'number'
     ? instanceData.collect_amount
-    : (typeof typeData.collect_amount === 'number' ? typeData.collect_amount : 0);
+    : (typeof typeData.collect_amount === 'number' ? typeData.collect_amount
+      : (typeof typeData.income_base   === 'number' ? typeData.income_base   : 0));
   var chargeResult = { amount: _getVariatedAmount(baseAmount, now, path) };
 
   var durationMs  = typeData.charge_time;

--- a/scripts/LocalEngine.js
+++ b/scripts/LocalEngine.js
@@ -202,6 +202,15 @@ export function loadGame(/* token */) {
   var mat = materialize(state, now);
   setState(mat.state);
 
+  // Re-arm one-shot materializers for any charges still in flight — without
+  // this, charges that cross a page reload would never fire node_ready.
+  var stillCharging = (mat.state && mat.state.nodes_charging) || [];
+  for (var i = 0; i < stillCharging.length; i++) {
+    if (typeof stillCharging[i].charge_end === 'number') {
+      _scheduleChargeReady(stillCharging[i].charge_end);
+    }
+  }
+
   var gameData = _buildLoadGameResponse(mat.state, now, isNewGame);
 
   // Schedule socket event emission via queueMicrotask so it runs after the
@@ -1124,9 +1133,34 @@ export function chargePerp(token, path) { // eslint-disable-line no-unused-vars
     ts:     now,
   });
 
+  // Live-tick: nothing in the page periodically calls materialize(), so
+  // without this the charge ripens silently — the perp's UI blinks at zero
+  // but no node_ready fires until the player reloads (which runs materialize
+  // on cold-start). Schedule a one-shot materialize at exactly charge_end.
+  _scheduleChargeReady(chargeEntry.charge_end);
+
   return Promise.resolve({
     result: { game_values: newGv, duration: durationMs, levelup: false, missions: {} },
   });
+}
+
+// One-shot per charge: at charge_end, run materialize() to transition the
+// charging entry into nodes_collect and emit node_ready. Tests stub
+// setTimeout via the override clock; we use the host setTimeout directly so
+// production play actually fires.
+function _scheduleChargeReady(chargeEnd) {
+  if (typeof setTimeout !== 'function') return;
+  var msUntil = Math.max(0, chargeEnd - clockNow());
+  setTimeout(function () {
+    var s = getState();
+    if (!s) return;
+    var mat = materialize(s, clockNow());
+    setState(mat.state);
+    var events = mat.events || [];
+    for (var i = 0; i < events.length; i++) {
+      _emit(events[i].ev, events[i].pl);
+    }
+  }, msUntil);
 }
 
 // ---------------------------------------------------------------------------
@@ -1422,13 +1456,19 @@ export function integrateCollected(_token, collectId) {
     if (seenGestalts[gestalt]) return;
     if (!ruleset.tokens || !ruleset.tokens[gestalt]) return;
     var tok = tokensMap[gestalt];
+    // Deterministic spread around the Database centre so multiple new
+    // tokens on the same integrate don't all stack on top of each other
+    // at (0,0). Hash is gestalt-keyed so replay produces identical layout.
+    var hash = _djb2(gestalt);
+    var dx = (hash         % 1200) - 600;
+    var dy = ((hash >>> 8) %  800) - 400;
     var newNode = {
       game_id:    gestalt,
       gestalt:    gestalt,
       game_type:  'TokenPerp',
       full_type:  'TokenPerp:' + gestalt,
       full_path:  'Database.' + gestalt,
-      instance_data: { amount: tok.amount || 0 }
+      instance_data: { amount: tok.amount || 0, x: 1024 + dx, y: 800 + dy }
     };
     newNodes = newNodes.concat([newNode]);
     updatedNodes.push({

--- a/scripts/LocalEngine.js
+++ b/scripts/LocalEngine.js
@@ -1305,21 +1305,20 @@ export function collectPerp(_token, gperpPath) {
 
   if (gameType === 'ContactPerp' || gameType === 'ProjectPerp') {
     var collectId = _generateId();
-    // Each `tokens` entry's `amount` is a percentage of profiles_value that
-    // carry that token type. ContactPerps use `tokens`, TokenPerps use
-    // `contained_tokens` (super-token decomposition); accept either.
+    // Each `tokens` entry's `amount` is a percentage of profiles carrying
+    // that token type. We pass it through unchanged — TokenPerp.setAmount
+    // computes absoluteAmount = profiles_value * amount / 100 downstream.
+    // ContactPerps use `tokens`; TokenPerps use `contained_tokens` for
+    // super-token decomposition; accept either.
     var tokensMap = {};
-    var profilesValue = cr.amount || 0;
     var contained = (typeData && (typeData.tokens || typeData.contained_tokens)) || [];
     for (var ct = 0; ct < contained.length; ct++) {
       var ctEntry = contained[ct];
       if (ctEntry && ctEntry.gestalt) {
-        tokensMap[ctEntry.gestalt] = {
-          amount: Math.floor(((ctEntry.amount || 0) * profilesValue) / 100)
-        };
+        tokensMap[ctEntry.gestalt] = { amount: ctEntry.amount || 0 };
       }
     }
-    var profileSet = { profiles_value: profilesValue, tokens_map: tokensMap };
+    var profileSet = { profiles_value: cr.amount || 0, tokens_map: tokensMap };
     dbEntry = {
       origin:      gperpPath,
       collect_id:  collectId,
@@ -1463,7 +1462,9 @@ export function integrateCollected(_token, collectId) {
     var tok = tokensMap[n.gestalt];
     if (!tok) return n;
     seenGestalts[n.gestalt] = true;
-    var newAmount = ((n.instance_data && n.instance_data.amount) || 0) + (tok.amount || 0);
+    // amount is a percentage [0,100]; cap so the bar (width = amount/100*60px)
+    // doesn't overflow and so absoluteAmount = profiles*amount/100 stays sane.
+    var newAmount = Math.min(100, ((n.instance_data && n.instance_data.amount) || 0) + (tok.amount || 0));
     var updated = Object.assign({}, n, {
       instance_data: Object.assign({}, n.instance_data, { amount: newAmount })
     });
@@ -1495,7 +1496,7 @@ export function integrateCollected(_token, collectId) {
       game_type:  'TokenPerp',
       full_type:  'TokenPerp:' + gestalt,
       full_path:  'Database.' + gestalt,
-      instance_data: { amount: tok.amount || 0 }
+      instance_data: { amount: Math.min(100, tok.amount || 0) }
     };
     newNodes = newNodes.concat([newNode]);
     updatedNodes.push({

--- a/scripts/LocalEngine.js
+++ b/scripts/LocalEngine.js
@@ -276,7 +276,9 @@ function _buildLoadGameResponse(state, now, isNewGame) {
     locale_persisted: !!state.locale,
     missions: ruleset.missions,
     mission_goals: state.mission_goals || [],
-    active_missions: state.active_missions || []
+    active_missions: state.active_missions || [],
+    mission_briefings_seen: state.mission_briefings_seen || {},
+    tokens_seen: state.tokens_seen || {}
   };
 }
 
@@ -1429,6 +1431,41 @@ export function integrateCollected(_token, collectId) {
 }
 
 // ---------------------------------------------------------------------------
+// dismissMissionBriefing(token, gestalt) — record that the player has closed
+// the briefing popup for a given mission so we don't re-open it on reload.
+// ---------------------------------------------------------------------------
+
+export function markTokenSeen(_token, gestalt) {
+  if (typeof gestalt !== 'string' || !gestalt) {
+    return Promise.resolve({ result: { error: 0 } });
+  }
+  var state = getState();
+  var seen = state.tokens_seen || {};
+  if (seen[gestalt]) {
+    return Promise.resolve({ result: { ok: true } });
+  }
+  var newSeen = Object.assign({}, seen, { [gestalt]: true });
+  var newState = Object.assign({}, state, { tokens_seen: newSeen });
+  _commitDelta(newState, state.addr, 'markTokenSeen', [gestalt], { gestalt: gestalt });
+  return Promise.resolve({ result: { ok: true } });
+}
+
+export function dismissMissionBriefing(_token, gestalt) {
+  if (typeof gestalt !== 'string' || !gestalt) {
+    return Promise.resolve({ result: { error: 0 } });
+  }
+  var state = getState();
+  var seen = state.mission_briefings_seen || {};
+  if (seen[gestalt]) {
+    return Promise.resolve({ result: { ok: true } });
+  }
+  var newSeen = Object.assign({}, seen, { [gestalt]: true });
+  var newState = Object.assign({}, state, { mission_briefings_seen: newSeen });
+  _commitDelta(newState, state.addr, 'dismissMissionBriefing', [gestalt], { gestalt: gestalt });
+  return Promise.resolve({ result: { ok: true } });
+}
+
+// ---------------------------------------------------------------------------
 // Stub handlers — Wave 4+ issues fill these in.
 // ---------------------------------------------------------------------------
 var _STUBS = [
@@ -1465,6 +1502,8 @@ var LocalEngine = Object.assign({
   chargePerp:         chargePerp,
   collectPerp:        collectPerp,
   integrateCollected: integrateCollected,
+  dismissMissionBriefing: dismissMissionBriefing,
+  markTokenSeen:      markTokenSeen,
   setEmitter:         setEmitter,
   setSendDelta:       setSendDelta,
   setPrngSeed:        setPrngSeed,

--- a/scripts/LocalEngine.js
+++ b/scripts/LocalEngine.js
@@ -1118,6 +1118,22 @@ export function chargePerp(token, path) { // eslint-disable-line no-unused-vars
     ap_snapshot: Math.max(0, (gv.ap_snapshot || 0) - 1),
   });
 
+  // Advance xp_level if the new XP crossed a threshold. The legacy port
+  // omitted this for chargePerp specifically (collectPerp / integrateCollected
+  // / buyKarma all do compute it), so the player's XP could drift past
+  // xp_level.xp_max — visible as a status-bar overflow on screen.
+  var oldLevelNum = gv.xp_level || 1;
+  var newLevelNum = _getLevelByXP(newGv.xp_value);
+  var levelup = newLevelNum > oldLevelNum;
+  if (levelup) {
+    var levels = _getRuleset().levels;
+    var newLevelInfo = levels[newLevelNum - 1] || levels[levels.length - 1];
+    newGv = Object.assign({}, newGv, {
+      xp_level: newLevelNum,
+      ap_snapshot: newLevelInfo.ap_max,
+    });
+  }
+
   setState(Object.assign({}, state, {
     nodes:          newNodes,
     nodes_charging: charging.concat([chargeEntry]),
@@ -1140,7 +1156,7 @@ export function chargePerp(token, path) { // eslint-disable-line no-unused-vars
   _scheduleChargeReady(chargeEntry.charge_end);
 
   return Promise.resolve({
-    result: { game_values: newGv, duration: durationMs, levelup: false, missions: {} },
+    result: { game_values: newGv, duration: durationMs, levelup: levelup, missions: {} },
   });
 }
 
@@ -1452,23 +1468,21 @@ export function integrateCollected(_token, collectId) {
   // First-time integration of a token type: append a new TokenPerp node
   // under Database.<gestalt>. Without this, DBTokens stays empty, the
   // Database tab stays blank, and integrate_profiles missions never tick.
+  // Seed without x/y so the UI's setRandomPosition (Render.js:2393) places
+  // the new tile with collision avoidance around (1024,800), then
+  // saveCoordsQueue persists the resolved position. Pre-seeding x/y
+  // bypassed that and made every new token stack at a single hashed point.
   Object.keys(tokensMap).forEach(function (gestalt) {
     if (seenGestalts[gestalt]) return;
     if (!ruleset.tokens || !ruleset.tokens[gestalt]) return;
     var tok = tokensMap[gestalt];
-    // Deterministic spread around the Database centre so multiple new
-    // tokens on the same integrate don't all stack on top of each other
-    // at (0,0). Hash is gestalt-keyed so replay produces identical layout.
-    var hash = _djb2(gestalt);
-    var dx = (hash         % 1200) - 600;
-    var dy = ((hash >>> 8) %  800) - 400;
     var newNode = {
       game_id:    gestalt,
       gestalt:    gestalt,
       game_type:  'TokenPerp',
       full_type:  'TokenPerp:' + gestalt,
       full_path:  'Database.' + gestalt,
-      instance_data: { amount: tok.amount || 0, x: 1024 + dx, y: 800 + dy }
+      instance_data: { amount: tok.amount || 0 }
     };
     newNodes = newNodes.concat([newNode]);
     updatedNodes.push({

--- a/scripts/Render.js
+++ b/scripts/Render.js
@@ -3897,21 +3897,14 @@ define(function(require) {
 
         // Start scroller
         node.dragging=true;
-        console.log('[pan] mousedown: page=', e.pageX, e.pageY,
-          'scrollerHasDoTouchStart=', typeof node.scroller.doTouchStart);
         node.scroller.doTouchStart([{
           pageX: e.pageX,
           pageY: e.pageY
         }], e.timeStamp);
       });
 
-      var _panMoveLogged = false;
       node.useDragHandler.on('mousemove',function(e){
         if (node.dragging) {
-          if (!_panMoveLogged) {
-            console.log('[pan] first mousemove during drag: page=', e.pageX, e.pageY);
-            _panMoveLogged = true;
-          }
           node.scroller.doTouchMove([{
             pageX: e.pageX,
             pageY: e.pageY
@@ -3920,10 +3913,6 @@ define(function(require) {
       });
 
       node.useDragHandler.on('mouseup',function(e){
-        if (node.dragging) {
-          console.log('[pan] mouseup ending drag at page=', e.pageX, e.pageY);
-          _panMoveLogged = false;
-        }
         node.dragging=false;
         node.scroller.doTouchEnd(e.timeStamp);
       });

--- a/scripts/Render.js
+++ b/scripts/Render.js
@@ -3864,26 +3864,13 @@ define(function(require) {
 
       node.on('dblclick',function(e){
         e.stopPropagation();
+        // Same animating-toggle anti-pattern as zoomIn/zoomOut: don't flip
+        // it back to false synchronously, the scroller animation reads the
+        // flag every frame.
         if (node.zoomScale !== 1) {
-          node.scroller.options.animating=true;
           node.scroller.zoomTo(1, true, node.userAbsPos.x,node.userAbsPos.y);
-          node.scroller.options.animating=false;
-          // Cursor FX
-          //node.cursor.radius=12;
-          //node.cursor.strokeWidth=3;
-          //node.cursor.setOpacity(1);
-          //node.cursor.FXSimple({scaleX:3,scaleY:3,opacity:0},250);
         } else {
-          //node.scroller.zoomTo(0.5, true, node.userAbsPos.x,node.userAbsPos.y);
-          node.scroller.options.animating=true;
           node.scroller.zoomTo(node.scroller.options.minZoom, true, node.userAbsPos.x,node.userAbsPos.y);
-          node.scroller.options.animating=false;
-
-          // Cursor FX
-          //node.cursor.radius=24;
-          //node.cursor.strokeWidth=6;
-          //node.cursor.setOpacity(1);
-          //node.cursor.FXSimple({scaleX:0,scaleY:0,opacity:0},250);
         }
       });
 
@@ -3983,17 +3970,17 @@ define(function(require) {
     ViewMap.prototype.zoomIn = function(){
       var node = this;
       var zoomTo = (node.zoomScale+0.25 > 1) ? 1 : node.zoomScale+0.25;
-      node.scroller.options.animating=true;
+      // Don't toggle options.animating around zoomTo — the zynga-scroller
+      // animation loop reads it on every frame, so flipping it back to false
+      // synchronously cancels the animation mid-setup and the +/- buttons
+      // become silent no-ops. Let the scroller manage its own state.
       node.scroller.zoomTo(zoomTo, true);
-      node.scroller.options.animating=false;
     };
 
     ViewMap.prototype.zoomOut = function(){
       var node = this;
       var zoomTo = (node.zoomScale-0.25 < 0.5) ? 0.5 : node.zoomScale-0.25;
-      node.scroller.options.animating=true;
       node.scroller.zoomTo(zoomTo, true);
-      node.scroller.options.animating=false;
     };
 
     ViewMap.prototype.FXShow = function(){

--- a/scripts/Render.js
+++ b/scripts/Render.js
@@ -32,9 +32,10 @@ define(function(require) {
         }
       };
     }
-    if (typeof Ticker.setFPS !== 'function') {
-      Ticker.setFPS = function(fps) { Ticker.framerate = fps; };
-    }
+    // Always override setFPS so we use the modern `framerate=` setter even
+    // when the legacy method still exists (it logs a deprecation warning
+    // on every call in current TweenJS builds).
+    Ticker.setFPS = function(fps) { Ticker.framerate = fps; };
 
     var app = require('app').getApplication();
     var setup = require('setup');

--- a/scripts/Render.js
+++ b/scripts/Render.js
@@ -3833,12 +3833,20 @@ define(function(require) {
         zooming: true,
         locking:false,
         bouncing:false,
-        //animating:true,
-        animating:false,
+        // animating:true means zoomTo and scrollTo with animate=true tween
+        // smoothly via core.effect.Animate; the previous stub left this
+        // false because it had no animation loop anyway.
+        animating:true,
         animationDuration:300,
         minZoom:0.5,
         maxZoom:1
       });
+      // Confirm we got the real Scroller, not the old stub (which had
+      // doTouchStart = function(){} — typeof would still be 'function',
+      // but the prototype name and method count let us detect it).
+      console.log('[viewmap] Scroller initialised: hasZoomTo=',
+        typeof node.scroller.zoomTo, 'protoKeys=',
+        Object.keys(Scroller.prototype).length);
       //node.scroller.setDimensions(node.parentNode.getSize().width, node.parentNode.getSize().height, node.getSize().width, node.getSize().height);
       node.scroller.setPosition(0,0);
       node.updateScroller();
@@ -3894,14 +3902,21 @@ define(function(require) {
 
         // Start scroller
         node.dragging=true;
+        console.log('[pan] mousedown: page=', e.pageX, e.pageY,
+          'scrollerHasDoTouchStart=', typeof node.scroller.doTouchStart);
         node.scroller.doTouchStart([{
           pageX: e.pageX,
           pageY: e.pageY
         }], e.timeStamp);
       });
 
+      var _panMoveLogged = false;
       node.useDragHandler.on('mousemove',function(e){
         if (node.dragging) {
+          if (!_panMoveLogged) {
+            console.log('[pan] first mousemove during drag: page=', e.pageX, e.pageY);
+            _panMoveLogged = true;
+          }
           node.scroller.doTouchMove([{
             pageX: e.pageX,
             pageY: e.pageY
@@ -3910,6 +3925,10 @@ define(function(require) {
       });
 
       node.useDragHandler.on('mouseup',function(e){
+        if (node.dragging) {
+          console.log('[pan] mouseup ending drag at page=', e.pageX, e.pageY);
+          _panMoveLogged = false;
+        }
         node.dragging=false;
         node.scroller.doTouchEnd(e.timeStamp);
       });
@@ -3970,16 +3989,16 @@ define(function(require) {
     ViewMap.prototype.zoomIn = function(){
       var node = this;
       var zoomTo = (node.zoomScale+0.25 > 1) ? 1 : node.zoomScale+0.25;
-      // Don't toggle options.animating around zoomTo — the zynga-scroller
-      // animation loop reads it on every frame, so flipping it back to false
-      // synchronously cancels the animation mid-setup and the +/- buttons
-      // become silent no-ops. Let the scroller manage its own state.
+      console.log('[zoom] zoomIn: from', node.zoomScale, 'to', zoomTo,
+        'scrollerHasZoomTo=', typeof node.scroller.zoomTo);
       node.scroller.zoomTo(zoomTo, true);
     };
 
     ViewMap.prototype.zoomOut = function(){
       var node = this;
       var zoomTo = (node.zoomScale-0.25 < 0.5) ? 0.5 : node.zoomScale-0.25;
+      console.log('[zoom] zoomOut: from', node.zoomScale, 'to', zoomTo,
+        'scrollerHasZoomTo=', typeof node.scroller.zoomTo);
       node.scroller.zoomTo(zoomTo, true);
     };
 

--- a/scripts/Render.js
+++ b/scripts/Render.js
@@ -3983,7 +3983,7 @@ define(function(require) {
       var node = this;
       var zoomTo = (node.zoomScale+0.25 > 1) ? 1 : node.zoomScale+0.25;
       node.scroller.options.animating=true;
-      node.scroller.zoomTo(node.zoomScale+0.25, true);
+      node.scroller.zoomTo(zoomTo, true);
       node.scroller.options.animating=false;
     };
 
@@ -4703,6 +4703,13 @@ define(function(require) {
         token.parents('.PopupTab').addClass('hasPopup');
         container.addClass('open');
         container.find('.Subpop[data-subpop-id='+subpopid+']').addClass('open');
+        // subpop-id is "token<gestalt>"; surface the gestalt so the game side
+        // can persist the seen-flag and clear the NEW badge across reloads.
+        var gestalt = (subpopid && subpopid.indexOf('token') === 0) ? subpopid.slice(5) : '';
+        if (gestalt) {
+          token.find('.new').remove();
+          node.trigger('popup_token_seen', [gestalt]);
+        }
       });
 
       node.jdomelem.on('click touchend','.SubpopClose, .Button[data-button-id=OKButton]',function(e){

--- a/scripts/Render.js
+++ b/scripts/Render.js
@@ -3805,6 +3805,7 @@ define(function(require) {
       node.scroller.options.minZoom = (minZoom < 0.5) ? 0.5 : minZoom;
       node.scroller.zoomTo(this.zoomScale);
       node.scroller.setDimensions(stage.width, stage.height, node.getSize().width, node.getSize().height);
+      node._updateZoomButtonsState();
     };
 
     ViewMap.prototype.initScroller = function(){
@@ -3841,12 +3842,6 @@ define(function(require) {
         minZoom:0.5,
         maxZoom:1
       });
-      // Confirm we got the real Scroller, not the old stub (which had
-      // doTouchStart = function(){} — typeof would still be 'function',
-      // but the prototype name and method count let us detect it).
-      console.log('[viewmap] Scroller initialised: hasZoomTo=',
-        typeof node.scroller.zoomTo, 'protoKeys=',
-        Object.keys(Scroller.prototype).length);
       //node.scroller.setDimensions(node.parentNode.getSize().width, node.parentNode.getSize().height, node.getSize().width, node.getSize().height);
       node.scroller.setPosition(0,0);
       node.updateScroller();
@@ -3984,21 +3979,31 @@ define(function(require) {
       } else {
         this.jdomelem.removeClass('zoomHide1');
       }
+      this._updateZoomButtonsState();
+    };
+
+    ViewMap.prototype._updateZoomButtonsState = function(){
+      if (!this.jdomelemZoom) return;
+      var maxZoom = (this.scroller && this.scroller.options && this.scroller.options.maxZoom) || 1;
+      var minZoom = (this.scroller && this.scroller.options && this.scroller.options.minZoom) || 0.5;
+      var atMax = this.zoomScale >= maxZoom - 0.001;
+      var atMin = this.zoomScale <= minZoom + 0.001;
+      this.jdomelemZoom.find('.ZoomIn').toggleClass('disabled', atMax);
+      this.jdomelemZoom.find('.ZoomOut').toggleClass('disabled', atMin);
+      this.jdomelemZoom.find('.Fullscreen').toggleClass('disabled', atMin && atMax);
     };
 
     ViewMap.prototype.zoomIn = function(){
       var node = this;
       var zoomTo = (node.zoomScale+0.25 > 1) ? 1 : node.zoomScale+0.25;
-      console.log('[zoom] zoomIn: from', node.zoomScale, 'to', zoomTo,
-        'scrollerHasZoomTo=', typeof node.scroller.zoomTo);
+      if (zoomTo === node.zoomScale) return;
       node.scroller.zoomTo(zoomTo, true);
     };
 
     ViewMap.prototype.zoomOut = function(){
       var node = this;
       var zoomTo = (node.zoomScale-0.25 < 0.5) ? 0.5 : node.zoomScale-0.25;
-      console.log('[zoom] zoomOut: from', node.zoomScale, 'to', zoomTo,
-        'scrollerHasZoomTo=', typeof node.scroller.zoomTo);
+      if (zoomTo === node.zoomScale) return;
       node.scroller.zoomTo(zoomTo, true);
     };
 

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -154,6 +154,8 @@ define(function(require) {
       app.remote.addMethod('ping');
       app.remote.addMethod('sellPowerup');
       app.remote.addMethod('setPerpCoordinates');
+      app.remote.addMethod('dismissMissionBriefing');
+      app.remote.addMethod('markTokenSeen');
 
       // Wire LocalEngine's event emitter to the in-process Socket bus so that
       // node_ready / new_items events from loadGame materialisation reach the

--- a/scripts/materializer.js
+++ b/scripts/materializer.js
@@ -106,20 +106,23 @@ function materialize(state, now) {
   var newGv = Object.assign({}, gv);
   if (
     typeof gv.ap_snapshot    === 'number' &&
-    typeof gv.ap_update      === 'number' &&
     typeof gv.ap_inc_value   === 'number' &&
     gv.ap_inc_interval > 0                &&
     typeof gv.ap_max         === 'number'
   ) {
-    var elapsed = Math.max(0, now - gv.ap_update);
-    var ticks   = Math.floor(elapsed / gv.ap_inc_interval);
+    // Lazy-init: when ap_update is null/undefined (e.g. fresh game), start
+    // the regen clock at `now` so the next materialize-after-elapsed-time
+    // can tick. Without this, ap_update stays null forever and regen never
+    // runs, so APs added in-memory by Game.js APTicker reset to ap_snapshot
+    // on every reload.
+    var apUpdate = (typeof gv.ap_update === 'number') ? gv.ap_update : now;
+    var elapsed  = Math.max(0, now - apUpdate);
+    var ticks    = Math.floor(elapsed / gv.ap_inc_interval);
     newGv = Object.assign({}, gv, {
       ap_snapshot: Math.min(gv.ap_max, gv.ap_snapshot + ticks * gv.ap_inc_value),
-      // Advance ap_update only to the last full-tick boundary so that the
+      // Advance ap_update only to the last full-tick boundary so the
       // fractional remainder is preserved across stepwise materializations.
-      // Setting ap_update = now would silently discard sub-interval progress
-      // and violate the composability invariant.
-      ap_update: gv.ap_update + ticks * gv.ap_inc_interval,
+      ap_update: apUpdate + ticks * gv.ap_inc_interval,
     });
   }
 

--- a/scripts/state.js
+++ b/scripts/state.js
@@ -395,11 +395,25 @@ reducers.integrateCollected = function integrateCollectedReducer(state, delta) {
 
   var newNodes = state.nodes;
   if (r.nodes && r.nodes.length) {
+    var existingPaths = {};
     var updMap = {};
     r.nodes.forEach(function (u) { updMap[u.full_path] = u; });
     newNodes = state.nodes.map(function (n) {
+      existingPaths[n.full_path] = true;
       var u = updMap[n.full_path];
       return u ? Object.assign({}, n, { instance_data: u.instance_data }) : n;
+    });
+    // Append fresh TokenPerp nodes (first-time integration of a token type).
+    r.nodes.forEach(function (u) {
+      if (existingPaths[u.full_path]) return;
+      newNodes = newNodes.concat([{
+        game_id:       u.game_id,
+        gestalt:       u.gestalt,
+        game_type:     u.game_type,
+        full_type:     u.full_type,
+        full_path:     u.full_path,
+        instance_data: u.instance_data || {}
+      }]);
     });
   }
 

--- a/scripts/state.js
+++ b/scripts/state.js
@@ -34,6 +34,8 @@ var OP_NAMES = [
   'ping',
   'checkUsername',
   'setLocale',
+  'dismissMissionBriefing',
+  'markTokenSeen',
 ];
 
 /**
@@ -104,6 +106,8 @@ export function freshState(selfAddr, seed) {
     last_seen_ts: 0,
     node_counter: 0,
     integrated_ids: {},
+    mission_briefings_seen: {},
+    tokens_seen: {},
   };
 }
 
@@ -405,6 +409,26 @@ reducers.integrateCollected = function integrateCollectedReducer(state, delta) {
     game_values:    newGv,
     nodes:          newNodes
   });
+};
+
+reducers.markTokenSeen = function markTokenSeenReducer(state, delta) {
+  var args = delta.args || [];
+  var gestalt = args[0];
+  if (typeof gestalt !== 'string' || !gestalt) return state;
+  var seen = Object.assign({}, state.tokens_seen || {});
+  if (seen[gestalt]) return state;
+  seen[gestalt] = true;
+  return Object.assign({}, state, { tokens_seen: seen });
+};
+
+reducers.dismissMissionBriefing = function dismissMissionBriefingReducer(state, delta) {
+  var args = delta.args || [];
+  var gestalt = args[0];
+  if (typeof gestalt !== 'string' || !gestalt) return state;
+  var seen = Object.assign({}, state.mission_briefings_seen || {});
+  if (seen[gestalt]) return state;
+  seen[gestalt] = true;
+  return Object.assign({}, state, { mission_briefings_seen: seen });
 };
 
 // Stubs — return state unchanged until Wave 4+ fills them in.

--- a/scripts/state.js
+++ b/scripts/state.js
@@ -369,11 +369,27 @@ reducers.collectPerp = function collectPerpReducer(state, delta) {
     });
   }
 
+  // Mission progression carried in delta.result.missions.mission_data
+  // mirrors the buyPerp path so cold-start replay reconstructs the same
+  // mission_goals + active_missions the live handler computed.
+  var newMissionGoals = state.mission_goals;
+  var newActiveMissions = state.active_missions;
+  if (r.missions && r.missions.mission_data) {
+    if (r.missions.mission_data.mission_goals) {
+      newMissionGoals = r.missions.mission_data.mission_goals;
+    }
+    if (r.missions.mission_data.active_missions) {
+      newActiveMissions = r.missions.mission_data.active_missions;
+    }
+  }
+
   return Object.assign({}, state, {
     nodes_collect: newCollect,
     game_values:   newGv,
     db_queue:      newQueue,
-    nodes:         newNodes
+    nodes:         newNodes,
+    mission_goals: newMissionGoals,
+    active_missions: newActiveMissions
   });
 };
 
@@ -417,11 +433,24 @@ reducers.integrateCollected = function integrateCollectedReducer(state, delta) {
     });
   }
 
+  var newMissionGoals = state.mission_goals;
+  var newActiveMissions = state.active_missions;
+  if (r.missions && r.missions.mission_data) {
+    if (r.missions.mission_data.mission_goals) {
+      newMissionGoals = r.missions.mission_data.mission_goals;
+    }
+    if (r.missions.mission_data.active_missions) {
+      newActiveMissions = r.missions.mission_data.active_missions;
+    }
+  }
+
   return Object.assign({}, state, {
     db_queue:       newQueue,
     integrated_ids: newIntegratedIds,
     game_values:    newGv,
-    nodes:          newNodes
+    nodes:          newNodes,
+    mission_goals: newMissionGoals,
+    active_missions: newActiveMissions
   });
 };
 

--- a/scripts/state.js
+++ b/scripts/state.js
@@ -167,6 +167,18 @@ function _seedNodesFromTree(src) {
 
 var reducers = {};
 
+// Pulls mission_goals + active_missions out of a delta result whose
+// progression handler shipped them under .missions.mission_data. Returns
+// pass-through values when the delta has no mission update so reducers can
+// always spread the result without a conditional.
+function _missionDataFromResult(state, r) {
+  var md = r && r.missions && r.missions.mission_data;
+  return {
+    mission_goals: (md && md.mission_goals) || state.mission_goals,
+    active_missions: (md && md.active_missions) || state.active_missions
+  };
+}
+
 reducers.setDisplayName = function setDisplayNameReducer(state, delta) {
   var args = delta.args || [];
   var dname = args[0];
@@ -275,16 +287,7 @@ reducers.buyPerp = function buyPerpReducer(state, delta) {
     }
   }
 
-  var missionGoals = state.mission_goals;
-  var activeMissions = state.active_missions;
-  if (r.missions && r.missions.mission_data) {
-    if (r.missions.mission_data.mission_goals) {
-      missionGoals = r.missions.mission_data.mission_goals;
-    }
-    if (r.missions.mission_data.active_missions) {
-      activeMissions = r.missions.mission_data.active_missions;
-    }
-  }
+  var mp = _missionDataFromResult(state, r);
 
   // Each buyPerp creates exactly one node, so the counter advances by 1 on
   // every replayed delta.  (The handler in LocalEngine does the same; we
@@ -296,8 +299,8 @@ reducers.buyPerp = function buyPerpReducer(state, delta) {
     nodes: nodes,
     db_queue: dbQueue,
     game_values: r.game_values || state.game_values,
-    mission_goals: missionGoals,
-    active_missions: activeMissions,
+    mission_goals: mp.mission_goals,
+    active_missions: mp.active_missions,
     node_counter: counter
   });
 };
@@ -369,27 +372,14 @@ reducers.collectPerp = function collectPerpReducer(state, delta) {
     });
   }
 
-  // Mission progression carried in delta.result.missions.mission_data
-  // mirrors the buyPerp path so cold-start replay reconstructs the same
-  // mission_goals + active_missions the live handler computed.
-  var newMissionGoals = state.mission_goals;
-  var newActiveMissions = state.active_missions;
-  if (r.missions && r.missions.mission_data) {
-    if (r.missions.mission_data.mission_goals) {
-      newMissionGoals = r.missions.mission_data.mission_goals;
-    }
-    if (r.missions.mission_data.active_missions) {
-      newActiveMissions = r.missions.mission_data.active_missions;
-    }
-  }
-
+  var mp = _missionDataFromResult(state, r);
   return Object.assign({}, state, {
     nodes_collect: newCollect,
     game_values:   newGv,
     db_queue:      newQueue,
     nodes:         newNodes,
-    mission_goals: newMissionGoals,
-    active_missions: newActiveMissions
+    mission_goals: mp.mission_goals,
+    active_missions: mp.active_missions
   });
 };
 
@@ -433,24 +423,14 @@ reducers.integrateCollected = function integrateCollectedReducer(state, delta) {
     });
   }
 
-  var newMissionGoals = state.mission_goals;
-  var newActiveMissions = state.active_missions;
-  if (r.missions && r.missions.mission_data) {
-    if (r.missions.mission_data.mission_goals) {
-      newMissionGoals = r.missions.mission_data.mission_goals;
-    }
-    if (r.missions.mission_data.active_missions) {
-      newActiveMissions = r.missions.mission_data.active_missions;
-    }
-  }
-
+  var mp = _missionDataFromResult(state, r);
   return Object.assign({}, state, {
     db_queue:       newQueue,
     integrated_ids: newIntegratedIds,
     game_values:    newGv,
     nodes:          newNodes,
-    mission_goals: newMissionGoals,
-    active_missions: newActiveMissions
+    mission_goals: mp.mission_goals,
+    active_missions: mp.active_missions
   });
 };
 

--- a/scripts/vendor-install.js
+++ b/scripts/vendor-install.js
@@ -14,7 +14,8 @@
 //   requirejs-text bower: 2.0.9     npm: 2.0.12+
 //   routie        bower: 0.3.2 (joestrong) — no matching npm pkg; stub in vendor/
 //   tpl           bower: dawsontoth commit — no npm pkg; impl in vendor/
-//   zynga-animate/scroller — no npm pkg; stubs in vendor/
+//   zynga-animate — no npm pkg; vendored verbatim
+//   zynga-scroller — no npm pkg; vendored from upstream + AMD wrapper
 //   jquery-mobile bower: 1.3.2     — no matching npm pkg with this version; stub in vendor/
 //
 // If internet access is available, replace the stubs with their real versions:
@@ -79,7 +80,7 @@ cp('sprintf-js/dist/sprintf.min.js',             'sprintf.js');
 cp('json2/lib/JSON2.js',                         'json2.js');
 
 console.log('\nVendor population complete.');
-console.log('Stubs already in repo: native-console.js, routie.js, tpl.js,');
+console.log('Stubs / vendored verbatim in repo: native-console.js, routie.js, tpl.js,');
 console.log('  zynga-animate.js, zynga-scroller.js, jquery-mobile.js');
 console.log('\nFiles in vendor/:');
 readdirSync(vendorDir).sort().forEach(f => console.log('  ' + f));

--- a/tests/handlers/chargePerp.test.js
+++ b/tests/handlers/chargePerp.test.js
@@ -388,3 +388,46 @@ describe('chargePerp — failure: non-chargeable node (no charge_time)', () => {
     expect(result.error).toBe(1);
   });
 });
+
+// ── level-up: chargePerp's xp_inc crosses the threshold ─────────────────────
+//
+// Level 1 (de + en): xp_min=0,  xp_max=10, ap_max=6
+// Level 2 (de + en): xp_min=11, xp_max=30, ap_max=8
+// chargePerp on contact035 awards xp_inc=1, so xp=10 → 11 crosses to lvl 2.
+
+describe('chargePerp — level-up refills AP and advances xp_level', () => {
+  beforeEach(() => {
+    setOverride(FIXED_NOW);
+    setState(mkState({
+      game_values: { xp_value: 10, xp_level: 1, ap_snapshot: 3, ap_max: 6 }
+    }));
+  });
+
+  it('returns levelup=true when xp_inc crosses the level threshold', async () => {
+    const { result } = await chargePerp('tok', NODE_PATH);
+    expect(result.levelup).toBe(true);
+  });
+
+  it('advances xp_level to the new level', async () => {
+    const { result } = await chargePerp('tok', NODE_PATH);
+    expect(result.game_values.xp_level).toBe(2);
+  });
+
+  it('refills ap_snapshot to the new level\'s ap_max (not -1 from charging)', async () => {
+    const { result } = await chargePerp('tok', NODE_PATH);
+    expect(result.game_values.ap_snapshot).toBe(8);
+  });
+});
+
+describe('chargePerp — no level-up keeps xp_level and decrements ap_snapshot', () => {
+  it('xp gain inside the same level reports levelup=false and AP-1', async () => {
+    setOverride(FIXED_NOW);
+    setState(mkState({
+      game_values: { xp_value: 5, xp_level: 1, ap_snapshot: 4, ap_max: 6 }
+    }));
+    const { result } = await chargePerp('tok', NODE_PATH);
+    expect(result.levelup).toBe(false);
+    expect(result.game_values.xp_level).toBe(1);
+    expect(result.game_values.ap_snapshot).toBe(3);
+  });
+});

--- a/tests/handlers/chargePerp.test.js
+++ b/tests/handlers/chargePerp.test.js
@@ -504,6 +504,32 @@ describe('chargePerp — live-tick setTimeout', () => {
 
     expect(events.some(function (e) { return e.ev === 'node_ready'; })).toBe(true);
   });
+
+  it('calling loadGame twice does not duplicate node_ready emits for one charge', async () => {
+    setState(mkState({
+      nodes_charging: [{
+        path:         NODE_PATH,
+        result:       { amount: 1100 },
+        charge_start: FIXED_NOW,
+        charge_end:   FIXED_NOW + CHARGE_TIME,
+        game_id:      'node-abc123',
+        game_type:    'ContactPerp'
+      }]
+    }));
+
+    var events = [];
+    setEmitter(function (ev, payload) {
+      if (ev === 'node_ready') events.push(payload);
+    });
+
+    await loadGame('tok');
+    await loadGame('tok');
+    setOverride(FIXED_NOW + CHARGE_TIME + 1);
+    vi.advanceTimersByTime(CHARGE_TIME + 1);
+
+    // Without _clearAllChargeReady, two timers would queue and fire twice.
+    expect(events.length).toBe(1);
+  });
 });
 
 // ── AP regen visibility ─────────────────────────────────────────────────────

--- a/tests/handlers/chargePerp.test.js
+++ b/tests/handlers/chargePerp.test.js
@@ -1,6 +1,6 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
-  chargePerp, setSendDelta, setEmitter,
+  chargePerp, loadGame, setSendDelta, setEmitter,
 } from '../../scripts/LocalEngine.js';
 import { getState, setState } from '../../scripts/boot.js';
 import { freshState, applyDelta } from '../../scripts/state.js';
@@ -429,5 +429,77 @@ describe('chargePerp — no level-up keeps xp_level and decrements ap_snapshot',
     expect(result.levelup).toBe(false);
     expect(result.game_values.xp_level).toBe(1);
     expect(result.game_values.ap_snapshot).toBe(3);
+  });
+});
+
+// ── live-tick: setTimeout fires materialize at charge_end ──────────────────
+//
+// chargePerp schedules a one-shot setTimeout per charge so the perp
+// transitions from nodes_charging → nodes_collect without requiring a page
+// reload. loadGame re-arms the timer for charges still in flight after a
+// cold start.
+
+describe('chargePerp — live-tick setTimeout', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    setOverride(FIXED_NOW);
+    setState(mkState());
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    clearOverride();
+    setEmitter(null);
+  });
+
+  it('schedules a setTimeout for charge_time ms at the host clock', async () => {
+    const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
+    await chargePerp('tok', NODE_PATH);
+    // contact035 charge_time = 30000 ms.
+    const matched = setTimeoutSpy.mock.calls.find(function (c) { return c[1] === CHARGE_TIME; });
+    expect(matched).toBeDefined();
+  });
+
+  it('emits node_ready when fake timers advance past charge_end', async () => {
+    var events = [];
+    setEmitter(function (ev, payload) { events.push({ ev: ev, payload: payload }); });
+
+    await chargePerp('tok', NODE_PATH);
+    // Advance the host wall clock that setTimeout reads, AND the injectable
+    // game clock that materialize() consults — both must cross charge_end.
+    setOverride(FIXED_NOW + CHARGE_TIME + 1);
+    vi.advanceTimersByTime(CHARGE_TIME + 1);
+
+    expect(events.some(function (e) { return e.ev === 'node_ready'; })).toBe(true);
+    // State should reflect the materialised transition.
+    const s = getState();
+    expect(s.nodes_charging.length).toBe(0);
+    expect(s.nodes_collect.length).toBe(1);
+    expect(s.nodes_collect[0].path).toBe(NODE_PATH);
+  });
+
+  it('loadGame re-arms timers for charges still in flight', async () => {
+    // Seed state with an active charge whose charge_end is 30s from now.
+    setState(mkState({
+      nodes_charging: [{
+        path:         NODE_PATH,
+        result:       { amount: 1100 },
+        charge_start: FIXED_NOW,
+        charge_end:   FIXED_NOW + CHARGE_TIME,
+        game_id:      'node-abc123',
+        game_type:    'ContactPerp'
+      }]
+    }));
+
+    var events = [];
+    setEmitter(function (ev, payload) { events.push({ ev: ev, payload: payload }); });
+
+    await loadGame('tok');
+    // Without rearm, advancing timers would not fire node_ready because no
+    // setTimeout was scheduled in this test session.
+    setOverride(FIXED_NOW + CHARGE_TIME + 1);
+    vi.advanceTimersByTime(CHARGE_TIME + 1);
+
+    expect(events.some(function (e) { return e.ev === 'node_ready'; })).toBe(true);
   });
 });

--- a/tests/handlers/chargePerp.test.js
+++ b/tests/handlers/chargePerp.test.js
@@ -502,3 +502,45 @@ describe('chargePerp — live-tick setTimeout', () => {
     expect(events.some(function (e) { return e.ev === 'node_ready'; })).toBe(true);
   });
 });
+
+// ── ClientPerp income payout end-to-end ─────────────────────────────────────
+//
+// chargePerp on a ClientPerp must base chargeResult.amount on income_base
+// when typeData has no collect_amount. Without this, cr.amount stays 0 and
+// collectPerp's ClientPerp branch adds zero cash — the car company appears
+// to do nothing.
+
+describe('chargePerp — ClientPerp uses income_base when collect_amount is missing', () => {
+  const CAR_PATH = 'Imperium.City.Pusher0.client007';
+
+  beforeEach(() => {
+    setOverride(FIXED_NOW);
+    setState(Object.assign({}, freshState('test@local'), {
+      nodes: [{
+        game_id: 'node_client007',
+        game_type: 'ClientPerp',
+        full_type: 'ClientPerp:client007',
+        gestalt: 'client007',
+        full_path: CAR_PATH,
+        instance_data: {}
+      }],
+      game_values: Object.assign({}, BASE_GV, { cash_value: 300, ap_snapshot: 6 })
+    }));
+  });
+
+  afterEach(() => {
+    clearOverride();
+    setSendDelta(null);
+    setEmitter(null);
+  });
+
+  it('chargeEntry.result.amount is roughly income_base (584 ± 5%)', async () => {
+    await chargePerp('tok', CAR_PATH);
+    const charging = getState().nodes_charging;
+    expect(charging).toHaveLength(1);
+    const amount = charging[0].result.amount;
+    // ±5% variation, round() can nudge boundary by 1.
+    expect(amount).toBeGreaterThanOrEqual(553);
+    expect(amount).toBeLessThanOrEqual(614);
+  });
+});

--- a/tests/handlers/chargePerp.test.js
+++ b/tests/handlers/chargePerp.test.js
@@ -38,7 +38,10 @@ var BASE_GV = {
   cash_spent:      0,
   xp_value:        0,
   ap_snapshot:     3,
-  ap_update:       0,
+  // ap_update at FIXED_NOW so the materialize-on-entry call regenerates
+  // zero ticks (elapsed = 0). Tests that exercise regen explicitly
+  // override this.
+  ap_update:       FIXED_NOW,
   ap_inc_value:    1,
   ap_inc_interval: 120_000,
   ap_max:          6,
@@ -500,6 +503,40 @@ describe('chargePerp — live-tick setTimeout', () => {
     vi.advanceTimersByTime(CHARGE_TIME + 1);
 
     expect(events.some(function (e) { return e.ev === 'node_ready'; })).toBe(true);
+  });
+});
+
+// ── AP regen visibility ─────────────────────────────────────────────────────
+//
+// Without materialize-on-entry, state.ap_snapshot stays at the last
+// handler's value while the UI's APTicker shows a higher number, and
+// chargePerp refuses despite the visible AP bar.
+
+describe('chargePerp — sees AP regen since the last materialize', () => {
+  beforeEach(() => {
+    setOverride(FIXED_NOW);
+    setState(mkState({
+      // ap_snapshot=0, ap_update set 2 minutes ago → one full tick ready.
+      game_values: Object.assign({}, BASE_GV, {
+        ap_snapshot: 0,
+        ap_update: FIXED_NOW - 120_000,
+        ap_inc_value: 1,
+        ap_inc_interval: 120_000,
+        ap_max: 6
+      })
+    }));
+  });
+
+  afterEach(() => {
+    clearOverride();
+    setSendDelta(null);
+    setEmitter(null);
+  });
+
+  it('charges successfully because materialize regenerates the queued AP tick', async () => {
+    const { result } = await chargePerp('tok', NODE_PATH);
+    expect(result.error).toBeUndefined();
+    expect(result.duration).toBe(CHARGE_TIME);
   });
 });
 

--- a/tests/handlers/chargePerp.test.js
+++ b/tests/handlers/chargePerp.test.js
@@ -471,7 +471,6 @@ describe('chargePerp — live-tick setTimeout', () => {
     vi.advanceTimersByTime(CHARGE_TIME + 1);
 
     expect(events.some(function (e) { return e.ev === 'node_ready'; })).toBe(true);
-    // State should reflect the materialised transition.
     const s = getState();
     expect(s.nodes_charging.length).toBe(0);
     expect(s.nodes_collect.length).toBe(1);

--- a/tests/handlers/collect-integrate.test.js
+++ b/tests/handlers/collect-integrate.test.js
@@ -605,15 +605,13 @@ describe('integrateCollected — level-up refills ap_snapshot to the new ap_max'
   });
 });
 
-// ── #85 root cause: tokens_map is populated from typeData.tokens ────────────
+// ── tokens_map populated from typeData.tokens ──────────────────────────────
 //
-// Contacts in the ruleset list yielded token types under `tokens`, not
-// `contained_tokens` (the latter is for TokenPerp super-token decomposition).
-// Each entry's `amount` is a percentage of profiles_value carrying that
-// token type. Without populated tokens_map, mission goals with workflow
-// "integrate_profiles" never advance — that's the 0/900 bug on mission002.
+// Contacts list yielded token types under `tokens`; each entry's `amount`
+// is a percentage of profiles_value. Without a populated tokens_map,
+// integrate_profiles missions can't advance.
 
-describe('collectPerp — tokens_map population from typeData.tokens (#85)', () => {
+describe('collectPerp — tokens_map population from typeData.tokens', () => {
   // contact001 (Nurse Helen) has 12 tokens, each at 100%.
   const PATH = 'Imperium.City.Agent0.contact001';
 

--- a/tests/handlers/collect-integrate.test.js
+++ b/tests/handlers/collect-integrate.test.js
@@ -7,9 +7,9 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
-  collectPerp, integrateCollected, setEmitter, setPrngSeed
+  collectPerp, integrateCollected, loadGame, setEmitter, setPrngSeed
 } from '../../scripts/LocalEngine.js';
-import { setState } from '../../scripts/boot.js';
+import { setState, getState } from '../../scripts/boot.js';
 import { freshState } from '../../scripts/state.js';
 import { setOverride, clearOverride, advance } from '../../scripts/clock.js';
 
@@ -752,5 +752,218 @@ describe('integrateCollected — payload shape for newly seeded TokenPerps', () 
     const persisted = getState().nodes.find(function (n) { return n.gestalt === 'token008'; });
     expect(persisted.game_type).toBe('TokenPerp');
     expect(persisted.full_type).toBe('TokenPerp:token008');
+  });
+});
+
+// ── Mission progression: collect_profiles + integrate_profiles ──────────────
+//
+// End-to-end: charge → collect → integrate from Jessica (contact035), and
+// assert that the integrate_profiles goal on mission002 (target token008,
+// amount 900) advances and completes. mission003 should activate when
+// mission002 completes (required_mission chain).
+
+describe('mission progression — integrate_profiles flow', () => {
+  const JESSICA = 'Imperium.City.Agent0.contact035';
+  const COLLECT_ID = 'mission-progress-001';
+
+  beforeEach(() => setOverride(FIXED_NOW));
+  afterEach(() => { clearOverride(); setEmitter(null); });
+
+  function seedMission002Active() {
+    setState(mkState({
+      active_missions: ['mission002'],
+      mission_goals: [{
+        mission: 'mission002',
+        workflow: 'integrate_profiles',
+        target: 'token008',
+        amount: 900,
+        position: 1,
+        current_amount: 0,
+        complete: false
+      }],
+      db_queue: [{
+        origin:      JESSICA,
+        collect_id:  COLLECT_ID,
+        profile_set: { profiles_value: 1100, tokens_map: { token008: { amount: 100 } } },
+        collect_dt:  FIXED_NOW
+      }]
+    }));
+  }
+
+  it('integrating Jessica advances mission002.current_amount to the absoluteAmount', async () => {
+    seedMission002Active();
+    const { result } = await integrateCollected('tok', COLLECT_ID);
+    const goal = getState().mission_goals.find(g => g.mission === 'mission002');
+    // profiles_value=1100, amount=100% → absolute=1100, capped at goal.amount=900.
+    expect(goal.current_amount).toBe(900);
+    expect(goal.complete).toBe(true);
+    // Response carries the same shape Game.js consumes.
+    expect(result.missions.complete_missions).toContain('mission002');
+  });
+
+  it('partial integrate (50% coverage) advances current_amount but stays incomplete', async () => {
+    setState(mkState({
+      active_missions: ['mission002'],
+      mission_goals: [{
+        mission: 'mission002',
+        workflow: 'integrate_profiles',
+        target: 'token008',
+        amount: 900,
+        position: 1,
+        current_amount: 0,
+        complete: false
+      }],
+      db_queue: [{
+        origin:      JESSICA,
+        collect_id:  COLLECT_ID,
+        profile_set: { profiles_value: 1000, tokens_map: { token008: { amount: 50 } } },
+        collect_dt:  FIXED_NOW
+      }]
+    }));
+
+    await integrateCollected('tok', COLLECT_ID);
+    const goal = getState().mission_goals.find(g => g.mission === 'mission002');
+    // profiles_value=1000, amount=50% → absolute=500.
+    expect(goal.current_amount).toBe(500);
+    expect(goal.complete).toBe(false);
+  });
+
+  it('completing mission002 activates mission003 (required_mission chain) with seeded goals', async () => {
+    seedMission002Active();
+    await integrateCollected('tok', COLLECT_ID);
+    const s = getState();
+    expect(s.active_missions).not.toContain('mission002');
+    expect(s.active_missions).toContain('mission003');
+    const m3goal = s.mission_goals.find(g => g.mission === 'mission003');
+    expect(m3goal).toBeDefined();
+    expect(m3goal.current_amount).toBe(0);
+    expect(m3goal.complete).toBe(false);
+  });
+
+  it('mission_goals delta replays cleanly through applyDelta', async () => {
+    seedMission002Active();
+    await integrateCollected('tok', COLLECT_ID);
+    // Cold-start replay: take the persisted state, run loadGame.
+    const s1 = getState();
+    setState(s1);
+    await loadGame('tok');
+    const goal = getState().mission_goals.find(g => g.mission === 'mission002');
+    expect(goal.current_amount).toBe(900);
+    expect(goal.complete).toBe(true);
+  });
+});
+
+describe('mission progression — collect_profiles flow', () => {
+  const JESSICA = 'Imperium.City.Agent0.contact035';
+
+  beforeEach(() => setOverride(FIXED_NOW));
+  afterEach(() => { clearOverride(); setEmitter(null); });
+
+  it('collecting Jessica advances mission001.current_amount by the collected profile count', async () => {
+    setState(mkState({
+      nodes: [mkNode('ContactPerp', JESSICA)],
+      nodes_collect: [{ path: JESSICA, result: { amount: 600 } }],
+      active_missions: ['mission001'],
+      mission_goals: [{
+        mission: 'mission001',
+        workflow: 'collect_profiles',
+        target: 'contact035',
+        amount: 900,
+        position: 2,
+        current_amount: 0,
+        complete: false
+      }]
+    }));
+
+    await collectPerp('tok', JESSICA);
+    const goal = getState().mission_goals.find(g => g.mission === 'mission001');
+    expect(goal.current_amount).toBe(600);
+    expect(goal.complete).toBe(false);
+  });
+
+  it('two collects from Jessica complete mission001 (cumulative)', async () => {
+    setState(mkState({
+      nodes: [mkNode('ContactPerp', JESSICA)],
+      nodes_collect: [{ path: JESSICA, result: { amount: 600 } }],
+      active_missions: ['mission001'],
+      mission_goals: [{
+        mission: 'mission001',
+        workflow: 'collect_profiles',
+        target: 'contact035',
+        amount: 900,
+        position: 2,
+        current_amount: 0,
+        complete: false
+      }]
+    }));
+
+    await collectPerp('tok', JESSICA);
+    setState(Object.assign({}, getState(), {
+      nodes_collect: [{ path: JESSICA, result: { amount: 600 } }]
+    }));
+    const { result } = await collectPerp('tok', JESSICA);
+
+    const goal = getState().mission_goals.find(g => g.mission === 'mission001');
+    expect(goal.current_amount).toBe(900);
+    expect(goal.complete).toBe(true);
+    expect(result.missions.complete_missions).toContain('mission001');
+  });
+
+  it('collecting from a non-target contact does not advance mission001', async () => {
+    const HELEN = 'Imperium.City.Agent1.contact001';
+    setState(mkState({
+      nodes: [mkNode('ContactPerp', HELEN)],
+      nodes_collect: [{ path: HELEN, result: { amount: 1500 } }],
+      active_missions: ['mission001'],
+      mission_goals: [{
+        mission: 'mission001',
+        workflow: 'collect_profiles',
+        target: 'contact035',
+        amount: 900,
+        position: 2,
+        current_amount: 0,
+        complete: false
+      }]
+    }));
+
+    await collectPerp('tok', HELEN);
+    const goal = getState().mission_goals.find(g => g.mission === 'mission001');
+    expect(goal.current_amount).toBe(0);
+    expect(goal.complete).toBe(false);
+  });
+});
+
+describe('loadGame seeds mission_goals from active_missions', () => {
+  beforeEach(() => setOverride(FIXED_NOW));
+  afterEach(() => { clearOverride(); setEmitter(null); });
+
+  it('fresh game with mission001 active gets goals seeded from ruleset on first loadGame', async () => {
+    setState(mkState({
+      active_missions: ['mission001'],
+      mission_goals: []
+    }));
+
+    await loadGame('tok');
+
+    const goals = getState().mission_goals;
+    const m1 = goals.find(g => g.mission === 'mission001');
+    expect(m1).toBeDefined();
+    expect(m1.workflow).toBe('collect_profiles');
+    expect(m1.target).toBe('contact035');
+    expect(m1.amount).toBe(900);
+    expect(m1.current_amount).toBe(0);
+    expect(m1.complete).toBe(false);
+  });
+
+  it('idempotent — re-running loadGame does not duplicate goals', async () => {
+    setState(mkState({
+      active_missions: ['mission001'],
+      mission_goals: []
+    }));
+
+    await loadGame('tok');
+    const goalsAfterFirst = getState().mission_goals.length;
+    await loadGame('tok');
+    expect(getState().mission_goals.length).toBe(goalsAfterFirst);
   });
 });

--- a/tests/handlers/collect-integrate.test.js
+++ b/tests/handlers/collect-integrate.test.js
@@ -500,4 +500,45 @@ describe('integrateCollected — token node updates', () => {
     const { getState } = await import('../../scripts/boot.js');
     expect(getState().db_queue).toHaveLength(0);
   });
+
+  it('appends a new TokenPerp node the first time a token type is integrated', async () => {
+    // token008 is a real ruleset entry (mission002 targets it). State has no
+    // node for it yet — integrateCollected must seed one under Database/.
+    setState(mkState({
+      locale: 'en',
+      db_queue: [{
+        origin:      'Imperium.City.contact001',
+        collect_id:  COLLECT_ID,
+        profile_set: { profiles_value: 50, tokens_map: { token008: { amount: 25 } } },
+        collect_dt:  FIXED_NOW
+      }]
+    }));
+
+    const { result } = await integrateCollected('tok', COLLECT_ID);
+    const newEntry = result.result.nodes.find(function (n) { return n.gestalt === 'token008'; });
+    expect(newEntry).toBeDefined();
+    expect(newEntry.game_type).toBe('TokenPerp');
+    expect(newEntry.full_path).toBe('Database.token008');
+    expect(newEntry.instance_data.amount).toBe(25);
+
+    const { getState } = await import('../../scripts/boot.js');
+    const persisted = getState().nodes.find(function (n) { return n.gestalt === 'token008'; });
+    expect(persisted).toBeDefined();
+    expect(persisted.full_path).toBe('Database.token008');
+  });
+
+  it('does not seed a node for a gestalt that is not in ruleset.tokens', async () => {
+    setState(mkState({
+      locale: 'en',
+      db_queue: [{
+        origin:      'Imperium.City.contact001',
+        collect_id:  COLLECT_ID,
+        profile_set: { profiles_value: 5, tokens_map: { not_a_real_token: { amount: 9 } } },
+        collect_dt:  FIXED_NOW
+      }]
+    }));
+
+    const { result } = await integrateCollected('tok', COLLECT_ID);
+    expect(result.result.nodes).toHaveLength(0);
+  });
 });

--- a/tests/handlers/collect-integrate.test.js
+++ b/tests/handlers/collect-integrate.test.js
@@ -611,6 +611,62 @@ describe('collectPerp — level-up refills ap_snapshot to the new ap_max', () =>
   });
 });
 
+describe('integrateCollected — ap cost', () => {
+  const COLLECT_ID = 'ap-cost-001';
+
+  beforeEach(() => setOverride(FIXED_NOW));
+  afterEach(() => { clearOverride(); setEmitter(null); });
+
+  it('decrements ap_snapshot by 1', async () => {
+    setState(mkState({
+      game_values: Object.assign({}, mkGv(), { ap_snapshot: 5, ap_max: 6 }),
+      db_queue: [{
+        origin:      'Imperium.City.contact001',
+        collect_id:  COLLECT_ID,
+        profile_set: { profiles_value: 1, tokens_map: {} },
+        collect_dt:  FIXED_NOW
+      }]
+    }));
+
+    const { result } = await integrateCollected('tok', COLLECT_ID);
+    expect(result.game_values.ap_snapshot).toBe(4);
+  });
+
+  it('clamps ap_snapshot at 0 — never goes negative', async () => {
+    setState(mkState({
+      game_values: Object.assign({}, mkGv(), { ap_snapshot: 0, ap_max: 6 }),
+      db_queue: [{
+        origin:      'Imperium.City.contact001',
+        collect_id:  COLLECT_ID,
+        profile_set: { profiles_value: 1, tokens_map: {} },
+        collect_dt:  FIXED_NOW
+      }]
+    }));
+
+    const { result } = await integrateCollected('tok', COLLECT_ID);
+    expect(result.game_values.ap_snapshot).toBe(0);
+  });
+
+  it('level-up refill overrides the AP cost — full ap_max after crossing threshold', async () => {
+    setState(mkState({
+      game_values: Object.assign({}, mkGv(), {
+        xp_value: 10, xp_level: 1, ap_snapshot: 3, ap_max: 6
+      }),
+      db_queue: [{
+        origin:      'Imperium.City.contact001',
+        collect_id:  COLLECT_ID,
+        profile_set: { profiles_value: 1, tokens_map: {}, xp_gain: 10 },
+        collect_dt:  FIXED_NOW
+      }]
+    }));
+
+    const { result } = await integrateCollected('tok', COLLECT_ID);
+    expect(result.levelup).toBe(true);
+    expect(result.game_values.xp_level).toBe(2);
+    expect(result.game_values.ap_snapshot).toBe(8); // level 2 ap_max, not 3-1=2
+  });
+});
+
 describe('integrateCollected — level-up refills ap_snapshot to the new ap_max', () => {
   const COLLECT_ID = 'lvlup-integrate-001';
 

--- a/tests/handlers/collect-integrate.test.js
+++ b/tests/handlers/collect-integrate.test.js
@@ -7,9 +7,11 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
-  collectPerp, integrateCollected, loadGame, setEmitter, setPrngSeed
+  collectPerp, integrateCollected, chargePerp, buyPerp, loadGame,
+  setEmitter, setPrngSeed
 } from '../../scripts/LocalEngine.js';
 import { setState, getState } from '../../scripts/boot.js';
+import { materialize } from '../../scripts/materializer.js';
 import { freshState } from '../../scripts/state.js';
 import { setOverride, clearOverride, advance } from '../../scripts/clock.js';
 
@@ -1115,6 +1117,42 @@ describe('mission rewards — apply on completion', () => {
 
     const { result } = await integrateCollected('tok', COLLECT_ID);
     expect(result.game_values.cash_value).toBe(startCash);
+  });
+
+  it('end-to-end: charge car company → wait → collect adds ~584 cash', async () => {
+    const CAR_PATH = 'Imperium.City.Pusher0.client007';
+    setState(mkState({
+      game_values: Object.assign({}, mkGv(), {
+        cash_value: 100, ap_snapshot: 6, xp_level: 1
+      }),
+      nodes: [{
+        game_id: 'client007', game_type: 'ClientPerp',
+        full_type: 'ClientPerp:client007', gestalt: 'client007',
+        full_path: CAR_PATH,
+        instance_data: {}
+      }]
+    }));
+
+    const chargeRes = await chargePerp('tok', CAR_PATH);
+    expect(chargeRes.result.error).toBeUndefined();
+    expect(chargeRes.result.duration).toBe(60000); // car charge_time
+    const cashAfterCharge = getState().game_values.cash_value;
+    expect(cashAfterCharge).toBe(100); // car has no charge_cost
+
+    // Move clock past charge_end and materialize so the entry transitions.
+    setOverride(FIXED_NOW + 60001);
+    const matResult = materialize(getState(), FIXED_NOW + 60001);
+    setState(matResult.state);
+    expect(getState().nodes_collect).toHaveLength(1);
+    expect(getState().nodes_collect[0].path).toBe(CAR_PATH);
+
+    const collectRes = await collectPerp('tok', CAR_PATH);
+    expect(collectRes.result.error).toBeUndefined();
+    const finalCash = collectRes.result.game_values.cash_value;
+    // 584 ± 5% variation, rounded.
+    expect(finalCash - cashAfterCharge).toBeGreaterThanOrEqual(553);
+    expect(finalCash - cashAfterCharge).toBeLessThanOrEqual(614);
+    expect(getState().game_values.cash_value).toBe(finalCash);
   });
 
   it('completing mission001 grants its xp reward via collectPerp', async () => {

--- a/tests/handlers/collect-integrate.test.js
+++ b/tests/handlers/collect-integrate.test.js
@@ -89,7 +89,9 @@ describe('full flow: ContactPerp charge → collect → integrate', () => {
 
     const data = await collectPerp('tok', PATH);
     expect(data.result.error).toBeUndefined();
-    expect(data.result.result.profile_set).toEqual({ profiles_value: 5, tokens_map: {} });
+    expect(data.result.result.profile_set.profiles_value).toBe(5);
+    // contact001's `tokens` list populates tokens_map (percentage * profiles).
+    expect(typeof data.result.result.profile_set.tokens_map).toBe('object');
     expect(data.result.result.origin).toBe(PATH);
     expect(typeof data.result.result.collect_id).toBe('string');
     expect(data.result.result.collect_id.length).toBeGreaterThan(0);
@@ -223,7 +225,6 @@ describe('collectPerp — ContactPerp', () => {
 
 describe('collectPerp — ProjectPerp', () => {
   const PATH = 'Imperium.City.project001';
-  const PS = { profiles_value: 10, tokens_map: {} };
 
   beforeEach(() => setOverride(FIXED_NOW));
   afterEach(() => clearOverride());
@@ -235,7 +236,8 @@ describe('collectPerp — ProjectPerp', () => {
     }));
 
     const { result } = await collectPerp('tok', PATH);
-    expect(result.result.profile_set).toEqual(PS);
+    expect(result.result.profile_set.profiles_value).toBe(10);
+    expect(typeof result.result.profile_set.tokens_map).toBe('object');
     expect(result.result.origin).toBe(PATH);
     expect(result.result.collect_id).toBeTruthy();
   });
@@ -252,7 +254,8 @@ describe('collectPerp — ProjectPerp', () => {
     expect(s.db_queue).toHaveLength(1);
     const q = s.db_queue[0];
     expect(q.collect_id).toBe(result.result.collect_id);
-    expect(q.profile_set).toEqual(PS);
+    expect(q.profile_set.profiles_value).toBe(10);
+    expect(typeof q.profile_set.tokens_map).toBe('object');
     expect(q.origin).toBe(PATH);
     expect(typeof q.collect_dt).toBe('number');
   });
@@ -599,5 +602,124 @@ describe('integrateCollected — level-up refills ap_snapshot to the new ap_max'
     expect(result.levelup).toBe(true);
     expect(result.game_values.xp_level).toBe(2);
     expect(result.game_values.ap_snapshot).toBe(8);
+  });
+});
+
+// ── #85 root cause: tokens_map is populated from typeData.tokens ────────────
+//
+// Contacts in the ruleset list yielded token types under `tokens`, not
+// `contained_tokens` (the latter is for TokenPerp super-token decomposition).
+// Each entry's `amount` is a percentage of profiles_value carrying that
+// token type. Without populated tokens_map, mission goals with workflow
+// "integrate_profiles" never advance — that's the 0/900 bug on mission002.
+
+describe('collectPerp — tokens_map population from typeData.tokens (#85)', () => {
+  // contact001 (Nurse Helen) has 12 tokens, each at 100%.
+  const PATH = 'Imperium.City.Agent0.contact001';
+
+  beforeEach(() => setOverride(FIXED_NOW));
+  afterEach(() => { clearOverride(); setEmitter(null); });
+
+  it('tokens_map carries an entry for every gestalt in typeData.tokens', async () => {
+    setState(mkState({
+      nodes:         [mkNode('ContactPerp', PATH)],
+      nodes_collect: [{ path: PATH, result: { amount: 10 } }]
+    }));
+
+    const { result } = await collectPerp('tok', PATH);
+    const tm = result.result.profile_set.tokens_map;
+    // contact001 lists token001, token002, ..., token018, origin012 — 12 in total.
+    expect(Object.keys(tm).sort()).toEqual([
+      'origin012',
+      'token001', 'token002', 'token003', 'token004', 'token005',
+      'token006', 'token007', 'token014', 'token015', 'token017',
+      'token018'
+    ].sort());
+  });
+
+  it('amount is floor(percentage * profiles_value / 100)', async () => {
+    setState(mkState({
+      nodes:         [mkNode('ContactPerp', PATH)],
+      nodes_collect: [{ path: PATH, result: { amount: 10 } }]
+    }));
+
+    const { result } = await collectPerp('tok', PATH);
+    // 100% * 10 profiles / 100 = 10 tokens per gestalt.
+    expect(result.result.profile_set.tokens_map.token001).toEqual({ amount: 10 });
+    expect(result.result.profile_set.tokens_map.token008).toBeUndefined(); // not in contact001's list
+  });
+
+  it('Jessica (contact035) yields token008 from her tokens list — unblocks mission002', async () => {
+    const JPATH = 'Imperium.CityVienna.Agent0.contact035';
+    setState(mkState({
+      nodes:         [mkNode('ContactPerp', JPATH)],
+      nodes_collect: [{ path: JPATH, result: { amount: 1100 } }]
+    }));
+
+    const { result } = await collectPerp('tok', JPATH);
+    // Jessica's token008 entry is 100% → 100% * 1100 = 1100 token008s.
+    expect(result.result.profile_set.tokens_map.token008).toEqual({ amount: 1100 });
+  });
+
+  it('tokens_map stays empty when typeData.tokens is missing', async () => {
+    // contact002 is not in the ruleset → typeData undefined → tokens_map empty.
+    const FPATH = 'Imperium.City.Agent0.contact002';
+    setState(mkState({
+      nodes:         [mkNode('ContactPerp', FPATH)],
+      nodes_collect: [{ path: FPATH, result: { amount: 5 } }]
+    }));
+
+    const { result } = await collectPerp('tok', FPATH);
+    expect(result.result.profile_set.tokens_map).toEqual({});
+  });
+});
+
+// ── integrateCollected payload shape ────────────────────────────────────────
+//
+// Newly seeded TokenPerp nodes must carry game_type and full_type so the
+// applyDelta reducer can append them on cold-start replay.
+
+describe('integrateCollected — payload shape for newly seeded TokenPerps', () => {
+  const COLLECT_ID = 'shape-001';
+
+  beforeEach(() => setOverride(FIXED_NOW));
+  afterEach(() => { clearOverride(); setEmitter(null); });
+
+  it('new node entries carry game_type=TokenPerp and full_type=TokenPerp:<gestalt>', async () => {
+    setState(mkState({
+      locale: 'en',
+      db_queue: [{
+        origin:      'Imperium.City.contact001',
+        collect_id:  COLLECT_ID,
+        profile_set: { profiles_value: 50, tokens_map: { token008: { amount: 25 } } },
+        collect_dt:  FIXED_NOW
+      }]
+    }));
+
+    const { result } = await integrateCollected('tok', COLLECT_ID);
+    const newEntry = result.result.nodes.find(function (n) { return n.gestalt === 'token008'; });
+    expect(newEntry).toBeDefined();
+    expect(newEntry.game_type).toBe('TokenPerp');
+    expect(newEntry.full_type).toBe('TokenPerp:token008');
+    expect(newEntry.full_path).toBe('Database.token008');
+    expect(newEntry.game_id).toBe('token008');
+  });
+
+  it('seeded entries replay correctly through applyDelta', async () => {
+    setState(mkState({
+      locale: 'en',
+      db_queue: [{
+        origin:      'Imperium.City.contact001',
+        collect_id:  COLLECT_ID,
+        profile_set: { profiles_value: 50, tokens_map: { token008: { amount: 25 } } },
+        collect_dt:  FIXED_NOW
+      }]
+    }));
+
+    await integrateCollected('tok', COLLECT_ID);
+    const { getState } = await import('../../scripts/boot.js');
+    const persisted = getState().nodes.find(function (n) { return n.gestalt === 'token008'; });
+    expect(persisted.game_type).toBe('TokenPerp');
+    expect(persisted.full_type).toBe('TokenPerp:token008');
   });
 });

--- a/tests/handlers/collect-integrate.test.js
+++ b/tests/handlers/collect-integrate.test.js
@@ -542,3 +542,62 @@ describe('integrateCollected — token node updates', () => {
     expect(result.result.nodes).toHaveLength(0);
   });
 });
+
+// ── level-up refills AP across collect/integrate paths ──────────────────────
+//
+// Level 1 (de + en): xp_min=0,  xp_max=10, ap_max=6
+// Level 2 (de + en): xp_min=11, xp_max=30, ap_max=8
+
+describe('collectPerp — level-up refills ap_snapshot to the new ap_max', () => {
+  const PATH = 'Imperium.City.Agent0.contact001';
+
+  beforeEach(() => setOverride(FIXED_NOW));
+  afterEach(() => { clearOverride(); setEmitter(null); });
+
+  it('crossing the xp_max threshold returns levelup=true and ap_snapshot=8', async () => {
+    setState(mkState({
+      // xp_value=10 + xp_inc=1 (contact001) = 11 → level 2.
+      game_values: Object.assign({}, mkGv(), {
+        xp_value: 10, xp_level: 1, ap_snapshot: 0, ap_max: 6
+      }),
+      nodes: [{
+        game_id: 'node_contact001', game_type: 'ContactPerp',
+        full_type: 'ContactPerp:contact001', gestalt: 'contact001',
+        full_path: PATH, instance_data: {}
+      }],
+      nodes_collect: [{ path: PATH, result: { amount: 5 } }]
+    }));
+
+    const { result } = await collectPerp('tok', PATH);
+    expect(result.levelup).toBe(true);
+    expect(result.game_values.xp_level).toBe(2);
+    expect(result.game_values.ap_snapshot).toBe(8);
+  });
+});
+
+describe('integrateCollected — level-up refills ap_snapshot to the new ap_max', () => {
+  const COLLECT_ID = 'lvlup-integrate-001';
+
+  beforeEach(() => setOverride(FIXED_NOW));
+  afterEach(() => { clearOverride(); setEmitter(null); });
+
+  it('crossing xp_max via xp_gain returns levelup=true and full AP', async () => {
+    setState(mkState({
+      game_values: Object.assign({}, mkGv(), {
+        xp_value: 5, xp_level: 1, ap_snapshot: 1, ap_max: 6
+      }),
+      db_queue: [{
+        origin: 'Imperium.City.contact001',
+        collect_id: COLLECT_ID,
+        // xp_gain on the profile_set drives xp gain on integrate.
+        profile_set: { profiles_value: 4, tokens_map: {}, xp_gain: 10, karma_gain: 0 },
+        collect_dt: FIXED_NOW
+      }]
+    }));
+
+    const { result } = await integrateCollected('tok', COLLECT_ID);
+    expect(result.levelup).toBe(true);
+    expect(result.game_values.xp_level).toBe(2);
+    expect(result.game_values.ap_snapshot).toBe(8);
+  });
+});

--- a/tests/handlers/collect-integrate.test.js
+++ b/tests/handlers/collect-integrate.test.js
@@ -756,11 +756,6 @@ describe('integrateCollected — payload shape for newly seeded TokenPerps', () 
 });
 
 // ── Mission progression: collect_profiles + integrate_profiles ──────────────
-//
-// End-to-end: charge → collect → integrate from Jessica (contact035), and
-// assert that the integrate_profiles goal on mission002 (target token008,
-// amount 900) advances and completes. mission003 should activate when
-// mission002 completes (required_mission chain).
 
 describe('mission progression — integrate_profiles flow', () => {
   const JESSICA = 'Imperium.City.Agent0.contact035';

--- a/tests/handlers/collect-integrate.test.js
+++ b/tests/handlers/collect-integrate.test.js
@@ -473,6 +473,39 @@ describe('integrateCollected — token node updates', () => {
     expect(result.game_values.profiles_value).toBe(4);
   });
 
+  it('caps instance_data.amount at 100 — bar width = amount/100*60px must not overflow', async () => {
+    const tokenNode = mkNode('TokenPerp', TOKEN_PATH, { amount: 90 });
+    tokenNode.gestalt = 'token_a';
+    setState(mkState({
+      nodes: [tokenNode],
+      db_queue: [{
+        origin:      'Imperium.City.contact001',
+        collect_id:  COLLECT_ID,
+        profile_set: { profiles_value: 4, tokens_map: { token_a: { amount: 50 } } },
+        collect_dt:  FIXED_NOW
+      }]
+    }));
+
+    const { result } = await integrateCollected('tok', COLLECT_ID);
+    expect(result.result.nodes[0].instance_data.amount).toBe(100);
+  });
+
+  it('caps a fresh-seeded TokenPerp at 100 too', async () => {
+    setState(mkState({
+      locale: 'en',
+      db_queue: [{
+        origin:      'Imperium.City.contact001',
+        collect_id:  COLLECT_ID,
+        profile_set: { profiles_value: 50, tokens_map: { token008: { amount: 250 } } },
+        collect_dt:  FIXED_NOW
+      }]
+    }));
+
+    const { result } = await integrateCollected('tok', COLLECT_ID);
+    const seeded = result.result.nodes.find(n => n.gestalt === 'token008');
+    expect(seeded.instance_data.amount).toBe(100);
+  });
+
   it('returns game_values, levelup, and missions for server parity', async () => {
     setState(mkState({
       db_queue: [{
@@ -635,15 +668,14 @@ describe('collectPerp — tokens_map population from typeData.tokens', () => {
     ].sort());
   });
 
-  it('amount is floor(percentage * profiles_value / 100)', async () => {
+  it('amount is the raw ruleset percentage (passed through unchanged)', async () => {
     setState(mkState({
       nodes:         [mkNode('ContactPerp', PATH)],
       nodes_collect: [{ path: PATH, result: { amount: 10 } }]
     }));
 
     const { result } = await collectPerp('tok', PATH);
-    // 100% * 10 profiles / 100 = 10 tokens per gestalt.
-    expect(result.result.profile_set.tokens_map.token001).toEqual({ amount: 10 });
+    expect(result.result.profile_set.tokens_map.token001).toEqual({ amount: 100 });
     expect(result.result.profile_set.tokens_map.token008).toBeUndefined(); // not in contact001's list
   });
 
@@ -655,8 +687,9 @@ describe('collectPerp — tokens_map population from typeData.tokens', () => {
     }));
 
     const { result } = await collectPerp('tok', JPATH);
-    // Jessica's token008 entry is 100% → 100% * 1100 = 1100 token008s.
-    expect(result.result.profile_set.tokens_map.token008).toEqual({ amount: 1100 });
+    // Jessica lists token008 at 100%; downstream absoluteAmount =
+    // profiles_value * amount / 100 = 1100, which exceeds mission002's 900 target.
+    expect(result.result.profile_set.tokens_map.token008).toEqual({ amount: 100 });
   });
 
   it('tokens_map stays empty when typeData.tokens is missing', async () => {

--- a/tests/handlers/collect-integrate.test.js
+++ b/tests/handlers/collect-integrate.test.js
@@ -634,7 +634,7 @@ describe('integrateCollected — ap cost', () => {
     expect(result.game_values.ap_snapshot).toBe(4);
   });
 
-  it('clamps ap_snapshot at 0 — never goes negative', async () => {
+  it('returns error 1 when ap_snapshot is 0 (parity with chargePerp)', async () => {
     setState(mkState({
       game_values: Object.assign({}, mkGv(), { ap_snapshot: 0, ap_max: 6 }),
       db_queue: [{
@@ -645,8 +645,8 @@ describe('integrateCollected — ap cost', () => {
       }]
     }));
 
-    const { result } = await integrateCollected('tok', COLLECT_ID);
-    expect(result.game_values.ap_snapshot).toBe(0);
+    const data = await integrateCollected('tok', COLLECT_ID);
+    expect(data.result.error).toBe(1);
   });
 
   it('level-up refill overrides the AP cost — full ap_max after crossing threshold', async () => {
@@ -903,6 +903,36 @@ describe('mission progression — integrate_profiles flow', () => {
     const goal = getState().mission_goals.find(g => g.mission === 'mission002');
     expect(goal.current_amount).toBe(900);
     expect(goal.complete).toBe(true);
+  });
+
+  it('progress is monotonic — a smaller integrate does not roll back current_amount', async () => {
+    // First integrate fills mission002 to 900 (Jessica 100% × 1100 profiles).
+    seedMission002Active();
+    await integrateCollected('tok', COLLECT_ID);
+
+    // Construct a hypothetical second integrate from a 50%-coverage contact
+    // that, naively, would compute a smaller absoluteAmount. Using
+    // _advanceIntegrateProfilesMissions directly via state setup: feed a
+    // db_queue entry whose profile_set has lower amount on token008, then
+    // assert mission002.current_amount stays at the high-water mark.
+    const s = getState();
+    s.mission_goals = s.mission_goals.map(g =>
+      g.mission === 'mission002'
+        ? Object.assign({}, g, { current_amount: 500, complete: false })
+        : g
+    );
+    s.active_missions = s.active_missions.concat(['mission002']);
+    s.db_queue = [{
+      origin: JESSICA, collect_id: 'second-integrate',
+      profile_set: { profiles_value: 100, tokens_map: { token008: { amount: 50 } } },
+      collect_dt: FIXED_NOW
+    }];
+    setState(s);
+
+    await integrateCollected('tok', 'second-integrate');
+    // 100 profiles × 50% = 50 absolute → would regress from 500 if not guarded.
+    const goal = getState().mission_goals.find(g => g.mission === 'mission002');
+    expect(goal.current_amount).toBeGreaterThanOrEqual(500);
   });
 });
 

--- a/tests/handlers/collect-integrate.test.js
+++ b/tests/handlers/collect-integrate.test.js
@@ -1018,3 +1018,125 @@ describe('loadGame seeds mission_goals from active_missions', () => {
     expect(getState().mission_goals.length).toBe(goalsAfterFirst);
   });
 });
+
+// ── Cash invariants & mission rewards ───────────────────────────────────────
+
+describe('cash invariants — collect/integrate must not deduct cash', () => {
+  const PATH = 'Imperium.City.Agent0.contact001';
+
+  beforeEach(() => setOverride(FIXED_NOW));
+  afterEach(() => { clearOverride(); setEmitter(null); });
+
+  it('ContactPerp collect leaves cash_value unchanged', async () => {
+    const startCash = 270;
+    setState(mkState({
+      game_values: Object.assign({}, mkGv(), { cash_value: startCash }),
+      nodes: [mkNode('ContactPerp', PATH)],
+      nodes_collect: [{ path: PATH, result: { amount: 5 } }]
+    }));
+
+    const { result } = await collectPerp('tok', PATH);
+    expect(result.game_values.cash_value).toBe(startCash);
+    expect(getState().game_values.cash_value).toBe(startCash);
+  });
+
+  it('integrateCollected leaves cash_value unchanged when no rewards fire', async () => {
+    const startCash = 270;
+    setState(mkState({
+      game_values: Object.assign({}, mkGv(), { cash_value: startCash }),
+      db_queue: [{
+        origin: PATH, collect_id: 'no-rewards',
+        profile_set: { profiles_value: 1, tokens_map: {} },
+        collect_dt: FIXED_NOW
+      }]
+    }));
+
+    const { result } = await integrateCollected('tok', 'no-rewards');
+    expect(result.game_values.cash_value).toBe(startCash);
+  });
+});
+
+describe('mission rewards — apply on completion', () => {
+  const JESSICA = 'Imperium.City.Agent0.contact035';
+  const COLLECT_ID = 'rewards-001';
+
+  beforeEach(() => setOverride(FIXED_NOW));
+  afterEach(() => { clearOverride(); setEmitter(null); });
+
+  it('completing mission002 grants its 100 cash + 1 xp reward', async () => {
+    const startCash = 200;
+    const startXp = 0;
+    setState(mkState({
+      game_values: Object.assign({}, mkGv(), {
+        cash_value: startCash, xp_value: startXp
+      }),
+      active_missions: ['mission002'],
+      mission_goals: [{
+        mission: 'mission002',
+        workflow: 'integrate_profiles',
+        target: 'token008',
+        amount: 900,
+        position: 1,
+        current_amount: 0,
+        complete: false
+      }],
+      db_queue: [{
+        origin: JESSICA, collect_id: COLLECT_ID,
+        profile_set: { profiles_value: 1100, tokens_map: { token008: { amount: 100 } } },
+        collect_dt: FIXED_NOW
+      }]
+    }));
+
+    const { result } = await integrateCollected('tok', COLLECT_ID);
+    expect(result.game_values.cash_value).toBe(startCash + 100);
+    expect(result.game_values.xp_value).toBeGreaterThanOrEqual(startXp + 1);
+  });
+
+  it('partial-progress integrate (no completion) yields no rewards', async () => {
+    const startCash = 200;
+    setState(mkState({
+      game_values: Object.assign({}, mkGv(), { cash_value: startCash }),
+      active_missions: ['mission002'],
+      mission_goals: [{
+        mission: 'mission002',
+        workflow: 'integrate_profiles',
+        target: 'token008',
+        amount: 900,
+        position: 1,
+        current_amount: 0,
+        complete: false
+      }],
+      db_queue: [{
+        origin: JESSICA, collect_id: COLLECT_ID,
+        profile_set: { profiles_value: 500, tokens_map: { token008: { amount: 50 } } },
+        collect_dt: FIXED_NOW
+      }]
+    }));
+
+    const { result } = await integrateCollected('tok', COLLECT_ID);
+    expect(result.game_values.cash_value).toBe(startCash);
+  });
+
+  it('completing mission001 grants its xp reward via collectPerp', async () => {
+    const startXp = 0;
+    setState(mkState({
+      game_values: Object.assign({}, mkGv(), { xp_value: startXp }),
+      nodes: [mkNode('ContactPerp', JESSICA)],
+      nodes_collect: [{ path: JESSICA, result: { amount: 1100 } }],
+      active_missions: ['mission001'],
+      mission_goals: [{
+        mission: 'mission001',
+        workflow: 'collect_profiles',
+        target: 'contact035',
+        amount: 900,
+        position: 2,
+        current_amount: 0,
+        complete: false
+      }]
+    }));
+
+    const { result } = await collectPerp('tok', JESSICA);
+    // contact035 xp_inc=1 + mission001 reward=2.
+    expect(result.game_values.xp_value).toBe(startXp + 1 + 2);
+  });
+});

--- a/tests/handlers/handlers.test.js
+++ b/tests/handlers/handlers.test.js
@@ -1045,6 +1045,38 @@ describe('buyPerp — failure: unknown gestalt', () => {
   });
 });
 
+// ── level-up: buyPerp's xp_inc crosses a threshold ─────────────────────────
+//
+// contact001 requires level 3 (xp_min=31, xp_max=54), xp_inc=1. Setting
+// xp_value=54, xp_level=3 means the next 1-XP buy lands the player at
+// xp=55 = level 4 (xp_min=55, xp_max=80, ap_max=14).
+
+describe('buyPerp — level-up refills ap_snapshot', () => {
+  beforeEach(() => {
+    setState(Object.assign(mkBuyPerpState(), {
+      game_values: {
+        xp_value: 54, xp_level: 3,
+        cash_value: 10000, cash_spent: 0,
+        karma_value: 0, profiles_value: 0, profiles_max: 1,
+        ap_snapshot: 1, ap_update: null
+      }
+    }));
+  });
+
+  it('returns levelup=true', async () => {
+    const { result } = await buyPerp('tok', 'Imperium', 'contact001');
+    expect(result.error).toBeUndefined();
+    expect(result.levelup).toBe(true);
+  });
+
+  it('advances xp_level and refills AP to the new level\'s ap_max', async () => {
+    const { result } = await buyPerp('tok', 'Imperium', 'contact001');
+    expect(result.game_values.xp_level).toBe(4);
+    expect(result.game_values.ap_snapshot).toBe(14);
+    expect(result.game_values.ap_max).toBe(14);
+  });
+});
+
 // ── setLocale ────────────────────────────────────────────────────────────────
 
 describe('setLocale', () => {

--- a/tests/handlers/handlers.test.js
+++ b/tests/handlers/handlers.test.js
@@ -595,7 +595,7 @@ var PROJECT_NODE = {
   }
 };
 
-// State with enough cash for any normal purchase (default seed: 300).
+// State with enough cash for any normal purchase (default seed: 270).
 function mkProjectState(overrides) {
   var base = freshState('test@local');
   return Object.assign({}, base, { nodes: [PROJECT_NODE] }, overrides || {});
@@ -662,7 +662,7 @@ describe('buyPowerup — happy path', () => {
     await buyPowerup('tok', PROJECT_NODE.full_path, 0, 'ad002');
     const s = getState();
     expect(s.nodes[0].instance_data.powerups).toHaveLength(1);
-    expect(s.game_values.cash_value).toBe(300 - 90);
+    expect(s.game_values.cash_value).toBe(270 - 90);
   });
 });
 

--- a/tests/handlers/handlers.test.js
+++ b/tests/handlers/handlers.test.js
@@ -2,7 +2,8 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   getToken, ping, getSessionLocale, setLocale, loadGame, getRanking, setEmitter,
   setDisplayName, setPerpCoordinates, buyKarma,
-  buyPowerup, sellPowerup, buySlots, buyPerp
+  buyPowerup, sellPowerup, buySlots, buyPerp,
+  dismissMissionBriefing, markTokenSeen
 } from '../../scripts/LocalEngine.js';
 import { getState, setState } from '../../scripts/boot.js';
 import { freshState, applyDelta } from '../../scripts/state.js';
@@ -1139,5 +1140,106 @@ describe('getSessionLocale — persisted locale', () => {
     setState(mkState());
     const data = await getSessionLocale();
     expect(data.result).toBe('de');
+  });
+});
+
+// ── dismissMissionBriefing ──────────────────────────────────────────────────
+
+describe('dismissMissionBriefing — happy path', () => {
+  beforeEach(() => setState(mkState()));
+
+  it('resolves to {result: {ok: true}}', async () => {
+    const data = await dismissMissionBriefing('tok', 'mission002');
+    expect(data).toEqual({ result: { ok: true } });
+  });
+
+  it('records the gestalt under state.mission_briefings_seen', async () => {
+    await dismissMissionBriefing('tok', 'mission002');
+    expect(getState().mission_briefings_seen).toEqual({ mission002: true });
+  });
+
+  it('is idempotent — re-dispatching the same gestalt does not throw', async () => {
+    await dismissMissionBriefing('tok', 'mission002');
+    const data = await dismissMissionBriefing('tok', 'mission002');
+    expect(data).toEqual({ result: { ok: true } });
+    expect(getState().mission_briefings_seen).toEqual({ mission002: true });
+  });
+
+  it('accumulates multiple dismissals', async () => {
+    await dismissMissionBriefing('tok', 'mission002');
+    await dismissMissionBriefing('tok', 'mission003');
+    expect(getState().mission_briefings_seen).toEqual({
+      mission002: true,
+      mission003: true
+    });
+  });
+});
+
+describe('dismissMissionBriefing — failure modes', () => {
+  beforeEach(() => setState(mkState()));
+
+  it('returns error 0 for empty string gestalt', async () => {
+    const data = await dismissMissionBriefing('tok', '');
+    expect(data).toEqual({ result: { error: 0 } });
+    expect(getState().mission_briefings_seen).toEqual({});
+  });
+
+  it('returns error 0 for non-string gestalt', async () => {
+    const data = await dismissMissionBriefing('tok', 42);
+    expect(data).toEqual({ result: { error: 0 } });
+  });
+
+  it('returns error 0 for undefined gestalt', async () => {
+    const data = await dismissMissionBriefing('tok');
+    expect(data).toEqual({ result: { error: 0 } });
+  });
+});
+
+// ── markTokenSeen ───────────────────────────────────────────────────────────
+
+describe('markTokenSeen — happy path', () => {
+  beforeEach(() => setState(mkState()));
+
+  it('resolves to {result: {ok: true}}', async () => {
+    const data = await markTokenSeen('tok', 'token008');
+    expect(data).toEqual({ result: { ok: true } });
+  });
+
+  it('records the gestalt under state.tokens_seen', async () => {
+    await markTokenSeen('tok', 'token008');
+    expect(getState().tokens_seen).toEqual({ token008: true });
+  });
+
+  it('is idempotent', async () => {
+    await markTokenSeen('tok', 'token008');
+    const data = await markTokenSeen('tok', 'token008');
+    expect(data).toEqual({ result: { ok: true } });
+    expect(getState().tokens_seen).toEqual({ token008: true });
+  });
+
+  it('accumulates multiple gestalts', async () => {
+    await markTokenSeen('tok', 'token001');
+    await markTokenSeen('tok', 'token008');
+    expect(getState().tokens_seen).toEqual({ token001: true, token008: true });
+  });
+});
+
+describe('markTokenSeen — failure modes', () => {
+  beforeEach(() => setState(mkState()));
+
+  it('returns error 0 for empty string gestalt', async () => {
+    const data = await markTokenSeen('tok', '');
+    expect(data).toEqual({ result: { error: 0 } });
+    expect(getState().tokens_seen).toEqual({});
+  });
+
+  it('returns error 0 for non-string gestalt', async () => {
+    const data = await markTokenSeen('tok', 42);
+    expect(data).toEqual({ result: { error: 0 } });
+  });
+
+  it('returns error 0 for undefined gestalt', async () => {
+    const data = await markTokenSeen('tok');
+    expect(data).toEqual({ result: { error: 0 } });
   });
 });

--- a/tests/handlers/handlers.test.js
+++ b/tests/handlers/handlers.test.js
@@ -447,6 +447,26 @@ describe('materialization on boot', () => {
 
     expect(emitted).toHaveLength(0);
   });
+
+  it('AP regen survives reload — first loadGame seeds the clock, second ticks', async () => {
+    setOverride(FIXED_NOW);
+    setState(mkState({
+      game_values: Object.assign({}, freshState('test@local').game_values, {
+        ap_snapshot: 0, ap_update: null
+      })
+    }));
+
+    // First load seeds ap_update without granting any ticks.
+    await loadGame('tok');
+    expect(getState().game_values.ap_update).toBe(FIXED_NOW);
+    expect(getState().game_values.ap_snapshot).toBe(0);
+
+    // Two minutes later (one ap_inc_interval at level 1) → +1 AP.
+    setOverride(FIXED_NOW + 120000);
+    await loadGame('tok');
+    expect(getState().game_values.ap_snapshot).toBe(1);
+    expect(getState().game_values.ap_update).toBe(FIXED_NOW + 120000);
+  });
 });
 
 // ── setDisplayName ────────────────────────────────────────────────────────────

--- a/tests/materializer/materializer.test.js
+++ b/tests/materializer/materializer.test.js
@@ -157,6 +157,28 @@ describe('AP regen rule', () => {
     });
     expect(materialize(s, 3000).state.game_values.ap_snapshot).toBe(10);
   });
+
+  it('null ap_update seeds the regen clock from now (no immediate ticks)', () => {
+    const s = baseState({
+      game_values: { ap_snapshot: 5, ap_update: null,
+                     ap_inc_value: 1, ap_inc_interval: 1000, ap_max: 20 }
+    });
+    const r = materialize(s, 7000);
+    expect(r.state.game_values.ap_snapshot).toBe(5); // no time has passed since seed
+    expect(r.state.game_values.ap_update).toBe(7000);
+  });
+
+  it('seeded clock ticks correctly on subsequent materialize', () => {
+    const seed = baseState({
+      game_values: { ap_snapshot: 0, ap_update: null,
+                     ap_inc_value: 1, ap_inc_interval: 1000, ap_max: 20 }
+    });
+    const s1 = materialize(seed, 1000).state;
+    expect(s1.game_values.ap_update).toBe(1000);
+    const s2 = materialize(s1, 4500).state;
+    expect(s2.game_values.ap_snapshot).toBe(3);    // 3 full ticks
+    expect(s2.game_values.ap_update).toBe(4000);   // last full-tick boundary
+  });
 });
 
 // ── idempotence ──────────────────────────────────────────────────────────────

--- a/tests/state/state.test.js
+++ b/tests/state/state.test.js
@@ -242,7 +242,6 @@ describe('applyDelta — dismissMissionBriefing reducer', () => {
     let s = freshState(addr);
     s = applyDelta(s, makeDismissDelta(addr, 'mission002', 1000));
     const result = applyDelta(s, makeDismissDelta(addr, 'mission002', 2000));
-    expect(result.mission_briefings_seen).toEqual(s.mission_briefings_seen);
     expect(result.mission_briefings_seen).toBe(s.mission_briefings_seen);
   });
 
@@ -305,7 +304,6 @@ describe('applyDelta — markTokenSeen reducer', () => {
     let s = freshState(addr);
     s = applyDelta(s, makeSeenDelta(addr, 'token008', 1000));
     const result = applyDelta(s, makeSeenDelta(addr, 'token008', 2000));
-    expect(result.tokens_seen).toEqual(s.tokens_seen);
     expect(result.tokens_seen).toBe(s.tokens_seen);
   });
 

--- a/tests/state/state.test.js
+++ b/tests/state/state.test.js
@@ -271,12 +271,6 @@ describe('applyDelta — dismissMissionBriefing reducer', () => {
     expect(applyDelta(s, makeDismissDelta(addr, null)).mission_briefings_seen).toEqual({});
   });
 
-  it('reset wipes mission_briefings_seen back to empty', () => {
-    let s = freshState(addr);
-    s = applyDelta(s, makeDismissDelta(addr, 'mission002', 1000));
-    const after = applyDelta(s, makeDelta(addr, 'reset', 2000));
-    expect(after.mission_briefings_seen).toEqual({});
-  });
 });
 
 // ---------------------------------------------------------------------------
@@ -326,10 +320,4 @@ describe('applyDelta — markTokenSeen reducer', () => {
     expect(applyDelta(s, makeSeenDelta(addr, 42)).tokens_seen).toEqual({});
   });
 
-  it('reset wipes tokens_seen back to empty', () => {
-    let s = freshState(addr);
-    s = applyDelta(s, makeSeenDelta(addr, 'token008', 1000));
-    const after = applyDelta(s, makeDelta(addr, 'reset', 2000));
-    expect(after.tokens_seen).toEqual({});
-  });
 });

--- a/tests/state/state.test.js
+++ b/tests/state/state.test.js
@@ -216,3 +216,122 @@ describe('applyDelta — setLocale reducer', () => {
   });
 
 });
+
+// ---------------------------------------------------------------------------
+// dismissMissionBriefing reducer
+// ---------------------------------------------------------------------------
+
+describe('applyDelta — dismissMissionBriefing reducer', () => {
+  const addr = 'alice@example.com';
+
+  function makeDismissDelta(addr, gestalt, ts) {
+    return { kind: 'delta', addr, op: 'dismissMissionBriefing', args: [gestalt], ts: ts || Date.now() };
+  }
+
+  it('freshState seeds mission_briefings_seen as an empty object', () => {
+    expect(freshState(addr).mission_briefings_seen).toEqual({});
+  });
+
+  it('records the dismissed gestalt under mission_briefings_seen', () => {
+    const s = freshState(addr);
+    const result = applyDelta(s, makeDismissDelta(addr, 'mission002'));
+    expect(result.mission_briefings_seen).toEqual({ mission002: true });
+  });
+
+  it('is idempotent — second dispatch leaves mission_briefings_seen unchanged', () => {
+    let s = freshState(addr);
+    s = applyDelta(s, makeDismissDelta(addr, 'mission002', 1000));
+    const result = applyDelta(s, makeDismissDelta(addr, 'mission002', 2000));
+    expect(result.mission_briefings_seen).toEqual(s.mission_briefings_seen);
+    expect(result.mission_briefings_seen).toBe(s.mission_briefings_seen);
+  });
+
+  it('accumulates multiple gestalts', () => {
+    let s = freshState(addr);
+    s = applyDelta(s, makeDismissDelta(addr, 'mission002', 1000));
+    s = applyDelta(s, makeDismissDelta(addr, 'mission003', 2000));
+    expect(s.mission_briefings_seen).toEqual({ mission002: true, mission003: true });
+  });
+
+  it('leaves mission_briefings_seen empty when args is missing', () => {
+    const s = freshState(addr);
+    const bad = { kind: 'delta', addr, op: 'dismissMissionBriefing', ts: 1000 };
+    const result = applyDelta(s, bad);
+    expect(result.mission_briefings_seen).toEqual({});
+  });
+
+  it('leaves mission_briefings_seen empty when gestalt is empty string', () => {
+    const s = freshState(addr);
+    const result = applyDelta(s, makeDismissDelta(addr, ''));
+    expect(result.mission_briefings_seen).toEqual({});
+  });
+
+  it('leaves mission_briefings_seen empty when gestalt is non-string', () => {
+    const s = freshState(addr);
+    expect(applyDelta(s, makeDismissDelta(addr, 42)).mission_briefings_seen).toEqual({});
+    expect(applyDelta(s, makeDismissDelta(addr, null)).mission_briefings_seen).toEqual({});
+  });
+
+  it('reset wipes mission_briefings_seen back to empty', () => {
+    let s = freshState(addr);
+    s = applyDelta(s, makeDismissDelta(addr, 'mission002', 1000));
+    const after = applyDelta(s, makeDelta(addr, 'reset', 2000));
+    expect(after.mission_briefings_seen).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// markTokenSeen reducer
+// ---------------------------------------------------------------------------
+
+describe('applyDelta — markTokenSeen reducer', () => {
+  const addr = 'alice@example.com';
+
+  function makeSeenDelta(addr, gestalt, ts) {
+    return { kind: 'delta', addr, op: 'markTokenSeen', args: [gestalt], ts: ts || Date.now() };
+  }
+
+  it('freshState seeds tokens_seen as an empty object', () => {
+    expect(freshState(addr).tokens_seen).toEqual({});
+  });
+
+  it('records the seen gestalt under tokens_seen', () => {
+    const s = freshState(addr);
+    const result = applyDelta(s, makeSeenDelta(addr, 'token008'));
+    expect(result.tokens_seen).toEqual({ token008: true });
+  });
+
+  it('is idempotent — second dispatch leaves tokens_seen unchanged', () => {
+    let s = freshState(addr);
+    s = applyDelta(s, makeSeenDelta(addr, 'token008', 1000));
+    const result = applyDelta(s, makeSeenDelta(addr, 'token008', 2000));
+    expect(result.tokens_seen).toEqual(s.tokens_seen);
+    expect(result.tokens_seen).toBe(s.tokens_seen);
+  });
+
+  it('accumulates multiple gestalts', () => {
+    let s = freshState(addr);
+    s = applyDelta(s, makeSeenDelta(addr, 'token001', 1000));
+    s = applyDelta(s, makeSeenDelta(addr, 'token008', 2000));
+    expect(s.tokens_seen).toEqual({ token001: true, token008: true });
+  });
+
+  it('leaves tokens_seen empty when args is missing', () => {
+    const s = freshState(addr);
+    const bad = { kind: 'delta', addr, op: 'markTokenSeen', ts: 1000 };
+    expect(applyDelta(s, bad).tokens_seen).toEqual({});
+  });
+
+  it('leaves tokens_seen empty when gestalt is empty or non-string', () => {
+    const s = freshState(addr);
+    expect(applyDelta(s, makeSeenDelta(addr, '')).tokens_seen).toEqual({});
+    expect(applyDelta(s, makeSeenDelta(addr, 42)).tokens_seen).toEqual({});
+  });
+
+  it('reset wipes tokens_seen back to empty', () => {
+    let s = freshState(addr);
+    s = applyDelta(s, makeSeenDelta(addr, 'token008', 1000));
+    const after = applyDelta(s, makeDelta(addr, 'reset', 2000));
+    expect(after.tokens_seen).toEqual({});
+  });
+});

--- a/tests/state/state.test.js
+++ b/tests/state/state.test.js
@@ -24,7 +24,7 @@ describe('freshState', () => {
 
   it('seeds game_values from data/default_game.json', () => {
     const s = freshState('alice@example.com');
-    expect(s.game_values.cash_value).toBe(300);
+    expect(s.game_values.cash_value).toBe(270);
     expect(s.game_values.karma_value).toBe(50);
     expect(s.game_values.xp_level).toBe(1);
     expect(s.game_values.ap_snapshot).toBe(6);

--- a/vendor/zynga-scroller.js
+++ b/vendor/zynga-scroller.js
@@ -1,40 +1,1358 @@
 // zynga-scroller — Scroller.js from zynga/scroller (commit dadd850).
-// Minimal AMD-wrapped stub so require('zynga-scroller') resolves without errors.
-// The game's Render.js uses the scroller; it is only loaded after a successful
-// getToken(), which never happens in the boots-to-broken state.
-// Full source: https://github.com/zynga/scroller/blob/dadd850/src/Scroller.js
+// AMD-wrapped to plug into the Render.js require('zynga-scroller').
+// The animate dependency (core.effect.Animate.start/stop) is provided by
+// vendor/zynga-animate.js, exposed under the AMD id 'zynga-animate'.
+// Source: https://github.com/zynga/scroller/blob/dadd850/src/Scroller.js
 (function(global, factory) {
   if (typeof define === 'function' && define.amd) {
-    define(['zynga-animate'], function(core) { return factory(global, core); });
+    define(['zynga-animate'], function(animate) { return factory(global, animate); });
   } else {
     global.Scroller = factory(global, global.core);
   }
-}(this, function(global, core) {
-  var Scroller = function(callback, options) {
-    this.__callback = callback;
-    this.options = { scrollingX: true, scrollingY: true, animating: true, animationDuration: 250,
-      bouncing: true, locking: true, paging: false, snapping: false, zooming: false,
-      minZoom: 0.5, maxZoom: 3, speedMultiplier: 1, scrollingComplete: function(){},
-      penetrationDeceleration: 0.03, penetrationAcceleration: 0.08 };
-    for (var key in options) { this.options[key] = options[key]; }
-  };
-  Scroller.prototype = {
-    setDimensions: function(){},
-    setPosition: function(){},
-    setSnapSize: function(){},
-    activatePullToRefresh: function(){},
-    triggerPullToRefresh: function(){},
-    finishPullToRefresh: function(){},
-    getValues: function(){ return { left:0, top:0, zoom:1 }; },
-    getScrollMax: function(){ return { left:0, top:0 }; },
-    zoomTo: function(){},
-    zoomBy: function(){},
-    scrollTo: function(){},
-    scrollBy: function(){},
-    doMouseZoom: function(){},
-    doTouchStart: function(){},
-    doTouchMove: function(){},
-    doTouchEnd: function(){}
-  };
+}(this, function(global, animate) {
+  // The scroller calls core.effect.Animate.start/stop, but our animate
+  // module exports those directly. Bridge the namespaces.
+  var core = (animate && animate.effect && animate.effect.Animate)
+    ? animate
+    : { effect: { Animate: animate } };
+
+var Scroller;
+
+(function() {
+	var NOOP = function(){};
+
+	/**
+	 * A pure logic 'component' for 'virtual' scrolling/zooming.
+	 */
+	Scroller = function(callback, options) {
+
+		this.__callback = callback;
+
+		this.options = {
+
+			/** Enable scrolling on x-axis */
+			scrollingX: true,
+
+			/** Enable scrolling on y-axis */
+			scrollingY: true,
+
+			/** Enable animations for deceleration, snap back, zooming and scrolling */
+			animating: true,
+
+			/** duration for animations triggered by scrollTo/zoomTo */
+			animationDuration: 250,
+
+			/** Enable bouncing (content can be slowly moved outside and jumps back after releasing) */
+			bouncing: true,
+
+			/** Enable locking to the main axis if user moves only slightly on one of them at start */
+			locking: true,
+
+			/** Enable pagination mode (switching between full page content panes) */
+			paging: false,
+
+			/** Enable snapping of content to a configured pixel grid */
+			snapping: false,
+
+			/** Enable zooming of content via API, fingers and mouse wheel */
+			zooming: false,
+
+			/** Minimum zoom level */
+			minZoom: 0.5,
+
+			/** Maximum zoom level */
+			maxZoom: 3,
+
+			/** Multiply or decrease scrolling speed **/
+			speedMultiplier: 1,
+
+			/** Callback that is fired on the later of touch end or deceleration end,
+				provided that another scrolling action has not begun. Used to know
+				when to fade out a scrollbar. */
+			scrollingComplete: NOOP,
+			
+			/** This configures the amount of change applied to deceleration when reaching boundaries  **/
+            penetrationDeceleration : 0.03,
+
+            /** This configures the amount of change applied to acceleration when reaching boundaries  **/
+            penetrationAcceleration : 0.08
+
+		};
+
+		for (var key in options) {
+			this.options[key] = options[key];
+		}
+
+	};
+
+
+	// Easing Equations (c) 2003 Robert Penner, all rights reserved.
+	// Open source under the BSD License.
+
+	/**
+	 * @param pos {Number} position between 0 (start of effect) and 1 (end of effect)
+	**/
+	var easeOutCubic = function(pos) {
+		return (Math.pow((pos - 1), 3) + 1);
+	};
+
+	/**
+	 * @param pos {Number} position between 0 (start of effect) and 1 (end of effect)
+	**/
+	var easeInOutCubic = function(pos) {
+		if ((pos /= 0.5) < 1) {
+			return 0.5 * Math.pow(pos, 3);
+		}
+
+		return 0.5 * (Math.pow((pos - 2), 3) + 2);
+	};
+
+
+	var members = {
+
+		/*
+		---------------------------------------------------------------------------
+			INTERNAL FIELDS :: STATUS
+		---------------------------------------------------------------------------
+		*/
+
+		/** {Boolean} Whether only a single finger is used in touch handling */
+		__isSingleTouch: false,
+
+		/** {Boolean} Whether a touch event sequence is in progress */
+		__isTracking: false,
+
+		/** {Boolean} Whether a deceleration animation went to completion. */
+		__didDecelerationComplete: false,
+
+		/**
+		 * {Boolean} Whether a gesture zoom/rotate event is in progress. Activates when
+		 * a gesturestart event happens. This has higher priority than dragging.
+		 */
+		__isGesturing: false,
+
+		/**
+		 * {Boolean} Whether the user has moved by such a distance that we have enabled
+		 * dragging mode. Hint: It's only enabled after some pixels of movement to
+		 * not interrupt with clicks etc.
+		 */
+		__isDragging: false,
+
+		/**
+		 * {Boolean} Not touching and dragging anymore, and smoothly animating the
+		 * touch sequence using deceleration.
+		 */
+		__isDecelerating: false,
+
+		/**
+		 * {Boolean} Smoothly animating the currently configured change
+		 */
+		__isAnimating: false,
+
+
+
+		/*
+		---------------------------------------------------------------------------
+			INTERNAL FIELDS :: DIMENSIONS
+		---------------------------------------------------------------------------
+		*/
+
+		/** {Integer} Available outer left position (from document perspective) */
+		__clientLeft: 0,
+
+		/** {Integer} Available outer top position (from document perspective) */
+		__clientTop: 0,
+
+		/** {Integer} Available outer width */
+		__clientWidth: 0,
+
+		/** {Integer} Available outer height */
+		__clientHeight: 0,
+
+		/** {Integer} Outer width of content */
+		__contentWidth: 0,
+
+		/** {Integer} Outer height of content */
+		__contentHeight: 0,
+
+		/** {Integer} Snapping width for content */
+		__snapWidth: 100,
+
+		/** {Integer} Snapping height for content */
+		__snapHeight: 100,
+
+		/** {Integer} Height to assign to refresh area */
+		__refreshHeight: null,
+
+		/** {Boolean} Whether the refresh process is enabled when the event is released now */
+		__refreshActive: false,
+
+		/** {Function} Callback to execute on activation. This is for signalling the user about a refresh is about to happen when he release */
+		__refreshActivate: null,
+
+		/** {Function} Callback to execute on deactivation. This is for signalling the user about the refresh being cancelled */
+		__refreshDeactivate: null,
+
+		/** {Function} Callback to execute to start the actual refresh. Call {@link #refreshFinish} when done */
+		__refreshStart: null,
+
+		/** {Number} Zoom level */
+		__zoomLevel: 1,
+
+		/** {Number} Scroll position on x-axis */
+		__scrollLeft: 0,
+
+		/** {Number} Scroll position on y-axis */
+		__scrollTop: 0,
+
+		/** {Integer} Maximum allowed scroll position on x-axis */
+		__maxScrollLeft: 0,
+
+		/** {Integer} Maximum allowed scroll position on y-axis */
+		__maxScrollTop: 0,
+
+		/* {Number} Scheduled left position (final position when animating) */
+		__scheduledLeft: 0,
+
+		/* {Number} Scheduled top position (final position when animating) */
+		__scheduledTop: 0,
+
+		/* {Number} Scheduled zoom level (final scale when animating) */
+		__scheduledZoom: 0,
+
+
+
+		/*
+		---------------------------------------------------------------------------
+			INTERNAL FIELDS :: LAST POSITIONS
+		---------------------------------------------------------------------------
+		*/
+
+		/** {Number} Left position of finger at start */
+		__lastTouchLeft: null,
+
+		/** {Number} Top position of finger at start */
+		__lastTouchTop: null,
+
+		/** {Date} Timestamp of last move of finger. Used to limit tracking range for deceleration speed. */
+		__lastTouchMove: null,
+
+		/** {Array} List of positions, uses three indexes for each state: left, top, timestamp */
+		__positions: null,
+
+
+
+		/*
+		---------------------------------------------------------------------------
+			INTERNAL FIELDS :: DECELERATION SUPPORT
+		---------------------------------------------------------------------------
+		*/
+
+		/** {Integer} Minimum left scroll position during deceleration */
+		__minDecelerationScrollLeft: null,
+
+		/** {Integer} Minimum top scroll position during deceleration */
+		__minDecelerationScrollTop: null,
+
+		/** {Integer} Maximum left scroll position during deceleration */
+		__maxDecelerationScrollLeft: null,
+
+		/** {Integer} Maximum top scroll position during deceleration */
+		__maxDecelerationScrollTop: null,
+
+		/** {Number} Current factor to modify horizontal scroll position with on every step */
+		__decelerationVelocityX: null,
+
+		/** {Number} Current factor to modify vertical scroll position with on every step */
+		__decelerationVelocityY: null,
+
+
+
+		/*
+		---------------------------------------------------------------------------
+			PUBLIC API
+		---------------------------------------------------------------------------
+		*/
+
+		/**
+		 * Configures the dimensions of the client (outer) and content (inner) elements.
+		 * Requires the available space for the outer element and the outer size of the inner element.
+		 * All values which are falsy (null or zero etc.) are ignored and the old value is kept.
+		 *
+		 * @param clientWidth {Integer ? null} Inner width of outer element
+		 * @param clientHeight {Integer ? null} Inner height of outer element
+		 * @param contentWidth {Integer ? null} Outer width of inner element
+		 * @param contentHeight {Integer ? null} Outer height of inner element
+		 */
+		setDimensions: function(clientWidth, clientHeight, contentWidth, contentHeight) {
+
+			var self = this;
+
+			// Only update values which are defined
+			if (clientWidth === +clientWidth) {
+				self.__clientWidth = clientWidth;
+			}
+
+			if (clientHeight === +clientHeight) {
+				self.__clientHeight = clientHeight;
+			}
+
+			if (contentWidth === +contentWidth) {
+				self.__contentWidth = contentWidth;
+			}
+
+			if (contentHeight === +contentHeight) {
+				self.__contentHeight = contentHeight;
+			}
+
+			// Refresh maximums
+			self.__computeScrollMax();
+
+			// Refresh scroll position
+			self.scrollTo(self.__scrollLeft, self.__scrollTop, true);
+
+		},
+
+
+		/**
+		 * Sets the client coordinates in relation to the document.
+		 *
+		 * @param left {Integer ? 0} Left position of outer element
+		 * @param top {Integer ? 0} Top position of outer element
+		 */
+		setPosition: function(left, top) {
+
+			var self = this;
+
+			self.__clientLeft = left || 0;
+			self.__clientTop = top || 0;
+
+		},
+
+
+		/**
+		 * Configures the snapping (when snapping is active)
+		 *
+		 * @param width {Integer} Snapping width
+		 * @param height {Integer} Snapping height
+		 */
+		setSnapSize: function(width, height) {
+
+			var self = this;
+
+			self.__snapWidth = width;
+			self.__snapHeight = height;
+
+		},
+
+
+		/**
+		 * Activates pull-to-refresh. A special zone on the top of the list to start a list refresh whenever
+		 * the user event is released during visibility of this zone. This was introduced by some apps on iOS like
+		 * the official Twitter client.
+		 *
+		 * @param height {Integer} Height of pull-to-refresh zone on top of rendered list
+		 * @param activateCallback {Function} Callback to execute on activation. This is for signalling the user about a refresh is about to happen when he release.
+		 * @param deactivateCallback {Function} Callback to execute on deactivation. This is for signalling the user about the refresh being cancelled.
+		 * @param startCallback {Function} Callback to execute to start the real async refresh action. Call {@link #finishPullToRefresh} after finish of refresh.
+		 */
+		activatePullToRefresh: function(height, activateCallback, deactivateCallback, startCallback) {
+
+			var self = this;
+
+			self.__refreshHeight = height;
+			self.__refreshActivate = activateCallback;
+			self.__refreshDeactivate = deactivateCallback;
+			self.__refreshStart = startCallback;
+
+		},
+
+
+		/**
+		 * Starts pull-to-refresh manually.
+		 */
+		triggerPullToRefresh: function() {
+			// Use publish instead of scrollTo to allow scrolling to out of boundary position
+			// We don't need to normalize scrollLeft, zoomLevel, etc. here because we only y-scrolling when pull-to-refresh is enabled
+			this.__publish(this.__scrollLeft, -this.__refreshHeight, this.__zoomLevel, true);
+
+			if (this.__refreshStart) {
+				this.__refreshStart();
+			}
+		},
+
+
+		/**
+		 * Signalizes that pull-to-refresh is finished.
+		 */
+		finishPullToRefresh: function() {
+
+			var self = this;
+
+			self.__refreshActive = false;
+			if (self.__refreshDeactivate) {
+				self.__refreshDeactivate();
+			}
+
+			self.scrollTo(self.__scrollLeft, self.__scrollTop, true);
+
+		},
+
+
+		/**
+		 * Returns the scroll position and zooming values
+		 *
+		 * @return {Map} `left` and `top` scroll position and `zoom` level
+		 */
+		getValues: function() {
+
+			var self = this;
+
+			return {
+				left: self.__scrollLeft,
+				top: self.__scrollTop,
+				zoom: self.__zoomLevel
+			};
+
+		},
+
+
+		/**
+		 * Returns the maximum scroll values
+		 *
+		 * @return {Map} `left` and `top` maximum scroll values
+		 */
+		getScrollMax: function() {
+
+			var self = this;
+
+			return {
+				left: self.__maxScrollLeft,
+				top: self.__maxScrollTop
+			};
+
+		},
+
+
+		/**
+		 * Zooms to the given level. Supports optional animation. Zooms
+		 * the center when no coordinates are given.
+		 *
+		 * @param level {Number} Level to zoom to
+		 * @param animate {Boolean ? false} Whether to use animation
+		 * @param originLeft {Number ? null} Zoom in at given left coordinate
+		 * @param originTop {Number ? null} Zoom in at given top coordinate
+		 * @param callback {Function ? null} A callback that gets fired when the zoom is complete.
+		 */
+		zoomTo: function(level, animate, originLeft, originTop, callback) {
+
+			var self = this;
+
+			if (!self.options.zooming) {
+				throw new Error("Zooming is not enabled!");
+			}
+
+			// Add callback if exists
+			if(callback) {
+				self.__zoomComplete = callback;
+			}
+
+			// Stop deceleration
+			if (self.__isDecelerating) {
+				core.effect.Animate.stop(self.__isDecelerating);
+				self.__isDecelerating = false;
+			}
+
+			var oldLevel = self.__zoomLevel;
+
+			// Normalize input origin to center of viewport if not defined
+			if (originLeft == null) {
+				originLeft = self.__clientWidth / 2;
+			}
+
+			if (originTop == null) {
+				originTop = self.__clientHeight / 2;
+			}
+
+			// Limit level according to configuration
+			level = Math.max(Math.min(level, self.options.maxZoom), self.options.minZoom);
+
+			// Recompute maximum values while temporary tweaking maximum scroll ranges
+			self.__computeScrollMax(level);
+
+			// Recompute left and top coordinates based on new zoom level
+			var left = ((originLeft + self.__scrollLeft) * level / oldLevel) - originLeft;
+			var top = ((originTop + self.__scrollTop) * level / oldLevel) - originTop;
+
+			// Limit x-axis
+			if (left > self.__maxScrollLeft) {
+				left = self.__maxScrollLeft;
+			} else if (left < 0) {
+				left = 0;
+			}
+
+			// Limit y-axis
+			if (top > self.__maxScrollTop) {
+				top = self.__maxScrollTop;
+			} else if (top < 0) {
+				top = 0;
+			}
+
+			// Push values out
+			self.__publish(left, top, level, animate);
+
+		},
+
+
+		/**
+		 * Zooms the content by the given factor.
+		 *
+		 * @param factor {Number} Zoom by given factor
+		 * @param animate {Boolean ? false} Whether to use animation
+		 * @param originLeft {Number ? 0} Zoom in at given left coordinate
+		 * @param originTop {Number ? 0} Zoom in at given top coordinate
+		 * @param callback {Function ? null} A callback that gets fired when the zoom is complete.
+		 */
+		zoomBy: function(factor, animate, originLeft, originTop, callback) {
+
+			var self = this;
+
+			self.zoomTo(self.__zoomLevel * factor, animate, originLeft, originTop, callback);
+
+		},
+
+
+		/**
+		 * Scrolls to the given position. Respect limitations and snapping automatically.
+		 *
+		 * @param left {Number?null} Horizontal scroll position, keeps current if value is <code>null</code>
+		 * @param top {Number?null} Vertical scroll position, keeps current if value is <code>null</code>
+		 * @param animate {Boolean?false} Whether the scrolling should happen using an animation
+		 * @param zoom {Number?null} Zoom level to go to
+		 */
+		scrollTo: function(left, top, animate, zoom) {
+
+			var self = this;
+
+			// Stop deceleration
+			if (self.__isDecelerating) {
+				core.effect.Animate.stop(self.__isDecelerating);
+				self.__isDecelerating = false;
+			}
+
+			// Correct coordinates based on new zoom level
+			if (zoom != null && zoom !== self.__zoomLevel) {
+
+				if (!self.options.zooming) {
+					throw new Error("Zooming is not enabled!");
+				}
+
+				left *= zoom;
+				top *= zoom;
+
+				// Recompute maximum values while temporary tweaking maximum scroll ranges
+				self.__computeScrollMax(zoom);
+
+			} else {
+
+				// Keep zoom when not defined
+				zoom = self.__zoomLevel;
+
+			}
+
+			if (!self.options.scrollingX) {
+
+				left = self.__scrollLeft;
+
+			} else {
+
+				if (self.options.paging) {
+					left = Math.round(left / self.__clientWidth) * self.__clientWidth;
+				} else if (self.options.snapping) {
+					left = Math.round(left / self.__snapWidth) * self.__snapWidth;
+				}
+
+			}
+
+			if (!self.options.scrollingY) {
+
+				top = self.__scrollTop;
+
+			} else {
+
+				if (self.options.paging) {
+					top = Math.round(top / self.__clientHeight) * self.__clientHeight;
+				} else if (self.options.snapping) {
+					top = Math.round(top / self.__snapHeight) * self.__snapHeight;
+				}
+
+			}
+
+			// Limit for allowed ranges
+			left = Math.max(Math.min(self.__maxScrollLeft, left), 0);
+			top = Math.max(Math.min(self.__maxScrollTop, top), 0);
+
+			// Don't animate when no change detected, still call publish to make sure
+			// that rendered position is really in-sync with internal data
+			if (left === self.__scrollLeft && top === self.__scrollTop) {
+				animate = false;
+			}
+
+			// Publish new values
+			self.__publish(left, top, zoom, animate);
+
+		},
+
+
+		/**
+		 * Scroll by the given offset
+		 *
+		 * @param left {Number ? 0} Scroll x-axis by given offset
+		 * @param top {Number ? 0} Scroll x-axis by given offset
+		 * @param animate {Boolean ? false} Whether to animate the given change
+		 */
+		scrollBy: function(left, top, animate) {
+
+			var self = this;
+
+			var startLeft = self.__isAnimating ? self.__scheduledLeft : self.__scrollLeft;
+			var startTop = self.__isAnimating ? self.__scheduledTop : self.__scrollTop;
+
+			self.scrollTo(startLeft + (left || 0), startTop + (top || 0), animate);
+
+		},
+
+
+
+		/*
+		---------------------------------------------------------------------------
+			EVENT CALLBACKS
+		---------------------------------------------------------------------------
+		*/
+
+		/**
+		 * Mouse wheel handler for zooming support
+		 */
+		doMouseZoom: function(wheelDelta, timeStamp, pageX, pageY) {
+
+			var self = this;
+			var change = wheelDelta > 0 ? 0.97 : 1.03;
+
+			return self.zoomTo(self.__zoomLevel * change, false, pageX - self.__clientLeft, pageY - self.__clientTop);
+
+		},
+
+
+		/**
+		 * Touch start handler for scrolling support
+		 */
+		doTouchStart: function(touches, timeStamp) {
+
+			// Array-like check is enough here
+			if (touches.length == null) {
+				throw new Error("Invalid touch list: " + touches);
+			}
+
+			if (timeStamp instanceof Date) {
+				timeStamp = timeStamp.valueOf();
+			}
+			if (typeof timeStamp !== "number") {
+				throw new Error("Invalid timestamp value: " + timeStamp);
+			}
+
+			var self = this;
+
+			// Reset interruptedAnimation flag
+			self.__interruptedAnimation = true;
+
+			// Stop deceleration
+			if (self.__isDecelerating) {
+				core.effect.Animate.stop(self.__isDecelerating);
+				self.__isDecelerating = false;
+				self.__interruptedAnimation = true;
+			}
+
+			// Stop animation
+			if (self.__isAnimating) {
+				core.effect.Animate.stop(self.__isAnimating);
+				self.__isAnimating = false;
+				self.__interruptedAnimation = true;
+			}
+
+			// Use center point when dealing with two fingers
+			var currentTouchLeft, currentTouchTop;
+			var isSingleTouch = touches.length === 1;
+			if (isSingleTouch) {
+				currentTouchLeft = touches[0].pageX;
+				currentTouchTop = touches[0].pageY;
+			} else {
+				currentTouchLeft = Math.abs(touches[0].pageX + touches[1].pageX) / 2;
+				currentTouchTop = Math.abs(touches[0].pageY + touches[1].pageY) / 2;
+			}
+
+			// Store initial positions
+			self.__initialTouchLeft = currentTouchLeft;
+			self.__initialTouchTop = currentTouchTop;
+
+			// Store current zoom level
+			self.__zoomLevelStart = self.__zoomLevel;
+
+			// Store initial touch positions
+			self.__lastTouchLeft = currentTouchLeft;
+			self.__lastTouchTop = currentTouchTop;
+
+			// Store initial move time stamp
+			self.__lastTouchMove = timeStamp;
+
+			// Reset initial scale
+			self.__lastScale = 1;
+
+			// Reset locking flags
+			self.__enableScrollX = !isSingleTouch && self.options.scrollingX;
+			self.__enableScrollY = !isSingleTouch && self.options.scrollingY;
+
+			// Reset tracking flag
+			self.__isTracking = true;
+
+			// Reset deceleration complete flag
+			self.__didDecelerationComplete = false;
+
+			// Dragging starts directly with two fingers, otherwise lazy with an offset
+			self.__isDragging = !isSingleTouch;
+
+			// Some features are disabled in multi touch scenarios
+			self.__isSingleTouch = isSingleTouch;
+
+			// Clearing data structure
+			self.__positions = [];
+
+		},
+
+
+		/**
+		 * Touch move handler for scrolling support
+		 */
+		doTouchMove: function(touches, timeStamp, scale) {
+
+			// Array-like check is enough here
+			if (touches.length == null) {
+				throw new Error("Invalid touch list: " + touches);
+			}
+
+			if (timeStamp instanceof Date) {
+				timeStamp = timeStamp.valueOf();
+			}
+			if (typeof timeStamp !== "number") {
+				throw new Error("Invalid timestamp value: " + timeStamp);
+			}
+
+			var self = this;
+
+			// Ignore event when tracking is not enabled (event might be outside of element)
+			if (!self.__isTracking) {
+				return;
+			}
+
+
+			var currentTouchLeft, currentTouchTop;
+
+			// Compute move based around of center of fingers
+			if (touches.length === 2) {
+				currentTouchLeft = Math.abs(touches[0].pageX + touches[1].pageX) / 2;
+				currentTouchTop = Math.abs(touches[0].pageY + touches[1].pageY) / 2;
+			} else {
+				currentTouchLeft = touches[0].pageX;
+				currentTouchTop = touches[0].pageY;
+			}
+
+			var positions = self.__positions;
+
+			// Are we already is dragging mode?
+			if (self.__isDragging) {
+
+				// Compute move distance
+				var moveX = currentTouchLeft - self.__lastTouchLeft;
+				var moveY = currentTouchTop - self.__lastTouchTop;
+
+				// Read previous scroll position and zooming
+				var scrollLeft = self.__scrollLeft;
+				var scrollTop = self.__scrollTop;
+				var level = self.__zoomLevel;
+
+				// Work with scaling
+				if (scale != null && self.options.zooming) {
+
+					var oldLevel = level;
+
+					// Recompute level based on previous scale and new scale
+					level = level / self.__lastScale * scale;
+
+					// Limit level according to configuration
+					level = Math.max(Math.min(level, self.options.maxZoom), self.options.minZoom);
+
+					// Only do further compution when change happened
+					if (oldLevel !== level) {
+
+						// Compute relative event position to container
+						var currentTouchLeftRel = currentTouchLeft - self.__clientLeft;
+						var currentTouchTopRel = currentTouchTop - self.__clientTop;
+
+						// Recompute left and top coordinates based on new zoom level
+						scrollLeft = ((currentTouchLeftRel + scrollLeft) * level / oldLevel) - currentTouchLeftRel;
+						scrollTop = ((currentTouchTopRel + scrollTop) * level / oldLevel) - currentTouchTopRel;
+
+						// Recompute max scroll values
+						self.__computeScrollMax(level);
+
+					}
+				}
+
+				if (self.__enableScrollX) {
+
+					scrollLeft -= moveX * this.options.speedMultiplier;
+					var maxScrollLeft = self.__maxScrollLeft;
+
+					if (scrollLeft > maxScrollLeft || scrollLeft < 0) {
+
+						// Slow down on the edges
+						if (self.options.bouncing) {
+
+							scrollLeft += (moveX / 2  * this.options.speedMultiplier);
+
+						} else if (scrollLeft > maxScrollLeft) {
+
+							scrollLeft = maxScrollLeft;
+
+						} else {
+
+							scrollLeft = 0;
+
+						}
+					}
+				}
+
+				// Compute new vertical scroll position
+				if (self.__enableScrollY) {
+
+					scrollTop -= moveY * this.options.speedMultiplier;
+					var maxScrollTop = self.__maxScrollTop;
+
+					if (scrollTop > maxScrollTop || scrollTop < 0) {
+
+						// Slow down on the edges
+						if (self.options.bouncing) {
+
+							scrollTop += (moveY / 2 * this.options.speedMultiplier);
+
+							// Support pull-to-refresh (only when only y is scrollable)
+							if (!self.__enableScrollX && self.__refreshHeight != null) {
+
+								if (!self.__refreshActive && scrollTop <= -self.__refreshHeight) {
+
+									self.__refreshActive = true;
+									if (self.__refreshActivate) {
+										self.__refreshActivate();
+									}
+
+								} else if (self.__refreshActive && scrollTop > -self.__refreshHeight) {
+
+									self.__refreshActive = false;
+									if (self.__refreshDeactivate) {
+										self.__refreshDeactivate();
+									}
+
+								}
+							}
+
+						} else if (scrollTop > maxScrollTop) {
+
+							scrollTop = maxScrollTop;
+
+						} else {
+
+							scrollTop = 0;
+
+						}
+					}
+				}
+
+				// Keep list from growing infinitely (holding min 10, max 20 measure points)
+				if (positions.length > 60) {
+					positions.splice(0, 30);
+				}
+
+				// Track scroll movement for decleration
+				positions.push(scrollLeft, scrollTop, timeStamp);
+
+				// Sync scroll position
+				self.__publish(scrollLeft, scrollTop, level);
+
+			// Otherwise figure out whether we are switching into dragging mode now.
+			} else {
+
+				var minimumTrackingForScroll = self.options.locking ? 3 : 0;
+				var minimumTrackingForDrag = 5;
+
+				var distanceX = Math.abs(currentTouchLeft - self.__initialTouchLeft);
+				var distanceY = Math.abs(currentTouchTop - self.__initialTouchTop);
+
+				self.__enableScrollX = self.options.scrollingX && distanceX >= minimumTrackingForScroll;
+				self.__enableScrollY = self.options.scrollingY && distanceY >= minimumTrackingForScroll;
+
+				positions.push(self.__scrollLeft, self.__scrollTop, timeStamp);
+
+				self.__isDragging = (self.__enableScrollX || self.__enableScrollY) && (distanceX >= minimumTrackingForDrag || distanceY >= minimumTrackingForDrag);
+				if (self.__isDragging) {
+					self.__interruptedAnimation = false;
+				}
+
+			}
+
+			// Update last touch positions and time stamp for next event
+			self.__lastTouchLeft = currentTouchLeft;
+			self.__lastTouchTop = currentTouchTop;
+			self.__lastTouchMove = timeStamp;
+			self.__lastScale = scale;
+
+		},
+
+
+		/**
+		 * Touch end handler for scrolling support
+		 */
+		doTouchEnd: function(timeStamp) {
+
+			if (timeStamp instanceof Date) {
+				timeStamp = timeStamp.valueOf();
+			}
+			if (typeof timeStamp !== "number") {
+				throw new Error("Invalid timestamp value: " + timeStamp);
+			}
+
+			var self = this;
+
+			// Ignore event when tracking is not enabled (no touchstart event on element)
+			// This is required as this listener ('touchmove') sits on the document and not on the element itself.
+			if (!self.__isTracking) {
+				return;
+			}
+
+			// Not touching anymore (when two finger hit the screen there are two touch end events)
+			self.__isTracking = false;
+
+			// Be sure to reset the dragging flag now. Here we also detect whether
+			// the finger has moved fast enough to switch into a deceleration animation.
+			if (self.__isDragging) {
+
+				// Reset dragging flag
+				self.__isDragging = false;
+
+				// Start deceleration
+				// Verify that the last move detected was in some relevant time frame
+				if (self.__isSingleTouch && self.options.animating && (timeStamp - self.__lastTouchMove) <= 100) {
+
+					// Then figure out what the scroll position was about 100ms ago
+					var positions = self.__positions;
+					var endPos = positions.length - 1;
+					var startPos = endPos;
+
+					// Move pointer to position measured 100ms ago
+					for (var i = endPos; i > 0 && positions[i] > (self.__lastTouchMove - 100); i -= 3) {
+						startPos = i;
+					}
+
+					// If start and stop position is identical in a 100ms timeframe,
+					// we cannot compute any useful deceleration.
+					if (startPos !== endPos) {
+
+						// Compute relative movement between these two points
+						var timeOffset = positions[endPos] - positions[startPos];
+						var movedLeft = self.__scrollLeft - positions[startPos - 2];
+						var movedTop = self.__scrollTop - positions[startPos - 1];
+
+						// Based on 50ms compute the movement to apply for each render step
+						self.__decelerationVelocityX = movedLeft / timeOffset * (1000 / 60);
+						self.__decelerationVelocityY = movedTop / timeOffset * (1000 / 60);
+
+						// How much velocity is required to start the deceleration
+						var minVelocityToStartDeceleration = self.options.paging || self.options.snapping ? 4 : 1;
+
+						// Verify that we have enough velocity to start deceleration
+						if (Math.abs(self.__decelerationVelocityX) > minVelocityToStartDeceleration || Math.abs(self.__decelerationVelocityY) > minVelocityToStartDeceleration) {
+
+							// Deactivate pull-to-refresh when decelerating
+							if (!self.__refreshActive) {
+								self.__startDeceleration(timeStamp);
+							}
+						}
+					} else {
+						self.options.scrollingComplete();
+					}
+				} else if ((timeStamp - self.__lastTouchMove) > 100) {
+					self.options.scrollingComplete();
+	 			}
+			}
+
+			// If this was a slower move it is per default non decelerated, but this
+			// still means that we want snap back to the bounds which is done here.
+			// This is placed outside the condition above to improve edge case stability
+			// e.g. touchend fired without enabled dragging. This should normally do not
+			// have modified the scroll positions or even showed the scrollbars though.
+			if (!self.__isDecelerating) {
+
+				if (self.__refreshActive && self.__refreshStart) {
+
+					// Use publish instead of scrollTo to allow scrolling to out of boundary position
+					// We don't need to normalize scrollLeft, zoomLevel, etc. here because we only y-scrolling when pull-to-refresh is enabled
+					self.__publish(self.__scrollLeft, -self.__refreshHeight, self.__zoomLevel, true);
+
+					if (self.__refreshStart) {
+						self.__refreshStart();
+					}
+
+				} else {
+
+					if (self.__interruptedAnimation || self.__isDragging) {
+						self.options.scrollingComplete();
+					}
+					self.scrollTo(self.__scrollLeft, self.__scrollTop, true, self.__zoomLevel);
+
+					// Directly signalize deactivation (nothing todo on refresh?)
+					if (self.__refreshActive) {
+
+						self.__refreshActive = false;
+						if (self.__refreshDeactivate) {
+							self.__refreshDeactivate();
+						}
+
+					}
+				}
+			}
+
+			// Fully cleanup list
+			self.__positions.length = 0;
+
+		},
+
+
+
+		/*
+		---------------------------------------------------------------------------
+			PRIVATE API
+		---------------------------------------------------------------------------
+		*/
+
+		/**
+		 * Applies the scroll position to the content element
+		 *
+		 * @param left {Number} Left scroll position
+		 * @param top {Number} Top scroll position
+		 * @param animate {Boolean?false} Whether animation should be used to move to the new coordinates
+		 */
+		__publish: function(left, top, zoom, animate) {
+
+			var self = this;
+
+			// Remember whether we had an animation, then we try to continue based on the current "drive" of the animation
+			var wasAnimating = self.__isAnimating;
+			if (wasAnimating) {
+				core.effect.Animate.stop(wasAnimating);
+				self.__isAnimating = false;
+			}
+
+			if (animate && self.options.animating) {
+
+				// Keep scheduled positions for scrollBy/zoomBy functionality
+				self.__scheduledLeft = left;
+				self.__scheduledTop = top;
+				self.__scheduledZoom = zoom;
+
+				var oldLeft = self.__scrollLeft;
+				var oldTop = self.__scrollTop;
+				var oldZoom = self.__zoomLevel;
+
+				var diffLeft = left - oldLeft;
+				var diffTop = top - oldTop;
+				var diffZoom = zoom - oldZoom;
+
+				var step = function(percent, now, render) {
+
+					if (render) {
+
+						self.__scrollLeft = oldLeft + (diffLeft * percent);
+						self.__scrollTop = oldTop + (diffTop * percent);
+						self.__zoomLevel = oldZoom + (diffZoom * percent);
+
+						// Push values out
+						if (self.__callback) {
+							self.__callback(self.__scrollLeft, self.__scrollTop, self.__zoomLevel);
+						}
+
+					}
+				};
+
+				var verify = function(id) {
+					return self.__isAnimating === id;
+				};
+
+				var completed = function(renderedFramesPerSecond, animationId, wasFinished) {
+					if (animationId === self.__isAnimating) {
+						self.__isAnimating = false;
+					}
+					if (self.__didDecelerationComplete || wasFinished) {
+						self.options.scrollingComplete();
+					}
+
+					if (self.options.zooming) {
+						self.__computeScrollMax();
+						if(self.__zoomComplete) {
+							self.__zoomComplete();
+							self.__zoomComplete = null;
+						}
+					}
+				};
+
+				// When continuing based on previous animation we choose an ease-out animation instead of ease-in-out
+				self.__isAnimating = core.effect.Animate.start(step, verify, completed, self.options.animationDuration, wasAnimating ? easeOutCubic : easeInOutCubic);
+
+			} else {
+
+				self.__scheduledLeft = self.__scrollLeft = left;
+				self.__scheduledTop = self.__scrollTop = top;
+				self.__scheduledZoom = self.__zoomLevel = zoom;
+
+				// Push values out
+				if (self.__callback) {
+					self.__callback(left, top, zoom);
+				}
+
+				// Fix max scroll ranges
+				if (self.options.zooming) {
+					self.__computeScrollMax();
+					if(self.__zoomComplete) {
+						self.__zoomComplete();
+						self.__zoomComplete = null;
+					}
+				}
+			}
+		},
+
+
+		/**
+		 * Recomputes scroll minimum values based on client dimensions and content dimensions.
+		 */
+		__computeScrollMax: function(zoomLevel) {
+
+			var self = this;
+
+			if (zoomLevel == null) {
+				zoomLevel = self.__zoomLevel;
+			}
+
+			self.__maxScrollLeft = Math.max((self.__contentWidth * zoomLevel) - self.__clientWidth, 0);
+			self.__maxScrollTop = Math.max((self.__contentHeight * zoomLevel) - self.__clientHeight, 0);
+
+		},
+
+
+
+		/*
+		---------------------------------------------------------------------------
+			ANIMATION (DECELERATION) SUPPORT
+		---------------------------------------------------------------------------
+		*/
+
+		/**
+		 * Called when a touch sequence end and the speed of the finger was high enough
+		 * to switch into deceleration mode.
+		 */
+		__startDeceleration: function(timeStamp) {
+
+			var self = this;
+
+			if (self.options.paging) {
+
+				var scrollLeft = Math.max(Math.min(self.__scrollLeft, self.__maxScrollLeft), 0);
+				var scrollTop = Math.max(Math.min(self.__scrollTop, self.__maxScrollTop), 0);
+				var clientWidth = self.__clientWidth;
+				var clientHeight = self.__clientHeight;
+
+				// We limit deceleration not to the min/max values of the allowed range, but to the size of the visible client area.
+				// Each page should have exactly the size of the client area.
+				self.__minDecelerationScrollLeft = Math.floor(scrollLeft / clientWidth) * clientWidth;
+				self.__minDecelerationScrollTop = Math.floor(scrollTop / clientHeight) * clientHeight;
+				self.__maxDecelerationScrollLeft = Math.ceil(scrollLeft / clientWidth) * clientWidth;
+				self.__maxDecelerationScrollTop = Math.ceil(scrollTop / clientHeight) * clientHeight;
+
+			} else {
+
+				self.__minDecelerationScrollLeft = 0;
+				self.__minDecelerationScrollTop = 0;
+				self.__maxDecelerationScrollLeft = self.__maxScrollLeft;
+				self.__maxDecelerationScrollTop = self.__maxScrollTop;
+
+			}
+
+			// Wrap class method
+			var step = function(percent, now, render) {
+				self.__stepThroughDeceleration(render);
+			};
+
+			// How much velocity is required to keep the deceleration running
+			var minVelocityToKeepDecelerating = self.options.snapping ? 4 : 0.1;
+
+			// Detect whether it's still worth to continue animating steps
+			// If we are already slow enough to not being user perceivable anymore, we stop the whole process here.
+			var verify = function() {
+				var shouldContinue = Math.abs(self.__decelerationVelocityX) >= minVelocityToKeepDecelerating || Math.abs(self.__decelerationVelocityY) >= minVelocityToKeepDecelerating;
+				if (!shouldContinue) {
+					self.__didDecelerationComplete = true;
+				}
+				return shouldContinue;
+			};
+
+			var completed = function(renderedFramesPerSecond, animationId, wasFinished) {
+				self.__isDecelerating = false;
+				if (self.__didDecelerationComplete) {
+					self.options.scrollingComplete();
+				}
+
+				// Animate to grid when snapping is active, otherwise just fix out-of-boundary positions
+				self.scrollTo(self.__scrollLeft, self.__scrollTop, self.options.snapping);
+			};
+
+			// Start animation and switch on flag
+			self.__isDecelerating = core.effect.Animate.start(step, verify, completed);
+
+		},
+
+
+		/**
+		 * Called on every step of the animation
+		 *
+		 * @param inMemory {Boolean?false} Whether to not render the current step, but keep it in memory only. Used internally only!
+		 */
+		__stepThroughDeceleration: function(render) {
+
+			var self = this;
+
+
+			//
+			// COMPUTE NEXT SCROLL POSITION
+			//
+
+			// Add deceleration to scroll position
+			var scrollLeft = self.__scrollLeft + self.__decelerationVelocityX;
+			var scrollTop = self.__scrollTop + self.__decelerationVelocityY;
+
+
+			//
+			// HARD LIMIT SCROLL POSITION FOR NON BOUNCING MODE
+			//
+
+			if (!self.options.bouncing) {
+
+				var scrollLeftFixed = Math.max(Math.min(self.__maxDecelerationScrollLeft, scrollLeft), self.__minDecelerationScrollLeft);
+				if (scrollLeftFixed !== scrollLeft) {
+					scrollLeft = scrollLeftFixed;
+					self.__decelerationVelocityX = 0;
+				}
+
+				var scrollTopFixed = Math.max(Math.min(self.__maxDecelerationScrollTop, scrollTop), self.__minDecelerationScrollTop);
+				if (scrollTopFixed !== scrollTop) {
+					scrollTop = scrollTopFixed;
+					self.__decelerationVelocityY = 0;
+				}
+
+			}
+
+
+			//
+			// UPDATE SCROLL POSITION
+			//
+
+			if (render) {
+
+				self.__publish(scrollLeft, scrollTop, self.__zoomLevel);
+
+			} else {
+
+				self.__scrollLeft = scrollLeft;
+				self.__scrollTop = scrollTop;
+
+			}
+
+
+			//
+			// SLOW DOWN
+			//
+
+			// Slow down velocity on every iteration
+			if (!self.options.paging) {
+
+				// This is the factor applied to every iteration of the animation
+				// to slow down the process. This should emulate natural behavior where
+				// objects slow down when the initiator of the movement is removed
+				var frictionFactor = 0.95;
+
+				self.__decelerationVelocityX *= frictionFactor;
+				self.__decelerationVelocityY *= frictionFactor;
+
+			}
+
+
+			//
+			// BOUNCING SUPPORT
+			//
+
+			if (self.options.bouncing) {
+
+				var scrollOutsideX = 0;
+				var scrollOutsideY = 0;
+
+				// This configures the amount of change applied to deceleration/acceleration when reaching boundaries
+				var penetrationDeceleration = self.options.penetrationDeceleration; 
+				var penetrationAcceleration = self.options.penetrationAcceleration; 
+
+				// Check limits
+				if (scrollLeft < self.__minDecelerationScrollLeft) {
+					scrollOutsideX = self.__minDecelerationScrollLeft - scrollLeft;
+				} else if (scrollLeft > self.__maxDecelerationScrollLeft) {
+					scrollOutsideX = self.__maxDecelerationScrollLeft - scrollLeft;
+				}
+
+				if (scrollTop < self.__minDecelerationScrollTop) {
+					scrollOutsideY = self.__minDecelerationScrollTop - scrollTop;
+				} else if (scrollTop > self.__maxDecelerationScrollTop) {
+					scrollOutsideY = self.__maxDecelerationScrollTop - scrollTop;
+				}
+
+				// Slow down until slow enough, then flip back to snap position
+				if (scrollOutsideX !== 0) {
+					if (scrollOutsideX * self.__decelerationVelocityX <= 0) {
+						self.__decelerationVelocityX += scrollOutsideX * penetrationDeceleration;
+					} else {
+						self.__decelerationVelocityX = scrollOutsideX * penetrationAcceleration;
+					}
+				}
+
+				if (scrollOutsideY !== 0) {
+					if (scrollOutsideY * self.__decelerationVelocityY <= 0) {
+						self.__decelerationVelocityY += scrollOutsideY * penetrationDeceleration;
+					} else {
+						self.__decelerationVelocityY = scrollOutsideY * penetrationAcceleration;
+					}
+				}
+			}
+		}
+	};
+
+	// Copy over members to prototype
+	for (var key in members) {
+		Scroller.prototype[key] = members[key];
+	}
+
+})();
+
   return Scroller;
 }));

--- a/views/mainmenu.html
+++ b/views/mainmenu.html
@@ -5,7 +5,7 @@
   <div class="RenderSprite MainMenuLogo <%= logoclass %>"></div>
   <div class="UserActions">
     <div id="LocaleToggle" class="UserButton"><%= game.setup.localeShort === 'de' ? '🇩🇪🇦🇹🇨🇭 DE' : '🇺🇸🇬🇧🇦🇺 EN' %></div>
-    <div id="UserData" class="UserButton"><%= D.userdata.display_name %></div>
+    <div id="UserData" class="UserButton"><%= _._('About') %></div>
   </div>
   <div id="MainMenuButtons" class="MainMenuButtons">
     <% _.each(D.buttons, function(button) { %> <div class="MainMenuButton<% if (button.states.active) { print(' active') }; %>" data-button-id="<%= button.id %>"><%= button.label %></div> <% }); %>

--- a/views/popup_user_data.html
+++ b/views/popup_user_data.html
@@ -3,7 +3,6 @@
   var states = D.states || {};
   var button = data.button || _._('Close');
   var game = _.game();
-  var user = game.data.user;
 %>
 <div class="PopupBody User">
   <div class="PopupHeader">
@@ -12,7 +11,7 @@
     <div class="PopupTitle"><%= data.title %></div>
     <div class="PopupText"><%= data.description %></div>
     <div class="PopupMenu">
-      <div class="PopupMenuButton active" data-tab="settings"><% print(_._('user Account')); %></div>
+      <div class="PopupMenuButton active" data-tab="settings">About</div>
       <% if (game.setup.userdebug) { %>
       <div class="PopupMenuButton" data-tab="debug"><% print(_._('userdebug tab')); %></div>
       <% } %>
@@ -23,17 +22,34 @@
       <div class="SubpopContainer">
       </div>
       <div class="PopupContentText">
-        <div class="PopupTitle"><% print(_._('user Dein Account')); %></div>
-        <div class="PopupList">
-        <%
-            print(_.renderView('form_displayname.html', {
-              D: D
-            }));
-        %>
+        <div class="PopupTitle">About this fork</div>
+        <div class="PopupParagraph">
+          This is a webxdc port of the original Data Dealer browser game,
+          repackaged so it can run inside a Delta Chat group with no server.
+          Source, issues and contributions:
+          <a href="https://github.com/experintellia/data_dealer" class="mln" target="_blank" rel="noopener">github.com/experintellia/data_dealer</a>.
+        </div>
+        <div class="PopupParagraph">
+          Your display name is set through your Delta Chat profile &mdash; change it
+          there and the game picks it up automatically.
         </div>
       </div>
       <div class="PopupContentText">
-        <div class="PopupParagraph"><% print(_._('user text below'));  %></div>
+        <div class="PopupTitle">The original game</div>
+        <div class="PopupParagraph">
+          Data Dealer was created in Vienna by Cuteacute Media OG between 2011
+          and 2014 (Ivan Averintsev, Wolfie Christl, Pascale Osterwalder,
+          Tobi Sch&auml;fer, Ralf Traunsteiner). It was a satirical browser game
+          about the personal-data trade, released as a public beta on
+          datadealer.com and open-sourced as
+          <a href="https://github.com/datadealer/dd_js" class="mln" target="_blank" rel="noopener">dd_js</a>,
+          <a href="https://github.com/datadealer/dd_rules" class="mln" target="_blank" rel="noopener">dd_rules</a> and
+          <a href="https://github.com/datadealer/dd_app" class="mln" target="_blank" rel="noopener">dd_app</a>.
+        </div>
+        <div class="PopupParagraph">
+          Background info and the original FAQ:
+          <a href="https://datadealer.com/beta" class="mln" target="_blank" rel="noopener">datadealer.com/beta</a>.
+        </div>
       </div>
       <div class="PopupButtons">
         <div class="Button" data-button-id="MainButton"><%= button %></div>


### PR DESCRIPTION
PR-#78 follow-ups + bugs surfaced as the simulator reached first-playable. Multiple rounds of user testing; each round addressed a layer of bugs and uncovered the next. Now rebased on top of master (post #92, #93, #94, #95, #96).

## What landed (chronological)

### Round 1 — `d84c372` + `a3d2d68`
- **Timers stuck after reload** — loadGame loop was unwrapping `gnode.data.charge_start.$date`; reducer stores plain epoch-ms. Read `v.charge_start` directly off the `nodes_charging` entry.
- **Buy dialog re-offered owned perps (Jessica)** — `compileProvided` only suppressed owned-AND-locked entries. Skip on `IPerps` ownership before any locked branching.
- **NEW badge stuck after read** — new `markTokenSeen` op + reducer + handler + remote method. Render's `.PopupToken` click triggers `popup_token_seen`; both `token.new` sites in `Game.js` AND-gate against `tokens_seen`.
- **Mission briefing reshow (v1)** — new `dismissMissionBriefing` op + reducer + handler + remote method.
- **View centering / zoom / fullscreen** — `_centerActiveView` targets `vm.width/2`; `fitToWindow` and `resetZoom` refresh scroller dimensions before centering.
- **Device menu → About dialog** — `popup_user_data.html` rewritten with fork repo + original-team credit + link to `datadealer.com/beta`.
- **Database tab empty + mission goal stuck (v1)** — `collectPerp` now populates `tokens_map`; `integrateCollected` appends fresh `TokenPerp` nodes under `Database.<gestalt>` for first-time integration.
- **`Ticker.setFPS` deprecation** — always override with `Ticker.framerate=`.

### Round 2 — `f43b943`
- **About button label** — top-bar button was echoing `display_name`; replaced with `<%= _._('About') %>` plus `About`/`Über` translations.
- **Mission goal stuck (v2)** — `Database.mergeCued` had `groot.updateGameValues(...)` commented out. Re-enabled.
- **Status bar overflow** — defensive `Math.min/max` clamps on AP/cash/profiles/karma/XP barsize.
- **Charge timer ripens silently** — one-shot `setTimeout` per `chargePerp` at exact `charge_end` runs `materialize()` + emits `node_ready`. Same rearm on `loadGame`.
- **Tab-switch no recenter** — `switch_view` listener calls `updateScroller()` + `_centerActiveView(true)`.
- **Mission briefing reshow (v2)** — moved dispatch from `popup.callback` into `popup_close` handler with a `popup.notificationMission` tag.
- **Token tile overlap (regression — reverted in round 3)** — round-2 added a `djb2(gestalt)` position seed, but it bypassed `setRandomPosition`'s collision avoidance.

### Round 3 — `66f4e2e`
- **Database token-stack regression** — reverted round-2 hash-jitter; pre-seeding `instance_data.x/y` disabled `setRandomPosition`.
- **Bar overflow root cause** — (1) `cash_max` was never initialised → NaN. (2) `chargePerp` awarded `xp_inc` but never recomputed `xp_level`.

### Round 4 — `2013e44` + `e55387b`
- **AP refill on level-up across all handlers** — only `buyKarma` + `chargePerp` set `ap_snapshot = newLevelInfo.ap_max`; `buyPerp` / `collectPerp` / `integrateCollected` updated `ap_max` only. Now consistent across all four. 8 tests lock in the invariant.

### Round 5 — `26d1d80`
- **#85 mission progress 0/900 — actual root cause** — `collectPerp` was reading `typeData.contained_tokens`, but ContactPerps store yielded tokens under `typeData.tokens` (`contained_tokens` is for TokenPerp super-token decomposition). `tokens_map` was therefore always empty in production. Fix: read `typeData.tokens` (with `contained_tokens` fallback).
- **+38 tests** for the dismiss/seen reducers, LocalEngine handlers, the `tokens_map` population, integrate payload shape, and the chargePerp setTimeout live-tick.

### Round 6 — `45f49d3` + `1de0a7d`
- **#88 zoom + panning — actual root cause** — `vendor/zynga-scroller.js` was a 40-line stub where every method (`zoomTo`, `scrollTo`, `doTouchStart`/`Move`/`End`) was a no-op. Replaced with the real ~1350-line implementation from `zynga/scroller@dadd850`, AMD-wrapped to bridge `core.effect.Animate.{start,stop}` to the `zynga-animate` module.
- **#91 About dialog close-button CSS overlap** — added `.PopupBody.User .PopupContent { overflow-y: auto }` and `.PopupBody.User .PopupTab { padding-bottom: 56px }`.

### Round 7 — `8cac9a2` + `43b5da2`
- **Database token bars overfilled** — `instance_data.amount` is a percentage [0,100]. Round 5 multiplied by `profiles_value`, dumping raw counts (1100 for Jessica) into it. `collectPerp` now passes the percentage through unchanged; `integrateCollected` caps accumulation at 100. Mission progress unchanged: Jessica 100% × 1100 profiles = 1100 absolute, exceeds mission002's 900.
- **Zoom buttons disabled state** — `ViewMap._updateZoomButtonsState` toggles `.disabled` on `.ZoomIn`/`.ZoomOut`/`.Fullscreen` based on `zoomScale` vs `minZoom`/`maxZoom`. CSS half-fades disabled buttons and disables `pointer-events`.

### Round 8 — `4b57242` + `949a1a5` (simplify) + `cbbeff9`
- **Briefing dismiss never persisted** — runtime trace logs revealed `dismissMissionBriefing` always entered the early-return branch. `_buildLoadGameResponse` returned `state.mission_briefings_seen` by reference; Game.js then mutated `groot.raw_data.mission_briefings_seen[gestalt] = true` synchronously, which through the shared object reference poisoned LocalEngine state. The handler then read `seen[gestalt] === true` and skipped the commit. Same hole for `tokens_seen`. Fix: clone both seen-maps in the response.
- **Mission progression server-side** — LocalEngine had no progression for `collect_profiles` or `integrate_profiles` workflows, so `mission_goals[].current_amount` stayed at 0 forever. New helpers: `_seedMissionGoals` (lazy seed from ruleset), `_advanceCollectProfilesMissions`, `_advanceIntegrateProfilesMissions`, `_completeMissionsIfReady` (handles required-mission chain activation). State reducers propagate `mission_goals` + `active_missions` for cold-start replay.
- **Integrate now costs 1 AP** — UI guarded against `ap_value < 1` but the handler never decremented. Matches `chargePerp`'s pattern.

### Round 9 — `90aae89` + `d34421c`
- **Mission reward cash/xp never applied** — completion fired but the rewards array (e.g. mission002 = +100 cash + 1 xp) was ignored. New `_collectMissionRewards` walks rewards of just-completed missions; `_applyRewardsToGv` folds totals into `game_values`. Hooked into all three handlers (`buyPerp`, `collectPerp`, `integrateCollected`); `_advanceBuyPerpMissions` now delegates to `_completeMissionsIfReady` for consistent reward + next-mission activation.
- **Starting capital → 270** — was 300; player could spend all cash on Jessica charges and soft-lock unable to afford the car (client007, price 30). 4 charges × 60 = 240, plus 30 for the car = 270 exactly.
- **ClientPerp cash payout** — chargePerp's `baseAmount` only read `typeData.collect_amount`; ClientPerps in the ruleset ship `income_base` (e.g. 584 for the car company) instead. So `chargeEntry.result.amount` stayed 0 and collect added zero cash — the car company appeared to do nothing when sold to. Fall back to `income_base` when no `collect_amount` is present.
- **Cash-flow regression guards** — verified ContactPerp collect doesn't deduct cash; integrate doesn't deduct cash; tests in place.

## Tests
- 280 → **352** vitest pass after rebase. `pnpm build` clean.

## Issues addressed
- #83 — Mission briefing reshow (✅ fixed; clone-maps fix in round 8 was the actual bug)
- #84 — About button label (✅ fixed round 2)
- #85 — Mission goal 0/900 (✅ fixed round 5; locked in by round-8 server-side progression)
- #86 — Status bar overflow (✅ fixed round 3)
- #87 — Charge-ready live (✅ fixed round 2; setTimeout test in round 5)
- #88 — Camera centre / zoom / panning (✅ fixed round 6)
- #89 — Token overlap (✅ fixed round 3)
- #91 — About dialog Close button overlap (✅ fixed round 6)

## Manual test checklist (verified by user)

### Cold boot
- [x] No `Ticker.setFPS is deprecated` in console.
- [x] Imperium opens centred on the seeded `database001` node.

### Tutorial / mission briefing
- [x] Fresh game shows `mission001` briefing.
- [x] Click Accept (or X), reload — briefing does NOT reappear.
- [x] Reload before any close — briefing DOES reappear (intended; the dismiss fires on close).

### Buy dialog
- [x] Buy Jessica Seno. Reopen → she's gone. Reload — still gone.

### Charging timers + live ready
- [ ] Charge mid-reload → counts down correctly.
- [ ] Wait for timer to hit zero **without reloading** → "ready / collect" shows live.

### Database tab + integrate flow
- [x] Charge Jessica → wait → collect → profile-set in conveyor.
- [x] Integrate → new TokenPerp icons spread on the Database tab.
- [x] `mission002` (900 of `token008`) ticks above 0 / 900 (round 8 fix).
- [x] Database token bars stay within frame (round 7 fix).

### Zoom + pan
- [x] +/− buttons zoom the map; greyed out at min/max.
- [x] Click-drag pans the map.
- [x] Tab switch (Imperium ↔ Database) recenters on the new view.

### NEW badge
- [x] Profile-set tiles show `New!` until clicked. Survives reload.

### About dialog
- [x] Top-bar button reads "About" / "Über".
- [x] Long body scrolls inside the popup; Close button does not overlap text.

### Level-up + bars
- [x] Status bars never overflow.
- [x] AP bar visually refills to full on every level-up across all handlers.

### Cash + AP + missions (round 9)
- [x] Starting cash is 270, enough for 4 Jessica charges + 1 car purchase.
- [x] Integrating costs 1 AP per profile-set.
- [ ] Mission completion shows the cash / xp reward.
- [ ] Charging + collecting from the car company adds cash (~584 per cycle).

### Regression sanity
- [x] Karma / project / client popups, charge / collect, buy slots / buy powerup all still work.
- [x] `pnpm test` → 352 / 352. `pnpm build` clean.

https://claude.ai/code/session_01ABUPNHRoUpRxAefU1mGcdN