### PR TITLE
Reject negative deltas in clock.advance (#133)

### DIFF
--- a/scripts/clock.js
+++ b/scripts/clock.js
@@ -43,7 +43,14 @@ export function clearOverride() {
  *
  * Equivalent to setOverride(now() + deltaMs).  If no override is currently
  * active, the base is the real Date.now() at the moment advance() is called.
+ *
+ * The contract is forward-only: deltaMs must be >= 0.  Passing a negative
+ * value throws RangeError so test bugs surface immediately rather than
+ * silently producing impossible clock states.  (state.js separately guards
+ * stored progress against backwards skew via Math.max(clockNow(),
+ * last_seen_ts), but that does not justify rewinding the clock here.)
  */
 export function advance(deltaMs) {
+  if (deltaMs < 0) throw new RangeError('clock.advance: deltaMs must be >= 0');
   _override = now() + deltaMs;
 }

--- a/tests/clock/clock.test.js
+++ b/tests/clock/clock.test.js
@@ -69,6 +69,13 @@ describe('advance()', () => {
     advance(86_400_000);
     expect(now()).toBe(1_000_000_000 + 86_400_000);
   });
+
+  it('throws RangeError on a negative deltaMs (forward-only contract)', () => {
+    setOverride(1_000_000);
+    expect(() => advance(-1)).toThrow(RangeError);
+    // Clock must not have moved.
+    expect(now()).toBe(1_000_000);
+  });
 });
 
 // ── clock-skew guard (state.js integration) ──────────────────────────────────


### PR DESCRIPTION
`scripts/clock.js`'s `advance(deltaMs)` did `_override = now() + deltaMs`, so `advance(-1000)` rewound the clock. The reducer's `Math.max(clockNow(), last_seen_ts)` skew guard prevents persisted state from rewinding, but a negative advance can still set up impossible clock states in tests and violates the forward-only contract documented in the file header. `advance()` now throws `RangeError` on a negative `deltaMs` so test bugs surface immediately.

Addresses one item from #133 (does not close it).

A new test in `tests/clock/clock.test.js` covers `advance(-1)` throwing and verifies the clock did not move.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MW4HVhDRfT9MHpveZfPTpY)_