### PR TITLE
Fix chargePerp double-deducting cash/AP on listener echo

### DIFF
--- a/scripts/LocalEngine.js
+++ b/scripts/LocalEngine.js
@@ -1463,13 +1463,21 @@ export function chargePerp(token, path) { // eslint-disable-line no-unused-vars
 
   setState(newStateCharge);
 
+  // Carry the post-mutation game_values snapshot so the reducer is idempotent
+  // when the listener replays this delta on top of the just-setState'd state
+  // (production webxdc echoes own updates into setUpdateListener). Without the
+  // snapshot, the reducer's incremental cash/ap math runs a second time and
+  // double-deducts — the UI then shows cash the engine no longer believes the
+  // player has, so subsequent charges fail with "no_cash" despite a green bar.
+  // cashDelta/xpInc remain in the payload for cold-replay backwards compat
+  // with deltas persisted before this fix.
   _persistDelta({
     kind:   'delta',
     addr:   state.addr,
     op:     'chargePerp',
     args:   [path],
     result: { chargeEntry: chargeEntry, nodeIdx: nodeIdx, cashDelta: chargeCost, xpInc: xpInc,
-              missions: chargeMissionResult.missions || null },
+              game_values: newGv, missions: chargeMissionResult.missions || null },
     ts:     now,
   });
 

--- a/scripts/state.js
+++ b/scripts/state.js
@@ -332,12 +332,19 @@ reducers.chargePerp = function chargePerpReducer(state, delta) {
   });
 
   var gv    = state.game_values || {};
-  var newGv = Object.assign({}, gv, {
-    cash_value:  (gv.cash_value  || 0) - cashDelta,
-    cash_spent:  (gv.cash_spent  || 0) + cashDelta,
-    xp_value:    (gv.xp_value   || 0) + xpInc,
-    ap_snapshot: Math.max(0, (gv.ap_snapshot || 0) - 1),
-  });
+  // Prefer the post-mutation snapshot when the handler ships one — applying a
+  // snapshot is idempotent, so the listener's echo of an own update doesn't
+  // double-deduct cash/ap on top of the handler's setState. Fall back to
+  // the incremental form for replay of older deltas that predate the
+  // snapshot field.
+  var newGv = r.game_values
+    ? Object.assign({}, gv, r.game_values)
+    : Object.assign({}, gv, {
+        cash_value:  (gv.cash_value  || 0) - cashDelta,
+        cash_spent:  (gv.cash_spent  || 0) + cashDelta,
+        xp_value:    (gv.xp_value   || 0) + xpInc,
+        ap_snapshot: Math.max(0, (gv.ap_snapshot || 0) - 1),
+      });
 
   var mp = _missionDataFromResult(state, r);
   return Object.assign({}, state, {

--- a/tests/handlers/chargePerp.test.js
+++ b/tests/handlers/chargePerp.test.js
@@ -607,3 +607,57 @@ describe('chargePerp — ClientPerp uses income_base when collect_amount is miss
     expect(amount).toBeLessThanOrEqual(614);
   });
 });
+
+// ── webxdc echo idempotence (regression for state-sync bug) ───────────────────
+//
+// Production webxdc invokes setUpdateListener for own sendUpdate calls, so
+// chargePerp's setState + sendUpdate sequence runs the reducer a second time
+// over already-mutated state. The reducer must therefore be idempotent for
+// that re-application, otherwise cash and ap_snapshot get double-deducted —
+// the UI shows the once-deducted snapshot returned by the handler while the
+// engine state holds the twice-deducted value, so the next charge fails with
+// "no_cash" / "no_AP" despite a green status bar.
+
+describe('chargePerp — listener echo is idempotent', () => {
+  beforeEach(() => {
+    setOverride(FIXED_NOW);
+    setState(mkState());
+  });
+
+  it('replaying the captured delta on top of the post-handler state matches handler state', async () => {
+    const captured = [];
+    setSendDelta(d => captured.push(d));
+
+    await chargePerp('tok', NODE_PATH);
+    const handlerState = getState();
+
+    // Simulate webxdc echoing the own update into setUpdateListener: apply
+    // the captured delta on top of the state the handler already wrote.
+    const echoed = applyDelta(handlerState, captured[0]);
+
+    expect(echoed.game_values.cash_value).toBe(handlerState.game_values.cash_value);
+    expect(echoed.game_values.cash_spent).toBe(handlerState.game_values.cash_spent);
+    expect(echoed.game_values.ap_snapshot).toBe(handlerState.game_values.ap_snapshot);
+    expect(echoed.game_values.xp_value).toBe(handlerState.game_values.xp_value);
+  });
+
+  it('cash is not double-deducted when listener echoes own update', async () => {
+    const captured = [];
+    setSendDelta(d => captured.push(d));
+
+    await chargePerp('tok', NODE_PATH);
+    const echoed = applyDelta(getState(), captured[0]);
+
+    expect(echoed.game_values.cash_value).toBe(500 - CHARGE_COST);
+  });
+
+  it('ap_snapshot is not double-deducted when listener echoes own update', async () => {
+    const captured = [];
+    setSendDelta(d => captured.push(d));
+
+    await chargePerp('tok', NODE_PATH);
+    const echoed = applyDelta(getState(), captured[0]);
+
+    expect(echoed.game_values.ap_snapshot).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a state-sync bug where the UI shows enough cash/AP to charge a perp but the handler refuses with "no_cash" / "no_AP".

## Root cause

`chargePerp` in `scripts/LocalEngine.js` calls `setState(newStateCharge)` and then emits the delta via `_persistDelta`. In production webxdc, `sendUpdate` echoes the own update back into the listener registered by `boot.js`, which re-applies the `chargePerp` reducer in `scripts/state.js`. That reducer used incremental math (`gv.cash_value - cashDelta`, `ap_snapshot - 1`), so it ran on top of state where the deduction had already been applied — double-charging cash and AP.

The handler returned the once-deducted snapshot to the UI, so the status bar showed values higher than the engine actually held. The gap widens by one `cashDelta` per charge until the engine's actual cash drops below the cost — at which point the next click fails despite a green bar.

Tests didn't catch it because `setSendDelta(...)` short-circuits `_persistDelta` before reaching `webxdc.sendUpdate` (LocalEngine.js:90-92), so the listener never echoed in unit tests.

## Fix

- Carry the post-mutation `game_values` snapshot in the chargePerp delta result.
- Make the reducer prefer the snapshot over the incremental form. Snapshot application is idempotent on its own output, so the listener echo no longer double-deducts.
- Keep the incremental form as a fallback so already-persisted pre-fix deltas still replay correctly on cold start.

## Tests

Three new regression tests in `tests/handlers/chargePerp.test.js` simulate the production webxdc echo by applying the captured delta on top of the post-handler state, asserting cash, cash_spent, ap_snapshot, and xp_value are not double-deducted. Full suite: 391/391 passing.

## Related issues

Addresses one finding from #115 (audit all state.js reducers for replay-safety + idempotency under self-echo) — specifically the chargePerp reducer. Does **not** close #115, which is a broader audit covering every handler.

Related: #114 (sibling instance of the same materializer-vs-reducer anti-pattern in `collectPerp`, with a different symptom — perp re-collectable after reload). Not fixed here.

## Test plan

- [x] Existing unit tests pass (`npx vitest run`)
- [x] New regression tests in `tests/handlers/chargePerp.test.js` cover the listener-echo path
- [ ] Manual smoke in Delta Chat Desktop: charge a perp repeatedly, verify cash and AP in the UI match the engine state across many cycles (no drift)

https://claude.ai/code/session_01Q2ejf3RVooZTdPaFVsDwNB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q2ejf3RVooZTdPaFVsDwNB)_