### PR TITLE
Fix language picker to handle touch events and prevent double selection

### DIFF
--- a/scripts/Game.js
+++ b/scripts/Game.js
@@ -988,14 +988,22 @@ define(function(require) {
         '</div>'
       );
       $('body').append($overlay);
-      $overlay.on('click', '.lang-pick', function() {
+      var picked = false;
+      $overlay.on('click touchend', '.lang-pick', function(e) {
+        e.stopPropagation();
+        e.preventDefault();
+        if (picked) { return; }
+        picked = true;
         var chosen = $(this).data('locale');
         $overlay.find('.lang-pick').addClass('disabled');
         app.remote.setLocale(chosen).done(function() { location.reload(); });
       });
       if (canDismiss) {
-        $overlay.on('click', function(e) {
-          if (!$(e.target).closest('.LangPickerBox').length) { $overlay.remove(); }
+        $overlay.on('click touchend', function(e) {
+          if (!$(e.target).closest('.LangPickerBox').length) {
+            e.preventDefault();
+            $overlay.remove();
+          }
         });
       }
     }


### PR DESCRIPTION
## Summary
Enhanced the language picker overlay to properly handle touch events on mobile devices and prevent multiple simultaneous selections.

## Key Changes
- Added `touchend` event listener alongside `click` events for better mobile support
- Implemented selection guard using a `picked` flag to prevent duplicate locale changes when users tap multiple times
- Added `e.stopPropagation()` and `e.preventDefault()` to language option clicks to prevent event bubbling
- Added `e.preventDefault()` to overlay dismissal to ensure proper event handling on touch devices

## Implementation Details
- The `picked` flag is set to `true` on first selection and checked before processing subsequent clicks/taps, effectively debouncing the language selection
- Touch event handling ensures the language picker works correctly on mobile and tablet devices
- Event propagation is properly controlled to prevent unintended overlay dismissal when selecting a language option

https://claude.ai/code/session_015k7HZFEERYXJMv5zAC5BZG