### PR TITLE
Follow-up to #121: await replay + drive loader progress bar

### DIFF
--- a/scripts/boot.js
+++ b/scripts/boot.js
@@ -4,7 +4,13 @@
 //   1. state = freshState(selfAddr) — selfAddr seeded BEFORE listener
 //      registration so applyDelta's addr guards never see an empty state.addr
 //      during boot replay (closes #117).
-//   2. webxdc.setUpdateListener(cb, 0)  — replays full update history.
+//   2. webxdc.setUpdateListener(cb, 0) — replays full update history.
+//      The webxdc spec returns a Promise that resolves once every update
+//      from `serial` up to the messenger's max_serial-at-registration has
+//      been delivered to `cb`. boot() awaits that promise so the engine
+//      is fully replayed before materializer / onReady fires; bootstrap.js
+//      can then swap the loader for the game UI without flickering through
+//      a partially-replayed state.
 //      The callback is the SOLE setState site in production: it routes both
 //      own-echoes (from sendUpdate) and remote peer deltas through the same
 //      applyDelta path. Handlers in scripts/LocalEngine.js never call
@@ -22,17 +28,30 @@
 import { freshState, applyDelta } from './state.js';
 
 var _currentState = null;
+var _bootPromise  = null;
+
+// Replay progress is updated on every listener callback during initial replay.
+// Polled by bootstrap.js to drive the <progress id="loader"> element. The
+// max_serial can grow if peers push new updates while we're catching up; the
+// listener promise still resolves when the messenger's snapshot-at-
+// registration max_serial is reached, so the bar may not visually fill — by
+// design, since the game can start while later peer updates land live.
+var _replayProgress = { serial: 0, max_serial: 0, done: false };
 
 /**
- * boot(options)
+ * boot(options) → Promise<LocalState>
+ *
+ * Idempotent: subsequent calls return the in-flight promise.
  *
  * options:
- *   selfAddr     — override webxdc.selfAddr (useful for simulator / tests)
- *   defaultGame  — override the default seed (object matching default_game.json shape)
- *   materializer — function(state) called once after replay quiesces (#11 hook)
- *   onReady      — function(state) called when the engine is ready
+ *   selfAddr          — override webxdc.selfAddr (useful for simulator / tests)
+ *   defaultGame       — override the default seed (object matching default_game.json shape)
+ *   materializer      — function(state) called once after replay quiesces (#11 hook)
+ *   onReady           — function(state) called when the engine is ready
+ *   onReplayProgress  — function(serial, max_serial) called per replayed update
  */
 export function boot(options) {
+  if (_bootPromise) return _bootPromise;
   options = options || {};
 
   var selfAddr = options.selfAddr != null
@@ -46,25 +65,56 @@ export function boot(options) {
   // the braces.
   _currentState = freshState(selfAddr, options.defaultGame);
 
-  // Replay full update history from serial 0.  Delta Chat core delivers all
-  // historical updates synchronously before returning, so the code below the
-  // setUpdateListener call runs after replay is complete.
-  // The listener body is the SOLE production setState site (issue #120).
-  webxdc.setUpdateListener(function (update) {  // eslint-disable-line no-undef
-    _currentState = applyDelta(_currentState, update.payload);
-  }, 0);
-
-  // Integration point for issue #11 (Thread N — materializer).
-  // The real materializer will advance time-based progress (charge timers,
-  // AP regen, etc.) against the replayed state.  For now this is a noop.
-  if (typeof options.materializer === 'function') {
-    options.materializer(_currentState);
+  var listenerPromise = null;
+  // eslint-disable-next-line no-undef
+  if (typeof webxdc !== 'undefined') {
+    // eslint-disable-next-line no-undef
+    listenerPromise = webxdc.setUpdateListener(function (update) {
+      _currentState = applyDelta(_currentState, update.payload);
+      var s = (typeof update.serial     === 'number') ? update.serial     : 0;
+      var m = (typeof update.max_serial === 'number') ? update.max_serial : s;
+      if (s > _replayProgress.serial)     _replayProgress.serial     = s;
+      if (m > _replayProgress.max_serial) _replayProgress.max_serial = m;
+      if (typeof options.onReplayProgress === 'function') {
+        try { options.onReplayProgress(_replayProgress.serial, _replayProgress.max_serial); }
+        catch (_) { /* never let the UI hook break replay */ }
+      }
+    }, 0);
   }
 
-  // Engine ready.
-  if (typeof options.onReady === 'function') {
-    options.onReady(_currentState);
-  }
+  // Promise.resolve handles three shapes uniformly:
+  //   - real webxdc returns a Promise → awaited
+  //   - dev shim (webxdc-shim.js) returns undefined → already resolved
+  //   - typeof webxdc === 'undefined' (node) → already resolved
+  _bootPromise = Promise.resolve(listenerPromise).then(function () {
+    _replayProgress.done = true;
+    if (typeof options.materializer === 'function') options.materializer(_currentState);
+    if (typeof options.onReady === 'function') options.onReady(_currentState);
+    return _currentState;
+  });
+  return _bootPromise;
+}
+
+/**
+ * getBootPromise() → Promise<LocalState> | null
+ * Returns the in-flight (or resolved) boot() promise, or null if boot()
+ * has not been invoked yet. Bootstrap.js polls this to gate UI hand-off.
+ */
+export function getBootPromise() {
+  return _bootPromise;
+}
+
+/**
+ * getReplayProgress() → { serial, max_serial, done }
+ * Snapshot of the current replay progress. `done` flips to true once the
+ * setUpdateListener promise resolves and materializer / onReady have run.
+ */
+export function getReplayProgress() {
+  return {
+    serial:     _replayProgress.serial,
+    max_serial: _replayProgress.max_serial,
+    done:       _replayProgress.done
+  };
 }
 
 /**

--- a/scripts/bootstrap.js
+++ b/scripts/bootstrap.js
@@ -1,19 +1,22 @@
-// Boots the app: render the loader view, preload templates, hand off
-// to app.start().  The original code routed through hash-based routie
-// routes (#load, #downtime) and ran a separate remote.getToken() up
-// front to detect a downed backend; in the webxdc port the local
-// engine is always available, so we go straight to app.start().
+// Boots the app: render the loader view, await engine replay, preload
+// templates, hand off to app.start().  The original code routed through
+// hash-based routie routes (#load, #downtime) and ran a separate
+// remote.getToken() up front to detect a downed backend; in the webxdc
+// port the local engine is always available, so we go straight to
+// app.start() once boot()'s setUpdateListener promise resolves.
 require([
   'require',
   'jquery',
   'i18n',
   'setup',
   'app',
+  'boot',
   'native-console',
   'tpl!../views/loader.html'
 ], function(require) {
 
-  var $ = require('jquery');
+  var $    = require('jquery');
+  var boot = require('boot');
 
   function showFatal(message, err) {
     console.error('Game start failed:', message, err);
@@ -28,17 +31,52 @@ require([
   var loaderView = require('tpl!../views/loader.html');
   $('#dd-control').html(loaderView());
 
-  var app = require('app').getApplication();
-  app.loadViews().then(function() {
-    console.info('Starting Game');
-    try {
-      app.start().fail(function() {
-        showFatal('app.start rejected', arguments.length ? arguments[0] : null);
-      });
-    } catch (err) {
-      showFatal('app.start threw', err);
+  // While the engine replays history, drive the loader's progress bar from
+  // boot.getReplayProgress(). max_serial can grow as live peer updates land
+  // mid-replay, so the bar may not visually fill — that's fine; the game
+  // still starts at the resolution of the listener promise.
+  var loaderEl = document.getElementById('loader');
+  var progressTimer = setInterval(function () {
+    var p = boot.getReplayProgress();
+    if (loaderEl) {
+      if (p.max_serial > 0) {
+        loaderEl.value = p.serial;
+        loaderEl.max   = p.max_serial;
+      }
     }
-  }, function(err) {
-    showFatal('app.loadViews rejected', err);
-  });
+    if (p.done) {
+      if (loaderEl && p.max_serial > 0) loaderEl.value = loaderEl.max;
+      clearInterval(progressTimer);
+    }
+  }, 100);
+
+  function continueStart() {
+    clearInterval(progressTimer);
+    var app = require('app').getApplication();
+    app.loadViews().then(function() {
+      console.info('Starting Game');
+      try {
+        app.start().fail(function() {
+          showFatal('app.start rejected', arguments.length ? arguments[0] : null);
+        });
+      } catch (err) {
+        showFatal('app.start threw', err);
+      }
+    }, function(err) {
+      showFatal('app.loadViews rejected', err);
+    });
+  }
+
+  // boot() was kicked off synchronously in esm-entry.js. If for some
+  // reason the AMD bridge resolves earlier (no webxdc), there's no
+  // promise to await — fall through to the start path immediately.
+  var bootPromise = boot.getBootPromise();
+  if (bootPromise && typeof bootPromise.then === 'function') {
+    bootPromise.then(continueStart, function (err) {
+      clearInterval(progressTimer);
+      showFatal('engine replay failed', err);
+    });
+  } else {
+    continueStart();
+  }
 });

--- a/scripts/esm-entry.js
+++ b/scripts/esm-entry.js
@@ -19,13 +19,15 @@ export { default as LocalEngine } from './LocalEngine.js';
 // any future AMD consumers can call require(['boot']).getState().
 export * as boot from './boot.js';
 
-// Bring the engine online before any AMD module can call into it.  Runs
-// synchronously: webxdc.js is loaded earlier in index.html so window.webxdc
-// is defined, and the messenger replays update history synchronously inside
-// setUpdateListener.  Without this, getState() returns null and the first
-// loadGame() call throws, taking app.start() with it and tripping the
-// `location.href = "/"` reload-on-failure handler in bootstrap.js — which
-// was producing the boot loop you were seeing.
+// Bring the engine online before any AMD module can call into it.
+// boot() returns a Promise that resolves once setUpdateListener has
+// replayed the full history. bootstrap.js fetches the promise via the
+// AMD bridge (require('boot').getBootPromise()) and gates app.start()
+// on its resolution so the UI never sees a partially-replayed state.
+// boot() itself runs the synchronous part (freshState + listener
+// registration) before returning, so getState() / sendUpdate() are safe
+// to call from AMD modules at any point — they just see fresh state
+// until replay catches up.
 if (typeof webxdc !== 'undefined') {
   boot();
 }


### PR DESCRIPTION
Follow-up to #121, stacked on its branch. Merge order: #121 → master, then this → master (or rebase on master once #121 lands).

## Why

Per the webxdc spec, `setUpdateListener` returns a Promise that resolves once every update from the registered serial up to the messenger's `max_serial`-at-registration has been delivered to the listener. Today `scripts/boot.js` ignores that promise — `materializer()` and `onReady()` fire immediately, so `app.start()` runs and `Game.loadGame()` reads a partially-replayed state. Not visibly broken on small histories, but a contract violation that grows worse as saves accumulate updates and on slower targets.

## What changes

- **`scripts/boot.js`** — `boot()` now returns a Promise. Idempotent under repeated calls. Tracks per-callback `(serial, max_serial)` on a tiny module-level snapshot and exposes `getReplayProgress()` / `getBootPromise()` for UI polling.
- **`scripts/bootstrap.js`** — requires the AMD-bridged `boot` module, polls `getReplayProgress()` every 100 ms to drive `<progress id="loader">`, and gates `app.start()` on `getBootPromise()` resolution.
- **`scripts/esm-entry.js`** — comment update only; the synchronous `boot()` invocation is unchanged so `getState()` is non-null from the moment AMD modules require `LocalEngine`.

## Edge cases handled

- **No webxdc** (Node/tests): `setUpdateListener` isn't called; `boot()`'s promise resolves immediately.
- **Dev shim** (`scripts/webxdc-shim.js`): returns `undefined` from `setUpdateListener`; `Promise.resolve(undefined)` resolves immediately.
- **Live peer updates mid-replay**: `max_serial` grows beyond the snapshot, so the bar may not visually fill before the listener promise resolves. **Acceptable per design** — the game still starts on time and later peer updates land via the same listener live.
- **Repeated `boot()` calls**: returns the in-flight promise, so esm-entry's invocation and any future explicit re-boot share the same outcome.

## Test plan

- [x] `pnpm test` — 472 passing (no behavioural change for unit tests; they never touch the boot promise path).
- [ ] **Reviewer ask**: manual smoke on Delta Chat Desktop with a save that has non-trivial history (e.g. a few thousand `setPerpCoordinates` deltas accumulated through play). Confirm loader progress bar animates and game UI does not flicker through partial state.
- [ ] Multi-device join: open the same `.xdc` on a second device with active peer chatter. Bar may stop short of full; game should still start.

https://claude.ai/code/session_120_followup_replay

---
_Generated by [Claude Code](https://claude.ai/code/session_01BjWeQ63bs2xq4Bf1QM8Byv)_