### PR TITLE
refactor(topscores): drop field-walk + collapse refreshFromPeers

### DIFF
--- a/scripts/Game.js
+++ b/scripts/Game.js
@@ -3300,28 +3300,9 @@ define(function(require) {
 
     Topscores.prototype.updateScores = function(){
       this.children.each(function(score){
-        score.fetchScore(score.scoretype,true);
-      });
-    };
-
-    // Invalidate the per-tab 30s fetch cache and re-fetch the visible tab.
-    // Hidden tabs are left to refetch on next viewtab_selected — they'd hit
-    // a stale fetchScore cache otherwise and silently no-op.
-    Topscores.prototype.refreshFromPeers = function(){
-      var anyForced = false;
-      this.children.each(function(score){
         score.lastFetch = null;
-        if (score.renderNode && !score.renderNode.hidden) {
-          score.fetchScore(score.scoretype, true);
-          anyForced = true;
-        }
+        score.fetchScore(score.scoretype, true);
       });
-      // If no tab is visible yet (initial load), refresh the first one so
-      // the user sees fresh data the first time they switch tabs anyway.
-      if (!anyForced) {
-        var first = this.children.set[0];
-        if (first) first.fetchScore(first.scoretype, true);
-      }
     };
 
     Topscores.prototype.extendEventHandlers = function() {
@@ -3353,12 +3334,11 @@ define(function(require) {
         score.fetchScore();
       });
 
-      // Live leaderboard refresh: refreshFromPeers fires on every remote or
-      // own peer-field change.  Topscores lives for the page lifetime, so the
-      // returned unsubscribe is intentionally dropped.
+      // Live leaderboard refresh on every state.peers ref change.
+      // Topscores lives for the page lifetime; the unsubscribe is dropped.
       if (bootMod && typeof bootMod.subscribePeersChanged === 'function') {
         bootMod.subscribePeersChanged(function () {
-          gnode.refreshFromPeers();
+          gnode.updateScores();
         });
       }
     };

--- a/scripts/boot.js
+++ b/scripts/boot.js
@@ -30,14 +30,10 @@ import { freshState, applyDelta } from './state.js';
 var _currentState = null;
 var _bootPromise  = null;
 
-// Subscribers to user-visible peer changes (display_name, cash, profiles,
-// xp, level, spent).  Used by the Topscores view to refresh without polling.
-// Per-delta book-keeping fields like last_seen_ts are deliberately excluded
-// so handlers that touch only the timestamp (setLocale, markTokenSeen, etc.)
-// don't trigger a leaderboard re-fetch.
+// Subscribers notified whenever applyDelta produces a new state.peers
+// reference.  Used by the Topscores view to refresh the leaderboard
+// without polling.  ESM-pure (no jQuery/event-bus dependency).
 var _peersChangedSubs = [];
-
-var _LEADERBOARD_FIELDS = ['display_name', 'cash', 'profiles', 'xp', 'level', 'spent'];
 
 // Replay progress is updated on every listener callback during initial replay.
 // Polled by bootstrap.js to drive the <progress id="loader"> element. The
@@ -81,7 +77,9 @@ export function boot(options) {
     listenerPromise = webxdc.setUpdateListener(function (update) {
       var prevPeers = _currentState && _currentState.peers;
       _currentState = applyDelta(_currentState, update.payload);
-      _maybeNotifyPeersChanged(prevPeers, _currentState && _currentState.peers);
+      if (_currentState && _currentState.peers !== prevPeers) {
+        _notifyPeersChanged();
+      }
       var s = (typeof update.serial     === 'number') ? update.serial     : 0;
       var m = (typeof update.max_serial === 'number') ? update.max_serial : s;
       if (s > _replayProgress.serial)     _replayProgress.serial     = s;
@@ -141,25 +139,26 @@ export function getState() {
  * Called by LocalEngine after materializer runs to persist the advanced state.
  * Also useful in tests to seed state before exercising handlers.
  *
- * Fires peers-changed subscribers when a user-visible peer field changed,
- * so handler-driven echoes (chargePerp, buyKarma, etc.) propagate to the
- * Topscores view via the same channel as remote peer deltas applied through
- * the listener.
+ * Fires peers-changed subscribers when newState.peers differs by reference
+ * from the previous state, so handler-driven echoes (chargePerp, buyKarma,
+ * etc.) propagate to the Topscores view via the same channel as remote
+ * peer deltas applied through the listener.
  */
 export function setState(newState) {
   var prevPeers = _currentState && _currentState.peers;
   _currentState = newState;
-  _maybeNotifyPeersChanged(prevPeers, newState && newState.peers);
+  if (newState && newState.peers !== prevPeers) {
+    _notifyPeersChanged();
+  }
 }
 
 /**
  * subscribePeersChanged(fn) → unsubscribe()
  *
- * Registers fn(state) to be invoked when a user-visible peer field changes
- * (display_name / cash / profiles / xp / level / spent).  Returns an
- * unsubscribe function.  Used by the legacy Topscores view (scripts/Game.js)
- * to refresh the leaderboard when remote peer deltas land or own deltas
- * mutate the self peer entry.
+ * Registers fn(state) to be invoked when state.peers reference changes.
+ * Returns an unsubscribe function.  The legacy Topscores view
+ * (scripts/Game.js) calls this to refresh the leaderboard when remote
+ * peer deltas land or own deltas mutate the self peer entry.
  */
 export function subscribePeersChanged(fn) {
   if (typeof fn !== 'function') return function noop() {};
@@ -170,34 +169,9 @@ export function subscribePeersChanged(fn) {
   };
 }
 
-// Fires _peersChangedSubs only when at least one peer's leaderboard fields
-// differ between prev and next.  Cheap object-identity short-circuits handle
-// the common no-op case (same .peers reference); the field walk runs only
-// when applyDelta produced a fresh peers object.
-function _maybeNotifyPeersChanged(prevPeers, nextPeers) {
-  if (prevPeers === nextPeers) return;
-  if (!_peersValueChanged(prevPeers, nextPeers)) return;
+function _notifyPeersChanged() {
   for (var i = 0; i < _peersChangedSubs.length; i++) {
     try { _peersChangedSubs[i](_currentState); }
     catch (_) { /* never let one subscriber break the listener */ }
   }
-}
-
-function _peersValueChanged(prev, next) {
-  var prevPeers = prev || {};
-  var nextPeers = next || {};
-  var nextKeys = Object.keys(nextPeers);
-  if (nextKeys.length !== Object.keys(prevPeers).length) return true;
-  for (var i = 0; i < nextKeys.length; i++) {
-    var k = nextKeys[i];
-    var p = prevPeers[k];
-    var n = nextPeers[k];
-    if (!p || !n) return true;
-    if (p === n) continue;
-    for (var f = 0; f < _LEADERBOARD_FIELDS.length; f++) {
-      var key = _LEADERBOARD_FIELDS[f];
-      if (p[key] !== n[key]) return true;
-    }
-  }
-  return false;
 }


### PR DESCRIPTION
## Summary

Follow-up to #128. The two patterns I added in that PR are heavier than the work they save. This PR strips them out and matches the simpler architecture suggested in review.

Net: 2 files, **+22 / −68 lines**, identical observable behaviour, all existing tests still pass.

## Changes

### `scripts/boot.js` — drop the field-walk

#128 added `_maybeNotifyPeersChanged` + `_peersValueChanged` + a `_LEADERBOARD_FIELDS` constant to walk every peer × every score field on every delta. Its only job was to suppress the notification when a delta touched only `last_seen_ts`.

The work that suppression saves is one in-process `getRanking` call (~1 ms) plus a 4-row template render — under any plausible delta rate, well within budget. Not worth ~30 lines of comparison code.

Replaced with a plain ref check + 4-line dispatcher:

```js
// listener + setState path:
if (newState.peers !== prevPeers) _notifyPeersChanged();

function _notifyPeersChanged() {
  for (var i = 0; i < _peersChangedSubs.length; i++) {
    try { _peersChangedSubs[i](_currentState); }
    catch (_) { /* never let one subscriber break the listener */ }
  }
}
```

### `scripts/Game.js` — collapse `refreshFromPeers` into `updateScores`

`refreshFromPeers` invalidated the per-tab 30s fetch cache and re-fetched only the visible tab. `updateScores` already exists, already invalidates and refetches with `force=true` — it just refetches every tab instead of only the visible one. Refetching all four tabs costs ~3 extra in-process `getRanking` calls per delta. Same budget argument.

Result: one `Topscores` refresh entry point instead of two; the subscriber wires straight to `updateScores()`.

## Tests

No test changes needed — all existing tests still cover the same surface:

- 512 unit tests passing (`pnpm test`)
- 2 topscores e2e tests passing — same fixture (two peers render with addr-keyed testids; a `state.peers` mutation refreshes the leaderboard without manual reload)
- `pnpm run build` clean

## Test plan

- [x] `pnpm test` — 512 passing
- [x] `npx playwright test tests/e2e/topscores.spec.ts` — 2 passing
- [x] `pnpm run build` — `data-dealer.xdc` produced
- [ ] Manual: smoke-test that the Topscores tab still tracks `state.peers` changes live in the running .xdc.

https://claude.ai/code/session_01CDzPUtxjezV5CAqeXpgKbh

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCMX2VeBSXp8yzh2apkkbR)_