### PR TITLE
Phase 5: CI build .xdc on PRs + release tags (#27)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-      actions: read
 
     steps:
       - uses: actions/checkout@v4
@@ -53,7 +52,7 @@ jobs:
           echo "count=$COUNT" >> $GITHUB_OUTPUT
 
       - name: Upload .xdc artifact
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' || startsWith(github.ref, 'refs/tags/v')
         id: upload_xdc
         uses: actions/upload-artifact@v4
         with:
@@ -69,7 +68,7 @@ jobs:
           message: |
             ## webxdc build ready
 
-            **Bundle:** `data-dealer.xdc` &mdash; ${{ steps.xdc_info.outputs.size }} / ${{ steps.xdc_info.outputs.count }} files
+            **Bundle:** `data-dealer.xdc` — ${{ steps.xdc_info.outputs.size }} / ${{ steps.xdc_info.outputs.count }} files
 
             [Download data-dealer.xdc](${{ steps.upload_xdc.outputs.artifact-url }})
 
@@ -77,28 +76,18 @@ jobs:
 
   release:
     name: Attach .xdc to GitHub Release
+    needs: [test]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: read
 
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: pnpm/action-setup@v4
+      - name: Download .xdc artifact
+        uses: actions/download-artifact@v4
         with:
-          version: 10
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Build
-        run: pnpm build
+          name: data-dealer-xdc
 
       - name: Attach to GitHub Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,12 +3,16 @@ name: Tests
 on:
   push:
     branches: [main, master]
+    tags: ['v*']
   pull_request:
 
 jobs:
   test:
     name: Unit tests
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      actions: read
 
     steps:
       - uses: actions/checkout@v4
@@ -38,3 +42,65 @@ jobs:
           name: coverage-report
           path: coverage/
           retention-days: 30
+
+      - name: Get .xdc bundle info
+        if: github.event_name == 'pull_request'
+        id: xdc_info
+        run: |
+          SIZE=$(du -sh data-dealer.xdc | cut -f1)
+          COUNT=$(unzip -l data-dealer.xdc | tail -1 | awk '{print $2}')
+          echo "size=$SIZE" >> $GITHUB_OUTPUT
+          echo "count=$COUNT" >> $GITHUB_OUTPUT
+
+      - name: Upload .xdc artifact
+        if: github.event_name == 'pull_request'
+        id: upload_xdc
+        uses: actions/upload-artifact@v4
+        with:
+          name: data-dealer-xdc
+          path: data-dealer.xdc
+          retention-days: 30
+
+      - name: Post sticky PR comment with artifact link
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: xdc-artifact
+          message: |
+            ## webxdc build ready
+
+            **Bundle:** `data-dealer.xdc` &mdash; ${{ steps.xdc_info.outputs.size }} / ${{ steps.xdc_info.outputs.count }} files
+
+            [Download data-dealer.xdc](${{ steps.upload_xdc.outputs.artifact-url }})
+
+            Drop the downloaded file into Delta Chat to test.
+
+  release:
+    name: Attach .xdc to GitHub Release
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: pnpm build
+
+      - name: Attach to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: data-dealer.xdc

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Data Dealer (webxdc port) #
 
+[![Tests](https://github.com/experintellia/data_dealer/actions/workflows/test.yml/badge.svg)](https://github.com/experintellia/data_dealer/actions/workflows/test.yml)
+
 ## About this fork
 
 This repository is a work-in-progress port of the [Data Dealer](http://datadealer.com) browser game into a [webxdc](https://webxdc.org) mini-app — a self-contained, offline-capable application that runs inside a Delta Chat group. The aim is a full-game port (not a demo), fusing three of the original repositories:


### PR DESCRIPTION
## Summary

- Extends `.github/workflows/test.yml` to upload `data-dealer.xdc` as a workflow artifact on every PR, post a sticky comment with the download link + bundle size + file count, and attach the `.xdc` to GitHub Releases on `v*` tag pushes
- Adds a Tests workflow badge to `README.md`

## What changed

**`.github/workflows/test.yml`**
- Added `tags: ['v*']` to the `push` trigger
- Added `pull-requests: write` + `actions: read` permissions to the `test` job
- After the existing `pnpm build` step (which already produces `data-dealer.xdc` via `@webxdc/vite-plugins`), three new PR-only steps:
  - Capture bundle size (`du -sh`) and file count (`unzip -l | tail -1`)
  - Upload `data-dealer.xdc` as artifact via `actions/upload-artifact@v4` (30-day retention)
  - Post / update sticky comment via `marocchino/sticky-pull-request-comment@v2` with the artifact URL, size, count, and "drop into Delta Chat" instructions
- New `release` job (runs only on `refs/tags/v*`): full build, then `softprops/action-gh-release@v2` attaches `data-dealer.xdc` to the GitHub Release

**`README.md`**
- Added Tests workflow status badge below the title

## Why extend test.yml rather than create build-xdc.yml

The existing `test` job already runs `pnpm build`, which produces the `.xdc`. Creating a separate `build-xdc.yml` would run `vite build` twice on every PR. Extending the existing job reuses the build output with zero extra cost.

## Coordinates with

- #26 (vite + @webxdc/vite-plugins) — closed and merged; `pnpm build` → `data-dealer.xdc` at repo root is confirmed
- #45 (test infra) — this extends the workflow #45 created
- #48 (Playwright in CI) — that issue's `playwright` job should extend this same workflow when it lands

## Test plan

- [ ] Open a draft PR → verify `Tests` check runs, artifact `data-dealer-xdc` appears under the run, sticky comment lands on the PR with download link + size + count
- [ ] Push another commit to the same PR → verify the comment is _updated_, not duplicated
- [ ] Tag `v0.0.0-test` and push → verify `release` job runs and `data-dealer.xdc` appears as a release asset; delete tag and release after

https://claude.ai/code/session_01ULj1qhs9c4dq65qw565LZM

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULj1qhs9c4dq65qw565LZM)_