### PR TITLE
Fix karma clamping, schema reset timing, and floating-point comparisons

### DIFF
--- a/scripts/LocalEngine.js
+++ b/scripts/LocalEngine.js
@@ -1307,6 +1307,7 @@ function _advanceBuyPerpMissions(state, gestalt) {
   var changed = false;
   var updatedGoals = missionGoals.map(function (goal) {
     if (goal.workflow === 'buy_perp' && goal.target === gestalt && !goal.complete) {
+      if (activeMissions.indexOf(goal.mission) === -1) return goal;
       changed = true;
       return _completeGoal(goal);
     }
@@ -1838,8 +1839,8 @@ export function integrateCollected(collectId) {
   // collect_id replay → no share change). This preserves the absolute
   // count `profiles_value * share / 100`, so mission_goals' monotonic
   // current_amount keeps advancing. See docs/ui-meters.md.
-  var M = (state.game_values && state.game_values.profiles_value) || 0;
-  var N = increment;
+  var M = Math.max(0, (state.game_values && state.game_values.profiles_value) || 0);
+  var N = Math.max(0, increment);
   var denom = M + N;
   // denom === 0 only happens on a replay against an empty DB — every
   // share would round-trip to oldShare and no new tokens can be seeded
@@ -1854,7 +1855,7 @@ export function integrateCollected(collectId) {
     if (tok) seenGestalts[n.gestalt] = true;
     var psContrib = tok ? (tok.amount || 0) * N : 0;
     var newShare = Math.min(100, (oldShare * M + psContrib) / denom);
-    if (newShare === oldShare) return n;
+    if (Math.abs(newShare - oldShare) < 1e-9) return n;
     var updated = Object.assign({}, n, {
       instance_data: Object.assign({}, n.instance_data, { amount: newShare })
     });

--- a/scripts/LocalEngine.js
+++ b/scripts/LocalEngine.js
@@ -1307,6 +1307,8 @@ function _advanceBuyPerpMissions(state, gestalt) {
   var changed = false;
   var updatedGoals = missionGoals.map(function (goal) {
     if (goal.workflow === 'buy_perp' && goal.target === gestalt && !goal.complete) {
+      // !goal.complete is not sufficient: completing a goal for a mission already
+      // removed from activeMissions leaves mission_goals in an inconsistent state.
       if (activeMissions.indexOf(goal.mission) === -1) return goal;
       changed = true;
       return _completeGoal(goal);

--- a/scripts/state.js
+++ b/scripts/state.js
@@ -562,8 +562,12 @@ export function applyDelta(state, delta) {
     return state;
   }
 
-  // Guard 2: schema version mismatch — reset rather than crash
-  if (state.schema_version !== SCHEMA_VERSION) {
+  // Guard 2: schema version mismatch — reset rather than crash.
+  // Deferred when state.addr is empty: addr has not been seeded yet, so
+  // resetting now would produce a fresh state that also has addr='' which
+  // Guard 3 then uses to block all subsequent own-addr deltas.  The reset
+  // fires on the first delta after boot() seeds the real addr.
+  if (state.addr && state.schema_version !== SCHEMA_VERSION) {
     return freshState(state.addr);
   }
 

--- a/tests/handlers/handlers.test.js
+++ b/tests/handlers/handlers.test.js
@@ -346,6 +346,19 @@ describe('buyKarma — happy path', () => {
     const { result } = await buyKarma(KARMA_GESTALT);
     expect(result.game_values.karma_value).toBe(100);
   });
+
+  it('clamps karma_value at -100 when already below the floor', async () => {
+    setState(mkState({
+      game_values: {
+        xp_value: 1, xp_level: 1, cash_value: 9999, cash_spent: 0,
+        karma_value: -106, profiles_value: 0, profiles_max: 1,
+        ap_snapshot: 6, ap_update: null
+      }
+    }));
+    // karma001 karma_points=5; -106+5=-101 → clamped to -100
+    const { result } = await buyKarma(KARMA_GESTALT);
+    expect(result.game_values.karma_value).toBe(-100);
+  });
 });
 
 describe('buyKarma — failure: insufficient cash', () => {


### PR DESCRIPTION
This PR addresses three separate bugs in game state management and mission progression:

**Summary**
Fixes edge cases in karma value clamping, schema version reset timing, and floating-point arithmetic in profile share calculations.

**Key Changes**

- **Karma clamping test**: Added test case to verify that karma values are properly clamped at the -100 floor when already below it (e.g., -106 + 5 = -101 → clamped to -100)

- **Schema reset timing**: Modified `applyDelta()` to defer schema version mismatch resets until after `state.addr` is seeded. This prevents creating a fresh state with an empty address during boot, which would then block all subsequent own-address deltas. The reset now fires on the first delta after `boot()` seeds the real address.

- **Mission goal completion guard**: Added a check in `_advanceBuyPerpMissions()` to prevent completing buy_perp goals for gestalts that are not in the active missions list, avoiding unintended goal progression.

- **Floating-point precision**: Fixed two issues in `integrateCollected()`:
  - Added `Math.max(0, ...)` guards on `profiles_value` and `increment` to ensure non-negative values in share calculations
  - Changed exact equality check (`newShare === oldShare`) to epsilon comparison (`Math.abs(newShare - oldShare) < 1e-9`) to handle floating-point rounding errors

**Implementation Details**

The schema reset deferral uses the presence of `state.addr` as a signal that the application has completed its boot sequence. This ensures the state machine reaches a consistent state before applying schema migrations.

The floating-point fix in share calculations prevents spurious token updates caused by accumulated rounding errors in the profile contribution formula.

https://claude.ai/code/session_017j4vaAA3crTLE2Bo4Mieqa