### PR TITLE
Fix stuck clock: bridge engine node_ready events to gnodes

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -85,6 +85,23 @@ const Application = function() {
       $(document).trigger(ev, [pl]);
     });
 
+    // Bridge document-level engine events into the in-game event bus the
+    // way the legacy socket.on("node_ready" / "new_items") handlers did
+    // before #142 retired the transport plumbing. Without this,
+    // _scheduleChargeReady's setTimeout publishes node_ready to document
+    // but no per-perp gnode listener (which lives on gnode.jq = $(this),
+    // not on document) ever fires — the timer decorator stays put and
+    // the collect icon never appears.
+    $(document).on('node_ready', function(e, pl) {
+      if (!app.game || !pl || !pl.id) return;
+      const gnode = app.game.getById(pl.id);
+      if (gnode) gnode.trigger('node_ready', [pl.result]);
+    });
+    $(document).on('new_items', function(e, pl) {
+      if (!app.game) return;
+      app.game.trigger('new_items', [pl]);
+    });
+
     $('#loadertext').text('Loading saved game');
     return app.remote.getSessionLocale().then(function(data) {
       const locale = data.result === 'de' ? 'de_AT' : 'en_US';

--- a/tests/e2e/collect-icon-after-charge.spec.ts
+++ b/tests/e2e/collect-icon-after-charge.spec.ts
@@ -1,0 +1,133 @@
+/**
+ * Regression test for the "stuck clock" / missing collect icon bug.
+ *
+ * Symptom (from user report)
+ * --------------------------
+ * After a perp finishes charging, the timer reaches zero and the clock
+ * sprite continues to pulsate — the collect icon (DecoratorReady,
+ * data-testid="dd-collect-ready") never appears, so the player cannot
+ * collect.
+ *
+ * Root cause
+ * ----------
+ * LocalEngine fires `node_ready` via the emitter wired up in scripts/app.js:
+ *
+ *   LocalEngine.setEmitter(function(ev, pl) {
+ *     $(document).trigger(ev, [pl]);
+ *   });
+ *
+ * In the legacy server-coupled build, scripts/app.js carried a
+ * `socket.on("node_ready", …)` handler that re-fired the event onto the
+ * matching GameNode:
+ *
+ *   app.game.getById(data.id).trigger('node_ready', [data.result]);
+ *
+ * That socket bridge was deleted in #142 (Retire dead transport / RPC
+ * plumbing) but no equivalent document-level listener replaced it.  The
+ * per-perp `gnode.on('node_ready', …)` handlers in Game.js
+ * (ContactPerp / ClientPerp / ProjectPerp / TokenPerp) listen on
+ * `gnode.jq = $(this)` — a separate jQuery target from `document` — so
+ * the event the engine emits never reaches `markReady()`.  The timer
+ * decorator stays put, FXSnooze fires once when the local clock crosses
+ * `endTime`, and no DecoratorReady is added.
+ *
+ * Test strategy
+ * -------------
+ * 1. Buy + charge contact035 through the engine (no canvas clicks).
+ * 2. Reload — Game.js replays the in-progress charge from state and
+ *    materialises the DecoratorTimer + chargeRunning state, putting the
+ *    UI in exactly the spot the user reports stuck.
+ * 3. Fire the same `$(document).trigger('node_ready', …)` call that
+ *    `_scheduleChargeReady`'s setTimeout would emit at `charge_end`.
+ *    This skips the 30 s wall-clock wait baked into the ruleset's
+ *    `charge_time` while still exercising the document → gnode bridge
+ *    that was missing.
+ * 4. Assert the DecoratorReady DOM marker (`data-testid="dd-collect-ready"`)
+ *    appears, and that the gnode's `chargeRunning` state has flipped to
+ *    false.  Both fail before the fix, both pass after.
+ */
+
+import { test, expect } from '@playwright/test';
+
+const GESTALT = 'contact035';
+const PATH = `Imperium.${GESTALT}`;
+
+async function waitForGameReady(page: import('@playwright/test').Page) {
+  await expect(page.locator('[data-testid="game-container"]')).toBeVisible({
+    timeout: 50_000,
+  });
+}
+
+test('collect-icon: DecoratorReady appears after node_ready emit (no stuck clock)', async ({ page }) => {
+  await page.goto('/?devtools=1');
+  await waitForGameReady(page);
+
+  // ── 1. Buy + charge contact035 through the engine. ────────────────────
+  // Game.js was instantiated against a state where contact035 didn't
+  // exist yet, so we reload below to let it pick up the in-progress
+  // charge and render the timer.
+  await page.evaluate(async (gestalt) => {
+    const eng = await new Promise<any>((res, rej) =>
+      (window as any).require(['LocalEngine'], res, rej),
+    );
+    await eng.buyPerp('Imperium', gestalt);
+    await eng.chargePerp(`Imperium.${gestalt}`);
+  }, GESTALT);
+
+  // ── 2. Reload — boot.js replays the delta log, the engine's
+  //       loadGame() materialises the in-progress charge, and Game.js
+  //       creates a gnode for contact035 with `_loadTimer` so
+  //       `extendRender` calls `markTimer` (DecoratorTimer + chargeRunning). ─
+  await page.reload();
+  await waitForGameReady(page);
+
+  await expect(page.locator('.DecoratorTimer').first()).toBeVisible({ timeout: 5_000 });
+
+  const midState = await page.evaluate((path) => {
+    const appMod = (window as any).require('app');
+    const game = appMod.getApplication().game;
+    const last = path.split('.').pop()!;
+    const gnode = game && game.getById(last);
+    return {
+      exists:        !!gnode,
+      chargeRunning: !!(gnode && gnode.states && gnode.states.chargeRunning),
+      hasReady:      !!(gnode && gnode.renderReady),
+    };
+  }, PATH);
+  expect(midState.exists).toBe(true);
+  expect(midState.chargeRunning).toBe(true);
+  expect(midState.hasReady).toBe(false);
+
+  // ── 3. Fire the node_ready document event the engine would emit at
+  //       charge_end. _scheduleChargeReady's host setTimeout uses
+  //       wall-clock time (msUntil = chargeEnd - clockNow at schedule
+  //       time, frozen even if the override clock advances later), so we
+  //       publish the event directly rather than waiting 30 s. ──────────
+  await page.evaluate((gestalt) => {
+    const $ = (window as any).jQuery || (window as any).$;
+    $(document).trigger('node_ready', [{
+      id:     gestalt,
+      type:   'ContactPerp',
+      path:   `Imperium.${gestalt}`,
+      result: { amount: 100 },
+    }]);
+  }, GESTALT);
+
+  // ── 4. The contract: the collect-ready decorator must appear and the
+  //       gnode must leave chargeRunning. Before the fix, the document
+  //       event has no bridge to gnode.markReady, so neither flips. ─────
+  await expect(page.locator('[data-testid="dd-collect-ready"]')).toBeVisible({ timeout: 2_000 });
+
+  const postState = await page.evaluate((path) => {
+    const appMod = (window as any).require('app');
+    const game = appMod.getApplication().game;
+    const last = path.split('.').pop()!;
+    const gnode = game && game.getById(last);
+    return {
+      chargeRunning: !!(gnode && gnode.states && gnode.states.chargeRunning),
+      hasReady:      !!(gnode && gnode.renderReady),
+    };
+  }, PATH);
+  expect(postState.chargeRunning).toBe(false);
+  expect(postState.hasReady).toBe(true);
+});


### PR DESCRIPTION
## Summary

After a perp finishes charging, the clock decorator kept pulsating and the collect icon never appeared, so the player could not collect.

`_scheduleChargeReady`'s setTimeout publishes `node_ready` via `$(document).trigger(...)`, but the per-perp `gnode.on('node_ready', …)` handlers in Game.js (ContactPerp / ClientPerp / ProjectPerp / TokenPerp) listen on `gnode.jq = $(this)` — a separate jQuery target — so `markReady()` was never called.

The legacy `socket.on('node_ready', …)` bridge that re-fired the event onto the matching GameNode was deleted in #142 with the rest of the transport plumbing; nothing replaced it. This PR reinstates the bridge as a document-level jQuery handler in `app.start`, and does the same for `new_items` so GameRoot's notification listener still fires.

## Test plan

- [x] New `tests/e2e/collect-icon-after-charge.spec.ts` buys + charges contact035, reloads to put the timer on screen, fires the engine's `node_ready` document event, and asserts the `dd-collect-ready` decorator appears and `chargeRunning` flips back to false. Fails before the fix, passes after.
- [x] All 14 existing e2e tests still pass
- [x] All 615 unit tests pass
- [x] `tsc --noEmit` clean

https://claude.ai/code/session_01TvvEGy9MR6ZXZCBDPyhWhh

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvvEGy9MR6ZXZCBDPyhWhh)_