### PR TITLE
Fix #103: weighted-average share merge for Database token bars

### DIFF
--- a/docs/ui-meters.md
+++ b/docs/ui-meters.md
@@ -63,9 +63,9 @@ one is `100`). Tokens that the new profileset does *not* contain get diluted:
 So the bar was an honest "how saturated is this trait in your DB" indicator
 that drifted up and down as new (possibly off-topic) profilesets were merged.
 
-### What the port does instead
+### What the port did before #103
 
-`scripts/LocalEngine.js:1709-1711` (round 7 of #81) clamp-sums:
+`scripts/LocalEngine.js` (round 7 of #81) clamp-summed:
 
 ```js
 var newAmount = Math.min(100,
@@ -73,18 +73,30 @@ var newAmount = Math.min(100,
 ```
 
 Combined with the ruleset where every `tokens[].amount === 100`, *one*
-integration of any contact saturates every token in its `tokens` list to
-100 %. The bar is full forever after.
+integration of any contact saturated every token in its `tokens` list to
+100 %. The bar was full forever after.
 
-### Where the LocalEngine port should bind / compute
+### What the port does now (#103)
 
-The bar binding is fine (`instance_data.amount` ↔ `database_amount` ↔ bar
-fill); the *computation* in `_integrateProfiles` needs to switch from
-`min(100, old + new)` to the weighted-average merge above. New token nodes
-seeded for first-time integration need the same formula, which collapses
-correctly when `M = 0` to `new_share`.
+`integrateCollected` runs the upstream weighted-average merge:
 
-This is **non-trivial** — see the *Why this is not a small fix* section below.
+```js
+var M = (state.game_values.profiles_value) || 0;   // BEFORE the merge
+var N = increment;                                  // 0 on duplicate replay
+// per existing TokenPerp node:
+//   tok present:  newShare = min(100, (oldShare*M + tok.amount*N) / (M+N))
+//   tok absent:   newShare =          oldShare*M / (M+N)
+// per first-time-seeded TokenPerp:
+//   newShare = min(100, tok.amount * N / (M+N))    (= tok.amount when M = 0)
+```
+
+Dilution preserves the absolute count `profiles_value × share / 100`, so
+`mission_goals.current_amount` — fed by absolute counts and clamped
+monotonically in `_advanceIntegrateProfilesMissions` — keeps advancing.
+No ruleset changes; no mission-target rebalancing. The math is a verbatim
+transcription of `dd_app/dd_calc.py:Database.merge` running on the client
+instead of on the server, in line with the wider "port faithfully, just
+drop the server" project goal.
 
 ---
 
@@ -136,53 +148,65 @@ The orange colour matches the per-token DecoratorAmount bar (`#E85E2B` in
 both `css/Render.css:822` and `statusbar.html`) — visually announcing
 "this is the database-wide aggregate of those per-token bars."
 
-### What the port does instead
+### What the port did before #103
 
-Same root cause as (A): once every `instance_data.amount` saturates at 100,
-the mean is also 100 for any number of integrated tokens. The bar and label
-read 100 % forever after the first couple of integrations.
+Same root cause as (A): once every `instance_data.amount` saturated at
+100, the mean was also 100 for any number of integrated tokens. The bar
+and label read 100 % forever after the first couple of integrations.
 
-### Where the LocalEngine port should bind / compute
+### What the port does now (#103)
 
-No binding change is required: `crosssum` is already correctly derived from
-`DBTokens`. Once (A) is fixed, (B) reflects the right value automatically.
-The `count = 1` start in `getDBTokensCrossSum` produces a slight bias
-(`mean × N/(N+1)`); upstream behaviour matches that, so leave it alone.
+No binding change was required: `crosssum` was already correctly derived
+from `DBTokens`. Once (A) was fixed (weighted-average merge with
+dilution), (B) reflects the right value automatically. The `count = 1`
+start in `getDBTokensCrossSum` produces a slight bias (`mean × N/(N+1)`);
+upstream behaviour matches that, so it was left alone.
 
 ---
 
-## Why this is not a small fix (deferred to follow-up)
+## How the fix landed (#103)
 
-The brief allowed an in-PR fix only if it was ≤30 LOC. Switching
-`_integrateProfiles` to the upstream weighted-average merge is small
-(~10 LOC in `scripts/LocalEngine.js`), but it has knock-on effects that
-make the change non-trivial:
+Implemented as a verbatim transcription of upstream
+`dd_app/dd_calc.py:Database.merge` (and `dd_merger.py:UpgradeToken`),
+running on the client. The math fits in ~25 LOC of `_integrateProfiles`.
+The dilution case
+(`new_share = oldShare × M / (M + N)` for tokens absent from the new
+profileset) preserves the absolute count `profiles_value × share / 100`,
+so `mission_goals.current_amount` — clamped monotonically in
+`_advanceIntegrateProfilesMissions` — keeps advancing through the same
+inflection points the original game produced. No mission targets and no
+ruleset rows were rebalanced. Vitest fixtures in
+`tests/handlers/collect-integrate.test.js` were re-derived from the
+formula; a Playwright spec
+`tests/e2e/share-merge.spec.ts` exercises both the dilution and the
+duplicate-replay invariants end-to-end.
 
-1. **Test fixtures encode the sum-and-cap semantic.** Several specs in
+The earlier draft of this doc enumerated three reasons the fix was
+"non-trivial". They've been resolved as follows, kept here so future
+readers see the trail:
+
+1. **Test fixtures encoded the sum-and-cap semantic.** Several specs in
    `tests/handlers/collect-integrate.test.js` (e.g. `instance_data.amount`
-   becomes `5` after `2 + 3`, or saturates at `100` after `90 + 50`) need
-   to be re-derived from the weighted-average formula and re-asserted.
-2. **Mission progression reads `DBTokensAbsolute`.** With shares no longer
-   pinned at 100 %, `groot.DBTokensAbsolute[goal.target] =
-   profiles_value * amount / 100` no longer races ahead of every goal.
-   `mission002` (target 900 of `token008`) currently completes the moment
-   you integrate any contact whose tokens list contains `token008`,
-   because `amount` jumps to 100 and `profiles_value` is already ≥ 900.
-   Under the corrected formula it would complete only once enough
-   `token008`-bearing profiles have actually been merged. Existing
-   `_advanceIntegrateProfilesMissions` tests will need new expectations,
-   and the ruleset's mission targets may need rebalancing for the new
-   pacing.
+   becomes `5` after `2 + 3`, or saturates at `100` after `90 + 50`)
+   were re-derived from the weighted-average formula and re-asserted in
+   #103. A new dilution spec was added.
+2. **Mission progression reads `DBTokensAbsolute`.** Shares are no longer
+   pinned at 100 %, but `goal.current_amount =
+   profiles_value × amount / 100` still races ahead of every existing
+   goal because dilution preserves the absolute count.
+   `mission002` (target 900 of `token008`) still completes the moment
+   you integrate any contact whose tokens list contains `token008` with
+   `profiles_value ≥ 900`, exactly as before — verified by the existing
+   `mission progression — integrate_profiles flow` specs continue to
+   pass unchanged.
 3. **Ruleset shape is uniformly `amount: 100`.** Every contact / city in
    `data/ruleset_3.{en,de}.json` ships `tokens[].amount = 100`, meaning
-   "every profile from this source carries this token type." This makes
-   the weighted average converge to a function of *which* contacts the
-   player owns and how often each is collected; the resulting curve
-   needs play-testing rather than a one-line code change.
-
-For these reasons (A) and (B) are filed as a single follow-up issue
-(linked from the PR that introduces this document) with the proposed
-weighted-average formula. The current investigation closes #98.
+   "every profile from this source carries this token type." Under the
+   weighted-average merge that converges to a function of *which*
+   contacts the player owns and how often each is collected — exactly
+   what the upstream curves did, since the ruleset ships unmodified
+   from `datadealer/dd_rules` (see `data/UPSTREAM.txt`). No port-side
+   rebalancing was applied.
 
 ---
 

--- a/scripts/LocalEngine.js
+++ b/scripts/LocalEngine.js
@@ -1844,22 +1844,19 @@ export function integrateCollected(_token, collectId) {
   var M = (state.game_values && state.game_values.profiles_value) || 0;
   var N = increment;
   var denom = M + N;
+  // denom === 0 only happens on a replay against an empty DB — every
+  // share would round-trip to oldShare and no new tokens can be seeded
+  // (seedShare = 0). Bail before the per-node arithmetic.
+  var skipMerge = denom === 0;
 
   var newNodes = (state.nodes || []).map(function (n) {
+    if (skipMerge) return n;
     if (n.game_type !== 'TokenPerp' || !n.gestalt) return n;
     var oldShare = (n.instance_data && n.instance_data.amount) || 0;
-    var newShare;
-    if (denom === 0) {
-      newShare = oldShare;
-    } else {
-      var tok = tokensMap[n.gestalt];
-      if (tok) {
-        seenGestalts[n.gestalt] = true;
-        newShare = Math.min(100, (oldShare * M + (tok.amount || 0) * N) / denom);
-      } else {
-        newShare = Math.min(100, (oldShare * M) / denom);
-      }
-    }
+    var tok = tokensMap[n.gestalt];
+    if (tok) seenGestalts[n.gestalt] = true;
+    var psContrib = tok ? (tok.amount || 0) * N : 0;
+    var newShare = Math.min(100, (oldShare * M + psContrib) / denom);
     if (newShare === oldShare) return n;
     var updated = Object.assign({}, n, {
       instance_data: Object.assign({}, n.instance_data, { amount: newShare })
@@ -1882,15 +1879,12 @@ export function integrateCollected(_token, collectId) {
   // the new tile with collision avoidance around (1024,800), then
   // saveCoordsQueue persists the resolved position. Pre-seeding x/y
   // bypassed that and made every new token stack at a single hashed point.
-  // Initial share = ps_share * N / (M + N) (= ps_share when M = 0,
-  // = 0 on a duplicate replay where N = 0).
-  Object.keys(tokensMap).forEach(function (gestalt) {
+  // Initial share = ps_share * N / (M + N) (= ps_share when M = 0).
+  if (!skipMerge) Object.keys(tokensMap).forEach(function (gestalt) {
     if (seenGestalts[gestalt]) return;
     if (!ruleset.tokens || !ruleset.tokens[gestalt]) return;
     var tok = tokensMap[gestalt];
-    var seedShare = denom === 0
-      ? 0
-      : Math.min(100, ((tok.amount || 0) * N) / denom);
+    var seedShare = Math.min(100, ((tok.amount || 0) * N) / denom);
     var newNode = {
       game_id:    gestalt,
       gestalt:    gestalt,
@@ -1899,7 +1893,7 @@ export function integrateCollected(_token, collectId) {
       full_path:  'Database.' + gestalt,
       instance_data: { amount: seedShare }
     };
-    newNodes = newNodes.concat([newNode]);
+    newNodes.push(newNode);
     updatedNodes.push({
       game_id:       newNode.game_id,
       gestalt:       newNode.gestalt,

--- a/scripts/LocalEngine.js
+++ b/scripts/LocalEngine.js
@@ -1829,15 +1829,40 @@ export function integrateCollected(_token, collectId) {
   var tokensMap = ps.tokens_map || {};
   var updatedNodes = [];
   var seenGestalts = {};
+
+  // Weighted-average share merge — upstream dd_app/dd_calc.py
+  // `Database.merge` computes:
+  //   new_share = min(100, (db_share * M + ps_share * N) / (M + N))
+  // for every TokenPerp the new profileset touches, and dilutes
+  // un-touched tokens by:
+  //   new_share = (db_share * M) / (M + N)
+  // `M` is `profiles_value` *before* this integration; `N` is the new
+  // profileset's `profiles_value` (== `increment`, so 0 on a duplicate
+  // collect_id replay → no share change). This preserves the absolute
+  // count `profiles_value * share / 100`, so mission_goals' monotonic
+  // current_amount keeps advancing. See docs/ui-meters.md.
+  var M = (state.game_values && state.game_values.profiles_value) || 0;
+  var N = increment;
+  var denom = M + N;
+
   var newNodes = (state.nodes || []).map(function (n) {
-    var tok = tokensMap[n.gestalt];
-    if (!tok) return n;
-    seenGestalts[n.gestalt] = true;
-    // amount is a percentage [0,100]; cap so the bar (width = amount/100*60px)
-    // doesn't overflow and so absoluteAmount = profiles*amount/100 stays sane.
-    var newAmount = Math.min(100, ((n.instance_data && n.instance_data.amount) || 0) + (tok.amount || 0));
+    if (n.game_type !== 'TokenPerp' || !n.gestalt) return n;
+    var oldShare = (n.instance_data && n.instance_data.amount) || 0;
+    var newShare;
+    if (denom === 0) {
+      newShare = oldShare;
+    } else {
+      var tok = tokensMap[n.gestalt];
+      if (tok) {
+        seenGestalts[n.gestalt] = true;
+        newShare = Math.min(100, (oldShare * M + (tok.amount || 0) * N) / denom);
+      } else {
+        newShare = Math.min(100, (oldShare * M) / denom);
+      }
+    }
+    if (newShare === oldShare) return n;
     var updated = Object.assign({}, n, {
-      instance_data: Object.assign({}, n.instance_data, { amount: newAmount })
+      instance_data: Object.assign({}, n.instance_data, { amount: newShare })
     });
     updatedNodes.push({
       game_id:       updated.game_id,
@@ -1857,17 +1882,22 @@ export function integrateCollected(_token, collectId) {
   // the new tile with collision avoidance around (1024,800), then
   // saveCoordsQueue persists the resolved position. Pre-seeding x/y
   // bypassed that and made every new token stack at a single hashed point.
+  // Initial share = ps_share * N / (M + N) (= ps_share when M = 0,
+  // = 0 on a duplicate replay where N = 0).
   Object.keys(tokensMap).forEach(function (gestalt) {
     if (seenGestalts[gestalt]) return;
     if (!ruleset.tokens || !ruleset.tokens[gestalt]) return;
     var tok = tokensMap[gestalt];
+    var seedShare = denom === 0
+      ? 0
+      : Math.min(100, ((tok.amount || 0) * N) / denom);
     var newNode = {
       game_id:    gestalt,
       gestalt:    gestalt,
       game_type:  'TokenPerp',
       full_type:  'TokenPerp:' + gestalt,
       full_path:  'Database.' + gestalt,
-      instance_data: { amount: Math.min(100, tok.amount || 0) }
+      instance_data: { amount: seedShare }
     };
     newNodes = newNodes.concat([newNode]);
     updatedNodes.push({

--- a/tests/e2e/share-merge.spec.ts
+++ b/tests/e2e/share-merge.spec.ts
@@ -19,26 +19,17 @@
 
 import { test, expect } from '@playwright/test';
 
-// Helper: invoke a function from a named AMD module inside the page.
-// Must be called from within page.evaluate().
-function amdGet(modId: string): Promise<unknown> {
-  return new Promise((resolve, reject) => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (window as any).require([modId], resolve, reject);
-  });
-}
-
-test('integrate dilutes untouched token shares + crosssum stays under 100', async ({ page }) => {
+test.beforeEach(async ({ page }) => {
   await page.goto('/?devtools=1');
   await expect(page.locator('[data-testid="game-container"]')).toBeVisible({
     timeout: 50_000,
   });
+});
 
-  // ── Seed two crafted db_queue entries that share token008 but differ on
-  //    the rest of their token lists, then integrate both and read the
-  //    resulting TokenPerp shares.  Doing this through `boot.setState` /
-  //    `LocalEngine.integrateCollected` keeps the test independent of
-  //    ruleset price/level gates and the canvas-heavy buy/charge flow.
+test('integrate dilutes untouched token shares + crosssum stays under 100', async ({ page }) => {
+  // Seed two crafted db_queue entries through `boot.setState` /
+  // `LocalEngine.integrateCollected` — keeps the test independent of
+  // ruleset price/level gates and the canvas-heavy buy/charge flow.
   const result = await page.evaluate(async () => {
     const boot = await new Promise<{
       getState(): any;
@@ -54,14 +45,6 @@ test('integrate dilutes untouched token shares + crosssum stays under 100', asyn
       ap_snapshot: 10,
       profiles_value: 0,
     });
-    // Two profilesets:
-    //   PS1 (200 profiles): token008 + token084
-    //   PS2 (200 profiles): token008 + token128 (no token084)
-    // After PS1: token084 share = 100, token008 share = 100, profiles=200.
-    // After PS2: token084 is *not* in PS2, so dilution kicks in:
-    //   share = 100 * 200 / (200 + 200) = 50.
-    // token008 is in both, so its share stays at 100.
-    // token128 is new: share = 100 * 200 / 400 = 50.
     state.db_queue = [
       {
         origin: 'Imperium.test.contactA',
@@ -126,11 +109,6 @@ test('integrate dilutes untouched token shares + crosssum stays under 100', asyn
 });
 
 test('integrating the same profileset twice does not change shares (N = 0 dup replay)', async ({ page }) => {
-  await page.goto('/?devtools=1');
-  await expect(page.locator('[data-testid="game-container"]')).toBeVisible({
-    timeout: 50_000,
-  });
-
   const out = await page.evaluate(async () => {
     const boot = await new Promise<any>((res, rej) =>
       (window as any).require(['boot'], res, rej),

--- a/tests/e2e/share-merge.spec.ts
+++ b/tests/e2e/share-merge.spec.ts
@@ -1,0 +1,196 @@
+/**
+ * Issue #103 — weighted-average share merge for the Database token bars.
+ *
+ * Drives the LocalEngine directly (matches gameplay.spec.ts strategy: no
+ * sprite clicks) to assert two invariants the upstream
+ * `dd_app/dd_calc.py:Database.merge` formula was supposed to guarantee:
+ *
+ *   1. Tokens absent from a new profileset are diluted as the DB grows
+ *      (so the per-tile bar moves *down* as well as up).
+ *   2. After several integrations the status-bar `crosssum` stays well
+ *      below 100 % whenever no single token is present in every merged
+ *      profileset (so the orange bar is no longer "always full").
+ *
+ * The pre-fix port clamp-summed per-integration deltas, which against a
+ * ruleset where every `tokens[].amount === 100` saturated every share at
+ * 100 % after one merge.  Both invariants would fail under that
+ * implementation, so this spec is a regression target for the fix.
+ */
+
+import { test, expect } from '@playwright/test';
+
+// Helper: invoke a function from a named AMD module inside the page.
+// Must be called from within page.evaluate().
+function amdGet(modId: string): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).require([modId], resolve, reject);
+  });
+}
+
+test('integrate dilutes untouched token shares + crosssum stays under 100', async ({ page }) => {
+  await page.goto('/?devtools=1');
+  await expect(page.locator('[data-testid="game-container"]')).toBeVisible({
+    timeout: 50_000,
+  });
+
+  // ── Seed two crafted db_queue entries that share token008 but differ on
+  //    the rest of their token lists, then integrate both and read the
+  //    resulting TokenPerp shares.  Doing this through `boot.setState` /
+  //    `LocalEngine.integrateCollected` keeps the test independent of
+  //    ruleset price/level gates and the canvas-heavy buy/charge flow.
+  const result = await page.evaluate(async () => {
+    const boot = await new Promise<{
+      getState(): any;
+      setState(s: any): void;
+    }>((res, rej) => (window as any).require(['boot'], res, rej));
+    const eng = await new Promise<any>((res, rej) =>
+      (window as any).require(['LocalEngine'], res, rej),
+    );
+
+    const state = boot.getState();
+    // Generous AP to cover both integrations (each costs 1 AP).
+    state.game_values = Object.assign({}, state.game_values, {
+      ap_snapshot: 10,
+      profiles_value: 0,
+    });
+    // Two profilesets:
+    //   PS1 (200 profiles): token008 + token084
+    //   PS2 (200 profiles): token008 + token128 (no token084)
+    // After PS1: token084 share = 100, token008 share = 100, profiles=200.
+    // After PS2: token084 is *not* in PS2, so dilution kicks in:
+    //   share = 100 * 200 / (200 + 200) = 50.
+    // token008 is in both, so its share stays at 100.
+    // token128 is new: share = 100 * 200 / 400 = 50.
+    state.db_queue = [
+      {
+        origin: 'Imperium.test.contactA',
+        collect_id: 'cq_test_a',
+        profile_set: {
+          profiles_value: 200,
+          tokens_map: { token008: { amount: 100 }, token084: { amount: 100 } },
+        },
+      },
+      {
+        origin: 'Imperium.test.contactB',
+        collect_id: 'cq_test_b',
+        profile_set: {
+          profiles_value: 200,
+          tokens_map: { token008: { amount: 100 }, token128: { amount: 100 } },
+        },
+      },
+    ];
+    state.integrated_ids = {};
+    boot.setState(state);
+
+    await eng.integrateCollected('tok', 'cq_test_a');
+    await eng.integrateCollected('tok', 'cq_test_b');
+
+    const finalNodes = boot.getState().nodes.filter(
+      (n: any) => n.game_type === 'TokenPerp',
+    );
+    const byGestalt: Record<string, number> = {};
+    finalNodes.forEach((n: any) => {
+      byGestalt[n.gestalt] = (n.instance_data && n.instance_data.amount) || 0;
+    });
+    const crosssumDenom = finalNodes.length + 1;
+    const crosssum =
+      finalNodes.reduce(
+        (acc: number, n: any) =>
+          acc + ((n.instance_data && n.instance_data.amount) || 0),
+        0,
+      ) / crosssumDenom;
+    return {
+      shares: byGestalt,
+      profiles_value: boot.getState().game_values.profiles_value,
+      tokenCount: finalNodes.length,
+      crosssum,
+    };
+  });
+
+  // Both profilesets contributed 200 profiles; total = 400.
+  expect(result.profiles_value).toBe(400);
+
+  // token008 in every profileset → stays at 100 %.
+  expect(result.shares.token008).toBeCloseTo(100, 6);
+  // token084 only in PS1 → diluted to 50 % after PS2 lands.
+  expect(result.shares.token084).toBeCloseTo(50, 6);
+  // token128 only in PS2 → seeded share = 100 * 200 / 400 = 50.
+  expect(result.shares.token128).toBeCloseTo(50, 6);
+
+  // Mean of {100, 50, 50} = 66.6 ≈ what the orange `crosssum` bar shows.
+  // The off-by-one (count+1) divisor in getDBTokensCrossSum brings it down
+  // a notch further. Either way it must be visibly below 100.
+  expect(result.crosssum).toBeLessThan(80);
+  expect(result.crosssum).toBeGreaterThan(0);
+});
+
+test('integrating the same profileset twice does not change shares (N = 0 dup replay)', async ({ page }) => {
+  await page.goto('/?devtools=1');
+  await expect(page.locator('[data-testid="game-container"]')).toBeVisible({
+    timeout: 50_000,
+  });
+
+  const out = await page.evaluate(async () => {
+    const boot = await new Promise<any>((res, rej) =>
+      (window as any).require(['boot'], res, rej),
+    );
+    const eng = await new Promise<any>((res, rej) =>
+      (window as any).require(['LocalEngine'], res, rej),
+    );
+
+    const state = boot.getState();
+    state.game_values = Object.assign({}, state.game_values, {
+      ap_snapshot: 10,
+      profiles_value: 0,
+    });
+    state.db_queue = [{
+      origin: 'Imperium.test.contactA',
+      collect_id: 'cq_dup_test',
+      profile_set: {
+        profiles_value: 100,
+        tokens_map: { token008: { amount: 100 } },
+      },
+    }];
+    state.integrated_ids = {};
+    boot.setState(state);
+
+    await eng.integrateCollected('tok', 'cq_dup_test');
+    const afterFirst = boot.getState();
+    const shareAfterFirst =
+      afterFirst.nodes.find((n: any) => n.gestalt === 'token008')?.instance_data
+        ?.amount ?? null;
+    const profilesAfterFirst = afterFirst.game_values.profiles_value;
+
+    // Re-queue the same collect_id and replay — handler should treat it as a
+    // duplicate (N = 0), neither growing profiles_value nor changing shares.
+    const replayState = boot.getState();
+    replayState.db_queue = [{
+      origin: 'Imperium.test.contactA',
+      collect_id: 'cq_dup_test',
+      profile_set: {
+        profiles_value: 100,
+        tokens_map: { token008: { amount: 100 } },
+      },
+    }];
+    boot.setState(replayState);
+
+    await eng.integrateCollected('tok', 'cq_dup_test');
+    const afterReplay = boot.getState();
+    const shareAfterReplay =
+      afterReplay.nodes.find((n: any) => n.gestalt === 'token008')?.instance_data
+        ?.amount ?? null;
+    const profilesAfterReplay = afterReplay.game_values.profiles_value;
+
+    return {
+      shareAfterFirst,
+      shareAfterReplay,
+      profilesAfterFirst,
+      profilesAfterReplay,
+    };
+  });
+
+  expect(out.shareAfterFirst).toBeCloseTo(100, 6);
+  expect(out.shareAfterReplay).toBeCloseTo(out.shareAfterFirst!, 6);
+  expect(out.profilesAfterReplay).toBe(out.profilesAfterFirst);
+});

--- a/tests/handlers/collect-integrate.test.js
+++ b/tests/handlers/collect-integrate.test.js
@@ -455,10 +455,15 @@ describe('integrateCollected — token node updates', () => {
   beforeEach(() => setOverride(FIXED_NOW));
   afterEach(() => clearOverride());
 
-  it('increments token node instance_data.amount from tokens_map', async () => {
+  it('merges instance_data.amount as a weighted-average share', async () => {
+    // Upstream dd_app/dd_calc.py Database.merge:
+    //   new_share = min(100, (db_share * M + ps_share * N) / (M + N))
+    // M = profiles_value before merge (here 6), N = ps.profiles_value (4),
+    // db_share = 2, ps_share = 3 → (2*6 + 3*4)/(6+4) = 24/10 = 2.4.
     const tokenNode = mkNode('TokenPerp', TOKEN_PATH, { amount: 2 });
     tokenNode.gestalt = 'token_a';
     setState(mkState({
+      game_values: mkGv({ profiles_value: 6 }),
       nodes: [tokenNode],
       db_queue: [{
         origin:      'Imperium.City.contact001',
@@ -470,21 +475,26 @@ describe('integrateCollected — token node updates', () => {
 
     const { result } = await integrateCollected('tok', COLLECT_ID);
     expect(result.result.nodes).toHaveLength(1);
-    expect(result.result.nodes[0].instance_data.amount).toBe(5);
+    expect(result.result.nodes[0].instance_data.amount).toBeCloseTo(2.4, 6);
     expect(result.result.increment).toBe(4);
     expect(result.result.dup).toBe(0);
-    expect(result.game_values.profiles_value).toBe(4);
+    expect(result.game_values.profiles_value).toBe(10);
   });
 
-  it('caps instance_data.amount at 100 — bar width = amount/100*60px must not overflow', async () => {
-    const tokenNode = mkNode('TokenPerp', TOKEN_PATH, { amount: 90 });
+  it('clamps instance_data.amount at 100 — bar width = amount/100*60px must not overflow', async () => {
+    // Construct a state where the weighted average overshoots 100 so the
+    // upstream `min(100, …)` clamp is exercised. db_share=99, M=10,
+    // ps_share=200 (hypothetical bad ruleset row), N=10 → (99*10 + 200*10)/20
+    // = 149.5, clamped to 100.
+    const tokenNode = mkNode('TokenPerp', TOKEN_PATH, { amount: 99 });
     tokenNode.gestalt = 'token_a';
     setState(mkState({
+      game_values: mkGv({ profiles_value: 10 }),
       nodes: [tokenNode],
       db_queue: [{
         origin:      'Imperium.City.contact001',
         collect_id:  COLLECT_ID,
-        profile_set: { profiles_value: 4, tokens_map: { token_a: { amount: 50 } } },
+        profile_set: { profiles_value: 10, tokens_map: { token_a: { amount: 200 } } },
         collect_dt:  FIXED_NOW
       }]
     }));
@@ -493,7 +503,9 @@ describe('integrateCollected — token node updates', () => {
     expect(result.result.nodes[0].instance_data.amount).toBe(100);
   });
 
-  it('caps a fresh-seeded TokenPerp at 100 too', async () => {
+  it('clamps a fresh-seeded TokenPerp at 100 too', async () => {
+    // Seed share = ps_share * N / (M + N). With M=0 this collapses to ps_share,
+    // so an over-100 ruleset row still hits the clamp at seed time.
     setState(mkState({
       locale: 'en',
       db_queue: [{
@@ -507,6 +519,57 @@ describe('integrateCollected — token node updates', () => {
     const { result } = await integrateCollected('tok', COLLECT_ID);
     const seeded = result.result.nodes.find(n => n.gestalt === 'token008');
     expect(seeded.instance_data.amount).toBe(100);
+  });
+
+  it('dilutes a TokenPerp not present in the new profileset', async () => {
+    // The whole point of the upstream merge: tokens that the new profileset
+    // does *not* contribute to should be diluted as the DB grows. This is
+    // what makes the per-tile bar (and the status-bar crosssum) move down,
+    // not just up. db_share=80, M=10, no ps_share, N=10 → 80*10/(10+10) = 40.
+    // Absolute count is preserved: M*old/100 = 8 == (M+N)*new/100.
+    const tokenA = mkNode('TokenPerp', 'Imperium.Database.token_a', { amount: 80 });
+    tokenA.gestalt = 'token_a';
+    setState(mkState({
+      game_values: mkGv({ profiles_value: 10 }),
+      nodes: [tokenA],
+      db_queue: [{
+        origin:      'Imperium.City.contact001',
+        collect_id:  COLLECT_ID,
+        profile_set: { profiles_value: 10, tokens_map: { token_b: { amount: 100 } } },
+        collect_dt:  FIXED_NOW
+      }]
+    }));
+
+    const { result } = await integrateCollected('tok', COLLECT_ID);
+    const updatedA = result.result.nodes.find(n => n.gestalt === 'token_a');
+    expect(updatedA).toBeDefined();
+    expect(updatedA.instance_data.amount).toBeCloseTo(40, 6);
+    // Absolute count of token_a profiles must not regress.
+    const absBefore = (10 * 80) / 100;
+    const absAfter  = ((10 + 10) * updatedA.instance_data.amount) / 100;
+    expect(absAfter).toBeCloseTo(absBefore, 6);
+  });
+
+  it('does not change shares on a duplicate collect_id replay (N = 0)', async () => {
+    const tokenNode = mkNode('TokenPerp', TOKEN_PATH, { amount: 40 });
+    tokenNode.gestalt = 'token_a';
+    setState(mkState({
+      game_values:    mkGv({ profiles_value: 10 }),
+      integrated_ids: { [COLLECT_ID]: true },
+      nodes: [tokenNode],
+      db_queue: [{
+        origin:      'Imperium.City.contact001',
+        collect_id:  COLLECT_ID,
+        profile_set: { profiles_value: 10, tokens_map: { token_a: { amount: 100 } } },
+        collect_dt:  FIXED_NOW
+      }]
+    }));
+
+    const { result } = await integrateCollected('tok', COLLECT_ID);
+    expect(result.result.dup).toBe(10);
+    expect(result.result.increment).toBe(0);
+    // Share is unchanged because N (= increment) is 0; M+N = M, db share kept.
+    expect(result.result.nodes ?? []).toHaveLength(0);
   });
 
   it('returns game_values, levelup, and missions for server parity', async () => {


### PR DESCRIPTION
Closes #103. Follow-up to the investigation merged in #102.

## Summary

`integrateCollected` now merges ProfileSet shares with the upstream
`dd_app/dd_calc.py:Database.merge` formula instead of clamp-summing
per-integration deltas. Same math as the server used; just running on
the client because there is no server in the webxdc port.

For every TokenPerp the new profileset *touches*:

```
new_share = min(100, (db_share·M + ps_share·N) / (M + N))
```

For TokenPerps the profileset does *not* contribute to:

```
new_share = (db_share·M) / (M + N)
```

…where `M` = `profiles_value` *before* the merge, `N` =
`ps.profiles_value` (= `increment`, so 0 on duplicate `collect_id`
replay → shares unchanged). First-time-seeded TokenPerps use the same
formula, which collapses to `ps_share` when `M = 0`.

The dilution case preserves the absolute count
(`profiles_value × share / 100`), so
`mission_goals.current_amount` — clamped monotonically in
`_advanceIntegrateProfilesMissions` — hits the same inflection points
the original game did. **No mission targets, no ruleset rows, and no
ruleset balancing values were touched.** Stays faithful to original
gameplay/progression — only the transport changed (LocalEngine on the
client instead of the Python backend).

## Files

- `scripts/LocalEngine.js` — `_integrateProfiles` loop replaced with
  the weighted-average merge + dilution + duplicate-replay no-op.
  Comment block transcribes the upstream formula.
- `tests/handlers/collect-integrate.test.js` — three pre-existing
  share assertions re-derived from the new formula; new specs added
  for **dilution** of an untouched token (the whole point of the
  fix) and **duplicate-replay no-op** (`N = 0`). Mission-progression
  specs pass unchanged because absolute counts are preserved.
- `tests/e2e/share-merge.spec.ts` (new) — Playwright spec drives
  `LocalEngine.integrateCollected` directly (matches
  `gameplay.spec.ts`'s no-canvas-clicks strategy) through two crafted
  db_queue entries, asserts dilution of an absent token, that the
  status-bar `crosssum` drops well below 100 % once shares diverge,
  and that a duplicate `collect_id` replay is a no-op.
- `docs/ui-meters.md` — updated in-place: the previous "non-trivial
  follow-up" section is rewritten as a closed-out trail of the three
  concerns that were resolved (re-derived fixtures, missions still
  hit their targets, ruleset shape vendored unchanged).

## Test plan

- [x] `pnpm test` → 387/387 vitest pass.
- [x] `pnpm test:e2e` → 7/7 Playwright pass (boot ×2,
      buy-perp-error, gameplay, persistence, share-merge ×2).
- [x] `pnpm build` clean.
- [x] Mission-progression specs (`integrate_profiles flow`,
      `monotonic`) pass unchanged — confirms preserved absolute count.
- [ ] Reviewer to spot-check the formula transcription against
      `dd_app/dd_calc.py:Database.merge` (linked in
      `docs/ui-meters.md`).

cc @experintellia for review.

https://claude.ai/code/session_threadHH_103

---
_Generated by [Claude Code](https://claude.ai/code/session_01SDrJ596bBmy2oWLN29STdw)_