### PR TITLE
Fix: Show 'no energy' error instead of 'no money' when feeding perps fails due to insufficient AP

### DIFF
--- a/scripts/Game.js
+++ b/scripts/Game.js
@@ -4175,11 +4175,19 @@ var Game = function() {
         app.remote.chargePerp(gnode.path).done(function(data) {
           if (data.result) {
             if (data.result.error) {
-              // No cash
-              if (gnode.renderPopup && gnode.renderPopup.open) {
-                gnode.renderPopup.trigger('no_cash');
+              // Error 1 = no AP (energy), Error 3 = no cash
+              if (data.result.error === 1) {
+                if (gnode.renderPopup && gnode.renderPopup.open) {
+                  gnode.renderPopup.trigger('no_AP');
+                } else {
+                  gnode.renderNode.FXNoAP();
+                }
               } else {
-                gnode.renderNode.FXNoCash();
+                if (gnode.renderPopup && gnode.renderPopup.open) {
+                  gnode.renderPopup.trigger('no_cash');
+                } else {
+                  gnode.renderNode.FXNoCash();
+                }
               }
               return;
             }


### PR DESCRIPTION
## Summary

When attempting to feed (charge) a perp and failing due to insufficient action points (AP/energy), the UI was incorrectly displaying the "no money" error instead of the "no energy" error.

## Changes

Modified `Game.js` chargePerp error handling to check the error code returned by the backend:
- Error code 1 = insufficient AP (energy) → displays `no_AP` error message
- Error code 3 = insufficient cash (money) → displays `no_cash` error message

Previously, all error codes were treated as "no cash" errors.

## Testing

The fix has been validated against existing test coverage in `tests/handlers/chargePerp.test.js` which confirms:
- Error 1 is returned when `ap_snapshot < 1`
- Error 3 is returned when `cash_value < charge_cost`

https://claude.ai/code/session_01WFg2MVcD9ZPPMab4dDayAk

---
_Generated by [Claude Code](https://claude.ai/code/session_01WFg2MVcD9ZPPMab4dDayAk)_