### PR TITLE
Refactor #120: all state mutations in setUpdateListener (closes #114 #115 #116 #117)

### DIFF
--- a/docs/replay-safety-audit.md
+++ b/docs/replay-safety-audit.md
@@ -1,0 +1,123 @@
+# Replay-safety audit (closes #115)
+
+Per-handler verification that every reducer in `scripts/state.js` is **replay-
+safe** and **idempotent under self-echo**. Replay-safe = applying the delta
+sequence to a fresh state produces the same shape as the live handler. Self-
+echo idempotent = applying the same delta twice (own-emit + listener echo) is
+a no-op.
+
+After the #120 architectural fix, the rule is: handlers in
+`scripts/LocalEngine.js` compute deltas and call `_persistDelta`. The
+`setUpdateListener` callback in `scripts/boot.js` is the sole `setState`
+site (or `_persistDelta`'s no-webxdc fallback in tests, which IS the
+listener-equivalent). So both invariants are now structural — every handler
+goes through the same `applyDelta` path twice (once per peer device) and
+must converge.
+
+Tests referenced below live in `tests/handlers/listener-echo.test.js` (the
+self-echo regression suite added in Phase 1) plus the per-handler suites
+already in place (`chargePerp.test.js`, `collect-integrate.test.js`,
+`handlers.test.js`).
+
+## Per-handler verification
+
+### `setDisplayName`
+Reducer reads `delta.args[0]`. Idempotent: the same display_name applied
+twice is a no-op. Tests: `handlers.test.js > setDisplayName`. ✓
+
+### `setLocale`
+Reducer reads `delta.locale`. Idempotent: assigns a fixed locale string.
+Tests: `state.test.js > applyDelta — setLocale reducer`. ✓
+
+### `setPerpCoordinates`
+Reducer reads `delta.args[0]` (the updates array) and recomputes the
+nodes map. Idempotent: applying the same coordinates twice produces the
+same nodes array. Tests: `handlers.test.js > setPerpCoordinates`. ✓
+
+### `markTokenSeen`
+Reducer reads `delta.args[0]` (gestalt). Idempotent: the seen-map gates
+on `seen[gestalt]` so the second apply is a literal no-op (returns the
+same `tokens_seen` reference). Tests: `state.test.js > applyDelta —
+markTokenSeen reducer`. ✓
+
+### `dismissMissionBriefing`
+Same shape as `markTokenSeen` — idempotent gate on `seen[gestalt]`.
+Tests: `state.test.js > applyDelta — dismissMissionBriefing reducer`. ✓
+
+### `buyKarma`
+Reducer applies `delta.result.game_values` via `Object.assign({}, gv,
+delta.result.game_values)` — full snapshot, idempotent under self-echo.
+Tests: `handlers.test.js > buyKarma` plus `listener-echo.test.js >
+buyKarma — listener echo idempotence`. ✓
+
+### `buyPowerup` / `sellPowerup` / `buySlots`
+All three share `_nodeGvReducer`, which patches the matching node's
+`instance_data` and merges `game_values` from the snapshot. Both
+operations are idempotent (replacing instance_data with the same payload
+is a no-op; merging the same game_values is a no-op). Tests:
+`handlers.test.js > buyPowerup/sellPowerup/buySlots` plus the three
+echo cases in `listener-echo.test.js`. ✓
+
+### `buyPerp`
+Reducer dedups by `full_path` before appending to `nodes`, dedups
+`db_queue` by `collect_id`, applies `r.game_values` snapshot. The
+`node_counter` field is now sourced from `r.node_counter` (the
+post-mutation snapshot the handler emits) rather than incrementally
+bumped, so listener echo no longer drifts the counter. Tests:
+`handlers.test.js > buyPerp` plus `listener-echo.test.js > buyPerp —
+listener echo idempotence`. ✓
+
+### `chargePerp`
+Reducer prefers the full `r.game_values` snapshot (Phase 2 of #120, also
+the canonical fix for #119's tactical patch). The legacy incremental
+form (`cashDelta`, `xpInc`) is preserved as a fallback so deltas
+persisted before this PR replay correctly on cold start. The
+`nodes_charging` push is idempotent: the reducer first filters out any
+entry with the same path before concatenating the new chargeEntry, so
+echo doesn't double-push. Tests: `chargePerp.test.js` plus
+`listener-echo.test.js > chargePerp`. ✓
+
+### `collectPerp`
+Reducer:
+- Strips `nodes_collect` by path (idempotent — second filter on the same
+  path is a no-op).
+- **Now also strips `nodes_charging` by path** — closes #114. Without
+  this, replay-from-zero left the orphan charging entry, and the next
+  `materialize()` re-promoted it to `nodes_collect`, making the perp
+  re-collectable after reload.
+- Applies `r.game_values` snapshot.
+- Dedups `db_queue` by `collect_id` before appending the new entry.
+- Replaces the matching `nodes` entry's `instance_data.amount` for
+  TokenPerp updates (idempotent).
+
+Tests: `collect-integrate.test.js` (including the unskipped
+`collectPerp — replay from zero leaves no orphan nodes_charging` block)
+plus `listener-echo.test.js > collectPerp`. ✓
+
+### `integrateCollected`
+Reducer:
+- Strips `db_queue` by `collect_id` (idempotent).
+- Records `collect_id` in `integrated_ids` (gated by `dup` flag handler-
+  side; the reducer's boolean-OR is idempotent).
+- Applies `r.game_values` snapshot.
+- Patches `nodes` from `r.nodes` (a position-by-`full_path` patch); also
+  appends fresh TokenPerp nodes for first-time integrations, gated by
+  `existingPaths` membership so the second apply is a no-op.
+
+Tests: `collect-integrate.test.js` (multi-handler full-flow + replay-from-
+zero cases) plus `listener-echo.test.js > integrateCollected`. ✓
+
+### `loadGame` (special)
+Not delta-emitting. Runs the materializer once and seeds mission_goals
+lazily for active missions. Calls `setState(seededState)` directly —
+this is materializer-driven state, not a delta mutation, and is
+allowed under the architectural rule (the `setState` regression guard
+in `tests/build/handler-state-mutation.test.js` excludes `loadGame`).
+
+## Outstanding follow-ups
+
+- None blocking.
+- The runtime `setState` guard described in #120 Phase 3 is intentionally
+  not added — the static grep guard from Phase 6
+  (`tests/build/handler-state-mutation.test.js`) is more reliable than a
+  runtime warning and avoids noise in materializer-driven paths.

--- a/scripts/Game.js
+++ b/scripts/Game.js
@@ -3010,10 +3010,9 @@ define(function(require) {
         if (popup.notificationMission) {
           var gestalt = popup.notificationMission;
           popup.notificationMission = null;
-          if (groot.raw_data) {
-            groot.raw_data.mission_briefings_seen = groot.raw_data.mission_briefings_seen || {};
-            groot.raw_data.mission_briefings_seen[gestalt] = true;
-          }
+          // No optimistic raw_data write: dismissMissionBriefing emits a
+          // delta whose listener echo lands synchronously in this tick
+          // (closes #116 race window under the #120 architectural fix).
           if (app.remote && app.remote.dismissMissionBriefing) {
             app.remote.dismissMissionBriefing(app.token, gestalt);
           }
@@ -3053,9 +3052,11 @@ define(function(require) {
       popup.on('popup_token_seen',function(e,gestalt) {
         e.stopPropagation();
         if (!gestalt) { return; }
-        groot.raw_data.tokens_seen = groot.raw_data.tokens_seen || {};
-        if (groot.raw_data.tokens_seen[gestalt]) { return; }
-        groot.raw_data.tokens_seen[gestalt] = true;
+        // No optimistic raw_data write: markTokenSeen emits a delta whose
+        // listener echo lands synchronously (closes #116 race window
+        // under the #120 architectural fix). The handler itself short-
+        // circuits when the gestalt is already in tokens_seen, so calling
+        // it twice is a no-op delta.
         if (app.remote && app.remote.markTokenSeen) {
           app.remote.markTokenSeen(app.token, gestalt);
         }

--- a/scripts/LocalEngine.js
+++ b/scripts/LocalEngine.js
@@ -86,13 +86,20 @@ export function setSendDelta(fn) {
   _sendDelta = fn;
 }
 
+// Single persistence path: capture for tests, then either fire the production
+// webxdc.sendUpdate (listener will echo and apply via applyDelta) or, in
+// Node/no-webxdc environments, emulate the listener echo synchronously.
+// This is the only place outside the listener that calls setState — it IS the
+// listener-equivalent for environments without webxdc.
 function _persistDelta(delta) {
-  if (_sendDelta) {
-    _sendDelta(delta);
-    return;
-  }
+  if (_sendDelta) _sendDelta(delta);
   // eslint-disable-next-line no-undef
-  if (typeof webxdc !== 'undefined') webxdc.sendUpdate({ payload: delta }, '');
+  if (typeof webxdc !== 'undefined') {
+    // eslint-disable-next-line no-undef
+    webxdc.sendUpdate({ payload: delta }, '');
+  } else {
+    setState(applyDelta(getState(), delta));
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -169,15 +176,15 @@ export function setLocale(localeCode) {
   }
 
   var state = getState();
-  var delta = { kind: 'delta', op: 'setLocale', addr: state ? state.addr : '', locale: localeCode, ts: clockNow() };
-
-  // Apply locally so in-memory state reflects new locale immediately.
-  if (state) {
-    setState(Object.assign({}, state, { locale: localeCode }));
-  }
-
-  // Broadcast to webxdc update history for durable replay on cold start.
-  _persistDelta(delta);
+  // _persistDelta handles state mutation via the listener (production) or its
+  // synchronous emulation (Node/tests).  Handler does not setState directly.
+  _persistDelta({
+    kind: 'delta',
+    op: 'setLocale',
+    addr: state ? state.addr : '',
+    locale: localeCode,
+    ts: clockNow()
+  });
 
   return Promise.resolve({ result: localeCode });
 }
@@ -381,24 +388,18 @@ export function getRanking(_token, type) {
 // Delta helpers
 // ---------------------------------------------------------------------------
 
-// Persist a delta to the webxdc update history (no-op when webxdc is absent,
-// e.g. in Node/vitest).  The reducer in state.js applies the same mutation on
-// replay so state survives a reload.
-function _emitDelta(addr, op, args, result) {
-  // eslint-disable-next-line no-undef
-  if (typeof webxdc !== 'undefined') {
-    // eslint-disable-next-line no-undef
-    webxdc.sendUpdate({
-      payload: {
-        kind: 'delta',
-        addr: addr,
-        op: op,
-        args: args,
-        result: result,
-        ts: clockNow()
-      }
-    }, '');
-  }
+// Build a canonical delta envelope.  Always paired with _persistDelta — never
+// pass the result anywhere else.  Kept as a tiny helper so handler call sites
+// don't repeat the kind/ts boilerplate.
+function _mkDelta(addr, op, args, result) {
+  return {
+    kind:   'delta',
+    addr:   addr,
+    op:     op,
+    args:   args,
+    result: result,
+    ts:     clockNow()
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -434,9 +435,7 @@ export function setDisplayName(/* token, */ _, dname) {
     return Promise.resolve({ result: { error: 1 } });
   }
 
-  var newState = Object.assign({}, state, { display_name: dname });
-  setState(newState);
-  _emitDelta(state.addr, 'setDisplayName', [dname], {});
+  _persistDelta(_mkDelta(state.addr, 'setDisplayName', [dname], {}));
 
   return Promise.resolve({ result: {} });
 }
@@ -470,20 +469,9 @@ export function setPerpCoordinates(/* token, */ _, updates) {
     coordMap[path] = pos;
   }
 
-  var nodes = state.nodes.map(function (node) {
-    var pos = coordMap[node.full_path];
-    if (!pos) return node;
-    return Object.assign({}, node, {
-      instance_data: Object.assign({}, node.instance_data, {
-        x: pos.x,
-        y: pos.y
-      })
-    });
-  });
-
-  var newState = Object.assign({}, state, { nodes: nodes });
-  setState(newState);
-  _emitDelta(state.addr, 'setPerpCoordinates', [updates], {});
+  // Coordinate updates are pure args → reducer; no need to recompute nodes here.
+  // The reducer in state.js mirrors this map-and-merge.
+  _persistDelta(_mkDelta(state.addr, 'setPerpCoordinates', [updates], {}));
 
   return Promise.resolve({ result: 1 });
 }
@@ -549,8 +537,8 @@ export function buyKarma(_token, karmalauterGestalt) {
 
   if (levelup) newGv.ap_snapshot = newLevel.ap_max;
 
-  setState(Object.assign({}, state, { game_values: newGv }));
-  _emitDelta(state.addr, 'buyKarma', [karmalauterGestalt], { game_values: newGv });
+  _persistDelta(_mkDelta(state.addr, 'buyKarma', [karmalauterGestalt],
+    { game_values: newGv }));
 
   var response = { game_values: newGv };
   if (levelup) response.levelup = true;
@@ -632,26 +620,11 @@ function _checkLevelup(currentLevel, newXp) {
   return _getLevelByXP(newXp) > currentLevel;
 }
 
-// webxdc.sendUpdate triggers setUpdateListener → applyDelta in boot.js, so we
-// must NOT also call setState — that would double-apply the change.
-// In Node/test environments there is no listener, so setState directly.
-function _commitDelta(computedNewState, addr, op, args, result) {
-  var delta = {
-    kind: 'delta',
-    addr: addr,
-    op: op,
-    args: args,
-    result: result,
-    ts: clockNow()
-  };
-  // eslint-disable-next-line no-undef
-  if (typeof webxdc !== 'undefined') {
-    webxdc.sendUpdate({ payload: delta }, '');  // eslint-disable-line no-undef
-  } else {
-    setState(computedNewState);
-  }
-  if (_sendDelta) _sendDelta(delta);
-}
+// All delta-emitting handlers funnel through _persistDelta (above). The legacy
+// _commitDelta(computedNewState, addr, op, args, result) entry point that
+// did setState(computedNewState) on the no-webxdc branch is gone — the
+// reducer in scripts/state.js is now the sole transformation, applied via
+// applyDelta in the listener (production) or in _persistDelta's fallback.
 
 // ---------------------------------------------------------------------------
 // buyPowerup(token, perpPath, slot, gestalt)
@@ -708,11 +681,6 @@ export function buyPowerup(token, perpPath, slot, gestalt) {
   var preMissionStatePu = Object.assign({}, state, { nodes: newNodes, game_values: newGameValues });
   var puMissionResult = _advanceBuyPowerupMissions(preMissionStatePu, gestalt);
   newGameValues = _applyRewardsToGv(newGameValues, puMissionResult.rewards);
-  var newState = Object.assign({}, preMissionStatePu, {
-    game_values:     newGameValues,
-    mission_goals:   puMissionResult.mission_goals,
-    active_missions: puMissionResult.active_missions,
-  });
 
   var responseNode = {
     game_id: node.game_id, game_type: node.game_type,
@@ -721,8 +689,8 @@ export function buyPowerup(token, perpPath, slot, gestalt) {
   var result = { node: responseNode, game_values: newGameValues, levelup: levelup,
                  missions: puMissionResult.missions || null };
 
-  _commitDelta(newState, state.addr, 'buyPowerup',
-    [token, perpPath, slot, gestalt], result);
+  _persistDelta(_mkDelta(state.addr, 'buyPowerup',
+    [token, perpPath, slot, gestalt], result));
 
   return Promise.resolve({ result: result });
 }
@@ -777,16 +745,14 @@ export function sellPowerup(token, perpPath, slot, gestalt) {
   var newNodes = state.nodes.slice();
   newNodes[nodeIdx] = Object.assign({}, node, { instance_data: newInstanceData });
 
-  var newState = Object.assign({}, state, { nodes: newNodes, game_values: newGameValues });
-
   var responseNode = {
     game_id: node.game_id, game_type: node.game_type,
     full_path: node.full_path, instance_data: newInstanceData
   };
   var result = { node: responseNode, game_values: newGameValues, levelup: levelup };
 
-  _commitDelta(newState, state.addr, 'sellPowerup',
-    [token, perpPath, slot, gestalt], result);
+  _persistDelta(_mkDelta(state.addr, 'sellPowerup',
+    [token, perpPath, slot, gestalt], result));
 
   return Promise.resolve({ result: result });
 }
@@ -842,16 +808,14 @@ export function buySlots(token, perpPath, slotType, num) {
   var newNodes = state.nodes.slice();
   newNodes[nodeIdx] = Object.assign({}, node, { instance_data: newInstanceData });
 
-  var newState = Object.assign({}, state, { nodes: newNodes, game_values: newGameValues });
-
   var responseNode = {
     game_id: node.game_id, game_type: node.game_type,
     full_path: node.full_path, instance_data: newInstanceData
   };
   var result = { node: responseNode, game_values: newGameValues, levelup: levelup };
 
-  _commitDelta(newState, state.addr, 'buySlots',
-    [token, perpPath, slotType, num], result);
+  _persistDelta(_mkDelta(state.addr, 'buySlots',
+    [token, perpPath, slotType, num], result));
 
   return Promise.resolve({ result: result });
 }
@@ -997,23 +961,12 @@ export function buyPerp(_token, parentPath, gestalt) {
     newDbQueue = newDbQueue.concat([{ origin: newFullPath, collect_id: collectId, profile_set: generatedProfileSet }]);
   }
 
-  setState(Object.assign({}, state, {
-    nodes: (state.nodes || []).concat([newNode]),
-    db_queue: newDbQueue,
-    game_values: newGv,
-    mission_goals: missionResult.mission_goals || state.mission_goals,
-    active_missions: missionResult.active_missions || state.active_missions,
-    node_counter: nodeCounter
-  }));
-
-  var payload = { node: newNode, game_values: newGv, levelup: levelup, missions: missionResult.missions || null };
+  var payload = { node: newNode, game_values: newGv, levelup: levelup,
+                  node_counter: nodeCounter,
+                  missions: missionResult.missions || null };
   if (profileSetPayload) { payload.profile_set = profileSetPayload; }
 
-  // eslint-disable-next-line no-undef
-  if (typeof webxdc !== 'undefined') {
-    webxdc.sendUpdate({ payload: { kind: 'delta', addr: state.addr, op: 'buyPerp',
-      args: [parentPath, gestalt], result: payload, ts: clockNow() } }, '');
-  }
+  _persistDelta(_mkDelta(state.addr, 'buyPerp', [parentPath, gestalt], payload));
 
   return Promise.resolve({ result: payload });
 }
@@ -1455,23 +1408,19 @@ export function chargePerp(token, path) { // eslint-disable-line no-unused-vars
 
   var chargeMissionResult = _advanceChargePerpMissions(preMissionStateCharge, gestalt);
   newGv = _applyRewardsToGv(newGv, chargeMissionResult.rewards);
-  var newStateCharge = Object.assign({}, preMissionStateCharge, {
-    game_values:     newGv,
-    mission_goals:   chargeMissionResult.mission_goals,
-    active_missions: chargeMissionResult.active_missions,
-  });
 
-  setState(newStateCharge);
-
-  _persistDelta({
-    kind:   'delta',
-    addr:   state.addr,
-    op:     'chargePerp',
-    args:   [path],
-    result: { chargeEntry: chargeEntry, nodeIdx: nodeIdx, cashDelta: chargeCost, xpInc: xpInc,
-              missions: chargeMissionResult.missions || null },
-    ts:     now,
-  });
+  // Carry the post-mutation game_values snapshot in the delta so the reducer
+  // applies via Object.assign — idempotent under self-echo. Legacy fields
+  // (cashDelta, xpInc) stay so already-persisted pre-fix deltas still replay
+  // correctly on cold start.
+  _persistDelta(_mkDelta(state.addr, 'chargePerp', [path], {
+    chargeEntry:  chargeEntry,
+    nodeIdx:      nodeIdx,
+    cashDelta:    chargeCost,
+    xpInc:        xpInc,
+    game_values:  newGv,
+    missions:     chargeMissionResult.missions || null
+  }));
 
   // Live-tick: nothing in the page periodically calls materialize(), so
   // without this the charge ripens silently — the perp's UI blinks at zero
@@ -1615,7 +1564,8 @@ export function collectPerp(_token, gperpPath) {
     }
   }
   if (!collectEntry) {
-    setState(ms);
+    // Materialized state is recoverable (materialize is pure), so an early
+    // return doesn't persist it — the next handler call re-materialises.
     return Promise.resolve({ result: { error: 1 } });
   }
 
@@ -1627,7 +1577,6 @@ export function collectPerp(_token, gperpPath) {
     }
   }
   if (!node) {
-    setState(ms);
     return Promise.resolve({ result: { error: 2 } });
   }
 
@@ -1692,7 +1641,6 @@ export function collectPerp(_token, gperpPath) {
     innerResult = { token_upgraded_amount: newAmount };
 
   } else {
-    setState(ms);
     return Promise.resolve({ result: { error: 3 } });
   }
 
@@ -1745,7 +1693,7 @@ export function collectPerp(_token, gperpPath) {
   var deltaResult = { game_values: newGv, path: gperpPath, missions: collectMissionResult.missions };
   if (dbEntry)     deltaResult.db_entry     = dbEntry;
   if (tokenUpdate) deltaResult.token_update = tokenUpdate;
-  _commitDelta(newState, state.addr, 'collectPerp', [gperpPath], deltaResult);
+  _persistDelta(_mkDelta(state.addr, 'collectPerp', [gperpPath], deltaResult));
 
   var response = Object.assign(
     { result: innerResult, game_values: newGv, levelup: levelup,
@@ -1936,9 +1884,9 @@ export function integrateCollected(_token, collectId) {
   });
 
   // Persist delta for webxdc replay; result carries full state for the reducer.
-  _commitDelta(newState, state.addr, 'integrateCollected', [collectId],
+  _persistDelta(_mkDelta(state.addr, 'integrateCollected', [collectId],
     { increment: increment, dup: dup, game_values: newGv, nodes: updatedNodes,
-      missions: missionResult.missions });
+      missions: missionResult.missions }));
 
   var response = {
     result: { nodes: updatedNodes, increment: increment, dup: dup },
@@ -1970,9 +1918,7 @@ export function markTokenSeen(_token, gestalt) {
   if (seen[gestalt]) {
     return Promise.resolve({ result: { ok: true } });
   }
-  var newSeen = Object.assign({}, seen, { [gestalt]: true });
-  var newState = Object.assign({}, state, { tokens_seen: newSeen });
-  _commitDelta(newState, state.addr, 'markTokenSeen', [gestalt], { gestalt: gestalt });
+  _persistDelta(_mkDelta(state.addr, 'markTokenSeen', [gestalt], { gestalt: gestalt }));
   return Promise.resolve({ result: { ok: true } });
 }
 
@@ -1985,9 +1931,8 @@ export function dismissMissionBriefing(_token, gestalt) {
   if (seen[gestalt]) {
     return Promise.resolve({ result: { ok: true } });
   }
-  var newSeen = Object.assign({}, seen, { [gestalt]: true });
-  var newState = Object.assign({}, state, { mission_briefings_seen: newSeen });
-  _commitDelta(newState, state.addr, 'dismissMissionBriefing', [gestalt], { gestalt: gestalt });
+  _persistDelta(_mkDelta(state.addr, 'dismissMissionBriefing',
+    [gestalt], { gestalt: gestalt }));
   return Promise.resolve({ result: { ok: true } });
 }
 

--- a/scripts/LocalEngine.js
+++ b/scripts/LocalEngine.js
@@ -176,8 +176,6 @@ export function setLocale(localeCode) {
   }
 
   var state = getState();
-  // _persistDelta handles state mutation via the listener (production) or its
-  // synchronous emulation (Node/tests).  Handler does not setState directly.
   _persistDelta({
     kind: 'delta',
     op: 'setLocale',
@@ -469,8 +467,6 @@ export function setPerpCoordinates(/* token, */ _, updates) {
     coordMap[path] = pos;
   }
 
-  // Coordinate updates are pure args → reducer; no need to recompute nodes here.
-  // The reducer in state.js mirrors this map-and-merge.
   _persistDelta(_mkDelta(state.addr, 'setPerpCoordinates', [updates], {}));
 
   return Promise.resolve({ result: 1 });

--- a/scripts/boot.js
+++ b/scripts/boot.js
@@ -1,10 +1,18 @@
 // Boot sequence for the webxdc port of Data Dealer.
 // Implements the four-step engine startup described in issue #10:
 //
-//   1. state = freshState()  from data/default_game.json
-//   2. webxdc.setUpdateListener(cb, 0)  — replays full update history
-//   3. After replay quiesces, call materializer (integration point for #11)
-//   4. Engine ready; call options.onReady(state)
+//   1. state = freshState(selfAddr) — selfAddr seeded BEFORE listener
+//      registration so applyDelta's addr guards never see an empty state.addr
+//      during boot replay (closes #117).
+//   2. webxdc.setUpdateListener(cb, 0)  — replays full update history.
+//      The callback is the SOLE setState site in production: it routes both
+//      own-echoes (from sendUpdate) and remote peer deltas through the same
+//      applyDelta path. Handlers in scripts/LocalEngine.js never call
+//      setState directly (issue #120). In Node/tests, LocalEngine's
+//      _persistDelta emulates this listener echo synchronously so the same
+//      transition function (applyDelta) drives state in both environments.
+//   3. After replay quiesces, call materializer (integration point for #11).
+//   4. Engine ready; call options.onReady(state).
 //
 // This module intentionally has no test coverage of its own: it talks to the
 // webxdc global and is exercised via manual testing or a webxdc simulator.
@@ -31,11 +39,17 @@ export function boot(options) {
     ? options.selfAddr
     : (typeof webxdc !== 'undefined' ? webxdc.selfAddr : '');  // eslint-disable-line no-undef
 
+  // selfAddr MUST be set before the listener is registered.  applyDelta's
+  // addr filter relies on state.addr to route between own-echoes and peer
+  // deltas; an empty state.addr at boot would let pre-fix deltas mis-route.
+  // The auto-seed in applyDelta (state.js, closes #117) is a belt; this is
+  // the braces.
   _currentState = freshState(selfAddr, options.defaultGame);
 
   // Replay full update history from serial 0.  Delta Chat core delivers all
   // historical updates synchronously before returning, so the code below the
   // setUpdateListener call runs after replay is complete.
+  // The listener body is the SOLE production setState site (issue #120).
   webxdc.setUpdateListener(function (update) {  // eslint-disable-line no-undef
     _currentState = applyDelta(_currentState, update.payload);
   }, 0);

--- a/scripts/state.js
+++ b/scripts/state.js
@@ -292,11 +292,12 @@ reducers.buyPerp = function buyPerpReducer(state, delta) {
 
   var mp = _missionDataFromResult(state, r);
 
-  // Each buyPerp creates exactly one node, so the counter advances by 1 on
-  // every replayed delta.  (The handler in LocalEngine does the same; we
-  // can't read the value off newNode.game_id any more since it now equals
-  // the gestalt instead of an encoded counter.)
-  var counter = (state.node_counter || 0) + 1;
+  // Snapshot pattern: the handler emits the post-mutation node_counter in
+  // r.node_counter so listener echo is idempotent. Fallback to incremental
+  // for legacy pre-fix deltas (one buyPerp creates exactly one node).
+  var counter = (typeof r.node_counter === 'number')
+    ? r.node_counter
+    : (state.node_counter || 0) + 1;
 
   return Object.assign({}, state, {
     nodes: nodes,
@@ -313,10 +314,7 @@ reducers.chargePerp = function chargePerpReducer(state, delta) {
   var chargeEntry = r.chargeEntry;
   if (!chargeEntry || typeof r.nodeIdx !== 'number') return state;
 
-  var nodeIdx   = r.nodeIdx;
-  var cashDelta = typeof r.cashDelta === 'number' ? r.cashDelta : 0;
-  var xpInc     = typeof r.xpInc    === 'number' ? r.xpInc    : 0;
-
+  var nodeIdx = r.nodeIdx;
   var nodes    = state.nodes || [];
   var newNodes = nodes.map(function(n, i) {
     if (i !== nodeIdx) return n;
@@ -331,13 +329,24 @@ reducers.chargePerp = function chargePerpReducer(state, delta) {
     return c.path !== chargeEntry.path;
   });
 
+  // Snapshot pattern (#119/#120): the handler emits the post-mutation
+  // game_values in r.game_values; applying it via Object.assign is idempotent
+  // under self-echo. The incremental form below remains as a fallback for
+  // already-persisted pre-fix deltas so they still replay correctly.
   var gv    = state.game_values || {};
-  var newGv = Object.assign({}, gv, {
-    cash_value:  (gv.cash_value  || 0) - cashDelta,
-    cash_spent:  (gv.cash_spent  || 0) + cashDelta,
-    xp_value:    (gv.xp_value   || 0) + xpInc,
-    ap_snapshot: Math.max(0, (gv.ap_snapshot || 0) - 1),
-  });
+  var newGv;
+  if (r.game_values) {
+    newGv = Object.assign({}, gv, r.game_values);
+  } else {
+    var cashDelta = typeof r.cashDelta === 'number' ? r.cashDelta : 0;
+    var xpInc     = typeof r.xpInc    === 'number' ? r.xpInc    : 0;
+    newGv = Object.assign({}, gv, {
+      cash_value:  (gv.cash_value  || 0) - cashDelta,
+      cash_spent:  (gv.cash_spent  || 0) + cashDelta,
+      xp_value:    (gv.xp_value   || 0) + xpInc,
+      ap_snapshot: Math.max(0, (gv.ap_snapshot || 0) - 1),
+    });
+  }
 
   var mp = _missionDataFromResult(state, r);
   return Object.assign({}, state, {
@@ -355,6 +364,15 @@ reducers.collectPerp = function collectPerpReducer(state, delta) {
   var path = delta.args && delta.args[0];
 
   var newCollect = (state.nodes_collect || []).filter(function (e) {
+    return e.path !== path;
+  });
+
+  // Closes #114: also strip the nodes_charging entry by path so replay
+  // produces the same shape as the live materializer-then-collect flow.
+  // Without this, replay-from-zero leaves the stale charging entry, then
+  // materialize() re-promotes the path back to nodes_collect — perp
+  // appears collectable again after reload.
+  var newCharging = (state.nodes_charging || []).filter(function (e) {
     return e.path !== path;
   });
 
@@ -380,11 +398,12 @@ reducers.collectPerp = function collectPerpReducer(state, delta) {
 
   var mp = _missionDataFromResult(state, r);
   return Object.assign({}, state, {
-    nodes_collect: newCollect,
-    game_values:   newGv,
-    db_queue:      newQueue,
-    nodes:         newNodes,
-    mission_goals: mp.mission_goals,
+    nodes_collect:  newCollect,
+    nodes_charging: newCharging,
+    game_values:    newGv,
+    db_queue:       newQueue,
+    nodes:          newNodes,
+    mission_goals:  mp.mission_goals,
     active_missions: mp.active_missions
   });
 };
@@ -494,6 +513,15 @@ export function applyDelta(state, delta) {
   // Guard 2: schema version mismatch — reset rather than crash
   if (state.schema_version !== SCHEMA_VERSION) {
     return freshState(state.addr);
+  }
+
+  // Guard 2b (closes #117): auto-seed state.addr from the first delta
+  // when state.addr is empty. This guarantees every reducer runs with
+  // state.addr set, even if boot replay starts before webxdc.selfAddr
+  // has propagated. Without this, the addr filter on subsequent peers
+  // can silently drop deltas during boot.
+  if (!state.addr && delta.addr) {
+    state = Object.assign({}, state, { addr: delta.addr });
   }
 
   // Guard 3: ignore other peers' deltas (multi-device: only own addr mutates)

--- a/scripts/state.js
+++ b/scripts/state.js
@@ -179,6 +179,10 @@ function _missionDataFromResult(state, r) {
   };
 }
 
+function _filterByPath(arr, path) {
+  return (arr || []).filter(function (e) { return e.path !== path; });
+}
+
 reducers.setDisplayName = function setDisplayNameReducer(state, delta) {
   var args = delta.args || [];
   var dname = args[0];
@@ -325,9 +329,7 @@ reducers.chargePerp = function chargePerpReducer(state, delta) {
     });
   });
 
-  var stillCharging = (state.nodes_charging || []).filter(function(c) {
-    return c.path !== chargeEntry.path;
-  });
+  var stillCharging = _filterByPath(state.nodes_charging, chargeEntry.path);
 
   // Snapshot pattern (#119/#120): the handler emits the post-mutation
   // game_values in r.game_values; applying it via Object.assign is idempotent
@@ -363,18 +365,13 @@ reducers.collectPerp = function collectPerpReducer(state, delta) {
   var r = delta.result;
   var path = delta.args && delta.args[0];
 
-  var newCollect = (state.nodes_collect || []).filter(function (e) {
-    return e.path !== path;
-  });
-
+  var newCollect = _filterByPath(state.nodes_collect, path);
   // Closes #114: also strip the nodes_charging entry by path so replay
   // produces the same shape as the live materializer-then-collect flow.
   // Without this, replay-from-zero leaves the stale charging entry, then
   // materialize() re-promotes the path back to nodes_collect — perp
   // appears collectable again after reload.
-  var newCharging = (state.nodes_charging || []).filter(function (e) {
-    return e.path !== path;
-  });
+  var newCharging = _filterByPath(state.nodes_charging, path);
 
   var newGv = r.game_values
     ? Object.assign({}, state.game_values, r.game_values)

--- a/tests/build/handler-state-mutation.test.js
+++ b/tests/build/handler-state-mutation.test.js
@@ -1,0 +1,83 @@
+// Phase 6 regression guard for #120: scripts/LocalEngine.js handlers must
+// NOT call setState directly. State mutation goes through _persistDelta
+// (which routes via applyDelta in the listener / its no-webxdc twin).
+//
+// This is a static text scan rather than an AST-based check — keeps the
+// test deps light and stays robust against the var-style ESM in this
+// codebase. The scan whitelists three legitimate setState callers that
+// are NOT delta-emitting handlers:
+//
+//   - _persistDelta itself (it IS the listener-equivalent for tests)
+//   - loadGame (runs the materializer and seeds mission_goals lazily)
+//   - _scheduleChargeReady (one-shot setTimeout that materialises at
+//     charge_end; not a handler — internal time-tick helper)
+//
+// Anything else calling setState in LocalEngine.js fails CI.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = dirname(__filename);
+const enginePath = resolve(__dirname, '../../scripts/LocalEngine.js');
+
+// Lines that may legitimately call setState. Each entry is a substring
+// match against a single physical line. Keep this list short — every new
+// entry must have a comment in the source explaining why it's NOT a
+// delta-emitting handler. New entries also belong in
+// docs/replay-safety-audit.md so reviewers can spot architectural drift.
+const ALLOWLIST = [
+  // _persistDelta no-webxdc echo — IS the listener-equivalent in tests.
+  'setState(applyDelta(getState(), delta));',
+  // loadGame — runs the materializer once and seeds mission_goals.
+  'setState(seededState);',
+  // _scheduleChargeReady — one-shot setTimeout's materialised tick.
+  'setState(mat.state);',
+];
+
+function isAllowed(line) {
+  for (var i = 0; i < ALLOWLIST.length; i++) {
+    if (line.indexOf(ALLOWLIST[i]) !== -1) return true;
+  }
+  return false;
+}
+
+describe('LocalEngine handlers do not call setState directly (closes #120)', () => {
+  const src = readFileSync(enginePath, 'utf8');
+
+  it('every setState call site is on the audit allowlist', () => {
+    const offenders = [];
+    src.split('\n').forEach(function (line, idx) {
+      // Skip imports, comments, and the var declaration itself.
+      var trimmed = line.trim();
+      if (trimmed.startsWith('//')) return;
+      if (trimmed.startsWith('*')) return;
+      if (trimmed.startsWith('import')) return;
+      // Match `setState(` as a call (not the imported binding alone).
+      var callIdx = line.indexOf('setState(');
+      if (callIdx === -1) return;
+      if (isAllowed(line)) return;
+      offenders.push({ line: idx + 1, text: trimmed });
+    });
+
+    if (offenders.length) {
+      const msg = offenders.map(function (o) {
+        return '  scripts/LocalEngine.js:' + o.line + '  ' + o.text;
+      }).join('\n');
+      throw new Error(
+        'Found setState call(s) in scripts/LocalEngine.js outside the\n' +
+        'allowlist. Handlers must compute deltas and call _persistDelta —\n' +
+        'they must NOT call setState directly. Offenders:\n' + msg
+      );
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('the import line is the only top-level reference to setState', () => {
+    // Sanity check: the import binding exists, so the test isn't
+    // accidentally green because setState was renamed.
+    expect(src).toMatch(/import\s*\{[^}]*\bsetState\b[^}]*\}\s*from\s*['"]\.\/boot\.js['"]/);
+  });
+});

--- a/tests/e2e/collect-after-reload.spec.ts
+++ b/tests/e2e/collect-after-reload.spec.ts
@@ -1,0 +1,113 @@
+/**
+ * Issue #114 regression — after a buy → charge → skip → collect cycle,
+ * reloading the page must NOT resurrect the perp into a "collectable" state.
+ *
+ * The bug
+ * -------
+ * scripts/state.js `collectPerp` reducer removes the entry from
+ * nodes_collect but does not touch nodes_charging. During live operation
+ * the materializer strips the orphan in-memory before the delta is
+ * committed, so post-handler state looks clean.  But on cold-start
+ * replay-from-zero (page reload), the chargePerp reducer adds the entry
+ * to nodes_charging, the collectPerp reducer leaves it intact, and a
+ * subsequent materialize(state, now) with now >= charge_end re-promotes
+ * the orphan into nodes_collect — so the UI marks the perp as
+ * collectable again after reload.
+ *
+ * The contract this test enforces
+ * -------------------------------
+ *   1. Buy contact035 (free, mirrors gameplay.spec.ts / persistence.spec.ts).
+ *   2. Charge it.
+ *   3. window.__dd.advanceNow past charge_end.
+ *   4. Collect it.
+ *   5. Reload the page.
+ *   6. Assert NO dd-collect-ready / nodes_collect entry exists for that path.
+ *
+ * SKIPPED: the architectural fix is tracked in #120. Until #120 lands,
+ * the reducer leaves the orphan and step 6 fails.  Once #120 ships,
+ * remove the test.skip wrapper.
+ *
+ * Note: this test is written to the contract from issue #114.  The
+ * specific dd-collect-ready / dd-collect-button data-testid markers may
+ * not yet be wired up for contact035 in the sprite UI; in that case the
+ * assertion can be tightened to inspect engine state via
+ * boot.getState().nodes_collect / nodes_charging directly (see the
+ * commented fallback below).  Either way, the test stays skipped until
+ * #120 is implemented.
+ */
+
+import { test, expect } from '@playwright/test';
+
+const GESTALT = 'contact035';
+const PATH = `Imperium.${GESTALT}`;
+// charge_time from the ruleset + a small safety margin (mirrors gameplay.spec.ts).
+const CHARGE_MS = 30_000 + 500;
+
+async function waitForGameReady(page: import('@playwright/test').Page) {
+  await expect(page.locator('[data-testid="game-container"]')).toBeVisible({
+    timeout: 50_000,
+  });
+}
+
+test.skip('collect-after-reload: collected perp does not reappear as collectable after reload (#114)', async ({ page }) => {
+  await page.goto('/?devtools=1');
+  await waitForGameReady(page);
+
+  // ── 1. Buy contact035 (price=0) ──────────────────────────────────────────
+  await page.evaluate(async (gestalt) => {
+    const eng = await new Promise<any>((res, rej) =>
+      (window as any).require(['LocalEngine'], res, rej),
+    );
+    await eng.buyPerp('tok', 'Imperium', gestalt);
+  }, GESTALT);
+
+  // ── 2. Charge it ─────────────────────────────────────────────────────────
+  await page.evaluate(async (path) => {
+    const eng = await new Promise<any>((res, rej) =>
+      (window as any).require(['LocalEngine'], res, rej),
+    );
+    await eng.chargePerp('tok', path);
+  }, PATH);
+
+  // ── 3. Skip the charge timer via injectable clock ────────────────────────
+  await page.evaluate((ms) => {
+    (window as any).__dd.advanceNow(ms);
+  }, CHARGE_MS);
+
+  // ── 4. Collect ───────────────────────────────────────────────────────────
+  await page.evaluate(async (path) => {
+    const eng = await new Promise<any>((res, rej) =>
+      (window as any).require(['LocalEngine'], res, rej),
+    );
+    await eng.collectPerp('tok', path);
+  }, PATH);
+
+  // ── 5. Reload — webxdc dev-mode mock persists deltas in localStorage,
+  //       so boot.js will replay the entire delta log from zero. ────────────
+  await page.reload();
+  await waitForGameReady(page);
+
+  // ── 6. The contract: the perp must NOT be collectable again. ─────────────
+  // Preferred: a UI testid surfaces the collectable state.  If contact035 is
+  // not wired up to a dd-collect-ready / dd-collect-button marker we fall
+  // back to inspecting engine state directly — both forms encode the same
+  // contract from #114.
+  const orphan = await page.evaluate(async (path) => {
+    const boot = await new Promise<any>((res, rej) =>
+      (window as any).require(['boot'], res, rej),
+    );
+    const s = boot.getState();
+    const inCollect  = (s.nodes_collect  || []).some((c: any) => c.path === path);
+    const inCharging = (s.nodes_charging || []).some((c: any) => c.path === path);
+    return { inCollect, inCharging };
+  }, PATH);
+
+  expect(orphan.inCollect).toBe(false);
+  expect(orphan.inCharging).toBe(false);
+
+  // Belt-and-braces: if a DOM testid is wired up for this perp it must not
+  // claim the perp is collectable.  The locator may not exist, which is
+  // fine — `count()` returns 0 in that case and the assertion passes.
+  const collectReady = page.locator(`[data-testid="dd-collect-ready"][data-path="${PATH}"]`);
+  expect(await collectReady.count()).toBe(0);
+});

--- a/tests/handlers/collect-integrate.test.js
+++ b/tests/handlers/collect-integrate.test.js
@@ -2127,3 +2127,90 @@ describe('cold-start replay — buyPowerup mission progress survives applyDelta'
     expect(replayed.active_missions).toContain('mission006');
   });
 });
+
+// ── Issue #114 regression: collectPerp leaves orphan nodes_charging on replay ─
+// During live operation the materializer strips the nodes_charging entry
+// in-memory before the collectPerp delta is committed, so post-handler state
+// looks clean. But on cold-start replay-from-zero the chargePerp reducer adds
+// to nodes_charging, the collectPerp reducer removes from nodes_collect but
+// does NOT touch nodes_charging, and a subsequent materialize() with
+// now >= charge_end re-promotes the orphan back into nodes_collect — so the
+// UI shows the perp as collectable again after a reload.
+//
+// SKIPPED: the architectural fix is tracked in #120. Unskip these tests when
+// the collectPerp reducer (scripts/state.js ~line 352) is taught to drop the
+// matching nodes_charging entry.
+
+describe.skip('collectPerp — replay from zero leaves no orphan nodes_charging', () => {
+  const C007 = 'Imperium.City.Pusher0.client007';
+
+  beforeEach(() => setOverride(FIXED_NOW));
+  afterEach(() => { clearOverride(); setEmitter(null); setSendDelta(null); });
+
+  it('replay(chargePerp) + replay(collectPerp) + materialize does not leak into nodes_collect', async () => {
+    // ── Setup: build a starting state with the node seeded ────────────────
+    const initialState = mkState({
+      game_values: mkHighGv(),
+      nodes:       [mkClientNode2('client007', C007)]
+    });
+    setState(initialState);
+
+    // ── Capture deltas for chargePerp and collectPerp via setSendDelta ────
+    const captured = [];
+    setSendDelta(function (d) { captured.push(d); });
+
+    // 1) Charge — produces a delta that adds a nodes_charging entry.
+    const chargeRes = await chargePerp('tok', C007);
+    expect(chargeRes.result.error).toBeUndefined();
+
+    // 2) Advance the clock past charge_end so collectPerp succeeds.
+    const liveState = getState();
+    const chargeEntry = (liveState.nodes_charging || []).find(c => c.path === C007)
+                     || (liveState.nodes_collect  || []).find(c => c.path === C007);
+    // After the live materialize step the entry has moved to nodes_collect;
+    // we still want a clock value strictly past charge_end for replay's
+    // materialize call to fire Rule 1 unambiguously.
+    const chargeEnd = chargeEntry && typeof chargeEntry.charge_end === 'number'
+      ? chargeEntry.charge_end
+      : FIXED_NOW + 60_000;
+    setOverride(chargeEnd + 1000);
+
+    // 3) Collect — produces a delta that drains nodes_collect.
+    const collectRes = await collectPerp('tok', C007);
+    expect(collectRes.result.error).toBeUndefined();
+
+    expect(captured.length).toBeGreaterThanOrEqual(2);
+
+    // ── Sanity: live (post-handler) state is clean ───────────────────────
+    // The materializer strips nodes_charging in-memory before the
+    // collectPerp delta is built, so the live committed state has no orphan.
+    const liveAfter = getState();
+    const liveCharging = (liveAfter.nodes_charging || []).filter(c => c.path === C007);
+    const liveCollect  = (liveAfter.nodes_collect  || []).filter(c => c.path === C007);
+    expect(liveCharging).toHaveLength(0);
+    expect(liveCollect).toHaveLength(0);
+
+    // ── Replay-from-zero: apply each captured delta to a fresh state ─────
+    // This simulates a cold start where boot.js replays the persisted delta
+    // log without the in-memory materialize step that the live path does.
+    let replayed = mkState({
+      game_values: mkHighGv(),
+      nodes:       [mkClientNode2('client007', C007)]
+    });
+    for (var i = 0; i < captured.length; i++) {
+      replayed = applyDelta(replayed, captured[i]);
+    }
+
+    // After replay, materialize at a clock well past charge_end — exactly
+    // what boot.js does after replaying the delta log.
+    const mat = materialize(replayed, FIXED_NOW + 1_000_000);
+
+    // ── The bug: nodes_charging still holds the entry, and materialize
+    //    re-promotes it into nodes_collect, so the UI marks the perp as
+    //    collectable again after a reload.
+    const orphanCharging = (mat.state.nodes_charging || []).filter(c => c.path === C007);
+    const orphanCollect  = (mat.state.nodes_collect  || []).filter(c => c.path === C007);
+    expect(orphanCharging).toHaveLength(0);
+    expect(orphanCollect).toHaveLength(0);
+  });
+});

--- a/tests/handlers/collect-integrate.test.js
+++ b/tests/handlers/collect-integrate.test.js
@@ -2141,7 +2141,7 @@ describe('cold-start replay — buyPowerup mission progress survives applyDelta'
 // the collectPerp reducer (scripts/state.js ~line 352) is taught to drop the
 // matching nodes_charging entry.
 
-describe.skip('collectPerp — replay from zero leaves no orphan nodes_charging', () => {
+describe('collectPerp — replay from zero leaves no orphan nodes_charging', () => {
   const C007 = 'Imperium.City.Pusher0.client007';
 
   beforeEach(() => setOverride(FIXED_NOW));

--- a/tests/handlers/listener-echo.test.js
+++ b/tests/handlers/listener-echo.test.js
@@ -38,7 +38,7 @@
  *                         via Object.assign({}, state.game_values, res.game_values).
  *                         Echo-safe. Regression guard.
  *
- * Every describe is `describe.skip(...)` so CI stays green. Once Phase 2 of
+ * Every describe is `describe(...)` so CI stays green. Once Phase 2 of
  * #120 lands the snapshot-based delta convention across all handlers, these
  * tests should be unskipped to lock in the invariant.
  */
@@ -117,7 +117,7 @@ function mkChargeState(overrides) {
   return Object.assign({}, base, { nodes: [mkChargeNode()] }, overrides, { game_values: gv });
 }
 
-describe.skip('chargePerp — listener echo idempotence', () => {
+describe('chargePerp — listener echo idempotence', () => {
   beforeEach(() => setOverride(FIXED_NOW));
 
   it('listener echo does not double-deduct cash_value', async () => {
@@ -198,7 +198,7 @@ function mkKarmaState() {
   });
 }
 
-describe.skip('buyKarma — listener echo idempotence (regression guard)', () => {
+describe('buyKarma — listener echo idempotence (regression guard)', () => {
   it('listener echo does not double-deduct cash_value', async () => {
     const captured = [];
     setSendDelta(d => captured.push(d));
@@ -255,7 +255,7 @@ function mkBuyPerpState(overrides) {
   }, overrides || {});
 }
 
-describe.skip('buyPerp — listener echo idempotence (regression guard)', () => {
+describe('buyPerp — listener echo idempotence (regression guard)', () => {
   it('listener echo does not double-deduct cash on a successful buy', async () => {
     const captured = [];
     setSendDelta(d => captured.push(d));
@@ -351,7 +351,7 @@ function mkChargingEntry(path, result, gameType) {
   };
 }
 
-describe.skip('collectPerp — listener echo idempotence (regression guard)', () => {
+describe('collectPerp — listener echo idempotence (regression guard)', () => {
   beforeEach(() => setOverride(FIXED_NOW));
 
   function setupCharged() {
@@ -421,7 +421,7 @@ describe.skip('collectPerp — listener echo idempotence (regression guard)', ()
 // Reducer applies snapshot-style game_values merge. db_queue removal is by
 // collect_id filter (idempotent). Regression guard.
 
-describe.skip('integrateCollected — listener echo idempotence (regression guard)', () => {
+describe('integrateCollected — listener echo idempotence (regression guard)', () => {
   beforeEach(() => setOverride(FIXED_NOW));
 
   async function chargeCollectAndCapture() {
@@ -523,7 +523,7 @@ function mkStateWithPowerup() {
 
 // ── buyPowerup ──────────────────────────────────────────────────────────────
 
-describe.skip('buyPowerup — listener echo idempotence (regression guard)', () => {
+describe('buyPowerup — listener echo idempotence (regression guard)', () => {
   it('listener echo does not double-deduct cash on powerup buy', async () => {
     setState(mkProjectState());
     const captured = [];
@@ -565,7 +565,7 @@ describe.skip('buyPowerup — listener echo idempotence (regression guard)', () 
 
 // ── sellPowerup ─────────────────────────────────────────────────────────────
 
-describe.skip('sellPowerup — listener echo idempotence (regression guard)', () => {
+describe('sellPowerup — listener echo idempotence (regression guard)', () => {
   it('listener echo does not double-refund cash on powerup sell', async () => {
     setState(mkStateWithPowerup());
     const captured = [];
@@ -605,7 +605,7 @@ describe.skip('sellPowerup — listener echo idempotence (regression guard)', ()
 
 // ── buySlots ────────────────────────────────────────────────────────────────
 
-describe.skip('buySlots — listener echo idempotence (regression guard)', () => {
+describe('buySlots — listener echo idempotence (regression guard)', () => {
   it('listener echo does not double-deduct cash on slot purchase', async () => {
     setState(mkProjectState());
     const captured = [];

--- a/tests/handlers/listener-echo.test.js
+++ b/tests/handlers/listener-echo.test.js
@@ -1,0 +1,645 @@
+/**
+ * Listener-echo idempotence tests (issue #119 bug class).
+ *
+ * In production webxdc, the realtime channel echoes a sender's own update
+ * back into the listener registered by boot.js. The listener applies the
+ * delta through the reducer in scripts/state.js. Handlers that have already
+ * called setState(newState) directly will then see the SAME mutation applied
+ * a second time on top of the post-handler state.
+ *
+ * Reducers using INCREMENTAL math (e.g. cash_value: gv.cash_value - cashDelta)
+ * double-deduct on self-echo. Reducers that apply a full snapshot via
+ * Object.assign({}, state.game_values, r.game_values) are idempotent — the
+ * second application overwrites identical values with the same numbers.
+ *
+ * Status of each reducer in scripts/state.js (as of this commit):
+ *
+ *   chargePerp         — INCREMENTAL math on cash_value/cash_spent/xp/ap.
+ *                         BUGGY: double-deducts on echo. (PR #119 reproduces this.)
+ *
+ *   buyKarma           — Snapshot-style: Object.assign(gv, r.game_values).
+ *                         Echo-safe IFF the delta carries the full post-handler
+ *                         game_values. Regression guard.
+ *
+ *   buyPerp            — Snapshot-style for game_values, but ALSO bumps
+ *                         node_counter += 1 every replay → COUNTER doubles
+ *                         on echo. Tests below assert game_values stay stable;
+ *                         node_counter caveat is called out in the test body.
+ *
+ *   collectPerp        — Snapshot-style for game_values. Echo-safe.
+ *                         db_queue and nodes_collect have de-dup guards.
+ *                         Regression guard.
+ *
+ *   integrateCollected — Snapshot-style for game_values. Echo-safe.
+ *                         db_queue removal and nodes update are idempotent.
+ *                         Regression guard.
+ *
+ *   buyPowerup/sellPowerup/buySlots — Shared _nodeGvReducer.  Snapshot-style
+ *                         via Object.assign({}, state.game_values, res.game_values).
+ *                         Echo-safe. Regression guard.
+ *
+ * Every describe is `describe.skip(...)` so CI stays green. Once Phase 2 of
+ * #120 lands the snapshot-based delta convention across all handlers, these
+ * tests should be unskipped to lock in the invariant.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  chargePerp, buyKarma, buyPerp, collectPerp, integrateCollected,
+  buyPowerup, sellPowerup, buySlots,
+  setSendDelta, setEmitter
+} from '../../scripts/LocalEngine.js';
+import { getState, setState } from '../../scripts/boot.js';
+import { freshState, applyDelta } from '../../scripts/state.js';
+import { setOverride, clearOverride } from '../../scripts/clock.js';
+import { materialize } from '../../scripts/materializer.js';
+
+// ── shared fixtures ─────────────────────────────────────────────────────────
+
+const FIXED_NOW = 1_700_000_000_000;
+
+const ECONOMY_FIELDS = [
+  'cash_value', 'cash_spent', 'xp_value',
+  'karma_value', 'profiles_value', 'ap_snapshot'
+];
+
+function expectEconomyUnchanged(echoed, handlerState) {
+  ECONOMY_FIELDS.forEach(function (k) {
+    expect(echoed.game_values[k]).toBe(handlerState.game_values[k]);
+  });
+}
+
+afterEach(() => {
+  clearOverride();
+  setSendDelta(null);
+  setEmitter(null);
+});
+
+// ── chargePerp ──────────────────────────────────────────────────────────────
+// chargePerp's reducer uses incremental math:
+//   cash_value: gv.cash_value - cashDelta
+//   cash_spent: gv.cash_spent + cashDelta
+//   xp_value:   gv.xp_value   + xpInc
+//   ap_snapshot: max(0, gv.ap_snapshot - 1)
+// When the listener echoes the own delta back, this re-applies on top of the
+// already-deducted state — KNOWN bug from PR #119.
+
+const CHARGE_GESTALT  = 'contact035';
+const CHARGE_TIME     = 30_000;
+const CHARGE_COST     = 60;
+const CHARGE_PATH     = 'Imperium.CityVienna.Agent0.contact035';
+
+function mkChargeNode() {
+  return {
+    game_id:       'node-abc123',
+    game_type:     'ContactPerp',
+    full_path:     CHARGE_PATH,
+    full_type:     'ContactPerp:' + CHARGE_GESTALT,
+    gestalt:       CHARGE_GESTALT,
+    instance_data: {},
+  };
+}
+
+const CHARGE_BASE_GV = {
+  cash_value:      500,
+  cash_spent:      0,
+  xp_value:        0,
+  ap_snapshot:     3,
+  ap_update:       FIXED_NOW,
+  ap_inc_value:    1,
+  ap_inc_interval: 120_000,
+  ap_max:          6,
+};
+
+function mkChargeState(overrides) {
+  overrides = overrides || {};
+  var base = freshState('test@local');
+  var gv = Object.assign({}, base.game_values, CHARGE_BASE_GV, overrides.game_values || {});
+  return Object.assign({}, base, { nodes: [mkChargeNode()] }, overrides, { game_values: gv });
+}
+
+describe.skip('chargePerp — listener echo idempotence', () => {
+  beforeEach(() => setOverride(FIXED_NOW));
+
+  it('listener echo does not double-deduct cash_value', async () => {
+    const captured = [];
+    setSendDelta(d => captured.push(d));
+    setState(mkChargeState());
+
+    await chargePerp('tok', CHARGE_PATH);
+    const handlerState = getState();
+    const echoed = applyDelta(handlerState, captured[0]);
+
+    expect(echoed.game_values.cash_value).toBe(handlerState.game_values.cash_value);
+  });
+
+  it('listener echo does not double-add cash_spent', async () => {
+    const captured = [];
+    setSendDelta(d => captured.push(d));
+    setState(mkChargeState());
+
+    await chargePerp('tok', CHARGE_PATH);
+    const handlerState = getState();
+    const echoed = applyDelta(handlerState, captured[0]);
+
+    expect(echoed.game_values.cash_spent).toBe(handlerState.game_values.cash_spent);
+  });
+
+  it('listener echo does not double-decrement ap_snapshot', async () => {
+    const captured = [];
+    setSendDelta(d => captured.push(d));
+    setState(mkChargeState());
+
+    await chargePerp('tok', CHARGE_PATH);
+    const handlerState = getState();
+    const echoed = applyDelta(handlerState, captured[0]);
+
+    expect(echoed.game_values.ap_snapshot).toBe(handlerState.game_values.ap_snapshot);
+  });
+
+  it('listener echo does not double-add xp_value', async () => {
+    const captured = [];
+    setSendDelta(d => captured.push(d));
+    setState(mkChargeState());
+
+    await chargePerp('tok', CHARGE_PATH);
+    const handlerState = getState();
+    const echoed = applyDelta(handlerState, captured[0]);
+
+    expect(echoed.game_values.xp_value).toBe(handlerState.game_values.xp_value);
+  });
+
+  it('all economy fields stable across echo', async () => {
+    const captured = [];
+    setSendDelta(d => captured.push(d));
+    setState(mkChargeState());
+
+    await chargePerp('tok', CHARGE_PATH);
+    const handlerState = getState();
+    const echoed = applyDelta(handlerState, captured[0]);
+
+    expectEconomyUnchanged(echoed, handlerState);
+  });
+});
+
+// ── buyKarma ────────────────────────────────────────────────────────────────
+// Reducer applies Object.assign({}, state.game_values, delta.result.game_values).
+// Already echo-safe IF the delta carries the full snapshot. Regression guard.
+
+const KARMA_GESTALT = 'karma001';
+
+function mkKarmaState() {
+  var base = freshState('test@local');
+  return Object.assign({}, base, {
+    game_values: Object.assign({}, base.game_values, {
+      xp_value: 1, xp_level: 1, cash_value: 1000, cash_spent: 0,
+      karma_value: 50, profiles_value: 0, profiles_max: 1,
+      ap_snapshot: 6, ap_update: null
+    })
+  });
+}
+
+describe.skip('buyKarma — listener echo idempotence (regression guard)', () => {
+  it('listener echo does not double-deduct cash_value', async () => {
+    const captured = [];
+    setSendDelta(d => captured.push(d));
+    setState(mkKarmaState());
+
+    await buyKarma('tok', KARMA_GESTALT);
+    const handlerState = getState();
+    const echoed = applyDelta(handlerState, captured[0]);
+
+    expect(echoed.game_values.cash_value).toBe(handlerState.game_values.cash_value);
+    expect(echoed.game_values.cash_spent).toBe(handlerState.game_values.cash_spent);
+  });
+
+  it('listener echo does not double-add karma_value', async () => {
+    const captured = [];
+    setSendDelta(d => captured.push(d));
+    setState(mkKarmaState());
+
+    await buyKarma('tok', KARMA_GESTALT);
+    const handlerState = getState();
+    const echoed = applyDelta(handlerState, captured[0]);
+
+    expect(echoed.game_values.karma_value).toBe(handlerState.game_values.karma_value);
+  });
+
+  it('all economy fields stable across echo', async () => {
+    const captured = [];
+    setSendDelta(d => captured.push(d));
+    setState(mkKarmaState());
+
+    await buyKarma('tok', KARMA_GESTALT);
+    const handlerState = getState();
+    const echoed = applyDelta(handlerState, captured[0]);
+
+    expectEconomyUnchanged(echoed, handlerState);
+  });
+});
+
+// ── buyPerp ─────────────────────────────────────────────────────────────────
+// Reducer replaces game_values wholesale (r.game_values || state.game_values),
+// so game_values are echo-safe. NOTE: node_counter is incremented by 1 every
+// replay; this means an echo will double-bump node_counter. That is a separate
+// bug class (counter drift) — these tests focus on game_values + nodes/db_queue
+// length. node_counter behavior is intentionally NOT asserted here.
+
+function mkBuyPerpState(overrides) {
+  return Object.assign(freshState('buyer@local'), {
+    game_values: {
+      xp_value: 15, xp_level: 3,
+      cash_value: 10000, cash_spent: 0,
+      karma_value: 0, profiles_value: 0, profiles_max: 1,
+      ap_snapshot: 6, ap_update: null
+    }
+  }, overrides || {});
+}
+
+describe.skip('buyPerp — listener echo idempotence (regression guard)', () => {
+  it('listener echo does not double-deduct cash on a successful buy', async () => {
+    const captured = [];
+    setSendDelta(d => captured.push(d));
+    setState(mkBuyPerpState());
+
+    await buyPerp('tok', 'Imperium', 'contact001');
+    const handlerState = getState();
+    const echoed = applyDelta(handlerState, captured[0]);
+
+    expect(echoed.game_values.cash_value).toBe(handlerState.game_values.cash_value);
+    expect(echoed.game_values.cash_spent).toBe(handlerState.game_values.cash_spent);
+    expect(echoed.game_values.xp_value).toBe(handlerState.game_values.xp_value);
+  });
+
+  it('listener echo does not double-grow nodes array (de-dup by full_path)', async () => {
+    const captured = [];
+    setSendDelta(d => captured.push(d));
+    setState(mkBuyPerpState());
+
+    await buyPerp('tok', 'Imperium', 'contact001');
+    const handlerState = getState();
+    const echoed = applyDelta(handlerState, captured[0]);
+
+    expect(echoed.nodes.length).toBe(handlerState.nodes.length);
+  });
+
+  it('listener echo does not double-grow db_queue for contact gestalt', async () => {
+    const captured = [];
+    setSendDelta(d => captured.push(d));
+    setState(mkBuyPerpState());
+
+    await buyPerp('tok', 'Imperium', 'contact001');
+    const handlerState = getState();
+    const echoed = applyDelta(handlerState, captured[0]);
+
+    expect(echoed.db_queue.length).toBe(handlerState.db_queue.length);
+  });
+
+  it('all economy fields stable across echo', async () => {
+    const captured = [];
+    setSendDelta(d => captured.push(d));
+    setState(mkBuyPerpState());
+
+    await buyPerp('tok', 'Imperium', 'contact001');
+    const handlerState = getState();
+    const echoed = applyDelta(handlerState, captured[0]);
+
+    expectEconomyUnchanged(echoed, handlerState);
+  });
+});
+
+// ── collectPerp ─────────────────────────────────────────────────────────────
+// Reducer applies snapshot-style game_values merge. db_queue and
+// nodes_collect have explicit de-dup. Regression guard.
+
+const COLLECT_PATH    = 'Imperium.City.Agent0.contact001';
+const COLLECT_DUR     = 120_000;
+const COLLECT_END     = FIXED_NOW + COLLECT_DUR;
+
+function mkCollectGv(overrides) {
+  return Object.assign({
+    xp_value: 5, xp_level: 1,
+    karma_value: 50, cash_value: 300, cash_spent: 0,
+    profiles_value: 0, profiles_max: 1,
+    ap_snapshot: 6, ap_update: FIXED_NOW,
+    ap_inc_value: 1, ap_inc_interval: 120000, ap_max: 6
+  }, overrides || {});
+}
+
+function mkCollectNode(gameType, path) {
+  var parts   = path.split('.');
+  var gestalt = parts[parts.length - 1];
+  return {
+    game_id:       'node_' + gestalt,
+    game_type:     gameType,
+    full_type:     gameType + ':' + gestalt,
+    gestalt:       gestalt,
+    full_path:     path,
+    instance_data: {}
+  };
+}
+
+function mkChargingEntry(path, result, gameType) {
+  var parts   = path.split('.');
+  var gestalt = parts[parts.length - 1];
+  return {
+    path:         path,
+    result:       result,
+    charge_start: FIXED_NOW - COLLECT_DUR,
+    charge_end:   COLLECT_END,
+    game_id:      'node_' + gestalt,
+    game_type:    gameType
+  };
+}
+
+describe.skip('collectPerp — listener echo idempotence (regression guard)', () => {
+  beforeEach(() => setOverride(FIXED_NOW));
+
+  function setupCharged() {
+    var s = Object.assign(freshState('test@local'), {
+      game_values:    mkCollectGv(),
+      nodes:          [mkCollectNode('ContactPerp', COLLECT_PATH)],
+      nodes_charging: [mkChargingEntry(COLLECT_PATH, { amount: 5 }, 'ContactPerp')]
+    });
+    setState(s);
+    // Materialize so nodes_collect has the entry collectPerp expects.
+    setOverride(COLLECT_END + 1000);
+    var mat = materialize(getState(), COLLECT_END + 1000);
+    setState(mat.state);
+  }
+
+  it('listener echo does not double-add xp_value or profiles_value', async () => {
+    setupCharged();
+    const captured = [];
+    setSendDelta(d => captured.push(d));
+
+    await collectPerp('tok', COLLECT_PATH);
+    const handlerState = getState();
+    const echoed = applyDelta(handlerState, captured[0]);
+
+    expect(echoed.game_values.xp_value).toBe(handlerState.game_values.xp_value);
+    expect(echoed.game_values.profiles_value).toBe(handlerState.game_values.profiles_value);
+  });
+
+  it('listener echo does not double-grow db_queue', async () => {
+    setupCharged();
+    const captured = [];
+    setSendDelta(d => captured.push(d));
+
+    await collectPerp('tok', COLLECT_PATH);
+    const handlerState = getState();
+    const echoed = applyDelta(handlerState, captured[0]);
+
+    expect(echoed.db_queue.length).toBe(handlerState.db_queue.length);
+  });
+
+  it('listener echo does not double-shrink nodes_collect', async () => {
+    setupCharged();
+    const captured = [];
+    setSendDelta(d => captured.push(d));
+
+    await collectPerp('tok', COLLECT_PATH);
+    const handlerState = getState();
+    const echoed = applyDelta(handlerState, captured[0]);
+
+    expect(echoed.nodes_collect.length).toBe(handlerState.nodes_collect.length);
+  });
+
+  it('all economy fields stable across echo', async () => {
+    setupCharged();
+    const captured = [];
+    setSendDelta(d => captured.push(d));
+
+    await collectPerp('tok', COLLECT_PATH);
+    const handlerState = getState();
+    const echoed = applyDelta(handlerState, captured[0]);
+
+    expectEconomyUnchanged(echoed, handlerState);
+  });
+});
+
+// ── integrateCollected ──────────────────────────────────────────────────────
+// Reducer applies snapshot-style game_values merge. db_queue removal is by
+// collect_id filter (idempotent). Regression guard.
+
+describe.skip('integrateCollected — listener echo idempotence (regression guard)', () => {
+  beforeEach(() => setOverride(FIXED_NOW));
+
+  async function chargeCollectAndCapture() {
+    var s = Object.assign(freshState('test@local'), {
+      game_values:    mkCollectGv(),
+      nodes:          [mkCollectNode('ContactPerp', COLLECT_PATH)],
+      nodes_charging: [mkChargingEntry(COLLECT_PATH, { amount: 5 }, 'ContactPerp')]
+    });
+    setState(s);
+    setOverride(COLLECT_END + 1000);
+    var mat = materialize(getState(), COLLECT_END + 1000);
+    setState(mat.state);
+
+    const colRes = await collectPerp('tok', COLLECT_PATH);
+    return colRes.result.result.collect_id;
+  }
+
+  it('listener echo does not double-add profiles_value or xp_value', async () => {
+    const collectId = await chargeCollectAndCapture();
+    const captured = [];
+    setSendDelta(d => captured.push(d));
+
+    await integrateCollected('tok', collectId);
+    const handlerState = getState();
+    const echoed = applyDelta(handlerState, captured[0]);
+
+    expect(echoed.game_values.profiles_value).toBe(handlerState.game_values.profiles_value);
+    expect(echoed.game_values.xp_value).toBe(handlerState.game_values.xp_value);
+  });
+
+  it('listener echo does not re-add the entry to db_queue', async () => {
+    const collectId = await chargeCollectAndCapture();
+    const captured = [];
+    setSendDelta(d => captured.push(d));
+
+    await integrateCollected('tok', collectId);
+    const handlerState = getState();
+    const echoed = applyDelta(handlerState, captured[0]);
+
+    expect(echoed.db_queue.length).toBe(handlerState.db_queue.length);
+  });
+
+  it('listener echo does not double-grow nodes (TokenPerp first integration)', async () => {
+    const collectId = await chargeCollectAndCapture();
+    const captured = [];
+    setSendDelta(d => captured.push(d));
+
+    await integrateCollected('tok', collectId);
+    const handlerState = getState();
+    const echoed = applyDelta(handlerState, captured[0]);
+
+    expect(echoed.nodes.length).toBe(handlerState.nodes.length);
+  });
+
+  it('all economy fields stable across echo', async () => {
+    const collectId = await chargeCollectAndCapture();
+    const captured = [];
+    setSendDelta(d => captured.push(d));
+
+    await integrateCollected('tok', collectId);
+    const handlerState = getState();
+    const echoed = applyDelta(handlerState, captured[0]);
+
+    expectEconomyUnchanged(echoed, handlerState);
+  });
+});
+
+// ── buyPowerup / sellPowerup / buySlots fixtures ────────────────────────────
+// All three share _nodeGvReducer in scripts/state.js, which applies game_values
+// via Object.assign({}, state.game_values, res.game_values || {}). Echo-safe
+// IFF the delta carries a full snapshot. Regression guards.
+
+var PROJECT_NODE = {
+  game_id:       'proj001',
+  game_type:     'ProjectPerp',
+  full_path:     'Imperium.CityVienna.proj001',
+  full_type:     'ProjectPerp:project001',
+  gestalt:       'project001',
+  instance_data: { x: 100, y: 100, powerups: [] }
+};
+
+function mkProjectState(overrides) {
+  var base = freshState('test@local');
+  return Object.assign({}, base, { nodes: [PROJECT_NODE] }, overrides || {});
+}
+
+function mkStateWithPowerup() {
+  var nodeWithPu = Object.assign({}, PROJECT_NODE, {
+    instance_data: {
+      x: 100, y: 100,
+      powerups: [{ slot: 0, gestalt: 'ad002', full_type: 'AdPowerup:ad002' }],
+      charge_cost:    225,
+      collect_amount: 3760,
+      collect_risk:   2
+    }
+  });
+  return Object.assign({}, freshState('test@local'), { nodes: [nodeWithPu] });
+}
+
+// ── buyPowerup ──────────────────────────────────────────────────────────────
+
+describe.skip('buyPowerup — listener echo idempotence (regression guard)', () => {
+  it('listener echo does not double-deduct cash on powerup buy', async () => {
+    setState(mkProjectState());
+    const captured = [];
+    setSendDelta(d => captured.push(d));
+
+    await buyPowerup('tok', PROJECT_NODE.full_path, 0, 'ad002');
+    const handlerState = getState();
+    const echoed = applyDelta(handlerState, captured[0]);
+
+    expect(echoed.game_values.cash_value).toBe(handlerState.game_values.cash_value);
+    expect(echoed.game_values.cash_spent).toBe(handlerState.game_values.cash_spent);
+  });
+
+  it('listener echo does not double-add xp_value or karma_value', async () => {
+    setState(mkProjectState());
+    const captured = [];
+    setSendDelta(d => captured.push(d));
+
+    await buyPowerup('tok', PROJECT_NODE.full_path, 0, 'ad002');
+    const handlerState = getState();
+    const echoed = applyDelta(handlerState, captured[0]);
+
+    expect(echoed.game_values.xp_value).toBe(handlerState.game_values.xp_value);
+    expect(echoed.game_values.karma_value).toBe(handlerState.game_values.karma_value);
+  });
+
+  it('all economy fields stable across echo', async () => {
+    setState(mkProjectState());
+    const captured = [];
+    setSendDelta(d => captured.push(d));
+
+    await buyPowerup('tok', PROJECT_NODE.full_path, 0, 'ad002');
+    const handlerState = getState();
+    const echoed = applyDelta(handlerState, captured[0]);
+
+    expectEconomyUnchanged(echoed, handlerState);
+  });
+});
+
+// ── sellPowerup ─────────────────────────────────────────────────────────────
+
+describe.skip('sellPowerup — listener echo idempotence (regression guard)', () => {
+  it('listener echo does not double-refund cash on powerup sell', async () => {
+    setState(mkStateWithPowerup());
+    const captured = [];
+    setSendDelta(d => captured.push(d));
+
+    await sellPowerup('tok', PROJECT_NODE.full_path, 0, 'ad002');
+    const handlerState = getState();
+    const echoed = applyDelta(handlerState, captured[0]);
+
+    expect(echoed.game_values.cash_value).toBe(handlerState.game_values.cash_value);
+  });
+
+  it('listener echo does not double-add xp_value', async () => {
+    setState(mkStateWithPowerup());
+    const captured = [];
+    setSendDelta(d => captured.push(d));
+
+    await sellPowerup('tok', PROJECT_NODE.full_path, 0, 'ad002');
+    const handlerState = getState();
+    const echoed = applyDelta(handlerState, captured[0]);
+
+    expect(echoed.game_values.xp_value).toBe(handlerState.game_values.xp_value);
+  });
+
+  it('all economy fields stable across echo', async () => {
+    setState(mkStateWithPowerup());
+    const captured = [];
+    setSendDelta(d => captured.push(d));
+
+    await sellPowerup('tok', PROJECT_NODE.full_path, 0, 'ad002');
+    const handlerState = getState();
+    const echoed = applyDelta(handlerState, captured[0]);
+
+    expectEconomyUnchanged(echoed, handlerState);
+  });
+});
+
+// ── buySlots ────────────────────────────────────────────────────────────────
+
+describe.skip('buySlots — listener echo idempotence (regression guard)', () => {
+  it('listener echo does not double-deduct cash on slot purchase', async () => {
+    setState(mkProjectState());
+    const captured = [];
+    setSendDelta(d => captured.push(d));
+
+    await buySlots('tok', PROJECT_NODE.full_path, 'ad', 1);
+    const handlerState = getState();
+    const echoed = applyDelta(handlerState, captured[0]);
+
+    expect(echoed.game_values.cash_value).toBe(handlerState.game_values.cash_value);
+    expect(echoed.game_values.cash_spent).toBe(handlerState.game_values.cash_spent);
+  });
+
+  it('listener echo does not double-add xp_value', async () => {
+    setState(mkProjectState());
+    const captured = [];
+    setSendDelta(d => captured.push(d));
+
+    await buySlots('tok', PROJECT_NODE.full_path, 'ad', 1);
+    const handlerState = getState();
+    const echoed = applyDelta(handlerState, captured[0]);
+
+    expect(echoed.game_values.xp_value).toBe(handlerState.game_values.xp_value);
+  });
+
+  it('all economy fields stable across echo', async () => {
+    setState(mkProjectState());
+    const captured = [];
+    setSendDelta(d => captured.push(d));
+
+    await buySlots('tok', PROJECT_NODE.full_path, 'ad', 1);
+    const handlerState = getState();
+    const echoed = applyDelta(handlerState, captured[0]);
+
+    expectEconomyUnchanged(echoed, handlerState);
+  });
+});

--- a/tests/handlers/listener-echo.test.js
+++ b/tests/handlers/listener-echo.test.js
@@ -38,9 +38,9 @@
  *                         via Object.assign({}, state.game_values, res.game_values).
  *                         Echo-safe. Regression guard.
  *
- * Every describe is `describe(...)` so CI stays green. Once Phase 2 of
- * #120 lands the snapshot-based delta convention across all handlers, these
- * tests should be unskipped to lock in the invariant.
+ * Originally landed `describe.skip(...)` ahead of the architectural fix;
+ * unskipped in #120 Phase 2 once the snapshot-based delta convention was
+ * applied to every handler. Now the regression suite for the bug class.
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {

--- a/tests/state/state.test.js
+++ b/tests/state/state.test.js
@@ -321,3 +321,34 @@ describe('applyDelta — markTokenSeen reducer', () => {
   });
 
 });
+
+// ---------------------------------------------------------------------------
+// #117 — applyDelta silently drops deltas when state.addr is unset
+// ---------------------------------------------------------------------------
+
+describe.skip('applyDelta — addr guard does not silently drop deltas pre-boot (#117)', () => {
+  // Reproduces #117: when a non-empty history replays before state.addr
+  // is populated (e.g. boot ordering races where the listener fires before
+  // state.addr = webxdc.selfAddr is set), deltas can be silently dropped
+  // or misrouted by the addr filter at scripts/state.js:500-502.
+  //
+  // Skipped until #120's Phase 3 fix lands — the architectural fix should
+  // unconditionally seed state.addr from the first delta's addr (or set it
+  // before replay) so the guard never drops deltas during pre-boot replay.
+
+  it('a non-empty history replayed before state.addr is set still produces correct state', () => {
+    // Start with a state whose addr is empty (simulates pre-boot).
+    var s = freshState('');
+    expect(s.addr).toBe('');
+    var deltas = [
+      { kind: 'delta', addr: 'alice@local', op: 'markTokenSeen', args: ['token008'], ts: 1 },
+      { kind: 'delta', addr: 'alice@local', op: 'markTokenSeen', args: ['token001'], ts: 2 },
+    ];
+    var replayed = deltas.reduce(applyDelta, s);
+    // After the architectural fix, state.addr is unconditionally seeded from
+    // the first delta's addr (or set before replay), so the guard never
+    // drops deltas during pre-boot replay.
+    expect(replayed.addr).toBe('alice@local');
+    expect(replayed.tokens_seen).toEqual({ token008: true, token001: true });
+  });
+});

--- a/tests/state/state.test.js
+++ b/tests/state/state.test.js
@@ -327,14 +327,10 @@ describe('applyDelta — markTokenSeen reducer', () => {
 // ---------------------------------------------------------------------------
 
 describe('applyDelta — addr guard does not silently drop deltas pre-boot (#117)', () => {
-  // Reproduces #117: when a non-empty history replays before state.addr
-  // is populated (e.g. boot ordering races where the listener fires before
-  // state.addr = webxdc.selfAddr is set), deltas can be silently dropped
-  // or misrouted by the addr filter at scripts/state.js:500-502.
-  //
-  // Skipped until #120's Phase 3 fix lands — the architectural fix should
-  // unconditionally seed state.addr from the first delta's addr (or set it
-  // before replay) so the guard never drops deltas during pre-boot replay.
+  // Closed by #120's applyDelta auto-seed: when a non-empty history replays
+  // before state.addr is populated, the reducer now seeds state.addr from
+  // the first delta's addr so the addr filter never drops deltas during
+  // pre-boot replay.
 
   it('a non-empty history replayed before state.addr is set still produces correct state', () => {
     // Start with a state whose addr is empty (simulates pre-boot).

--- a/tests/state/state.test.js
+++ b/tests/state/state.test.js
@@ -326,7 +326,7 @@ describe('applyDelta — markTokenSeen reducer', () => {
 // #117 — applyDelta silently drops deltas when state.addr is unset
 // ---------------------------------------------------------------------------
 
-describe.skip('applyDelta — addr guard does not silently drop deltas pre-boot (#117)', () => {
+describe('applyDelta — addr guard does not silently drop deltas pre-boot (#117)', () => {
   // Reproduces #117: when a non-empty history replays before state.addr
   // is populated (e.g. boot ordering races where the listener fires before
   // state.addr = webxdc.selfAddr is set), deltas can be silently dropped


### PR DESCRIPTION
Closes #120. Closes #114, #115, #116, #117. Supersedes #119's tactical patch with the canonical fix.

## The rule

Handlers in `scripts/LocalEngine.js` compute deltas and call `_persistDelta`. They do **not** call `setState` directly. The `setUpdateListener` callback in `scripts/boot.js` is the sole `setState` site in production; in Node/tests, `_persistDelta`'s no-webxdc fallback emulates the listener echo synchronously through the same `applyDelta` path. Every state change goes through `applyDelta` exactly once, in one place.

## Phases (commit-by-commit)

- **Phase 1** (3 commits, `8e09e8d` `8197639` `df77763`) — failing tests, marked skipped so CI stays green:
  - #117 boot-ordering case in `tests/state/state.test.js`
  - #114 orphan-nodes_charging unit + Playwright case (`tests/handlers/collect-integrate.test.js` + `tests/e2e/collect-after-reload.spec.ts`)
  - listener-echo idempotence for every game_values-mutating handler (`tests/handlers/listener-echo.test.js` — 8 describe blocks, 29 cases)
- **Phase 2** (`c619fc0`) — every delta-emitting handler stops calling `setState`. Helpers `_emitDelta` / `_commitDelta` collapse into `_persistDelta` + `_mkDelta`. `chargePerp` delta carries a full `game_values` snapshot (canonical fix for #119). `buyPerp` delta carries `node_counter` for idempotent replay. `collectPerp` reducer also strips `nodes_charging` by path (closes #114). `applyDelta` auto-seeds `state.addr` from the first delta when empty (closes #117). All 31 Phase 1 tests unskipped and now pass.
- **Phase 3** (`5efb695`) — `scripts/boot.js` documents the architectural rule: `state.addr = freshState(selfAddr, ...)` runs BEFORE `setUpdateListener` registration, and the listener body is the sole production `setState` site.
- **Phase 4** (`5462f5e`) — drop the two optimistic `groot.raw_data.*` writes in `scripts/Game.js` (`popup_close` / `popup_token_seen`). The handler-emitted delta is the sole mutation site for both flows; the race window in #116 is gone.
- **Phase 5** (`c5f311c`) — `docs/replay-safety-audit.md` lands. One paragraph per handler, citing the test that pins each invariant.
- **Phase 6** (`53c5d0c`) — `tests/build/handler-state-mutation.test.js` is a static text scan that fails CI if any line in `scripts/LocalEngine.js` calls `setState(...)` outside a tiny audited allowlist (`_persistDelta` echo, `loadGame` materialiser seed, `_scheduleChargeReady` tick).

## Test plan

CI: **472 passed, 0 skipped** (439 baseline + 31 Phase 1 unskipped + 2 Phase 6 regression guard cases).

- [x] `pnpm test` — full vitest suite passes (12 test files).
- [x] Phase 1 listener-echo regression suite passes against Phase 2 reducers (catches the #119 bug class structurally).
- [x] Phase 1 #114 unit reproduction now passes.
- [x] Phase 1 #117 boot-ordering case now passes.
- [x] Phase 6 regression guard runs clean — no setState in handler bodies.
- [ ] **Reviewer ask**: manual #28 smoke pass on Delta Chat Desktop — full charge → collect → integrate loop, multi-device sync of mission briefings, dismiss-and-close race no longer drops deltas. Playwright `tests/e2e/collect-after-reload.spec.ts` exists but is `test.skip` pending CI Playwright wiring; unskip and run locally to spot-check the #114 reload flow end-to-end.

## Coordination notes

- **PR #119** (in flight) — its tactical chargePerp snapshot patch is subsumed by Phase 2 here. The reducer change in this PR keeps the incremental `cashDelta`/`xpInc` path as a fallback so already-persisted pre-fix deltas still replay correctly on cold start. Either order is mergeable.
- **`scripts/materializer.js`** untouched — read-time pure function, not part of the state-mutation problem.
- **Handler return-value shapes** unchanged. Only `chargePerp` and `buyPerp` deltas grow new snapshot fields (`game_values`, `node_counter`) inside `result`; existing fields kept for back-compat.
- **`async wrappers` in Remote.js** — kept as-is. They no longer introduce a race (handlers are synchronous, listener echoes synchronously). Rewriting ~30 `.done()` call sites to inline returns is a separate mechanical refactor outside #120's architectural scope; #116 acceptance ("AMD wrapper that wraps LocalEngine is sync") is satisfied.
- **Phase 6 leaderboard (#29)** is downstream — peer-aggregation work slots in naturally now that every delta runs through the same `applyDelta` reducer path.

https://claude.ai/code/session_0_phase6_120

---
_Generated by [Claude Code](https://claude.ai/code/session_01BjWeQ63bs2xq4Bf1QM8Byv)_