### PR TITLE
Follow-up to #121: assert AP bar tracks engine state + fix updateGameValues

### DIFF
--- a/docs/response-shapes.md
+++ b/docs/response-shapes.md
@@ -40,7 +40,10 @@ handler-map.md is fixed in this document.
   profiles_value?: number,
   cash_value?: number,
   ap_increment?: number,
-  ap_snapshot?: number,        // only read when levelup === true
+  ap_snapshot?: number,        // synced into the visible AP whenever it
+                               //   differs from the local ap_value (so the
+                               //   bar tracks engine state after every
+                               //   AP-consuming handler, not only on levelup)
   karma_value?: number,
   xp_value?: number
 }

--- a/scripts/Game.js
+++ b/scripts/Game.js
@@ -1873,13 +1873,18 @@ define(function(require) {
       if (gv.xp_value !== undefined) {
         groot.setXP(gv.xp_value,silent);
       }
-      // levelup
-      if (gv.ap_snapshot !== undefined && levelup === true) {
+      // ap_snapshot is the authoritative engine AP — sync the visible
+      // ap_value whenever it differs, not only on levelup. Without this,
+      // the statusbar AP bar shows stale text after every chargePerp /
+      // integrateCollected (handlers decrement ap_snapshot but Game.js
+      // never reapplied it pre-#120 follow-up).
+      if (gv.ap_snapshot !== undefined && gv.ap_snapshot !== groot.ap_value) {
         groot.setAP(gv.ap_snapshot,silent);
-        if (!silent) {
-          groot.getDatabase().checkNotifications();
-          groot.makeNotifications({levelup: groot.xp_level.number});
-        }
+      }
+      // levelup-only side effects.
+      if (gv.ap_snapshot !== undefined && levelup === true && !silent) {
+        groot.getDatabase().checkNotifications();
+        groot.makeNotifications({levelup: groot.xp_level.number});
       }
     };
 

--- a/tests/e2e/ap-bar.spec.ts
+++ b/tests/e2e/ap-bar.spec.ts
@@ -1,0 +1,94 @@
+/**
+ * AP (energy) bar visual update test.
+ *
+ * Asserts the statusbar's AP indicator visually decrements when a charge
+ * action consumes 1 AP — the same property #119 broke at the engine level
+ * (cash/AP drift between UI and state) and #120's architectural fix
+ * structurally rules out. This is a regression guard that the *visual*
+ * bar follows engine state across the listener-echo path.
+ *
+ * Strategy mirrors gameplay.spec.ts: drive the engine via RequireJS, then
+ * sync the in-page Game layer's statusbar via game.updateGameValues so
+ * the data-testid DOM nodes reflect the new values.
+ *
+ * Perp used: contact035 — price=0, charge_cost=60, charge_time=30s,
+ * game_type=ContactPerp.
+ */
+
+import { test, expect } from '@playwright/test';
+
+const GESTALT = 'contact035';
+const PATH    = `Imperium.${GESTALT}`;
+
+test('energy bar: charge action decrements visual AP value and bar width', async ({ page }) => {
+  await page.goto('/?devtools=1');
+  await expect(page.locator('[data-testid="game-container"]')).toBeVisible({
+    timeout: 50_000,
+  });
+  await expect(page.locator('[data-testid="dd-ap-counter"]')).toBeVisible();
+
+  // ── 1. Read initial AP from the engine (authoritative) ───────────────────
+  const initial = await page.evaluate(async () => {
+    const boot = await new Promise<any>((res, rej) =>
+      (window as any).require(['boot'], res, rej),
+    );
+    const gv = boot.getState().game_values;
+    return { ap: gv.ap_snapshot as number, ap_max: gv.ap_max as number };
+  });
+
+  // Fresh game starts with full AP per default_game.json (ap_snapshot=6).
+  expect(initial.ap).toBeGreaterThan(0);
+  expect(initial.ap_max).toBeGreaterThan(initial.ap - 1);
+
+  // ── 2. Capture the initial visual bar width as a reference ───────────────
+  // Read the inline style.width set by the statusbar template — that's
+  // the value driven by D.AP_barsize and animated by FXSimpleCue. Reading
+  // it as a string avoids races with the animation's interpolated frames.
+  const readBarWidth = async () =>
+    page.locator('[data-testid="dd-ap-bar"]').evaluate((el) =>
+      parseFloat((el as HTMLElement).style.width || '0'),
+    );
+  const initialBarWidth = await readBarWidth();
+  expect(initialBarWidth).toBeGreaterThan(0);
+
+  // ── 3. Buy + charge contact035 — chargePerp consumes exactly 1 AP ────────
+  const chargeResult = await page.evaluate(async (args) => {
+    const eng = await new Promise<any>((res, rej) =>
+      (window as any).require(['LocalEngine'], res, rej),
+    );
+    await eng.buyPerp('tok', 'Imperium', args.gestalt);
+    return eng.chargePerp('tok', args.path);
+  }, { gestalt: GESTALT, path: PATH });
+
+  expect(chargeResult.result).not.toHaveProperty('error');
+  const apAfter = chargeResult.result.game_values.ap_snapshot as number;
+  // Engine-level invariant: chargePerp deducts exactly one AP
+  // (or refills to ap_max on a level-up, which contact035 cannot trigger
+  // from a fresh game's xp_value=0).
+  expect(apAfter).toBe(initial.ap - 1);
+
+  // ── 4. Sync the in-page Game layer so the statusbar template re-renders ──
+  await page.evaluate((gv) => {
+    const appModule: any = (window as any).require('app');
+    const game: any =
+      appModule && appModule.getApplication && appModule.getApplication().game;
+    if (game) game.updateGameValues(gv);
+  }, chargeResult.result.game_values);
+
+  // ── 5. Assert the DOM reflects the new AP value ──────────────────────────
+  // The statusbar StatusText prints "<AP_val>/<AP_max>". After updateGameValues
+  // the FX animation completes in ~250ms, so use a short timeout.
+  const expectedText = `${apAfter}/${initial.ap_max}`;
+  await expect(page.locator('[data-testid="dd-ap-value"]')).toHaveText(expectedText, {
+    timeout: 2_000,
+  });
+
+  // ── 6. Assert the visual bar width also shrank ───────────────────────────
+  // The StatusGraph's `width:<%= D.AP_barsize %>px` is recomputed
+  // proportionally on every setAP — at ap_max-1 / ap_max the bar should be
+  // strictly narrower than at full AP. Use expect.poll so the FXSimpleCue
+  // animation (~250ms) is allowed to settle before the assertion.
+  await expect
+    .poll(readBarWidth, { timeout: 2_000 })
+    .toBeLessThan(initialBarWidth);
+});

--- a/views/statusbar.html
+++ b/views/statusbar.html
@@ -12,11 +12,11 @@
     <div class="StatusIconFX"><div class="StatusIcon cash"></div></div>
     <div class="StatusText" data-status-id="Profiles" data-testid="cash-value"><% print(_.toKSNum(D.cash_val)); %></div>
   </div>
-  <div class="StatusItem AP<% if (D.AP_active > 0.2) { print(' active'); } %>" data-status-id="AP">
+  <div class="StatusItem AP<% if (D.AP_active > 0.2) { print(' active'); } %>" data-status-id="AP" data-testid="dd-ap-counter">
     <div class="StatusBackground"></div>
-    <div class="StatusGraph" data-status-id="AP" style="width:<%= D.AP_barsize %>px;"></div>
+    <div class="StatusGraph" data-status-id="AP" data-testid="dd-ap-bar" style="width:<%= D.AP_barsize %>px;"></div>
     <div class="StatusIconFX"><div class="StatusIcon ap"></div></div>
-    <div class="StatusText" data-status-id="AP"><% print(Math.round(D.AP_val)) %>/<% print(Math.round(D.AP_max)) %></div>
+    <div class="StatusText" data-status-id="AP" data-testid="dd-ap-value"><% print(Math.round(D.AP_val)) %>/<% print(Math.round(D.AP_max)) %></div>
     <div class="StatusRemain" data-status-id="AP"></div>
   </div>
   <div class="StatusItem Karma<% if (D.karma_active > 0.2) { print(' active'); } %>" data-status-id="karma" data-testid="dd-karma-counter">


### PR DESCRIPTION
Stacked on #121. Adds an e2e regression test that the energy bar visually decrements when AP is consumed — and fixes a pre-existing bug the test surfaced.

## Why

Writing the test was meant to be a pure regression guard. Instead it failed against `master`+#121: after `chargePerp`, `dd-ap-value` still rendered `6/6`. Tracing it back: `GameRoot.updateGameValues` only synced `ap_value` from `gv.ap_snapshot` when `levelup === true`. The legacy contract (`response-shapes.md`) relied on a `gv.ap_increment` delta field that **no LocalEngine handler emits** in the webxdc port. So every non-levelup chargePerp / integrateCollected left `ap_value` stale, and the bar drifted from engine state until the next levelup.

Engine state was always correct (chargePerp's reducer decrements `ap_snapshot` correctly, and #120 closes the listener-echo double-deduct). The UI half was the gap.

## Changes

- **`scripts/Game.js`** — drop the `levelup === true` gate on the `ap_snapshot` sync. `setAP()` now fires whenever `gv.ap_snapshot` differs from `ap_value`. Level-up-only side effects (`checkNotifications`, `makeNotifications`) stay gated.
- **`views/statusbar.html`** — add `data-testid="dd-ap-counter"` / `dd-ap-value` / `dd-ap-bar` to the AP `StatusItem`, mirroring the existing cash/profile/karma testid convention.
- **`docs/response-shapes.md`** — update the `ap_snapshot` comment to reflect the new always-sync behaviour.
- **`tests/e2e/ap-bar.spec.ts`** (new) — drives a real `chargePerp` via the RequireJS bridge, syncs `game.updateGameValues`, asserts:
  1. `dd-ap-value` text drops from `N/M` to `N-1/M`.
  2. `dd-ap-bar` inline `style.width` shrinks (poll-based, rides the 250 ms `FXSimpleCue` animation).

## Test plan

- [x] `pnpm test` — 472 vitest passing.
- [x] `npx playwright test tests/e2e/ap-bar.spec.ts` — 1 new case green.
- [ ] **Reviewer ask**: manual smoke on Delta Chat Desktop — charge a perp, watch the AP bar visually drop by one tick. Pre-fix: bar stays full until next levelup; post-fix: bar tracks engine state in real time.

## Coordination

- Stacks on **#121** for the test scaffolding (`window.__dd.advanceNow`, the `boot` AMD bridge, the `dd-cash-counter`/`dd-profile-counter` testid convention this PR mirrors). The fix in `Game.js:updateGameValues` is independent of #121's architectural changes — landable on master alone if needed; it's stacked because #121 hasn't merged yet.
- Sibling to **#120** — closes the UI half of the engine/UI drift bug class. The engine fix in #121 plus this UI fix together make the energy bar a structurally correct mirror of `state.game_values.ap_snapshot`.
- Independent of **#122** (the loading-screen progress follow-up) — they touch disjoint files.

https://claude.ai/code/session_120_followup_ap_bar

---
_Generated by [Claude Code](https://claude.ai/code/session_01BjWeQ63bs2xq4Bf1QM8Byv)_