### PR TITLE
Fix stuck buy_perp goals when items are owned before mission activation

### DIFF
--- a/scripts/LocalEngine.js
+++ b/scripts/LocalEngine.js
@@ -999,6 +999,21 @@ function _seedGoalRow(missionGestalt, g) {
   };
 }
 
+// Marks buy_perp goals complete when the player already owns the target node.
+// Returns the same array reference when nothing changed so callers can use
+// reference equality to detect whether any repairs were made.
+function _autoCompleteBuyPerpGoals(goals, nodes) {
+  var owned = {};
+  (nodes || []).forEach(function (n) { if (n.gestalt) owned[n.gestalt] = true; });
+  var changed = false;
+  var result = goals.map(function (g) {
+    if (g.workflow !== 'buy_perp' || g.complete || !owned[g.target]) return g;
+    changed = true;
+    return Object.assign({}, g, { complete: true, current_amount: g.amount || 1 });
+  });
+  return changed ? result : goals;
+}
+
 // Without this, fresh games (or saves activated by legacy code) have empty
 // mission_goals and progression handlers find nothing to advance.
 function _seedMissionGoals(state) {
@@ -1025,8 +1040,11 @@ function _seedMissionGoals(state) {
     });
   });
 
-  if (!added) return state;
-  return Object.assign({}, state, { mission_goals: newGoals });
+  // Repair stuck buy_perp goals for items the player already owns — covers
+  // both newly seeded goals and goals seeded before a prior session ended.
+  var repairedGoals = _autoCompleteBuyPerpGoals(newGoals, state.nodes);
+  if (!added && repairedGoals === newGoals) return state;
+  return Object.assign({}, state, { mission_goals: repairedGoals });
 }
 
 // current_amount math mirrors TokenPerp.setAmount → DBTokensAbsolute
@@ -1123,6 +1141,9 @@ function _completeMissionsIfReady(updatedGoals, activeMissions) {
         updatedGoals = updatedGoals.concat([_seedGoalRow(gestalt, g)]);
       });
     });
+    // Auto-complete buy_perp goals for items the player already owns so a
+    // mission that unlocks after the item was bought doesn't get stuck.
+    updatedGoals = _autoCompleteBuyPerpGoals(updatedGoals, getState().nodes);
   }
 
   var updatedMissions = activeMissions.filter(function (m) {

--- a/scripts/LocalEngine.js
+++ b/scripts/LocalEngine.js
@@ -999,7 +999,10 @@ function _seedGoalRow(missionGestalt, g) {
   };
 }
 
-// Marks buy_perp goals complete when the player already owns the target node.
+function _completeGoal(goal) {
+  return Object.assign({}, goal, { complete: true, current_amount: goal.amount || 1 });
+}
+
 // Returns the same array reference when nothing changed so callers can use
 // reference equality to detect whether any repairs were made.
 function _autoCompleteBuyPerpGoals(goals, nodes) {
@@ -1009,7 +1012,7 @@ function _autoCompleteBuyPerpGoals(goals, nodes) {
   var result = goals.map(function (g) {
     if (g.workflow !== 'buy_perp' || g.complete || !owned[g.target]) return g;
     changed = true;
-    return Object.assign({}, g, { complete: true, current_amount: g.amount || 1 });
+    return _completeGoal(g);
   });
   return changed ? result : goals;
 }
@@ -1212,7 +1215,7 @@ function _advanceChargePerpMissions(state, gestalt) {
     if (goal.target !== gestalt) return goal;
     if (activeMissions.indexOf(goal.mission) === -1) return goal;
     changed = true;
-    return Object.assign({}, goal, { complete: true, current_amount: goal.amount || 1 });
+    return _completeGoal(goal);
   });
 
   if (!changed) {
@@ -1236,7 +1239,7 @@ function _advanceBuyPowerupMissions(state, powerupGestalt) {
     if (goal.target !== powerupGestalt) return goal;
     if (activeMissions.indexOf(goal.mission) === -1) return goal;
     changed = true;
-    return Object.assign({}, goal, { complete: true, current_amount: goal.amount || 1 });
+    return _completeGoal(goal);
   });
 
   if (!changed) {
@@ -1260,7 +1263,7 @@ function _advanceUpgradeTokenMissions(state, tokenGestalt) {
     if (goal.target !== tokenGestalt) return goal;
     if (activeMissions.indexOf(goal.mission) === -1) return goal;
     changed = true;
-    return Object.assign({}, goal, { complete: true, current_amount: goal.amount || 1 });
+    return _completeGoal(goal);
   });
 
   if (!changed) {
@@ -1286,7 +1289,7 @@ function _advanceBuyPerpMissions(state, gestalt) {
   var updatedGoals = missionGoals.map(function (goal) {
     if (goal.workflow === 'buy_perp' && goal.target === gestalt && !goal.complete) {
       changed = true;
-      return Object.assign({}, goal, { complete: true, current_amount: goal.amount || 1 });
+      return _completeGoal(goal);
     }
     return goal;
   });

--- a/tests/handlers/handlers.test.js
+++ b/tests/handlers/handlers.test.js
@@ -1109,15 +1109,6 @@ describe('buyPerp — level-up refills ap_snapshot', () => {
 });
 
 // ── buyPerp — stuck mission repair ───────────────────────────────────────────
-//
-// Regression: if the player buys a contact before the mission that requires
-// that buy_perp goal becomes active, _seedGoalRow produces complete:false for
-// that goal.  Because buyPerp returns error 4 on a duplicate purchase, the
-// player is permanently stuck.
-//
-// Fix: _autoCompleteBuyPerpGoals scans buy_perp goals on loadGame (_seedMissionGoals)
-// and when completing a mission (_completeMissionsIfReady) to mark them done
-// when the target is already owned.
 
 const NURSE_NODE = {
   game_id:       'contact001',
@@ -1178,19 +1169,6 @@ describe('buyPerp — loadGame repairs stuck buy_perp goal', () => {
 });
 
 describe('buyPerp — mission activating after nurse already owned seeds goal as complete', () => {
-  // Set up: mission006 is active with 2 of 3 goals complete.  contact001 is
-  // already in nodes.  Buying the final mission006 powerup triggers
-  // _completeMissionsIfReady which activates mission007 and should immediately
-  // auto-complete its buy_perp goal because the nurse is already owned.
-  const PROJ_NODE = {
-    game_id:       'project001',
-    game_type:     'ProjectPerp',
-    full_type:     'ProjectPerp:project001',
-    gestalt:       'project001',
-    full_path:     'Imperium.project001',
-    instance_data: { powerups: [] }
-  };
-
   beforeEach(() => {
     setState(Object.assign(mkBuyPerpState(), {
       active_missions: ['mission006'],
@@ -1199,17 +1177,17 @@ describe('buyPerp — mission activating after nurse already owned seeds goal as
         { mission: 'mission006', workflow: 'buy_powerup', target: 'ad002',         amount: null, position: 2, current_amount: 1, complete: true  },
         { mission: 'mission006', workflow: 'buy_powerup', target: 'teammember020', amount: null, position: 3, current_amount: 0, complete: false }
       ],
-      nodes: mkBuyPerpState().nodes.concat([PROJ_NODE, NURSE_NODE])
+      nodes: mkBuyPerpState().nodes.concat([PROJECT_NODE, NURSE_NODE])
     }));
   });
 
   it('mission007 is added to active_missions after buying the final mission006 powerup', async () => {
-    await buyPowerup('tok', PROJ_NODE.full_path, 0, 'teammember020');
+    await buyPowerup('tok', PROJECT_NODE.full_path, 0, 'teammember020');
     expect(getState().active_missions).toContain('mission007');
   });
 
   it('mission007 buy_perp goal is complete because nurse is already owned', async () => {
-    await buyPowerup('tok', PROJ_NODE.full_path, 0, 'teammember020');
+    await buyPowerup('tok', PROJECT_NODE.full_path, 0, 'teammember020');
     const goal = getState().mission_goals.find(
       (g) => g.mission === 'mission007' && g.workflow === 'buy_perp'
     );

--- a/tests/handlers/handlers.test.js
+++ b/tests/handlers/handlers.test.js
@@ -1108,6 +1108,116 @@ describe('buyPerp — level-up refills ap_snapshot', () => {
   });
 });
 
+// ── buyPerp — stuck mission repair ───────────────────────────────────────────
+//
+// Regression: if the player buys a contact before the mission that requires
+// that buy_perp goal becomes active, _seedGoalRow produces complete:false for
+// that goal.  Because buyPerp returns error 4 on a duplicate purchase, the
+// player is permanently stuck.
+//
+// Fix: _autoCompleteBuyPerpGoals scans buy_perp goals on loadGame (_seedMissionGoals)
+// and when completing a mission (_completeMissionsIfReady) to mark them done
+// when the target is already owned.
+
+const NURSE_NODE = {
+  game_id:       'contact001',
+  game_type:     'ContactPerp',
+  full_type:     'ContactPerp:contact001',
+  gestalt:       'contact001',
+  full_path:     'Imperium.contact001',
+  instance_data: {}
+};
+
+describe('buyPerp — loadGame repairs stuck buy_perp goal', () => {
+  it('marks buy_perp goal complete when target node is already owned at load time', async () => {
+    setState(Object.assign(mkBuyPerpState(), {
+      active_missions: ['mission007'],
+      mission_goals: [{
+        mission:        'mission007',
+        workflow:       'buy_perp',
+        target:         'contact001',
+        amount:         null,
+        position:       1,
+        current_amount: 0,
+        complete:       false
+      }],
+      nodes: mkBuyPerpState().nodes.concat([NURSE_NODE])
+    }));
+
+    await loadGame('tok');
+
+    const goal = getState().mission_goals.find(
+      (g) => g.mission === 'mission007' && g.workflow === 'buy_perp'
+    );
+    expect(goal).toBeDefined();
+    expect(goal.complete).toBe(true);
+  });
+
+  it('does not alter buy_perp goals when the target is not yet owned', async () => {
+    setState(Object.assign(mkBuyPerpState(), {
+      active_missions: ['mission007'],
+      mission_goals: [{
+        mission:        'mission007',
+        workflow:       'buy_perp',
+        target:         'contact001',
+        amount:         null,
+        position:       1,
+        current_amount: 0,
+        complete:       false
+      }]
+    }));
+
+    await loadGame('tok');
+
+    const goal = getState().mission_goals.find(
+      (g) => g.mission === 'mission007' && g.workflow === 'buy_perp'
+    );
+    expect(goal).toBeDefined();
+    expect(goal.complete).toBe(false);
+  });
+});
+
+describe('buyPerp — mission activating after nurse already owned seeds goal as complete', () => {
+  // Set up: mission006 is active with 2 of 3 goals complete.  contact001 is
+  // already in nodes.  Buying the final mission006 powerup triggers
+  // _completeMissionsIfReady which activates mission007 and should immediately
+  // auto-complete its buy_perp goal because the nurse is already owned.
+  const PROJ_NODE = {
+    game_id:       'project001',
+    game_type:     'ProjectPerp',
+    full_type:     'ProjectPerp:project001',
+    gestalt:       'project001',
+    full_path:     'Imperium.project001',
+    instance_data: { powerups: [] }
+  };
+
+  beforeEach(() => {
+    setState(Object.assign(mkBuyPerpState(), {
+      active_missions: ['mission006'],
+      mission_goals: [
+        { mission: 'mission006', workflow: 'buy_powerup', target: 'upgrade001',    amount: null, position: 1, current_amount: 1, complete: true  },
+        { mission: 'mission006', workflow: 'buy_powerup', target: 'ad002',         amount: null, position: 2, current_amount: 1, complete: true  },
+        { mission: 'mission006', workflow: 'buy_powerup', target: 'teammember020', amount: null, position: 3, current_amount: 0, complete: false }
+      ],
+      nodes: mkBuyPerpState().nodes.concat([PROJ_NODE, NURSE_NODE])
+    }));
+  });
+
+  it('mission007 is added to active_missions after buying the final mission006 powerup', async () => {
+    await buyPowerup('tok', PROJ_NODE.full_path, 0, 'teammember020');
+    expect(getState().active_missions).toContain('mission007');
+  });
+
+  it('mission007 buy_perp goal is complete because nurse is already owned', async () => {
+    await buyPowerup('tok', PROJ_NODE.full_path, 0, 'teammember020');
+    const goal = getState().mission_goals.find(
+      (g) => g.mission === 'mission007' && g.workflow === 'buy_perp'
+    );
+    expect(goal).toBeDefined();
+    expect(goal.complete).toBe(true);
+  });
+});
+
 // ── setLocale ────────────────────────────────────────────────────────────────
 
 describe('setLocale', () => {


### PR DESCRIPTION
## Summary
Fixes a regression where players could become permanently stuck if they purchased a contact before the mission requiring that purchase became active. The fix automatically completes `buy_perp` goals when the target item is already owned by the player.

## Problem
When a player bought a contact before the mission that requires it became active, the goal seeding logic would create an incomplete `buy_perp` goal. Since the item was already owned, attempting to complete the goal would fail with error 4 (duplicate purchase), leaving the player stuck and unable to progress.

## Solution
Introduced `_autoCompleteBuyPerpGoals()` function that:
- Scans `buy_perp` goals and marks them complete when the target node is already in the player's inventory
- Is called in two critical places:
  1. **`_seedMissionGoals()`** - When loading a game, repairs any stuck goals from previous sessions
  2. **`_completeMissionsIfReady()`** - When a mission completes and activates new missions, auto-completes any `buy_perp` goals for items already owned

## Key Changes
- Added `_autoCompleteBuyPerpGoals()` helper function that efficiently checks node ownership and marks goals complete
- Updated `_seedMissionGoals()` to repair stuck goals on game load
- Updated `_completeMissionsIfReady()` to auto-complete goals when new missions are activated
- Added comprehensive test coverage for both load-time and mission-activation scenarios

https://claude.ai/code/session_019HUUrasRfZR2g5v2EhWpZ1