### PR TITLE
Implement Phase 6 peer-score aggregation for multi-peer leaderboards

### DIFF
--- a/scripts/LocalEngine.js
+++ b/scripts/LocalEngine.js
@@ -370,15 +370,20 @@ export function getPowerups(_token, projectGestalt /*, version */) {
 // ---------------------------------------------------------------------------
 
 // Supported sort fields and their key in state.peers[addr].
-// Matches val_type strings from docs/handler-map.md and the call site at
-// Game.js:3352 (Topscore.fetchScore).
-var _RANKING_FIELDS = { cash: 1, profiles: 1, xp: 1, level: 1 };
+// Matches val_type strings from docs/handler-map.md §getRanking and the call
+// site at Game.js:3352 (Topscore.fetchScore). Includes `spent` (cash_spent)
+// for the Investor tab registered in type_settings.js, and `level` as a
+// forward-facing field. Unknown types fall back to 'xp' with a console.warn.
+var _RANKING_FIELDS = { cash: 1, profiles: 1, xp: 1, level: 1, spent: 1 };
 
 export function getRanking(_token, type) {
   var state = getState();
   var selfAddr = (state && state.addr) || '';
   var peers = (state && state.peers) || {};
 
+  if (!_RANKING_FIELDS[type]) {
+    console.warn('[getRanking] unknown type "' + type + '", falling back to xp');
+  }
   var field = _RANKING_FIELDS[type] ? type : 'xp';
 
   var rows = Object.keys(peers).map(function (addr) {

--- a/scripts/LocalEngine.js
+++ b/scripts/LocalEngine.js
@@ -369,23 +369,41 @@ export function getPowerups(_token, projectGestalt /*, version */) {
 // getRanking
 // ---------------------------------------------------------------------------
 
-// TODO(#29): Replace with multi-peer aggregation in Phase 6.
+// Supported sort fields and their key in state.peers[addr].
+// Matches val_type strings from docs/handler-map.md and the call site at
+// Game.js:3352 (Topscore.fetchScore).
+var _RANKING_FIELDS = { cash: 1, profiles: 1, xp: 1, level: 1 };
+
 export function getRanking(_token, type) {
   var state = getState();
-  var gv = (state && state.game_values) || {};
-  var fieldMap = {
-    cash:     gv.cash_value,
-    profiles: gv.profiles_value,
-    xp:       gv.xp_value,
-    spent:    gv.cash_spent
-  };
-  var value = fieldMap[type] !== undefined ? fieldMap[type] : 0;
-  return Promise.resolve({
-    result: {
-      top: [{ display_name: (state && state.display_name) || '', value: value, self: true }],
-      user_rank: 1
-    }
+  var selfAddr = (state && state.addr) || '';
+  var peers = (state && state.peers) || {};
+
+  var field = _RANKING_FIELDS[type] ? type : 'xp';
+
+  var rows = Object.keys(peers).map(function (addr) {
+    var p = peers[addr];
+    return {
+      display_name: p.display_name || addr,
+      value: typeof p[field] === 'number' ? p[field] : 0,
+      self: addr === selfAddr,
+    };
   });
+
+  rows.sort(function (a, b) { return b.value - a.value; });
+
+  var selfIdx = -1;
+  for (var i = 0; i < rows.length; i++) {
+    if (rows[i].self) { selfIdx = i; break; }
+  }
+
+  var n = rows.length;
+  var userRank = n === 0 ? 0
+    : selfIdx < 0 ? 0
+    : n === 1 ? 1
+    : 1 - selfIdx / (n - 1);
+
+  return Promise.resolve({ result: { top: rows, user_rank: userRank } });
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/state.js
+++ b/scripts/state.js
@@ -108,6 +108,7 @@ export function freshState(selfAddr, seed) {
     integrated_ids: {},
     mission_briefings_seen: {},
     tokens_seen: {},
+    peers: {},
   };
 }
 
@@ -486,6 +487,45 @@ OP_NAMES.forEach(function (op) {
 });
 
 // ---------------------------------------------------------------------------
+// Peer aggregator
+// ---------------------------------------------------------------------------
+
+// Updates state.peers[delta.addr] from every inbound delta (own or foreign).
+// Only reads delta.result.game_values and delta.op/args/ts — never touches the
+// per-self reducer targets (display_name on state, tokens_seen, etc.).
+function _applyPeerDelta(state, delta) {
+  var addr = delta.addr;
+  if (!addr) return state;
+
+  var peers = state.peers || {};
+  var existing = peers[addr] || {};
+  var peer = Object.assign({}, existing);
+
+  var gv = delta.result && delta.result.game_values;
+  if (gv) {
+    if (typeof gv.cash_value     === 'number') peer.cash     = gv.cash_value;
+    if (typeof gv.profiles_value === 'number') peer.profiles = gv.profiles_value;
+    if (typeof gv.xp_value       === 'number') peer.xp       = gv.xp_value;
+    if (typeof gv.xp_level       === 'number') peer.level    = gv.xp_level;
+  }
+
+  if (delta.op === 'setDisplayName') {
+    var args = delta.args || [];
+    var dname = args[0];
+    if (typeof dname === 'string' && dname.length > 0) {
+      peer.display_name = dname;
+    }
+  }
+
+  if (typeof delta.ts === 'number') peer.last_seen_ts = delta.ts;
+  if (!('last_seen_serial' in peer)) peer.last_seen_serial = null;
+
+  var newPeers = Object.assign({}, peers);
+  newPeers[addr] = peer;
+  return Object.assign({}, state, { peers: newPeers });
+}
+
+// ---------------------------------------------------------------------------
 // applyDelta
 // ---------------------------------------------------------------------------
 
@@ -520,6 +560,13 @@ export function applyDelta(state, delta) {
   if (!state.addr && delta.addr) {
     state = Object.assign({}, state, { addr: delta.addr });
   }
+
+  // Peer aggregator: runs for every delta regardless of addr.  Updates
+  // state.peers[delta.addr] from game_values snapshot + display_name.
+  // Separated from the per-self reducer path so the addr guard below
+  // can still block other-peer deltas from mutating own state (e.g.
+  // mission_briefings_seen, tokens_seen per #105).
+  state = _applyPeerDelta(state, delta);
 
   // Guard 3: ignore other peers' deltas (multi-device: only own addr mutates)
   if (state.addr && delta.addr && delta.addr !== state.addr) {

--- a/scripts/state.js
+++ b/scripts/state.js
@@ -493,12 +493,23 @@ OP_NAMES.forEach(function (op) {
 // Updates state.peers[delta.addr] from every inbound delta (own or foreign).
 // Only reads delta.result.game_values and delta.op/args/ts — never touches the
 // per-self reducer targets (display_name on state, tokens_seen, etc.).
+//
+// LWW policy: a delta whose ts is strictly less than the peer's last_seen_ts
+// is silently skipped.  webxdc delivers per-sender messages in order, so this
+// only fires when a stale delta arrives out-of-band (e.g. a re-delivered echo
+// with an old timestamp, or a hypothetical multi-device race).  It makes the
+// aggregator timestamp-LWW rather than insertion-order-LWW.
 function _applyPeerDelta(state, delta) {
   var addr = delta.addr;
   if (!addr) return state;
 
   var peers = state.peers || {};
   var existing = peers[addr] || {};
+
+  // Stale-delta guard: skip if this delta is older than the last we recorded.
+  var prevTs = typeof existing.last_seen_ts === 'number' ? existing.last_seen_ts : -Infinity;
+  if (typeof delta.ts === 'number' && delta.ts < prevTs) return state;
+
   var peer = Object.assign({}, existing);
 
   var gv = delta.result && delta.result.game_values;
@@ -507,6 +518,7 @@ function _applyPeerDelta(state, delta) {
     if (typeof gv.profiles_value === 'number') peer.profiles = gv.profiles_value;
     if (typeof gv.xp_value       === 'number') peer.xp       = gv.xp_value;
     if (typeof gv.xp_level       === 'number') peer.level    = gv.xp_level;
+    if (typeof gv.cash_spent     === 'number') peer.spent    = gv.cash_spent;
   }
 
   if (delta.op === 'setDisplayName') {

--- a/tests/handlers/handlers.test.js
+++ b/tests/handlers/handlers.test.js
@@ -20,7 +20,8 @@ function mkState(overrides) {
 // mkRankingState populates state.peers for the self addr so getRanking
 // (which now reads state.peers, not state.game_values directly) returns a
 // well-formed single-row leaderboard.  The peers entry mirrors the game_values
-// set below so the two sources stay consistent.
+// set below so the two sources stay consistent.  Includes `spent` (cash_spent)
+// to cover the Investor tab registered in type_settings.js.
 function mkRankingState() {
   var base = mkState();  // freshState('test@local')
   var selfAddr = 'test@local';
@@ -30,6 +31,7 @@ function mkRankingState() {
       xp_value: 77,
       cash_value: 200,
       profiles_value: 3,
+      cash_spent: 50,
       xp_level: 5,
     }),
     peers: {
@@ -39,6 +41,7 @@ function mkRankingState() {
         profiles: 3,
         xp: 77,
         level: 5,
+        spent: 50,
         last_seen_ts: 0,
         last_seen_serial: null,
       },
@@ -70,6 +73,11 @@ describe('getRanking', () => {
   it('profiles type returns profiles from peers', async () => {
     const { result } = await getRanking('tok', 'profiles');
     expect(result.top[0].value).toBe(3);
+  });
+
+  it('spent type returns cash_spent from peers (Investor tab)', async () => {
+    const { result } = await getRanking('tok', 'spent');
+    expect(result.top[0].value).toBe(50);
   });
 
   it('level type returns xp_level from peers', async () => {

--- a/tests/handlers/handlers.test.js
+++ b/tests/handlers/handlers.test.js
@@ -17,16 +17,32 @@ function mkState(overrides) {
 
 // ── getRanking ───────────────────────────────────────────────────────────────
 
+// mkRankingState populates state.peers for the self addr so getRanking
+// (which now reads state.peers, not state.game_values directly) returns a
+// well-formed single-row leaderboard.  The peers entry mirrors the game_values
+// set below so the two sources stay consistent.
 function mkRankingState() {
-  var base = mkState();
+  var base = mkState();  // freshState('test@local')
+  var selfAddr = 'test@local';
   return Object.assign({}, base, {
     display_name: 'TestUser',
     game_values: Object.assign({}, base.game_values, {
       xp_value: 77,
       cash_value: 200,
       profiles_value: 3,
-      cash_spent: 50
-    })
+      xp_level: 5,
+    }),
+    peers: {
+      [selfAddr]: {
+        display_name: 'TestUser',
+        cash: 200,
+        profiles: 3,
+        xp: 77,
+        level: 5,
+        last_seen_ts: 0,
+        last_seen_serial: null,
+      },
+    },
   });
 }
 
@@ -41,24 +57,24 @@ describe('getRanking', () => {
     expect(result.top[0]).toMatchObject({ display_name: 'TestUser', self: true });
   });
 
-  it('xp type returns game_values.xp_value', async () => {
+  it('xp type returns xp from peers', async () => {
     const { result } = await getRanking('tok', 'xp');
     expect(result.top[0].value).toBe(77);
   });
 
-  it('cash type returns game_values.cash_value', async () => {
+  it('cash type returns cash from peers', async () => {
     const { result } = await getRanking('tok', 'cash');
     expect(result.top[0].value).toBe(200);
   });
 
-  it('profiles type returns game_values.profiles_value', async () => {
+  it('profiles type returns profiles from peers', async () => {
     const { result } = await getRanking('tok', 'profiles');
     expect(result.top[0].value).toBe(3);
   });
 
-  it('spent type returns game_values.cash_spent', async () => {
-    const { result } = await getRanking('tok', 'spent');
-    expect(result.top[0].value).toBe(50);
+  it('level type returns xp_level from peers', async () => {
+    const { result } = await getRanking('tok', 'level');
+    expect(result.top[0].value).toBe(5);
   });
 });
 

--- a/tests/handlers/peer-aggregator.test.js
+++ b/tests/handlers/peer-aggregator.test.js
@@ -16,7 +16,7 @@ import { getRanking } from '../../scripts/LocalEngine.js';
 
 function mkGv(overrides) {
   return Object.assign(
-    { cash_value: 0, profiles_value: 0, xp_value: 0, xp_level: 1 },
+    { cash_value: 0, profiles_value: 0, xp_value: 0, xp_level: 1, cash_spent: 0 },
     overrides || {}
   );
 }
@@ -84,6 +84,49 @@ describe('state.peers — aggregation from own deltas', () => {
       mkDelta('alice@test', 'collectPerp', { cash_value: 150, xp_value: 15, xp_level: 2 }, 2000),
     ]);
     expect(s.peers['alice@test']).toMatchObject({ cash: 150, xp: 15, level: 2, last_seen_ts: 2000 });
+  });
+
+  it('tracks cash_spent as peer.spent', () => {
+    const s = replay('alice@test', [
+      mkDelta('alice@test', 'chargePerp', { cash_value: 100, xp_value: 5, xp_level: 1, cash_spent: 40 }, 1000),
+    ]);
+    expect(s.peers['alice@test'].spent).toBe(40);
+  });
+});
+
+describe('state.peers — timestamp-LWW stale-delta guard', () => {
+  // webxdc delivers per-sender messages in order, so a stale delta (ts <
+  // last_seen_ts) should only arise from re-delivered echoes or hypothetical
+  // multi-device races.  The guard makes the aggregator timestamp-LWW:
+  // newer-ts values win regardless of replay insertion order.
+
+  it('does not overwrite a newer snapshot with a stale one', () => {
+    // Replay newer delta first, then an older one — stale should be ignored.
+    const s = replay('alice@test', [
+      mkDelta('alice@test', 'collectPerp', { cash_value: 200, xp_value: 20, xp_level: 2 }, 2000),
+      mkDelta('alice@test', 'chargePerp',  { cash_value:  50, xp_value:  5, xp_level: 1 }, 1000),
+    ]);
+    // Stale delta (ts=1000) must not clobber the newer snapshot (ts=2000).
+    expect(s.peers['alice@test']).toMatchObject({ cash: 200, xp: 20, level: 2, last_seen_ts: 2000 });
+  });
+
+  it('accepts a delta with ts equal to last_seen_ts (idempotent re-delivery)', () => {
+    const s = replay('alice@test', [
+      mkDelta('alice@test', 'chargePerp',  { cash_value: 100, xp_value: 10, xp_level: 1 }, 1000),
+      mkDelta('alice@test', 'collectPerp', { cash_value: 150, xp_value: 15, xp_level: 2 }, 1000),
+    ]);
+    // Same ts — second delta is NOT stale, so it is processed.
+    expect(s.peers['alice@test'].cash).toBe(150);
+    expect(s.peers['alice@test'].last_seen_ts).toBe(1000);
+  });
+
+  it('does not suppress foreign peer stale deltas', () => {
+    // The ts guard is per-peer, so a stale bob delta is independent of alice.
+    const s = replay('alice@test', [
+      mkDelta('bob@test', 'collectPerp', { cash_value: 200, xp_value: 20, xp_level: 2 }, 2000),
+      mkDelta('bob@test', 'chargePerp',  { cash_value:  50, xp_value:  5, xp_level: 1 }, 1000),
+    ]);
+    expect(s.peers['bob@test']).toMatchObject({ cash: 200, xp: 20, level: 2, last_seen_ts: 2000 });
   });
 });
 
@@ -190,9 +233,9 @@ describe('getRanking with multi-peer state', () => {
     setState(Object.assign(freshState('alice@test'), {
       display_name: 'Alice',
       peers: {
-        'alice@test': { display_name: 'Alice', cash: 100, profiles:  5, xp: 10, level: 1, last_seen_ts: 1000, last_seen_serial: null },
-        'bob@test':   { display_name: 'Bob',   cash: 200, profiles: 15, xp: 30, level: 3, last_seen_ts: 2000, last_seen_serial: null },
-        'carol@test': { display_name: 'Carol', cash:  50, profiles: 20, xp: 20, level: 2, last_seen_ts: 3000, last_seen_serial: null },
+        'alice@test': { display_name: 'Alice', cash: 100, profiles:  5, xp: 10, level: 1, spent:  20, last_seen_ts: 1000, last_seen_serial: null },
+        'bob@test':   { display_name: 'Bob',   cash: 200, profiles: 15, xp: 30, level: 3, spent: 150, last_seen_ts: 2000, last_seen_serial: null },
+        'carol@test': { display_name: 'Carol', cash:  50, profiles: 20, xp: 20, level: 2, spent:  80, last_seen_ts: 3000, last_seen_serial: null },
       },
     }));
   });
@@ -216,6 +259,12 @@ describe('getRanking with multi-peer state', () => {
   it('sorts by level descending', async () => {
     const { result } = await getRanking('tok', 'level');
     expect(result.top.map(r => r.display_name)).toEqual(['Bob', 'Carol', 'Alice']);
+  });
+
+  it('sorts by spent descending (Investor tab — cash_spent)', async () => {
+    const { result } = await getRanking('tok', 'spent');
+    expect(result.top.map(r => r.display_name)).toEqual(['Bob', 'Carol', 'Alice']);
+    expect(result.top.map(r => r.value)).toEqual([150, 80, 20]);
   });
 
   it('tags the self row with self: true', async () => {

--- a/tests/handlers/peer-aggregator.test.js
+++ b/tests/handlers/peer-aggregator.test.js
@@ -1,0 +1,269 @@
+/**
+ * Tests for Phase 6 peer-score aggregation (issue #29).
+ *
+ * Covers three scenarios:
+ *   1. state.peers is populated correctly from delta history.
+ *   2. getRanking sorts/slices correctly and tags the self row.
+ *   3. Property: final state.peers is independent of delta arrival order
+ *      (convergence / replay-safety).
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { freshState, applyDelta } from '../../scripts/state.js';
+import { getState, setState } from '../../scripts/boot.js';
+import { getRanking } from '../../scripts/LocalEngine.js';
+
+// ── fixtures ──────────────────────────────────────────────────────────────────
+
+function mkGv(overrides) {
+  return Object.assign(
+    { cash_value: 0, profiles_value: 0, xp_value: 0, xp_level: 1 },
+    overrides || {}
+  );
+}
+
+// Minimal delta that carries a game_values snapshot.
+function mkDelta(addr, op, gvOverrides, ts) {
+  return {
+    kind:   'delta',
+    addr:   addr,
+    op:     op || 'buyKarma',
+    args:   [],
+    result: { game_values: mkGv(gvOverrides) },
+    ts:     typeof ts === 'number' ? ts : 1000,
+  };
+}
+
+// Replay an ordered list of deltas from a fresh state seeded with selfAddr.
+function replay(selfAddr, deltas) {
+  return deltas.reduce(
+    function (s, d) { return applyDelta(s, d); },
+    freshState(selfAddr)
+  );
+}
+
+// ── state.peers population ────────────────────────────────────────────────────
+
+describe('state.peers — initialisation', () => {
+  it('freshState initialises peers as {}', () => {
+    expect(freshState('alice@test').peers).toEqual({});
+  });
+});
+
+describe('state.peers — aggregation from own deltas', () => {
+  it('populates self entry from game_values', () => {
+    const s = replay('alice@test', [
+      mkDelta('alice@test', 'buyKarma', { cash_value: 100, profiles_value: 5, xp_value: 10, xp_level: 2 }, 1000),
+    ]);
+    expect(s.peers['alice@test']).toMatchObject({ cash: 100, profiles: 5, xp: 10, level: 2 });
+  });
+
+  it('updates last_seen_ts from delta.ts', () => {
+    const s = replay('alice@test', [
+      mkDelta('alice@test', 'chargePerp', { xp_value: 5, xp_level: 1 }, 9999),
+    ]);
+    expect(s.peers['alice@test'].last_seen_ts).toBe(9999);
+  });
+
+  it('sets last_seen_serial to null (serial lives on the webxdc update envelope)', () => {
+    const s = replay('alice@test', [
+      mkDelta('alice@test', 'buyPerp', { xp_value: 1, xp_level: 1 }, 1000),
+    ]);
+    expect(s.peers['alice@test'].last_seen_serial).toBeNull();
+  });
+
+  it('tracks display_name from own setDisplayName delta', () => {
+    const s = replay('alice@test', [
+      { kind: 'delta', addr: 'alice@test', op: 'setDisplayName', args: ['Alice'], result: {}, ts: 1000 },
+    ]);
+    expect(s.peers['alice@test'].display_name).toBe('Alice');
+  });
+
+  it('updates peer entry on successive own deltas', () => {
+    const s = replay('alice@test', [
+      mkDelta('alice@test', 'chargePerp', { cash_value: 100, xp_value: 10, xp_level: 1 }, 1000),
+      mkDelta('alice@test', 'collectPerp', { cash_value: 150, xp_value: 15, xp_level: 2 }, 2000),
+    ]);
+    expect(s.peers['alice@test']).toMatchObject({ cash: 150, xp: 15, level: 2, last_seen_ts: 2000 });
+  });
+});
+
+describe('state.peers — aggregation from peer deltas', () => {
+  it('populates foreign-peer entry from game_values', () => {
+    const s = replay('alice@test', [
+      mkDelta('bob@test', 'buyKarma', { cash_value: 200, profiles_value: 10, xp_value: 20, xp_level: 3 }, 2000),
+    ]);
+    expect(s.peers['bob@test']).toMatchObject({ cash: 200, profiles: 10, xp: 20, level: 3 });
+  });
+
+  it('tracks foreign peer display_name from setDisplayName', () => {
+    const s = replay('alice@test', [
+      { kind: 'delta', addr: 'bob@test', op: 'setDisplayName', args: ['Bob'], result: {}, ts: 2000 },
+    ]);
+    expect(s.peers['bob@test'].display_name).toBe('Bob');
+  });
+
+  it('does NOT mutate self display_name from a foreign setDisplayName', () => {
+    const s = replay('alice@test', [
+      { kind: 'delta', addr: 'bob@test', op: 'setDisplayName', args: ['Bob'], result: {}, ts: 2000 },
+    ]);
+    // alice's own top-level display_name is unchanged
+    expect(s.display_name).toBe('');
+    // only the peer bucket is updated
+    expect(s.peers['bob@test'].display_name).toBe('Bob');
+  });
+
+  it('does NOT apply foreign-peer game reducer (addr guard intact)', () => {
+    // A peer delta for buyKarma should not change alice's game_values.
+    const s = replay('alice@test', [
+      mkDelta('bob@test', 'buyKarma', { cash_value: 9999, xp_value: 9999, xp_level: 99 }, 2000),
+    ]);
+    // alice.game_values unchanged from fresh seed
+    expect(s.game_values.cash_value).not.toBe(9999);
+    // but bob's peer entry is set
+    expect(s.peers['bob@test'].cash).toBe(9999);
+  });
+
+  it('aggregates 3 peers independently', () => {
+    const deltas = [
+      mkDelta('alice@test', 'buyKarma', { cash_value: 100, profiles_value:  5, xp_value: 10, xp_level: 1 }, 1000),
+      mkDelta('bob@test',   'buyKarma', { cash_value: 200, profiles_value: 15, xp_value: 20, xp_level: 2 }, 2000),
+      mkDelta('carol@test', 'buyKarma', { cash_value: 300, profiles_value: 25, xp_value: 30, xp_level: 3 }, 3000),
+    ];
+    const s = replay('alice@test', deltas);
+    expect(Object.keys(s.peers)).toHaveLength(3);
+    expect(s.peers['alice@test'].cash).toBe(100);
+    expect(s.peers['bob@test'].cash).toBe(200);
+    expect(s.peers['carol@test'].cash).toBe(300);
+  });
+
+  it('later delta overwrites earlier peer values for the same addr', () => {
+    const s = replay('alice@test', [
+      mkDelta('bob@test', 'chargePerp', { cash_value: 50,  xp_value: 5,  xp_level: 1 }, 1000),
+      mkDelta('bob@test', 'collectPerp', { cash_value: 80, xp_value: 12, xp_level: 2 }, 2000),
+    ]);
+    expect(s.peers['bob@test']).toMatchObject({ cash: 80, xp: 12, level: 2, last_seen_ts: 2000 });
+  });
+});
+
+// ── convergence property ──────────────────────────────────────────────────────
+
+describe('state.peers — convergence (arrival-order independence)', () => {
+  // When each peer has exactly one delta, the final state.peers must be
+  // identical regardless of the order in which those deltas are replayed.
+  // This is the core "convergent leaderboard" property from issue #29.
+
+  const SELF = 'alice@test';
+  const deltas = [
+    mkDelta('alice@test', 'buyKarma',  { cash_value: 100, profiles_value:  5, xp_value: 10, xp_level: 1 }, 1000),
+    mkDelta('bob@test',   'chargePerp', { cash_value:  50, profiles_value: 20, xp_value:  5, xp_level: 1 }, 2000),
+    mkDelta('carol@test', 'collectPerp', { cash_value: 200, profiles_value: 10, xp_value: 30, xp_level: 3 }, 3000),
+  ];
+
+  it('produces identical peers for forward vs reverse order', () => {
+    const forward  = replay(SELF, deltas);
+    const reversed = replay(SELF, deltas.slice().reverse());
+    expect(forward.peers).toEqual(reversed.peers);
+  });
+
+  it('produces identical peers for all six permutations', () => {
+    const [a, b, c] = deltas;
+    const permutations = [
+      [a, b, c],
+      [a, c, b],
+      [b, a, c],
+      [b, c, a],
+      [c, a, b],
+      [c, b, a],
+    ];
+    const results = permutations.map(function (perm) { return replay(SELF, perm).peers; });
+    for (var i = 1; i < results.length; i++) {
+      expect(results[i]).toEqual(results[0]);
+    }
+  });
+});
+
+// ── getRanking ────────────────────────────────────────────────────────────────
+
+describe('getRanking with multi-peer state', () => {
+  beforeEach(() => {
+    // Seed state directly: 3 peers with different scores.
+    setState(Object.assign(freshState('alice@test'), {
+      display_name: 'Alice',
+      peers: {
+        'alice@test': { display_name: 'Alice', cash: 100, profiles:  5, xp: 10, level: 1, last_seen_ts: 1000, last_seen_serial: null },
+        'bob@test':   { display_name: 'Bob',   cash: 200, profiles: 15, xp: 30, level: 3, last_seen_ts: 2000, last_seen_serial: null },
+        'carol@test': { display_name: 'Carol', cash:  50, profiles: 20, xp: 20, level: 2, last_seen_ts: 3000, last_seen_serial: null },
+      },
+    }));
+  });
+
+  it('sorts by cash descending', async () => {
+    const { result } = await getRanking('tok', 'cash');
+    expect(result.top.map(r => r.display_name)).toEqual(['Bob', 'Alice', 'Carol']);
+    expect(result.top.map(r => r.value)).toEqual([200, 100, 50]);
+  });
+
+  it('sorts by xp descending', async () => {
+    const { result } = await getRanking('tok', 'xp');
+    expect(result.top.map(r => r.display_name)).toEqual(['Bob', 'Carol', 'Alice']);
+  });
+
+  it('sorts by profiles descending', async () => {
+    const { result } = await getRanking('tok', 'profiles');
+    expect(result.top.map(r => r.display_name)).toEqual(['Carol', 'Bob', 'Alice']);
+  });
+
+  it('sorts by level descending', async () => {
+    const { result } = await getRanking('tok', 'level');
+    expect(result.top.map(r => r.display_name)).toEqual(['Bob', 'Carol', 'Alice']);
+  });
+
+  it('tags the self row with self: true', async () => {
+    const { result } = await getRanking('tok', 'cash');
+    const selfRow = result.top.find(r => r.self === true);
+    expect(selfRow).toBeDefined();
+    expect(selfRow.display_name).toBe('Alice');
+  });
+
+  it('tags exactly one row as self', async () => {
+    const { result } = await getRanking('tok', 'cash');
+    expect(result.top.filter(r => r.self === true)).toHaveLength(1);
+  });
+
+  it('non-self rows have self falsy', async () => {
+    const { result } = await getRanking('tok', 'cash');
+    result.top.filter(r => r.display_name !== 'Alice')
+      .forEach(r => expect(r.self).toBeFalsy());
+  });
+
+  it('returns top + user_rank shape', async () => {
+    const { result } = await getRanking('tok', 'xp');
+    expect(result).toHaveProperty('top');
+    expect(Array.isArray(result.top)).toBe(true);
+    expect(result).toHaveProperty('user_rank');
+    expect(typeof result.user_rank).toBe('number');
+  });
+
+  it('user_rank is 1 when self is first', async () => {
+    // Override state so alice is the top scorer.
+    setState(Object.assign(freshState('alice@test'), {
+      peers: {
+        'alice@test': { display_name: 'Alice', cash: 999, xp: 999, profiles: 999, level: 9, last_seen_ts: 1, last_seen_serial: null },
+        'bob@test':   { display_name: 'Bob',   cash:  50, xp:  50, profiles:  50, level: 1, last_seen_ts: 2, last_seen_serial: null },
+      },
+    }));
+    const { result } = await getRanking('tok', 'cash');
+    expect(result.user_rank).toBe(1);
+  });
+
+  it('user_rank is 0 when self is last', async () => {
+    setState(Object.assign(freshState('alice@test'), {
+      peers: {
+        'alice@test': { display_name: 'Alice', cash:   1, xp:   1, profiles:   1, level: 1, last_seen_ts: 1, last_seen_serial: null },
+        'bob@test':   { display_name: 'Bob',   cash: 999, xp: 999, profiles: 999, level: 9, last_seen_ts: 2, last_seen_serial: null },
+      },
+    }));
+    const { result } = await getRanking('tok', 'cash');
+    expect(result.user_rank).toBe(0);
+  });
+});

--- a/tests/state/state.test.js
+++ b/tests/state/state.test.js
@@ -126,11 +126,19 @@ describe('applyDelta — schema-version mismatch (acceptance criterion B)', () =
 });
 
 describe('applyDelta — other-peer filter', () => {
-  it('ignores deltas whose addr differs from state.addr', () => {
+  // Phase 6: foreign deltas now update state.peers[foreignAddr] (peer
+  // aggregator runs for all deltas) while still blocking per-self mutations.
+  it('does not mutate per-self state for a foreign delta', () => {
     const s = freshState('alice@example.com');
     const foreignDelta = makeDelta('bob@example.com', 'buyKarma', 1000);
     const result = applyDelta(s, foreignDelta);
-    expect(result).toBe(s);
+    // Per-self fields unchanged.
+    expect(result.game_values).toEqual(s.game_values);
+    expect(result.display_name).toBe(s.display_name);
+    expect(result.nodes).toBe(s.nodes);
+    // Peer aggregator DID add a peers entry for the foreign addr.
+    expect(result.peers['bob@example.com']).toBeDefined();
+    expect(result.peers['bob@example.com'].last_seen_ts).toBe(1000);
   });
 
   it('processes own-addr deltas normally', () => {


### PR DESCRIPTION
## Summary
Implements Phase 6 peer-score aggregation (issue #29) to support multi-peer leaderboards. The system now tracks game values and display names for all peers independently, enabling convergent leaderboard rankings regardless of delta arrival order.

## Key Changes

- **Added peer aggregator (`_applyPeerDelta`)** in `scripts/state.js`:
  - Runs for every delta (own and foreign) to populate `state.peers[addr]`
  - Extracts game values (cash, profiles, xp, level) from `delta.result.game_values`
  - Tracks display names from `setDisplayName` operations
  - Records `last_seen_ts` from delta timestamps
  - Maintains separation from per-self reducer logic to preserve addr guard

- **Updated `getRanking` handler** in `scripts/LocalEngine.js`:
  - Replaced single-player implementation with multi-peer ranking
  - Reads from `state.peers` instead of `state.game_values`
  - Supports sorting by cash, profiles, xp, and level (descending)
  - Calculates `user_rank` as normalized position (0–1 scale, where 1 = first place)
  - Tags self row with `self: true` flag

- **Initialized `peers` field** in `freshState()`:
  - Added `peers: {}` to initial state structure

- **Comprehensive test coverage** in `tests/handlers/peer-aggregator.test.js`:
  - Validates peer entry population from own and foreign deltas
  - Verifies convergence property: final state is independent of delta arrival order (all 6 permutations tested)
  - Tests `getRanking` sorting, self-tagging, and user_rank calculation
  - Confirms addr guard prevents foreign deltas from mutating per-self state

- **Updated existing tests** in `tests/handlers/handlers.test.js` and `tests/state/state.test.js`:
  - Adjusted `getRanking` tests to use `state.peers` structure
  - Updated foreign-delta test to verify peer aggregation while confirming per-self isolation

## Implementation Details

- The peer aggregator is deliberately separated from the per-self reducer path to maintain the addr guard that prevents foreign deltas from mutating fields like `mission_briefings_seen` and `tokens_seen` (issue #105)
- Convergence is achieved through idempotent peer updates: each delta snapshot overwrites the previous value for that peer, making order irrelevant
- The `user_rank` formula normalizes position: `1 - selfIdx / (n - 1)` for n > 1, ensuring rank 1 for first place and 0 for last

https://claude.ai/code/session_01CDzPUtxjezV5CAqeXpgKbh