### PR TITLE
Fix #130: foreign deltas can no longer seed state.addr

### DIFF
--- a/scripts/boot.js
+++ b/scripts/boot.js
@@ -68,10 +68,9 @@ export function boot(options) {
     : (typeof webxdc !== 'undefined' ? webxdc.selfAddr : '');  // eslint-disable-line no-undef
 
   // selfAddr MUST be set before the listener is registered.  applyDelta's
-  // addr filter relies on state.addr to route between own-echoes and peer
-  // deltas; an empty state.addr at boot would let pre-fix deltas mis-route.
-  // The auto-seed in applyDelta (state.js, closes #117) is a belt; this is
-  // the braces.
+  // addr guard rejects any delta whose addr differs from state.addr, including
+  // when state.addr is empty (closes #130); seeding it here ensures replayed
+  // own-echoes are never dropped.
   _currentState = freshState(selfAddr, options.defaultGame);
 
   var listenerPromise = null;

--- a/scripts/state.js
+++ b/scripts/state.js
@@ -564,15 +564,6 @@ export function applyDelta(state, delta) {
     return freshState(state.addr);
   }
 
-  // Guard 2b (closes #117): auto-seed state.addr from the first delta
-  // when state.addr is empty. This guarantees every reducer runs with
-  // state.addr set, even if boot replay starts before webxdc.selfAddr
-  // has propagated. Without this, the addr filter on subsequent peers
-  // can silently drop deltas during boot.
-  if (!state.addr && delta.addr) {
-    state = Object.assign({}, state, { addr: delta.addr });
-  }
-
   // Peer aggregator: runs for every delta regardless of addr.  Updates
   // state.peers[delta.addr] from game_values snapshot + display_name.
   // Separated from the per-self reducer path so the addr guard below
@@ -580,8 +571,10 @@ export function applyDelta(state, delta) {
   // mission_briefings_seen, tokens_seen per #105).
   state = _applyPeerDelta(state, delta);
 
-  // Guard 3: ignore other peers' deltas (multi-device: only own addr mutates)
-  if (state.addr && delta.addr && delta.addr !== state.addr) {
+  // Guard 3: ignore other peers' deltas (multi-device: only own addr mutates).
+  // Runs before any state.addr mutation; also fires when state.addr is empty
+  // so a foreign delta can never seed our identity (closes #130).
+  if (delta.addr && delta.addr !== state.addr) {
     return state;
   }
 

--- a/tests/state/state.test.js
+++ b/tests/state/state.test.js
@@ -148,6 +148,20 @@ describe('applyDelta — other-peer filter', () => {
     expect(result).not.toBe(s);
     expect(result.schema_version).toBe(SCHEMA_VERSION);
   });
+
+  // Regression test for #130: a foreign delta arriving before selfAddr is
+  // established must not seed state.addr and must be dropped from own state.
+  it('empty state.addr + foreign delta: state.addr stays empty, delta dropped', () => {
+    const s = freshState(); // state.addr === ''
+    const foreignDelta = makeDelta('bob@example.com', 'ping', 1000);
+    const result = applyDelta(s, foreignDelta);
+    expect(result.addr).toBe('');
+    // Per-self fields unchanged (delta was dropped from own state).
+    expect(result.game_values).toEqual(s.game_values);
+    expect(result.nodes).toBe(s.nodes);
+    // Peer aggregator still ran.
+    expect(result.peers['bob@example.com']).toBeDefined();
+  });
 });
 
 describe('applyDelta — malformed delta guard', () => {
@@ -331,28 +345,33 @@ describe('applyDelta — markTokenSeen reducer', () => {
 });
 
 // ---------------------------------------------------------------------------
-// #117 — applyDelta silently drops deltas when state.addr is unset
+// #117 / #130 — addr guard and pre-boot replay
 // ---------------------------------------------------------------------------
 
-describe('applyDelta — addr guard does not silently drop deltas pre-boot (#117)', () => {
-  // Closed by #120's applyDelta auto-seed: when a non-empty history replays
-  // before state.addr is populated, the reducer now seeds state.addr from
-  // the first delta's addr so the addr filter never drops deltas during
-  // pre-boot replay.
+describe('applyDelta — addr guard and pre-boot replay (#117 / #130)', () => {
+  // #117 is closed by boot.js seeding state.addr from webxdc.selfAddr BEFORE
+  // the listener is registered.  #130 removes the unsafe Guard 2b that seeded
+  // state.addr from the first inbound delta (which could be a peer delta).
 
-  it('a non-empty history replayed before state.addr is set still produces correct state', () => {
-    // Start with a state whose addr is empty (simulates pre-boot).
-    var s = freshState('');
-    expect(s.addr).toBe('');
+  it('replays own deltas correctly when selfAddr is set before replay starts', () => {
+    // The correct usage: always pass selfAddr to freshState (as boot.js does).
     var deltas = [
       { kind: 'delta', addr: 'alice@local', op: 'markTokenSeen', args: ['token008'], ts: 1 },
       { kind: 'delta', addr: 'alice@local', op: 'markTokenSeen', args: ['token001'], ts: 2 },
     ];
-    var replayed = deltas.reduce(applyDelta, s);
-    // After the architectural fix, state.addr is unconditionally seeded from
-    // the first delta's addr (or set before replay), so the guard never
-    // drops deltas during pre-boot replay.
+    var replayed = deltas.reduce(applyDelta, freshState('alice@local'));
     expect(replayed.addr).toBe('alice@local');
     expect(replayed.tokens_seen).toEqual({ token008: true, token001: true });
+  });
+
+  it('empty state.addr + own-addr delta is dropped (not seeded) — use boot.js pattern instead', () => {
+    // Without selfAddr set upfront, even own-addr deltas cannot be processed
+    // because state.addr is unknown.  This reinforces that boot.js MUST seed
+    // selfAddr before replay (closes #130: foreign deltas must not do it).
+    var s = freshState('');
+    var delta = { kind: 'delta', addr: 'alice@local', op: 'markTokenSeen', args: ['token008'], ts: 1 };
+    var result = applyDelta(s, delta);
+    expect(result.addr).toBe('');
+    expect(result.tokens_seen).toEqual({});
   });
 });


### PR DESCRIPTION
## Summary

- Removes Guard 2b from `applyDelta` (`scripts/state.js`): the block that seeded `state.addr` from an inbound delta's `addr` when `state.addr` was empty. On cold-start or schema reset, if the webxdc replay delivered a peer delta before the local identity was established, the peer's addr was silently captured as our own; all subsequent own-game deltas then failed the addr guard and were dropped.
- Strengthens Guard 3 to `if (delta.addr && delta.addr !== state.addr)`: now fires when `state.addr` is empty too, so a foreign delta can never seed our identity regardless of boot order.
- Updates the `#117` test block to document the correct boot.js-first pattern, and adds a regression test for the empty-addr + foreign-delta case (per acceptance criteria in #130).

## Test plan

- [x] `npx vitest run tests/state/state.test.js` — all 38 tests pass
- [x] New test: `empty state.addr + foreign delta: state.addr stays empty, delta dropped`
- [x] Updated test: `#117 / #130 — addr guard and pre-boot replay` section verifies correct replay when `selfAddr` is passed to `freshState` upfront (the `boot.js` pattern)

Closes #130

https://claude.ai/code/session_0126fD7gv1Uej5G7zbycjhwB

---
_Generated by [Claude Code](https://claude.ai/code/session_0126fD7gv1Uej5G7zbycjhwB)_