### PR TITLE
Remove congratulation messages from leaderboard

### DIFF
--- a/i18n/de_AT.json
+++ b/i18n/de_AT.json
@@ -253,38 +253,6 @@
     null,
     "Data Dealer Highscore<br />Investierte Kohle"
   ],
-  "topscore cash text %s": [
-    null,
-    "Du hast es noch nicht in die Highscore-Liste geschafft, hast aber aktuell mehr Cash als %s aller Data Dealer, yeah."
-  ],
-  "topscore profiles text %s": [
-    null,
-    "Du hast es noch nicht in die Highscore-Liste geschafft, hast aber mehr Profile gesammelt als %s aller Data Dealer, yeah."
-  ],
-  "topscore xp text %s": [
-    null,
-    "Du hast es noch nicht in die Highscore-Liste geschafft, hast aber mehr XP als %s aller Data Dealer, yeah."
-  ],
-  "topscore spent text %s": [
-    null,
-    "Du hast es noch nicht in die Highscore-Liste geschafft, hast aber mehr Cash verdient + investiert als %s aller Data Dealer!"
-  ],
-  "topscore cash inranking": [
-    null,
-    "Congrats, du hast so viel Cash, dass du es damit in die Highscore-Liste aller Data Dealer geschafft hast! Weiter so."
-  ],
-  "topscore profiles inranking": [
-    null,
-    "Congrats, du hast schon so viele Profile gesammelt, dass du in der Highscore-Liste aller Data Dealer bist! Weiter so."
-  ],
-  "topscore xp text inranking": [
-    null,
-    "Congrats, mit deinem aktuellen XP-Stand bist du momentan in der Highscore-Liste aller Data Dealer! Weiter so."
-  ],
-  "topscore spent text inranking": [
-    null,
-    "Congrats, du hast so viel Cash verdient + investiert, dass du damit aktuell in der Highscore-Liste gelandet bist! Weiter so."
-  ],
   "topscore Cash": [
     null,
     "Cash"

--- a/i18n/en_US.json
+++ b/i18n/en_US.json
@@ -253,38 +253,6 @@
     null,
     "Data Dealer Highscore<br />Cash Invested"
   ],
-  "topscore cash text %s": [
-    null,
-    "You didn't make it to the top yet, but you've got more cash than %s of all other data dealers, yeah."
-  ],
-  "topscore profiles text %s": [
-    null,
-    "You didn't make it to the top yet, but you've collected more profiles than %s of all other players, yeah."
-  ],
-  "topscore xp text %s": [
-    null,
-    "You didn't make it to the top yet, but you've got more xp than %s of all other players, yeah."
-  ],
-  "topscore spent text %s": [
-    null,
-    "You didn't make it to the top yet, but you've earned & invested more cash than %s of all other players!"
-  ],
-  "topscore cash inranking": [
-    null,
-    "Congrats, you've hoarded loads of cash and you're amongst the top data dealers. Keep it up!"
-  ],
-  "topscore profiles inranking": [
-    null,
-    "Congrats, you've collected enough people's profiles to find yourself among the top data dealers! Right on."
-  ],
-  "topscore xp text inranking": [
-    null,
-    "Congrats, you're amongst the most experienced data dealers! Top notch, keep it up!"
-  ],
-  "topscore spent text inranking": [
-    null,
-    "Congrats, you've burned enough cash to call yourself a serious top investor. Keep the cash flow pumping!"
-  ],
   "topscore Cash": [
     null,
     "Cash"

--- a/scripts/type_settings.js
+++ b/scripts/type_settings.js
@@ -281,18 +281,6 @@ define(function(require) {
             "profiles": _._('topscore profiles headline'),
             "xp": _._('topscore xp headline'),
             "spent": _._('topscore spent headline')
-          },
-          "type_texts_notinranking": {
-            "cash": _._('topscore cash text %s'),
-            "profiles": _._('topscore profiles text %s'),
-            "xp": _._('topscore xp text %s'),
-            "spent": _._('topscore spent text %s')
-          },
-          "type_texts": {
-            "cash": _._('topscore cash inranking'),
-            "profiles": _._('topscore profiles inranking'),
-            "xp": _._('topscore xp text inranking'),
-            "spent": _._('topscore spent text inranking')
           }
         }
       },

--- a/views/topscore_rank.html
+++ b/views/topscore_rank.html
@@ -1,15 +1,7 @@
 <%
   var data = D.data || {};
-  var type = D.type || 'cash';
   var rank = data.user_rank;
-  var barwidth = rank * 200;
-  var type_text = data.type_texts_notinranking[type];
-  var rank_parsed = _.span(_.toKSNum(rank*100)+"%");
-  type_text = _.sprintf(type_text, rank_parsed);
-  var type_text_inranking = data.type_texts[type];
-  var rank_text = (data.user_in_top) ? type_text_inranking : type_text;
 %>
-  <div class="TopscoreRankVal"><% print(rank_text); %></div>
 <% if (!data.user_in_top) { %>
-  <div class="TopscoreRankBarWrap"><div class="TopscoreRankBarPerc"><%= _.toKSNum(rank*100) + "%" %></div><div class="TopscoreRankBar" style="width:<%= barwidth %>px;"></div></div>
+  <div class="TopscoreRankBarWrap"><div class="TopscoreRankBarPerc"><%= _.toKSNum(rank*100) + "%" %></div><div class="TopscoreRankBar" style="width:<%= rank * 200 %>px;"></div></div>
 <% } %>


### PR DESCRIPTION
## Summary
Removes all personalized commentary from the leaderboard to make it group-friendly. In a group of 3-50 people, personalized messages like "You didn't make it to the top yet..." and "Congrats, you've made it!" don't make sense since everyone is always near the top percentile and sees everyone else's stats.

The leaderboard now displays neutral rankings with titles only, making it suitable for shared multiplayer viewing.

## Changes
- **scripts/type_settings.js**: Removed unused `type_texts_notinranking` and `type_texts` configuration objects
- **views/topscore_rank.html**: Removed code that rendered personalized rank messages; kept only the percentile rank bar for players not in top
- **i18n/en_US.json**: Removed 8 personalized message translation keys
- **i18n/de_AT.json**: Removed corresponding German translations

## Result
Leaderboard displays only titles ("Cash", "Profiles", "XP", "Investor") with a visual rank bar. No personalized commentary or messages.