### PR TITLE
Fix #97: add chargePerp/collectCash mission workflows + tests for missions 003–016

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2091,18 +2091,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@jridgewell/source-map": {
-      "version": "0.3.11",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
-      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.25"
-      }
-    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -3000,20 +2988,6 @@
         "vite-plugin-zip-pack": "^1.2.4"
       }
     },
-    "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
@@ -3253,14 +3227,6 @@
         "browserslist": "*"
       }
     },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -3363,14 +3329,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -4833,17 +4791,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4852,18 +4799,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
       }
     },
     "node_modules/stackback": {
@@ -5046,26 +4981,6 @@
       "integrity": "sha512-Nk8c4lXvMB98MtbmjX7JwJRgJOL8fluecYCfCeYBznwmpOs8Bf15hLM6z4z71EDAhQVrQrI+wt1aLWSXZq+hXA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/terser": {
-      "version": "5.46.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.2.tgz",
-      "integrity": "sha512-uxfo9fPcSgLDYob/w1FuL0c99MWiJDnv+5qXSQc5+Ki5NjVNsYi66INnMFBjf6uFz6OnX12piJQPF4IpjJTNTw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.15.0",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/test-exclude": {
       "version": "7.0.2",

--- a/scripts/LocalEngine.js
+++ b/scripts/LocalEngine.js
@@ -704,13 +704,21 @@ export function buyPowerup(token, perpPath, slot, gestalt) {
   var newNodes = state.nodes.slice();
   newNodes[nodeIdx] = Object.assign({}, node, { instance_data: newInstanceData });
 
-  var newState = Object.assign({}, state, { nodes: newNodes, game_values: newGameValues });
+  var preMissionStatePu = Object.assign({}, state, { nodes: newNodes, game_values: newGameValues });
+  var puMissionResult = _advanceBuyPowerupMissions(preMissionStatePu, gestalt);
+  newGameValues = _applyRewardsToGv(newGameValues, puMissionResult.rewards);
+  var newState = Object.assign({}, preMissionStatePu, {
+    game_values:     newGameValues,
+    mission_goals:   puMissionResult.mission_goals,
+    active_missions: puMissionResult.active_missions,
+  });
 
   var responseNode = {
     game_id: node.game_id, game_type: node.game_type,
     full_path: node.full_path, instance_data: newInstanceData
   };
-  var result = { node: responseNode, game_values: newGameValues, levelup: levelup };
+  var result = { node: responseNode, game_values: newGameValues, levelup: levelup,
+                 missions: puMissionResult.missions || null };
 
   _commitDelta(newState, state.addr, 'buyPowerup',
     [token, perpPath, slot, gestalt], result);
@@ -1209,6 +1217,78 @@ function _applyRewardsToGv(gv, rewards) {
   });
 }
 
+function _advanceChargePerpMissions(state, gestalt) {
+  var activeMissions = state.active_missions || [];
+  var missionGoals = state.mission_goals || [];
+
+  if (!activeMissions.length || !missionGoals.length) {
+    return { missions: null, mission_goals: missionGoals, active_missions: activeMissions };
+  }
+
+  var changed = false;
+  var updatedGoals = missionGoals.map(function (goal) {
+    if (goal.workflow !== 'charge_perp' || goal.complete) return goal;
+    if (goal.target !== gestalt) return goal;
+    if (activeMissions.indexOf(goal.mission) === -1) return goal;
+    changed = true;
+    return Object.assign({}, goal, { complete: true, current_amount: goal.amount || 1 });
+  });
+
+  if (!changed) {
+    return { missions: null, mission_goals: missionGoals, active_missions: activeMissions };
+  }
+
+  return _completeMissionsIfReady(updatedGoals, activeMissions);
+}
+
+function _advanceBuyPowerupMissions(state, powerupGestalt) {
+  var activeMissions = state.active_missions || [];
+  var missionGoals = state.mission_goals || [];
+
+  if (!activeMissions.length || !missionGoals.length) {
+    return { missions: null, mission_goals: missionGoals, active_missions: activeMissions };
+  }
+
+  var changed = false;
+  var updatedGoals = missionGoals.map(function (goal) {
+    if (goal.workflow !== 'buy_powerup' || goal.complete) return goal;
+    if (goal.target !== powerupGestalt) return goal;
+    if (activeMissions.indexOf(goal.mission) === -1) return goal;
+    changed = true;
+    return Object.assign({}, goal, { complete: true, current_amount: goal.amount || 1 });
+  });
+
+  if (!changed) {
+    return { missions: null, mission_goals: missionGoals, active_missions: activeMissions };
+  }
+
+  return _completeMissionsIfReady(updatedGoals, activeMissions);
+}
+
+function _advanceUpgradeTokenMissions(state, tokenGestalt) {
+  var activeMissions = state.active_missions || [];
+  var missionGoals = state.mission_goals || [];
+
+  if (!activeMissions.length || !missionGoals.length) {
+    return { missions: null, mission_goals: missionGoals, active_missions: activeMissions };
+  }
+
+  var changed = false;
+  var updatedGoals = missionGoals.map(function (goal) {
+    if (goal.workflow !== 'upgrade_token' || goal.complete) return goal;
+    if (goal.target !== tokenGestalt) return goal;
+    if (activeMissions.indexOf(goal.mission) === -1) return goal;
+    changed = true;
+    return Object.assign({}, goal, { complete: true, current_amount: goal.amount || 1 });
+  });
+
+  if (!changed) {
+    return { missions: null, mission_goals: missionGoals, active_missions: activeMissions };
+  }
+
+  return _completeMissionsIfReady(updatedGoals, activeMissions);
+}
+
 /**
  * Advance any active mission goals that have workflow==='buy_perp' and
  * target===gestalt.  Pure; does not mutate state.
@@ -1228,6 +1308,35 @@ function _advanceBuyPerpMissions(state, gestalt) {
       return Object.assign({}, goal, { complete: true, current_amount: goal.amount || 1 });
     }
     return goal;
+  });
+
+  if (!changed) {
+    return { missions: null, mission_goals: missionGoals, active_missions: activeMissions };
+  }
+
+  return _completeMissionsIfReady(updatedGoals, activeMissions);
+}
+
+function _advanceCollectCashMissions(state, gestalt, cashGain) {
+  var activeMissions = state.active_missions || [];
+  var missionGoals = state.mission_goals || [];
+
+  if (!activeMissions.length || !missionGoals.length || !cashGain || !gestalt) {
+    return { missions: null, mission_goals: missionGoals, active_missions: activeMissions };
+  }
+
+  var changed = false;
+  var updatedGoals = missionGoals.map(function (goal) {
+    if (goal.workflow !== 'collect_cash' || goal.complete) return goal;
+    if (goal.target !== gestalt) return goal;
+    if (activeMissions.indexOf(goal.mission) === -1) return goal;
+    var newAmount = Math.min((goal.current_amount || 0) + cashGain, goal.amount);
+    if (newAmount === goal.current_amount) return goal;
+    changed = true;
+    return Object.assign({}, goal, {
+      current_amount: newAmount,
+      complete: newAmount >= goal.amount
+    });
   });
 
   if (!changed) {
@@ -1337,11 +1446,21 @@ export function chargePerp(token, path) { // eslint-disable-line no-unused-vars
     });
   }
 
-  setState(Object.assign({}, state, {
+  var preMissionStateCharge = Object.assign({}, state, {
     nodes:          newNodes,
     nodes_charging: charging.concat([chargeEntry]),
     game_values:    newGv,
-  }));
+  });
+
+  var chargeMissionResult = _advanceChargePerpMissions(preMissionStateCharge, gestalt);
+  newGv = _applyRewardsToGv(newGv, chargeMissionResult.rewards);
+  var newStateCharge = Object.assign({}, preMissionStateCharge, {
+    game_values:     newGv,
+    mission_goals:   chargeMissionResult.mission_goals,
+    active_missions: chargeMissionResult.active_missions,
+  });
+
+  setState(newStateCharge);
 
   _persistDelta({
     kind:   'delta',
@@ -1359,7 +1478,8 @@ export function chargePerp(token, path) { // eslint-disable-line no-unused-vars
   _scheduleChargeReady(chargeEntry.charge_end, chargeEntry.path);
 
   return Promise.resolve({
-    result: { game_values: newGv, duration: durationMs, levelup: levelup, missions: {} },
+    result: { game_values: newGv, duration: durationMs, levelup: levelup,
+              missions: chargeMissionResult.missions || {} },
   });
 }
 
@@ -1602,12 +1722,17 @@ export function collectPerp(_token, gperpPath) {
     last_seen_ts:  Math.max(now, ms.last_seen_ts || 0)
   });
 
-  // Only ContactPerp collects feed collect_profiles goals; ProjectPerp /
-  // ClientPerp / TokenPerp paths skip mission progression.
-  var collectMissionResult = (gameType === 'ContactPerp')
-    ? _advanceCollectProfilesMissions(preMissionState, gestalt, cr.amount || 0)
-    : { missions: null, mission_goals: preMissionState.mission_goals,
-        active_missions: preMissionState.active_missions };
+  var collectMissionResult;
+  if (gameType === 'ContactPerp') {
+    collectMissionResult = _advanceCollectProfilesMissions(preMissionState, gestalt, cr.amount || 0);
+  } else if (gameType === 'ClientPerp') {
+    collectMissionResult = _advanceCollectCashMissions(preMissionState, gestalt, cr.amount || 0);
+  } else if (gameType === 'TokenPerp') {
+    collectMissionResult = _advanceUpgradeTokenMissions(preMissionState, gestalt);
+  } else {
+    collectMissionResult = { missions: null, mission_goals: preMissionState.mission_goals,
+      active_missions: preMissionState.active_missions };
+  }
   newGv = _applyRewardsToGv(newGv, collectMissionResult.rewards);
   var newState = Object.assign({}, preMissionState, {
     game_values: newGv,

--- a/scripts/LocalEngine.js
+++ b/scripts/LocalEngine.js
@@ -650,6 +650,7 @@ function _commitDelta(computedNewState, addr, op, args, result) {
   } else {
     setState(computedNewState);
   }
+  if (_sendDelta) _sendDelta(delta);
 }
 
 // ---------------------------------------------------------------------------
@@ -1467,7 +1468,8 @@ export function chargePerp(token, path) { // eslint-disable-line no-unused-vars
     addr:   state.addr,
     op:     'chargePerp',
     args:   [path],
-    result: { chargeEntry: chargeEntry, nodeIdx: nodeIdx, cashDelta: chargeCost, xpInc: xpInc },
+    result: { chargeEntry: chargeEntry, nodeIdx: nodeIdx, cashDelta: chargeCost, xpInc: xpInc,
+              missions: chargeMissionResult.missions || null },
     ts:     now,
   });
 

--- a/scripts/state.js
+++ b/scripts/state.js
@@ -241,9 +241,12 @@ function _nodeGvReducer(state, delta) {
     return Object.assign({}, n, { instance_data: res.node.instance_data });
   });
 
+  var mp = _missionDataFromResult(state, res);
   return Object.assign({}, state, {
-    nodes:       newNodes,
-    game_values: Object.assign({}, state.game_values, res.game_values || {})
+    nodes:           newNodes,
+    game_values:     Object.assign({}, state.game_values, res.game_values || {}),
+    mission_goals:   mp.mission_goals,
+    active_missions: mp.active_missions,
   });
 }
 
@@ -336,10 +339,13 @@ reducers.chargePerp = function chargePerpReducer(state, delta) {
     ap_snapshot: Math.max(0, (gv.ap_snapshot || 0) - 1),
   });
 
+  var mp = _missionDataFromResult(state, r);
   return Object.assign({}, state, {
-    nodes:          newNodes,
-    nodes_charging: stillCharging.concat([chargeEntry]),
-    game_values:    newGv,
+    nodes:           newNodes,
+    nodes_charging:  stillCharging.concat([chargeEntry]),
+    game_values:     newGv,
+    mission_goals:   mp.mission_goals,
+    active_missions: mp.active_missions,
   });
 };
 

--- a/tests/handlers/collect-integrate.test.js
+++ b/tests/handlers/collect-integrate.test.js
@@ -8,10 +8,11 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   collectPerp, integrateCollected, chargePerp, buyPerp, buyPowerup, loadGame,
-  setEmitter, setPrngSeed
+  setEmitter, setPrngSeed, setSendDelta
 } from '../../scripts/LocalEngine.js';
 import { setState, getState } from '../../scripts/boot.js';
 import { materialize } from '../../scripts/materializer.js';
+import { applyDelta } from '../../scripts/state.js';
 import { freshState } from '../../scripts/state.js';
 import { setOverride, clearOverride, advance } from '../../scripts/clock.js';
 
@@ -1982,5 +1983,84 @@ describe('mission progression — M_BIGAPPLE Big Apple, Big Data! (buy_perp)', (
     expect(result.missions.complete_missions).toContain(M_BIGAPPLE);
     // No required_mission points to M_BIGAPPLE, so no new mission activates.
     expect(s.active_missions).toHaveLength(0);
+  });
+});
+
+// ── Cold-start replay regression tests ───────────────────────────────────────
+// Verify that mission progress produced by chargePerp and buyPowerup survives
+// a simulated cold-start reload: capture the delta via setSendDelta, then
+// replay it with applyDelta against the pre-action state and assert that
+// mission_goals and active_missions reflect the completed goal.
+
+describe('cold-start replay — chargePerp mission progress survives applyDelta', () => {
+  const C007 = 'Imperium.City.Pusher0.client007';
+
+  beforeEach(() => setOverride(FIXED_NOW));
+  afterEach(() => { clearOverride(); setEmitter(null); setSendDelta(null); });
+
+  it('chargePerp delta carries missions so mission003 goal survives reload', async () => {
+    const initialState = mkState({
+      game_values: mkHighGv(),
+      nodes: [mkClientNode2('client007', C007)],
+      active_missions: ['mission003'],
+      mission_goals: [{
+        mission: 'mission003', workflow: 'charge_perp', target: 'client007',
+        amount: null, position: 1, current_amount: 0, complete: false
+      }]
+    });
+    setState(initialState);
+
+    var capturedDelta = null;
+    setSendDelta(function (d) { capturedDelta = d; });
+
+    await chargePerp('tok', C007);
+    expect(capturedDelta).not.toBeNull();
+
+    // Simulate cold-start: replay the delta against the state that existed
+    // before the charge (as if the app was killed and restarted mid-session).
+    const replayed = applyDelta(initialState, capturedDelta);
+    const goal = replayed.mission_goals.find(g => g.mission === 'mission003');
+    expect(goal).toBeDefined();
+    expect(goal.complete).toBe(true);
+    expect(replayed.active_missions).not.toContain('mission003');
+    expect(replayed.active_missions).toContain('mission004');
+  });
+});
+
+describe('cold-start replay — buyPowerup mission progress survives applyDelta', () => {
+  const P001 = 'Imperium.City.project001';
+
+  beforeEach(() => setOverride(FIXED_NOW));
+  afterEach(() => { clearOverride(); setEmitter(null); setSendDelta(null); });
+
+  it('buyPowerup delta carries missions so mission006 partial progress survives reload', async () => {
+    const initialState = mkState({
+      game_values: mkHighGv({ xp_level: 2 }),
+      nodes: [mkProjectNode('project001', P001)],
+      active_missions: ['mission006'],
+      mission_goals: [
+        { mission: 'mission006', workflow: 'buy_powerup', target: 'upgrade001',
+          amount: null, position: 1, current_amount: 0, complete: false },
+        { mission: 'mission006', workflow: 'buy_powerup', target: 'ad002',
+          amount: null, position: 2, current_amount: 0, complete: false },
+        { mission: 'mission006', workflow: 'buy_powerup', target: 'teammember020',
+          amount: null, position: 3, current_amount: 0, complete: false }
+      ]
+    });
+    setState(initialState);
+
+    var capturedDelta = null;
+    setSendDelta(function (d) { capturedDelta = d; });
+
+    await buyPowerup('tok', P001, 0, 'upgrade001');
+    expect(capturedDelta).not.toBeNull();
+
+    // Replay the delta against the initial state (cold-start simulation).
+    const replayed = applyDelta(initialState, capturedDelta);
+    const goals = replayed.mission_goals.filter(g => g.mission === 'mission006');
+    expect(goals.find(g => g.target === 'upgrade001').complete).toBe(true);
+    expect(goals.find(g => g.target === 'ad002').complete).toBe(false);
+    // Mission still active — only one of three goals complete.
+    expect(replayed.active_missions).toContain('mission006');
   });
 });

--- a/tests/handlers/collect-integrate.test.js
+++ b/tests/handlers/collect-integrate.test.js
@@ -1871,3 +1871,116 @@ describe('mission progression — M_ALFONSO Alfonso (buy_perp)', () => {
     expect(result.missions.complete_missions).toContain(M_ALFONSO);
   });
 });
+
+// ── M_BOGUS — Bogus company tangle ───────────────────────────────────────────
+// buy_perp(proxy004)
+
+describe('mission progression — M_BOGUS Bogus company tangle (buy_perp)', () => {
+  var M_BOGUS = '3cb9492322191121ebf7a10aafd0fc4a000';
+  var M_MULT  = '1da63b8adf60878f693dfb9d9f73690f000';
+
+  beforeEach(() => setOverride(FIXED_NOW));
+  afterEach(() => { clearOverride(); setEmitter(null); });
+
+  it('buying proxy004 completes M_BOGUS and activates M_MULT (Multiplication 101)', async () => {
+    setState(mkState({
+      game_values: mkHighGv({ xp_level: 9 }),
+      nodes: [],
+      active_missions: [M_BOGUS],
+      mission_goals: [{
+        mission: M_BOGUS, workflow: 'buy_perp', target: 'proxy004',
+        amount: null, position: 1, current_amount: 0, complete: false
+      }]
+    }));
+
+    const { result } = await buyPerp('tok', 'Imperium', 'proxy004');
+    const s = getState();
+    expect(s.mission_goals.find(g => g.mission === M_BOGUS).complete).toBe(true);
+    expect(s.active_missions).not.toContain(M_BOGUS);
+    expect(s.active_missions).toContain(M_MULT);
+    expect(result.missions.complete_missions).toContain(M_BOGUS);
+  });
+});
+
+// ── M_MULT — Multiplication 101 ───────────────────────────────────────────────
+// buy_perp(token055) + upgrade_token(token055)
+
+describe('mission progression — M_MULT Multiplication 101 (buy_perp + upgrade_token)', () => {
+  var M_MULT   = '1da63b8adf60878f693dfb9d9f73690f000';
+  var M_BIGAPPLE = '2f59d10a67ca7ee9006dfe5db31a4c5f000';
+  const T055 = 'Imperium.token055';
+
+  beforeEach(() => setOverride(FIXED_NOW));
+  afterEach(() => { clearOverride(); setEmitter(null); });
+
+  function seedMMult() {
+    setState(mkState({
+      game_values: mkHighGv({ xp_level: 7 }),
+      nodes: [],
+      active_missions: [M_MULT],
+      mission_goals: [
+        { mission: M_MULT, workflow: 'buy_perp', target: 'token055',
+          amount: null, position: 1, current_amount: 0, complete: false },
+        { mission: M_MULT, workflow: 'upgrade_token', target: 'token055',
+          amount: null, position: 2, current_amount: 0, complete: false }
+      ]
+    }));
+  }
+
+  it('buying token055 marks buy_perp goal complete; mission stays active', async () => {
+    seedMMult();
+    await buyPerp('tok', 'Imperium', 'token055');
+    const goal = getState().mission_goals.find(
+      g => g.mission === M_MULT && g.workflow === 'buy_perp');
+    expect(goal.complete).toBe(true);
+    expect(getState().active_missions).toContain(M_MULT);
+  });
+
+  it('collecting from token055 after buying it completes M_MULT and activates M_BIGAPPLE', async () => {
+    seedMMult();
+    await buyPerp('tok', 'Imperium', 'token055');
+
+    // Seed collect entry for the TokenPerp node buyPerp created.
+    const s1 = getState();
+    setState(Object.assign({}, s1, {
+      nodes_collect: [{ path: T055, result: { amount: 0 } }]
+    }));
+
+    const { result } = await collectPerp('tok', T055);
+    const s = getState();
+    expect(s.mission_goals.filter(g => g.mission === M_MULT).every(g => g.complete)).toBe(true);
+    expect(s.active_missions).not.toContain(M_MULT);
+    expect(s.active_missions).toContain(M_BIGAPPLE);
+    expect(result.missions.complete_missions).toContain(M_MULT);
+  });
+});
+
+// ── M_BIGAPPLE — Big Apple, Big Data! ────────────────────────────────────────
+// buy_perp(city004)  — final mission in the trunk chain
+
+describe('mission progression — M_BIGAPPLE Big Apple, Big Data! (buy_perp)', () => {
+  var M_BIGAPPLE = '2f59d10a67ca7ee9006dfe5db31a4c5f000';
+
+  beforeEach(() => setOverride(FIXED_NOW));
+  afterEach(() => { clearOverride(); setEmitter(null); });
+
+  it('buying city004 completes M_BIGAPPLE (last mission — no chain follow-up)', async () => {
+    setState(mkState({
+      game_values: mkHighGv({ xp_level: 11 }),
+      nodes: [],
+      active_missions: [M_BIGAPPLE],
+      mission_goals: [{
+        mission: M_BIGAPPLE, workflow: 'buy_perp', target: 'city004',
+        amount: null, position: 1, current_amount: 0, complete: false
+      }]
+    }));
+
+    const { result } = await buyPerp('tok', 'Imperium', 'city004');
+    const s = getState();
+    expect(s.mission_goals.find(g => g.mission === M_BIGAPPLE).complete).toBe(true);
+    expect(s.active_missions).not.toContain(M_BIGAPPLE);
+    expect(result.missions.complete_missions).toContain(M_BIGAPPLE);
+    // No required_mission points to M_BIGAPPLE, so no new mission activates.
+    expect(s.active_missions).toHaveLength(0);
+  });
+});

--- a/tests/handlers/collect-integrate.test.js
+++ b/tests/handlers/collect-integrate.test.js
@@ -7,7 +7,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
-  collectPerp, integrateCollected, chargePerp, buyPerp, loadGame,
+  collectPerp, integrateCollected, chargePerp, buyPerp, buyPowerup, loadGame,
   setEmitter, setPrngSeed
 } from '../../scripts/LocalEngine.js';
 import { setState, getState } from '../../scripts/boot.js';
@@ -1206,5 +1206,668 @@ describe('mission rewards — apply on completion', () => {
     const { result } = await collectPerp('tok', JESSICA);
     // contact035 xp_inc=1 + mission001 reward=2.
     expect(result.game_values.xp_value).toBe(startXp + 1 + 2);
+  });
+});
+
+// ── Per-mission integration tests: missions 003–016 ──────────────────────────
+//
+// Covers all new workflow helpers added in #97:
+//   _advanceChargePerpMissions   (charge_perp goals)
+//   _advanceCollectCashMissions  (collect_cash goals)
+//   _advanceBuyPowerupMissions   (buy_powerup goals)
+//   _advanceUpgradeTokenMissions (upgrade_token goals)
+//
+// Each block seeds active_missions + mission_goals, calls the relevant
+// handler(s), and asserts: goal progress · completion · reward · chain.
+
+// IDs for the hash-named missions (title in parentheses).
+var M_CASH_IN  = 'a388da08d87dc9fd6d543977a2047262000'; // Cash in!
+var M_DB_MACH  = 'e59302bed28769c3c76761c14516e764000'; // Database machine
+var M_PSYCHO   = 'e33a3ef9d70038e0a9c6d088f37d02cb000'; // Psycho
+var M_COUCH    = 'af1149c315321ef4f477893fcc1807e1000'; // Couch Potato
+var M_EMPLOYEE = 'b638f35b5ec6b0558981378c9037c3d3000'; // Employee Monitoring
+var M_IMAGE    = '9f5735d01587f640cc862e0a82280d3f000'; // Improve your image
+var M_COLLAB   = '16f302f84b84498a734dfdbe1a7794b9000'; // Unofficial collaboration
+var M_ALFONSO  = 'dc481d7863ceb18575c50d36e2c5ecfe000'; // Alfonso
+
+// High-level game_values: enough cash/level/AP for all purchases in tests.
+function mkHighGv(overrides) {
+  return mkGv(Object.assign({ xp_level: 10, cash_value: 100000, ap_snapshot: 6 }, overrides || {}));
+}
+
+function mkProjectNode(gestalt, path) {
+  return { game_id: gestalt, game_type: 'ProjectPerp', full_type: 'ProjectPerp:' + gestalt,
+    gestalt: gestalt, full_path: path, instance_data: {} };
+}
+function mkClientNode2(gestalt, path) {
+  return { game_id: gestalt, game_type: 'ClientPerp', full_type: 'ClientPerp:' + gestalt,
+    gestalt: gestalt, full_path: path, instance_data: {} };
+}
+function mkContactNode(gestalt, path) {
+  return { game_id: gestalt, game_type: 'ContactPerp', full_type: 'ContactPerp:' + gestalt,
+    gestalt: gestalt, full_path: path, instance_data: {} };
+}
+function mkTokenNode2(gestalt, path, amount) {
+  return { game_id: gestalt, game_type: 'TokenPerp', full_type: 'TokenPerp:' + gestalt,
+    gestalt: gestalt, full_path: path, instance_data: { amount: amount || 0 } };
+}
+
+// ── mission003 — Rookie Dealer ───────────────────────────────────────────────
+// charge_perp(client007, amount:null)
+
+describe('mission progression — mission003 Rookie Dealer (charge_perp)', () => {
+  const C007 = 'Imperium.City.Pusher0.client007';
+
+  beforeEach(() => setOverride(FIXED_NOW));
+  afterEach(() => { clearOverride(); setEmitter(null); });
+
+  it('charging client007 completes goal, grants +600 cash reward, activates mission004', async () => {
+    setState(mkState({
+      game_values: mkHighGv(),
+      nodes: [mkClientNode2('client007', C007)],
+      active_missions: ['mission003'],
+      mission_goals: [{
+        mission: 'mission003', workflow: 'charge_perp', target: 'client007',
+        amount: null, position: 1, current_amount: 0, complete: false
+      }]
+    }));
+    const startCash = getState().game_values.cash_value;
+
+    const { result } = await chargePerp('tok', C007);
+    expect(result.error).toBeUndefined();
+
+    const s = getState();
+    const goal = s.mission_goals.find(g => g.mission === 'mission003');
+    expect(goal.complete).toBe(true);
+    expect(s.active_missions).not.toContain('mission003');
+    expect(s.active_missions).toContain('mission004');
+    // client007 charge_cost=0; mission003 reward = +600 cash
+    expect(s.game_values.cash_value).toBe(startCash + 600);
+    expect(s.mission_goals.filter(g => g.mission === 'mission004')).toHaveLength(2);
+  });
+});
+
+// ── mission004 — You're a winner! ────────────────────────────────────────────
+// buy_perp(project001, null) + charge_perp(project001, null)
+
+describe("mission progression — mission004 You're a winner! (buy_perp + charge_perp)", () => {
+  const P001 = 'Imperium.project001';
+
+  beforeEach(() => setOverride(FIXED_NOW));
+  afterEach(() => { clearOverride(); setEmitter(null); });
+
+  function seedM004() {
+    setState(mkState({
+      game_values: mkHighGv({ xp_level: 2 }),
+      nodes: [],
+      active_missions: ['mission004'],
+      mission_goals: [
+        { mission: 'mission004', workflow: 'buy_perp', target: 'project001',
+          amount: null, position: 1, current_amount: 0, complete: false },
+        { mission: 'mission004', workflow: 'charge_perp', target: 'project001',
+          amount: null, position: 2, current_amount: 0, complete: false }
+      ]
+    }));
+  }
+
+  it('buying project001 marks the buy_perp goal complete; mission stays active', async () => {
+    seedM004();
+    await buyPerp('tok', 'Imperium', 'project001');
+    const goals = getState().mission_goals.filter(g => g.mission === 'mission004');
+    expect(goals.find(g => g.workflow === 'buy_perp').complete).toBe(true);
+    expect(goals.find(g => g.workflow === 'charge_perp').complete).toBe(false);
+    expect(getState().active_missions).toContain('mission004');
+  });
+
+  it('charging project001 after buying it completes mission004 and activates M_CASH_IN', async () => {
+    seedM004();
+    await buyPerp('tok', 'Imperium', 'project001');
+    const { result } = await chargePerp('tok', P001);
+    expect(result.error).toBeUndefined();
+
+    const s = getState();
+    expect(s.active_missions).not.toContain('mission004');
+    expect(s.active_missions).toContain(M_CASH_IN);
+    expect(result.missions.complete_missions).toContain('mission004');
+  });
+});
+
+// ── M_CASH_IN — Cash in! ─────────────────────────────────────────────────────
+// collect_cash(client007, 500)
+
+describe('mission progression — M_CASH_IN Cash in! (collect_cash)', () => {
+  const C007 = 'Imperium.City.Pusher0.client007';
+
+  beforeEach(() => setOverride(FIXED_NOW));
+  afterEach(() => { clearOverride(); setEmitter(null); });
+
+  it('collecting 200 cash advances goal to 200 without completing mission', async () => {
+    setState(mkState({
+      game_values: mkHighGv({ cash_value: 0 }),
+      nodes: [mkClientNode2('client007', C007)],
+      nodes_collect: [{ path: C007, result: { amount: 200 } }],
+      active_missions: [M_CASH_IN],
+      mission_goals: [{
+        mission: M_CASH_IN, workflow: 'collect_cash', target: 'client007',
+        amount: 500, position: 1, current_amount: 0, complete: false
+      }]
+    }));
+
+    await collectPerp('tok', C007);
+    const goal = getState().mission_goals.find(g => g.mission === M_CASH_IN);
+    expect(goal.current_amount).toBe(200);
+    expect(goal.complete).toBe(false);
+    expect(getState().active_missions).toContain(M_CASH_IN);
+  });
+
+  it('collecting 600 fills the 500 goal, grants +200 cash reward, activates mission006', async () => {
+    setState(mkState({
+      game_values: mkHighGv({ cash_value: 0 }),
+      nodes: [mkClientNode2('client007', C007)],
+      nodes_collect: [{ path: C007, result: { amount: 600 } }],
+      active_missions: [M_CASH_IN],
+      mission_goals: [{
+        mission: M_CASH_IN, workflow: 'collect_cash', target: 'client007',
+        amount: 500, position: 1, current_amount: 0, complete: false
+      }]
+    }));
+
+    const { result } = await collectPerp('tok', C007);
+    const s = getState();
+    const goal = s.mission_goals.find(g => g.mission === M_CASH_IN);
+    expect(goal.current_amount).toBe(500); // capped at goal.amount
+    expect(goal.complete).toBe(true);
+    expect(s.active_missions).not.toContain(M_CASH_IN);
+    expect(s.active_missions).toContain('mission006');
+    // start=0 + collect=600 + reward=200 = 800
+    expect(s.game_values.cash_value).toBe(800);
+    expect(result.missions.complete_missions).toContain(M_CASH_IN);
+  });
+});
+
+// ── mission006 — Upgrade raffle ───────────────────────────────────────────────
+// buy_powerup(upgrade001 on project001) + buy_powerup(ad002) + buy_powerup(teammember020)
+
+describe('mission progression — mission006 Upgrade raffle (buy_powerup x3)', () => {
+  const P001 = 'Imperium.City.project001';
+
+  beforeEach(() => setOverride(FIXED_NOW));
+  afterEach(() => { clearOverride(); setEmitter(null); });
+
+  it('buying upgrade001 marks goal 1 complete; mission still active', async () => {
+    setState(mkState({
+      game_values: mkHighGv({ xp_level: 2 }),
+      nodes: [mkProjectNode('project001', P001)],
+      active_missions: ['mission006'],
+      mission_goals: [
+        { mission: 'mission006', workflow: 'buy_powerup', target: 'upgrade001',
+          amount: null, position: 1, current_amount: 0, complete: false },
+        { mission: 'mission006', workflow: 'buy_powerup', target: 'ad002',
+          amount: null, position: 2, current_amount: 0, complete: false },
+        { mission: 'mission006', workflow: 'buy_powerup', target: 'teammember020',
+          amount: null, position: 3, current_amount: 0, complete: false }
+      ]
+    }));
+    await buyPowerup('tok', P001, 0, 'upgrade001');
+    const goals = getState().mission_goals.filter(g => g.mission === 'mission006');
+    expect(goals.find(g => g.target === 'upgrade001').complete).toBe(true);
+    expect(goals.find(g => g.target === 'ad002').complete).toBe(false);
+    expect(getState().active_missions).toContain('mission006');
+  });
+
+  it('buying all three powerups completes mission006, grants reward, activates mission007', async () => {
+    setState(mkState({
+      game_values: mkHighGv({ xp_level: 2 }),
+      nodes: [mkProjectNode('project001', P001)],
+      active_missions: ['mission006'],
+      mission_goals: [
+        { mission: 'mission006', workflow: 'buy_powerup', target: 'upgrade001',
+          amount: null, position: 1, current_amount: 0, complete: false },
+        { mission: 'mission006', workflow: 'buy_powerup', target: 'ad002',
+          amount: null, position: 2, current_amount: 0, complete: false },
+        { mission: 'mission006', workflow: 'buy_powerup', target: 'teammember020',
+          amount: null, position: 3, current_amount: 0, complete: false }
+      ]
+    }));
+
+    await buyPowerup('tok', P001, 0, 'upgrade001');
+    await buyPowerup('tok', P001, 1, 'ad002');
+    const { result } = await buyPowerup('tok', P001, 2, 'teammember020');
+
+    const s = getState();
+    expect(s.mission_goals.filter(g => g.mission === 'mission006').every(g => g.complete)).toBe(true);
+    expect(s.active_missions).not.toContain('mission006');
+    expect(s.active_missions).toContain('mission007');
+    expect(result.missions.complete_missions).toContain('mission006');
+  });
+});
+
+// ── mission007 — Nurse Helen ──────────────────────────────────────────────────
+// buy_perp(contact001, null) + collect_profiles(contact001, 3000) + integrate_profiles(token017, 3000)
+
+describe('mission progression — mission007 Nurse Helen (buy+collect+integrate)', () => {
+  const CT1 = 'Imperium.contact001';
+
+  beforeEach(() => setOverride(FIXED_NOW));
+  afterEach(() => { clearOverride(); setEmitter(null); });
+
+  function seedM007() {
+    setState(mkState({
+      game_values: mkHighGv({ xp_level: 3 }),
+      nodes: [],
+      active_missions: ['mission007'],
+      mission_goals: [
+        { mission: 'mission007', workflow: 'buy_perp', target: 'contact001',
+          amount: null, position: 1, current_amount: 0, complete: false },
+        { mission: 'mission007', workflow: 'collect_profiles', target: 'contact001',
+          amount: 3000, position: 2, current_amount: 0, complete: false },
+        { mission: 'mission007', workflow: 'integrate_profiles', target: 'token017',
+          amount: 3000, position: 3, current_amount: 0, complete: false }
+      ]
+    }));
+  }
+
+  it('buying contact001 marks buy_perp goal complete; mission stays active', async () => {
+    seedM007();
+    await buyPerp('tok', 'Imperium', 'contact001');
+    const goal = getState().mission_goals.find(
+      g => g.mission === 'mission007' && g.workflow === 'buy_perp');
+    expect(goal.complete).toBe(true);
+    expect(getState().active_missions).toContain('mission007');
+  });
+
+  it('full 3-step flow completes mission007 and activates M_DB_MACH', async () => {
+    seedM007();
+    await buyPerp('tok', 'Imperium', 'contact001');
+
+    // Seed collect entry for the node buyPerp just created.
+    const s1 = getState();
+    setState(Object.assign({}, s1, {
+      nodes_collect: [{ path: CT1, result: { amount: 3000 } }]
+    }));
+
+    const { result: colRes } = await collectPerp('tok', CT1);
+    const collectId = colRes.result.collect_id;
+
+    const { result: intRes } = await integrateCollected('tok', collectId);
+
+    const s = getState();
+    expect(s.mission_goals.filter(g => g.mission === 'mission007').every(g => g.complete)).toBe(true);
+    expect(s.active_missions).not.toContain('mission007');
+    expect(s.active_missions).toContain(M_DB_MACH);
+    expect(intRes.missions.complete_missions).toContain('mission007');
+  });
+});
+
+// ── M_DB_MACH — Database machine ─────────────────────────────────────────────
+// upgrade_token(token007, null)
+
+describe('mission progression — M_DB_MACH Database machine (upgrade_token)', () => {
+  const T007 = 'Database.token007';
+
+  beforeEach(() => setOverride(FIXED_NOW));
+  afterEach(() => { clearOverride(); setEmitter(null); });
+
+  it('collecting from token007 completes upgrade_token goal and activates mission008', async () => {
+    setState(mkState({
+      game_values: mkHighGv(),
+      nodes: [mkTokenNode2('token007', T007, 0)],
+      nodes_collect: [{ path: T007, result: { amount: 0 } }],
+      active_missions: [M_DB_MACH],
+      mission_goals: [{
+        mission: M_DB_MACH, workflow: 'upgrade_token', target: 'token007',
+        amount: null, position: 1, current_amount: 0, complete: false
+      }]
+    }));
+
+    const { result } = await collectPerp('tok', T007);
+    expect(result.error).toBeUndefined();
+
+    const s = getState();
+    const goal = s.mission_goals.find(g => g.mission === M_DB_MACH);
+    expect(goal.complete).toBe(true);
+    expect(s.active_missions).not.toContain(M_DB_MACH);
+    expect(s.active_missions).toContain('mission008');
+    expect(result.missions.complete_missions).toContain(M_DB_MACH);
+  });
+});
+
+// ── mission008 — Sick World ───────────────────────────────────────────────────
+// buy_perp(client002, null) + charge_perp(client002, null) + buy_perp(contact019, null)
+
+describe('mission progression — mission008 Sick World (buy+charge+buy)', () => {
+  const C2 = 'Imperium.client002';
+
+  beforeEach(() => setOverride(FIXED_NOW));
+  afterEach(() => { clearOverride(); setEmitter(null); });
+
+  function seedM008() {
+    setState(mkState({
+      game_values: mkHighGv({ xp_level: 4 }),
+      nodes: [],
+      active_missions: ['mission008'],
+      mission_goals: [
+        { mission: 'mission008', workflow: 'buy_perp', target: 'client002',
+          amount: null, position: 1, current_amount: 0, complete: false },
+        { mission: 'mission008', workflow: 'charge_perp', target: 'client002',
+          amount: null, position: 2, current_amount: 0, complete: false },
+        { mission: 'mission008', workflow: 'buy_perp', target: 'contact019',
+          amount: null, position: 3, current_amount: 0, complete: false }
+      ]
+    }));
+  }
+
+  it('buying client002 then charging then buying contact019 completes mission008 + activates mission005', async () => {
+    seedM008();
+    await buyPerp('tok', 'Imperium', 'client002');
+    await chargePerp('tok', C2);
+    const { result } = await buyPerp('tok', 'Imperium', 'contact019');
+
+    const s = getState();
+    expect(s.mission_goals.filter(g => g.mission === 'mission008').every(g => g.complete)).toBe(true);
+    expect(s.active_missions).not.toContain('mission008');
+    expect(s.active_missions).toContain('mission005');
+    expect(result.missions.complete_missions).toContain('mission008');
+  });
+});
+
+// ── mission005 — So green! ────────────────────────────────────────────────────
+// integrate_profiles(token084, 10000) + collect_cash(client007, 500)
+
+describe('mission progression — mission005 So green! (integrate_profiles + collect_cash)', () => {
+  const C007 = 'Imperium.City.Pusher0.client007';
+  const COLL_ID = 'so-green-001';
+
+  beforeEach(() => setOverride(FIXED_NOW));
+  afterEach(() => { clearOverride(); setEmitter(null); });
+
+  function seedM005(extraGoalFields) {
+    setState(mkState({
+      game_values: mkHighGv({ cash_value: 0 }),
+      nodes: [mkClientNode2('client007', C007)],
+      active_missions: ['mission005'],
+      mission_goals: [
+        Object.assign({ mission: 'mission005', workflow: 'integrate_profiles', target: 'token084',
+          amount: 10000, position: 1, current_amount: 0, complete: false }, extraGoalFields || {}),
+        { mission: 'mission005', workflow: 'collect_cash', target: 'client007',
+          amount: 500, position: 2, current_amount: 0, complete: false }
+      ]
+    }));
+  }
+
+  it('integrating 10000 profiles at 100% token084 fills integrate_profiles goal', async () => {
+    setState(mkState({
+      game_values: mkHighGv({ cash_value: 0 }),
+      nodes: [mkClientNode2('client007', C007)],
+      active_missions: ['mission005'],
+      mission_goals: [
+        { mission: 'mission005', workflow: 'integrate_profiles', target: 'token084',
+          amount: 10000, position: 1, current_amount: 0, complete: false },
+        { mission: 'mission005', workflow: 'collect_cash', target: 'client007',
+          amount: 500, position: 2, current_amount: 0, complete: false }
+      ],
+      db_queue: [{
+        origin: 'Imperium.City.contact001',
+        collect_id: COLL_ID,
+        profile_set: { profiles_value: 10000, tokens_map: { token084: { amount: 100 } } },
+        collect_dt: FIXED_NOW
+      }]
+    }));
+
+    await integrateCollected('tok', COLL_ID);
+    const goal = getState().mission_goals.find(
+      g => g.mission === 'mission005' && g.workflow === 'integrate_profiles');
+    expect(goal.current_amount).toBe(10000);
+    expect(goal.complete).toBe(true);
+    expect(getState().active_missions).toContain('mission005'); // cash goal still pending
+  });
+
+  it('collect_cash + integrate both complete → mission005 done, grants reward, activates M_PSYCHO', async () => {
+    setState(mkState({
+      game_values: mkHighGv({ cash_value: 0 }),
+      nodes: [mkClientNode2('client007', C007)],
+      nodes_collect: [{ path: C007, result: { amount: 600 } }],
+      active_missions: ['mission005'],
+      mission_goals: [
+        { mission: 'mission005', workflow: 'integrate_profiles', target: 'token084',
+          amount: 10000, position: 1, current_amount: 10000, complete: true },
+        { mission: 'mission005', workflow: 'collect_cash', target: 'client007',
+          amount: 500, position: 2, current_amount: 0, complete: false }
+      ]
+    }));
+
+    const { result } = await collectPerp('tok', C007);
+    const s = getState();
+    expect(s.mission_goals.filter(g => g.mission === 'mission005').every(g => g.complete)).toBe(true);
+    expect(s.active_missions).not.toContain('mission005');
+    expect(s.active_missions).toContain(M_PSYCHO);
+    // start=0 + collect=600 + reward=1000 = 1600
+    expect(s.game_values.cash_value).toBe(1600);
+    expect(result.missions.complete_missions).toContain('mission005');
+  });
+});
+
+// ── M_PSYCHO — Psycho ─────────────────────────────────────────────────────────
+// buy_perp(project003) + buy_powerup(upgrade015 on project003) + charge_perp(project003)
+
+describe('mission progression — M_PSYCHO Psycho (buy_perp + buy_powerup + charge_perp)', () => {
+  const P3 = 'Imperium.project003';
+
+  beforeEach(() => setOverride(FIXED_NOW));
+  afterEach(() => { clearOverride(); setEmitter(null); });
+
+  it('all three goals complete → M_PSYCHO done, activates M_COUCH', async () => {
+    setState(mkState({
+      game_values: mkHighGv({ xp_level: 5 }),
+      nodes: [],
+      active_missions: [M_PSYCHO],
+      mission_goals: [
+        { mission: M_PSYCHO, workflow: 'buy_perp', target: 'project003',
+          amount: null, position: 1, current_amount: 0, complete: false },
+        { mission: M_PSYCHO, workflow: 'buy_powerup', target: 'upgrade015',
+          amount: null, position: 2, current_amount: 0, complete: false },
+        { mission: M_PSYCHO, workflow: 'charge_perp', target: 'project003',
+          amount: null, position: 3, current_amount: 0, complete: false }
+      ]
+    }));
+
+    await buyPerp('tok', 'Imperium', 'project003');
+    await buyPowerup('tok', P3, 0, 'upgrade015');
+    const { result } = await chargePerp('tok', P3);
+    expect(result.error).toBeUndefined();
+
+    const s = getState();
+    expect(s.mission_goals.filter(g => g.mission === M_PSYCHO).every(g => g.complete)).toBe(true);
+    expect(s.active_missions).not.toContain(M_PSYCHO);
+    expect(s.active_missions).toContain(M_COUCH);
+    expect(result.missions.complete_missions).toContain(M_PSYCHO);
+  });
+});
+
+// ── M_COUCH — Couch Potato ────────────────────────────────────────────────────
+// collect_profiles(contact019, 6000) + integrate_profiles(token088, 6000) + collect_cash(client002, 500)
+
+describe('mission progression — M_COUCH Couch Potato (collect+integrate+cash)', () => {
+  const CT19 = 'Imperium.contact019';
+  const C2   = 'Imperium.City.Pusher0.client002';
+  const COLL_ID = 'couch-001';
+
+  beforeEach(() => setOverride(FIXED_NOW));
+  afterEach(() => { clearOverride(); setEmitter(null); });
+
+  it('all three goals complete → M_COUCH done, activates M_EMPLOYEE', async () => {
+    setState(mkState({
+      game_values: mkHighGv({ cash_value: 0 }),
+      nodes: [
+        mkContactNode('contact019', CT19),
+        mkClientNode2('client002', C2)
+      ],
+      nodes_collect: [
+        { path: CT19, result: { amount: 6000 } },
+        { path: C2,   result: { amount: 600  } }
+      ],
+      active_missions: [M_COUCH],
+      mission_goals: [
+        { mission: M_COUCH, workflow: 'collect_profiles', target: 'contact019',
+          amount: 6000, position: 1, current_amount: 0, complete: false },
+        { mission: M_COUCH, workflow: 'integrate_profiles', target: 'token088',
+          amount: 6000, position: 2, current_amount: 0, complete: false },
+        { mission: M_COUCH, workflow: 'collect_cash', target: 'client002',
+          amount: 500, position: 3, current_amount: 0, complete: false }
+      ]
+    }));
+
+    // Step 1: collect from contact019 — fills collect_profiles goal.
+    const { result: c19Res } = await collectPerp('tok', CT19);
+    const collectId = c19Res.result.collect_id;
+    const goal1 = getState().mission_goals.find(
+      g => g.mission === M_COUCH && g.workflow === 'collect_profiles');
+    expect(goal1.current_amount).toBe(6000);
+    expect(goal1.complete).toBe(true);
+
+    // Step 2: integrate — fills integrate_profiles goal via token088 in tokens_map.
+    await integrateCollected('tok', collectId);
+    const goal2 = getState().mission_goals.find(
+      g => g.mission === M_COUCH && g.workflow === 'integrate_profiles');
+    expect(goal2.complete).toBe(true);
+
+    // Step 3: collect cash from client002.
+    const { result } = await collectPerp('tok', C2);
+    const s = getState();
+    expect(s.mission_goals.filter(g => g.mission === M_COUCH).every(g => g.complete)).toBe(true);
+    expect(s.active_missions).not.toContain(M_COUCH);
+    expect(s.active_missions).toContain(M_EMPLOYEE);
+    expect(result.missions.complete_missions).toContain(M_COUCH);
+  });
+});
+
+// ── M_EMPLOYEE — Employee Monitoring ─────────────────────────────────────────
+// buy_perp(client006) + collect_cash(client006, 2000)
+
+describe('mission progression — M_EMPLOYEE Employee Monitoring (buy_perp + collect_cash)', () => {
+  const C6 = 'Imperium.client006';
+
+  beforeEach(() => setOverride(FIXED_NOW));
+  afterEach(() => { clearOverride(); setEmitter(null); });
+
+  it('buying client006 then collecting 2000+ cash completes M_EMPLOYEE, activates M_IMAGE', async () => {
+    setState(mkState({
+      game_values: mkHighGv(),
+      nodes: [],
+      active_missions: [M_EMPLOYEE],
+      mission_goals: [
+        { mission: M_EMPLOYEE, workflow: 'buy_perp', target: 'client006',
+          amount: null, position: 1, current_amount: 0, complete: false },
+        { mission: M_EMPLOYEE, workflow: 'collect_cash', target: 'client006',
+          amount: 2000, position: 2, current_amount: 0, complete: false }
+      ]
+    }));
+
+    await buyPerp('tok', 'Imperium', 'client006');
+    // Seed collect entry for the newly created node.
+    const s1 = getState();
+    setState(Object.assign({}, s1, {
+      nodes_collect: [{ path: C6, result: { amount: 2500 } }]
+    }));
+
+    const { result } = await collectPerp('tok', C6);
+    const s = getState();
+    const goals = s.mission_goals.filter(g => g.mission === M_EMPLOYEE);
+    expect(goals.every(g => g.complete)).toBe(true);
+    expect(s.active_missions).not.toContain(M_EMPLOYEE);
+    expect(s.active_missions).toContain(M_IMAGE);
+    expect(result.missions.complete_missions).toContain(M_EMPLOYEE);
+  });
+});
+
+// ── M_IMAGE — Improve your image ─────────────────────────────────────────────
+// buy_powerup(teammember043 on project003) + buy_powerup(ad006 on project003)
+
+describe('mission progression — M_IMAGE Improve your image (buy_powerup x2)', () => {
+  const P3 = 'Imperium.City.project003';
+
+  beforeEach(() => setOverride(FIXED_NOW));
+  afterEach(() => { clearOverride(); setEmitter(null); });
+
+  it('buying teammember043 then ad006 on project003 completes M_IMAGE, activates M_COLLAB', async () => {
+    setState(mkState({
+      game_values: mkHighGv({ xp_level: 5 }),
+      nodes: [mkProjectNode('project003', P3)],
+      active_missions: [M_IMAGE],
+      mission_goals: [
+        { mission: M_IMAGE, workflow: 'buy_powerup', target: 'teammember043',
+          amount: null, position: 1, current_amount: 0, complete: false },
+        { mission: M_IMAGE, workflow: 'buy_powerup', target: 'ad006',
+          amount: null, position: 2, current_amount: 0, complete: false }
+      ]
+    }));
+
+    await buyPowerup('tok', P3, 0, 'teammember043');
+    const { result } = await buyPowerup('tok', P3, 1, 'ad006');
+
+    const s = getState();
+    expect(s.mission_goals.filter(g => g.mission === M_IMAGE).every(g => g.complete)).toBe(true);
+    expect(s.active_missions).not.toContain(M_IMAGE);
+    expect(s.active_missions).toContain(M_COLLAB);
+    expect(result.missions.complete_missions).toContain(M_IMAGE);
+  });
+});
+
+// ── M_COLLAB — Unofficial collaboration ──────────────────────────────────────
+// buy_perp(agent004) + buy_perp(contact026)
+
+describe('mission progression — M_COLLAB Unofficial collaboration (buy_perp x2)', () => {
+  beforeEach(() => setOverride(FIXED_NOW));
+  afterEach(() => { clearOverride(); setEmitter(null); });
+
+  it('buying agent004 then contact026 completes M_COLLAB, activates M_ALFONSO', async () => {
+    setState(mkState({
+      game_values: mkHighGv({ xp_level: 7 }),
+      nodes: [],
+      active_missions: [M_COLLAB],
+      mission_goals: [
+        { mission: M_COLLAB, workflow: 'buy_perp', target: 'agent004',
+          amount: null, position: 1, current_amount: 0, complete: false },
+        { mission: M_COLLAB, workflow: 'buy_perp', target: 'contact026',
+          amount: null, position: 2, current_amount: 0, complete: false }
+      ]
+    }));
+
+    await buyPerp('tok', 'Imperium', 'agent004');
+    const { result } = await buyPerp('tok', 'Imperium', 'contact026');
+
+    const s = getState();
+    expect(s.mission_goals.filter(g => g.mission === M_COLLAB).every(g => g.complete)).toBe(true);
+    expect(s.active_missions).not.toContain(M_COLLAB);
+    expect(s.active_missions).toContain(M_ALFONSO);
+    expect(result.missions.complete_missions).toContain(M_COLLAB);
+  });
+});
+
+// ── M_ALFONSO — Alfonso ───────────────────────────────────────────────────────
+// buy_perp(pusher003)
+
+describe('mission progression — M_ALFONSO Alfonso (buy_perp)', () => {
+  beforeEach(() => setOverride(FIXED_NOW));
+  afterEach(() => { clearOverride(); setEmitter(null); });
+
+  it('buying pusher003 completes M_ALFONSO, grants reward, activates 3cb94923... chain', async () => {
+    const M_BOGUS = '3cb9492322191121ebf7a10aafd0fc4a000';
+    setState(mkState({
+      game_values: mkHighGv(),
+      nodes: [],
+      active_missions: [M_ALFONSO],
+      mission_goals: [{
+        mission: M_ALFONSO, workflow: 'buy_perp', target: 'pusher003',
+        amount: null, position: 1, current_amount: 0, complete: false
+      }]
+    }));
+
+    const { result } = await buyPerp('tok', 'Imperium', 'pusher003');
+    const s = getState();
+    expect(s.mission_goals.find(g => g.mission === M_ALFONSO).complete).toBe(true);
+    expect(s.active_missions).not.toContain(M_ALFONSO);
+    expect(s.active_missions).toContain(M_BOGUS);
+    expect(result.missions.complete_missions).toContain(M_ALFONSO);
   });
 });


### PR DESCRIPTION
## Summary

- Added four new mission-advancement helpers to `LocalEngine.js`: `_advanceChargePerpMissions`, `_advanceCollectCashMissions`, `_advanceBuyPowerupMissions`, and `_advanceUpgradeTokenMissions`, covering all previously missing workflow types in the ruleset
- Wired each helper into its handler: `chargePerp` (charge_perp goals), `collectPerp` ClientPerp branch (collect_cash goals), `collectPerp` TokenPerp branch (upgrade_token goals), and `buyPowerup` (buy_powerup goals)
- Added 19 integration tests across all 14 missions in chain positions 3–16 (mission003 → dc481d78), asserting goal progress, completion, reward application, and `required_mission` chain activation for every workflow type
- Audited `amount: null` goals: `_completeMissionsIfReady` does not auto-complete them — each `_advance*Missions` handler drives completion on the first matching event, matching original dd_app event-trigger semantics

## Test plan

- [ ] `pnpm test` green: 378 tests pass (19 new)
- [ ] mission003 charge_perp: charging client007 marks goal complete, +600 cash reward, activates mission004
- [ ] mission004 buy+charge: both goals must complete before mission fires; activates M_CASH_IN
- [ ] M_CASH_IN collect_cash: partial progress stays incomplete; full collection caps at goal.amount and activates mission006
- [ ] mission006 buy_powerup x3: all three powerups on project001 must be bought before mission completes
- [ ] mission007–mission008 multi-workflow chains: buy/collect/integrate/charge all advance goals and chain correctly
- [ ] mission005 So green!: independent integrate_profiles + collect_cash goals; mission fires only when both complete
- [ ] M_PSYCHO through dc481d78: each remaining mission in chain advances and activates the next

Closes #97

https://claude.ai/code/session_01PHTh5FiNhcUaZDC8yUpsWA

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHTh5FiNhcUaZDC8yUpsWA)_