### PR TITLE
chore(biome): add config + apply formatter + enable linter + CI gate + pre-commit hook

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Lint + format check (Biome)
+        run: pnpm exec biome check .
+
       - name: Type-check (tsc --noEmit)
         run: pnpm typecheck
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,19 +163,41 @@ are no longer on npm, a compatibility stub was written in-tree:
 If internet access is available, replace the stubs with their original
 pinned versions using the URLs documented in `scripts/vendor-install.js`.
 
+## Linting and formatting (Biome)
+
+This project uses [Biome](https://biomejs.dev/) for both formatting and linting.
+The config lives in `biome.json`. High-churn style rules are disabled for legacy
+code; the enabled set focuses on catching real bugs in new code.
+
+```bash
+pnpm lint          # check only (what CI runs)
+pnpm lint:fix      # apply safe + unsafe auto-fixes
+pnpm exec biome format --write .  # reformat all files
+```
+
+A `lefthook` pre-commit hook runs `biome check` on staged JS/TS/CSS files
+automatically after `pnpm install`. To install it manually: `pnpm exec lefthook install`.
+
+When suppressing a violation that isn't worth fixing in legacy code, use an
+inline directive with a reason:
+
+```js
+// biome-ignore lint/suspicious/noShadowRestrictedNames: legacy class predates ES6 Set
+var Set = function(set) { … };
+```
+
 ## CI
 
-`.github/workflows/test.yml` runs `pnpm install && pnpm test` on every push
-to `main`/`master` and on every pull request. Coverage is uploaded as a
-workflow artifact.
+`.github/workflows/test.yml` runs on every push to `main`/`master` and on every
+pull request. Required steps: Biome check → tsc --noEmit → build → tests.
+Coverage is uploaded as a workflow artifact.
 
-To make the test check required, a repo admin should enable branch protection
-on `main`: **Settings → Branches → Add rule** → enable
-"Require status checks to pass before merging" → add the `Unit tests` job.
+To make checks required, enable branch protection on `main`:
+**Settings → Branches → Add rule** → "Require status checks to pass before merging"
+→ add the `Unit tests` job.
 
 ## Out of scope in this PR
 
 - Converting `Game.js` / `Render.js` / AMD modules to ESM → issue #58
 - TypeScript adoption → issue #32
-- Biome lint/format → issue #33
 - CI workflow for `.xdc` builds → issue #27

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "organizeImports": { "enabled": true },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100,
+    "lineEnding": "lf"
+  },
+  "linter": { "enabled": false },
+  "files": {
+    "ignore": ["dist", "node_modules", "vendor", "data", "i18n", "*.min.js", "css/Render.css"]
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "semicolons": "always",
+      "trailingCommas": "es5",
+      "arrowParentheses": "always"
+    }
+  }
+}

--- a/biome.json
+++ b/biome.json
@@ -8,7 +8,40 @@
     "lineWidth": 100,
     "lineEnding": "lf"
   },
-  "linter": { "enabled": false },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "suspicious": {
+        "noExplicitAny": "off",
+        "noPrototypeBuiltins": "off",
+        "noAssignInExpressions": "off",
+        "noRedeclare": "off"
+      },
+      "style": {
+        "useImportType": "off",
+        "noVar": "off",
+        "useTemplate": "off",
+        "noParameterAssign": "off",
+        "useSingleVarDeclarator": "off",
+        "noArguments": "off",
+        "noUselessElse": "off",
+        "noCommaOperator": "off"
+      },
+      "complexity": {
+        "noForEach": "off",
+        "useOptionalChain": "off",
+        "useArrowFunction": "off"
+      },
+      "correctness": {
+        "noInnerDeclarations": "off",
+        "noInvalidUseBeforeDeclaration": "off"
+      },
+      "performance": {
+        "noDelete": "off"
+      }
+    }
+  },
   "files": {
     "ignore": ["dist", "node_modules", "vendor", "data", "i18n", "*.min.js", "css/Render.css"]
   },

--- a/css/dd.css
+++ b/css/dd.css
@@ -1,6 +1,9 @@
-.Stage *, .MainMenu *, .button, button {
-   user-select: none;
-  -o-user-select:none;
+.Stage *,
+.MainMenu *,
+.button,
+button {
+  user-select: none;
+  -o-user-select: none;
   -moz-user-select: none;
   -khtml-user-select: none;
   -webkit-user-select: none;
@@ -8,54 +11,55 @@
 #debug *,
 input,
 .allowselect {
-   user-select: auto;
+  user-select: auto;
   -o-user-select: auto;
   -moz-user-select: auto;
   -khtml-user-select: auto;
   -webkit-user-select: auto;
 }
 @font-face {
-      font-family: Bowlby;
-      font-style: normal;
-      font-weight: normal;
-      src: local('Bowlby One SC Regular'), local('BowlbyOneSC-Regular'), url('../font/BowlbyOneSC.woff') format('woff');
+  font-family: Bowlby;
+  font-style: normal;
+  font-weight: normal;
+  src: local("Bowlby One SC Regular"), local("BowlbyOneSC-Regular"), url("../font/BowlbyOneSC.woff")
+    format("woff");
 }
 @font-face {
-      font-family: Voltaire;
-      src: url('../font/Voltaire-Regular.ttf');
+  font-family: Voltaire;
+  src: url("../font/Voltaire-Regular.ttf");
 }
 @font-face {
-      font-family: Numbers;
-      src: url('../font/Skranji-Regular.ttf');
+  font-family: Numbers;
+  src: url("../font/Skranji-Regular.ttf");
 }
 @font-face {
-      font-family: SourceSansBlack;
-      font-style: normal;
-      font-weight: normal;
-      src: local('Source Sans Pro Black'), local('SourceSansPro-Black'), url('../font/SourceSansPro-Black.woff') format('woff');
+  font-family: SourceSansBlack;
+  font-style: normal;
+  font-weight: normal;
+  src: local("Source Sans Pro Black"), local("SourceSansPro-Black"),
+    url("../font/SourceSansPro-Black.woff") format("woff");
 }
-
 
 body {
-  margin:0;
-  padding:0;
-  width:100%;
-  height:100%;
-  overflow:hidden;
-  background:#011;
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  background: #011;
   background: url(../img/dd_auth_header.jpg) no-repeat #011;
-  background-size:100%;
+  background-size: 100%;
 }
 
 #debug {
-  margin:0 auto;
-  width:960px;
-  background:#000;
-  color:#0F0;
+  margin: 0 auto;
+  width: 960px;
+  background: #000;
+  color: #0f0;
 }
 
 .hidden {
-  display:none;
+  display: none;
 }
 
 html {
@@ -95,12 +99,20 @@ html {
 }
 
 @-webkit-keyframes DDSpinnerRotate {
-  from { -webkit-transform: rotate(0deg); }
-  to   { -webkit-transform: rotate(360deg); }
+  from {
+    -webkit-transform: rotate(0deg);
+  }
+  to {
+    -webkit-transform: rotate(360deg);
+  }
 }
 @keyframes DDSpinnerRotate {
-  from { transform: rotate(0deg); }
-  to   { transform: rotate(360deg); }
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 #loader {
@@ -142,5 +154,3 @@ html {
   min-height: 18px;
   text-transform: uppercase;
 }
-
-

--- a/css/dd.css
+++ b/css/dd.css
@@ -5,6 +5,7 @@ button {
   user-select: none;
   -o-user-select: none;
   -moz-user-select: none;
+  /* biome-ignore lint/correctness/noUnknownProperty: legacy vendor prefix for KHTML/Konqueror */
   -khtml-user-select: none;
   -webkit-user-select: none;
 }
@@ -14,6 +15,7 @@ input,
   user-select: auto;
   -o-user-select: auto;
   -moz-user-select: auto;
+  /* biome-ignore lint/correctness/noUnknownProperty: legacy vendor prefix for KHTML/Konqueror */
   -khtml-user-select: auto;
   -webkit-user-select: auto;
 }

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,5 @@
+pre-commit:
+  commands:
+    biome:
+      glob: "*.{js,ts,css}"
+      run: pnpm exec biome check --no-errors-on-unmatched {staged_files}

--- a/package.json
+++ b/package.json
@@ -14,14 +14,18 @@
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check .",
+    "lint:fix": "biome check --fix --unsafe ."
   },
   "devDependencies": {
+    "@biomejs/biome": "1.9.4",
     "@playwright/test": "^1.56.1",
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^3.0.0",
     "@webxdc/types": "^2.1.2",
     "@webxdc/vite-plugins": "^1.6.0",
+    "lefthook": "^2.1.6",
     "typescript": "^5.3.0",
     "vite": "^8.0.10",
     "vite-plugin-static-copy": "^4.1.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,5 @@
+import { existsSync } from 'node:fs';
 import { defineConfig, devices } from '@playwright/test';
-import { existsSync } from 'fs';
 
 // On this dev machine Chromium lives at a fixed path; in CI `playwright install`
 // puts it wherever Playwright decides.  Only override when the path exists so

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@biomejs/biome':
+        specifier: 1.9.4
+        version: 1.9.4
       '@playwright/test':
         specifier: ^1.56.1
         version: 1.56.1
@@ -23,6 +26,9 @@ importers:
       '@webxdc/vite-plugins':
         specifier: ^1.6.0
         version: 1.6.0(terser@5.46.2)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(terser@5.46.2)(yaml@2.8.3))
+      lefthook:
+        specifier: ^2.1.6
+        version: 2.1.6
       typescript:
         specifier: ^5.3.0
         version: 5.9.3
@@ -536,6 +542,63 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@biomejs/biome@1.9.4':
+    resolution: {integrity: sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@1.9.4':
+    resolution: {integrity: sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@1.9.4':
+    resolution: {integrity: sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@1.9.4':
+    resolution: {integrity: sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-arm64@1.9.4':
+    resolution: {integrity: sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-linux-x64-musl@1.9.4':
+    resolution: {integrity: sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-x64@1.9.4':
+    resolution: {integrity: sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-win32-arm64@1.9.4':
+    resolution: {integrity: sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@1.9.4':
+    resolution: {integrity: sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -1378,6 +1441,60 @@ packages:
 
   jszip@3.10.1:
     resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
+  lefthook-darwin-arm64@2.1.6:
+    resolution: {integrity: sha512-hyB7eeiX78BS66f70byTJacDLC/xV1vgMv9n+idFUsrM7J3Udd/ag9Ag5NP3t0eN0EqQqAtrNnt35EH01lxnRQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  lefthook-darwin-x64@2.1.6:
+    resolution: {integrity: sha512-5Ka6cFxiH83krt+OMRQtmS6zqoZR5SLXSudLjTbZA1c3ZqF0+dqkeb4XcB6plx6WR0GFizabuc6Bi3iXPIe1eQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  lefthook-freebsd-arm64@2.1.6:
+    resolution: {integrity: sha512-VswyOg5CVN3rMaOJ2HtnkltiMKgFHW/wouWxXsV8RxSa4tgWOKxM0EmSXi8qc2jX+LRga6B0uOY6toXS01zWxA==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  lefthook-freebsd-x64@2.1.6:
+    resolution: {integrity: sha512-vXsCUFYuVwrVWwcypB7Zt2Hf+5pl1V1la7ZfvGYZaTRURu0zF/XUnMF/nOz/PebGv0f4x/iOWXWwP7E42xRWsg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  lefthook-linux-arm64@2.1.6:
+    resolution: {integrity: sha512-WDJiQhJdZOvKORZd+kF/ms2l6NSsXzdA9ahflyr65V90AC4jES223W8VtEMbGPUtHuGWMEZ/v/XvwlWv0Ioz9g==}
+    cpu: [arm64]
+    os: [linux]
+
+  lefthook-linux-x64@2.1.6:
+    resolution: {integrity: sha512-C18nCd7nTX1AVL4TcvwMmLAO1VI1OuGluIOTjiPkBQ746Ls1HhL5rl//jMPACmT28YmxIQJ2ZcLPNmhvEVBZvw==}
+    cpu: [x64]
+    os: [linux]
+
+  lefthook-openbsd-arm64@2.1.6:
+    resolution: {integrity: sha512-mZOMxM8HiPxVFXDO3PtCUbH4GB8rkveXhsgXF27oAZTYVzQ3gO9vT6r/pxit6msqRXz3fvcwimLVJgb8eRsa8A==}
+    cpu: [arm64]
+    os: [openbsd]
+
+  lefthook-openbsd-x64@2.1.6:
+    resolution: {integrity: sha512-sG9ALLZSnnMOfXu+B7SmxFhJhuoAh4bqi5En5aaHJET48TqrLOcWWZuH+7ArFM6gr/U5KfSUvdmHFmY8WqCcIg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  lefthook-windows-arm64@2.1.6:
+    resolution: {integrity: sha512-lD8yFWY4Csuljd0Rqs7EQaySC0VvDf7V3rN1FhRMUISTRDHutebIom1Loc8ckQPvKYGC6mftT9k0GvipsS+Brw==}
+    cpu: [arm64]
+    os: [win32]
+
+  lefthook-windows-x64@2.1.6:
+    resolution: {integrity: sha512-q4z2n3xucLscoWiyMwFViEj3N8MDSkPulMwcJYuCYFHoPhP1h+icqNu7QRLGYj6AnVrCQweiUJY3Tb2X+GbD/A==}
+    cpu: [x64]
+    os: [win32]
+
+  lefthook@2.1.6:
+    resolution: {integrity: sha512-w9sBoR0mdN+kJc3SB85VzpiAAl451/rxdCRcZlwW71QLjkeH3EBQFgc4VMj5apePychYDHAlqEWTB8J8JK/j1Q==}
+    hasBin: true
 
   lie@3.3.0:
     resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
@@ -2573,6 +2690,41 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
+  '@biomejs/biome@1.9.4':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 1.9.4
+      '@biomejs/cli-darwin-x64': 1.9.4
+      '@biomejs/cli-linux-arm64': 1.9.4
+      '@biomejs/cli-linux-arm64-musl': 1.9.4
+      '@biomejs/cli-linux-x64': 1.9.4
+      '@biomejs/cli-linux-x64-musl': 1.9.4
+      '@biomejs/cli-win32-arm64': 1.9.4
+      '@biomejs/cli-win32-x64': 1.9.4
+
+  '@biomejs/cli-darwin-arm64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@1.9.4':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@1.9.4':
+    optional: true
+
+  '@biomejs/cli-linux-x64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-win32-x64@1.9.4':
+    optional: true
+
   '@emnapi/core@1.10.0':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
@@ -3267,6 +3419,49 @@ snapshots:
       pako: 1.0.11
       readable-stream: 2.3.8
       setimmediate: 1.0.5
+
+  lefthook-darwin-arm64@2.1.6:
+    optional: true
+
+  lefthook-darwin-x64@2.1.6:
+    optional: true
+
+  lefthook-freebsd-arm64@2.1.6:
+    optional: true
+
+  lefthook-freebsd-x64@2.1.6:
+    optional: true
+
+  lefthook-linux-arm64@2.1.6:
+    optional: true
+
+  lefthook-linux-x64@2.1.6:
+    optional: true
+
+  lefthook-openbsd-arm64@2.1.6:
+    optional: true
+
+  lefthook-openbsd-x64@2.1.6:
+    optional: true
+
+  lefthook-windows-arm64@2.1.6:
+    optional: true
+
+  lefthook-windows-x64@2.1.6:
+    optional: true
+
+  lefthook@2.1.6:
+    optionalDependencies:
+      lefthook-darwin-arm64: 2.1.6
+      lefthook-darwin-x64: 2.1.6
+      lefthook-freebsd-arm64: 2.1.6
+      lefthook-freebsd-x64: 2.1.6
+      lefthook-linux-arm64: 2.1.6
+      lefthook-linux-x64: 2.1.6
+      lefthook-openbsd-arm64: 2.1.6
+      lefthook-openbsd-x64: 2.1.6
+      lefthook-windows-arm64: 2.1.6
+      lefthook-windows-x64: 2.1.6
 
   lie@3.3.0:
     dependencies:

--- a/scripts/Game.js
+++ b/scripts/Game.js
@@ -11,322 +11,325 @@ import * as bootMod from './boot.js';
 import i18n from './i18n.js';
 import { getRender } from './Render.js';
 
-var Game = function() {
+var Game = function () {
+  var _ = globalThis._;
+  var $ = globalThis.jQuery || globalThis.$;
+  var sprintf = window.sprintf;
 
-    var _ = globalThis._;
-    var $ = globalThis.jQuery || globalThis.$;
-    var sprintf = window.sprintf;
+  var app = appModule.getApplication();
+  var extend = utilDefault.extend;
+  var Render = getRender();
+  var typeSettings = getTypeSettings();
 
-    var app = appModule.getApplication();
-    var extend = utilDefault.extend;
-    var Render = getRender();
-    var typeSettings = getTypeSettings();
+  //////////////////////////////////////////
+  //
+  // The Game API
+  //
+  // Instantiates a tree like structure of
+  // game controllers, talks to the backend
+  // and make use of the Render.js API
+  //
+  // Here be dragons...
+  //
+  //////////////////////////////////////////
 
-    //////////////////////////////////////////
-    //
-    // The Game API
-    //
-    // Instantiates a tree like structure of
-    // game controllers, talks to the backend 
-    // and make use of the Render.js API
-    // 
-    // Here be dragons...
-    //
-    //////////////////////////////////////////
+  /////////////////////////////////////////////
+  // Some generic tools and getter functions
+  /////////////////////////////////////////////
 
+  var _instances = [];
 
-    /////////////////////////////////////////////
-    // Some generic tools and getter functions
-    /////////////////////////////////////////////
+  var _ids = {};
 
-    var _instances = [];
+  var add = function (node) {
+    _instances[node._id] = node;
+    _ids[node.id] = node;
+  };
 
-    var _ids = {};
+  var get = function (_id) {
+    return _instances[_id];
+  };
 
-    var add = function(node) {
-      _instances[node._id] = node;
-      _ids[node.id] = node;
-    };
+  var remove = function (_id) {
+    if (get(_id)) {
+      delete _ids[get(_id).id];
+    }
+    _instances[_id] = undefined;
+  };
 
-    var get = function(_id) {
-      return _instances[_id];
-    };
-
-    var remove = function(_id) {
-      if (get(_id)) {
-        delete _ids[get(_id).id];
+  var clear = function () {
+    // Clear everything that has been instantiated so far
+    for (var n = 0; n < _instances.length; n++) {
+      var node = _instances[n];
+      if (node) {
+        node.remove();
       }
-      _instances[_id]=undefined;
-    };
+    }
+    _instances.length = 0;
+  };
 
-    var clear = function() {
-      // Clear everything that has been instantiated so far
-      for (var n=0;n<_instances.length;n++) {
-        var node = _instances[n];
-        if (node) {
-          node.remove();
-        }
-      }
-      _instances.length = 0;
-    };
+  var init = function (data) {
+    // Inits GameRoot as a Singleton, for now.
+    app.game = new GameRoot();
+    app.game.loadGame(data);
+    return app.game;
+  };
 
-    var init = function(data) {
-      // Inits GameRoot as a Singleton, for now.
-      app.game = new GameRoot();
-      app.game.loadGame(data);
-      return app.game;
-    };
+  ////////////////////////////////
+  // The Set
+  ////////////////////////////////
 
-    ////////////////////////////////
-    // The Set
-    ////////////////////////////////
+  var Set = function (set) {
+    if (!set) {
+      set = [];
+    }
+    this.set = set;
+    this.length = this.set.length;
+    return this;
+  };
 
-    var Set = function(set){
-      if (!set) {
-        set = [];
-      }
-      this.set = set;
-      this.length = this.set.length;
-      return this;
-    };
+  Set.prototype.add = function (node) {
+    this.set.push(node);
+    this.length = this.set.length;
+  };
 
-    Set.prototype.add = function(node){
-      this.set.push(node);
-      this.length = this.set.length;
-    };
+  Set.prototype.prepend = function (node) {
+    this.set.unshift(node);
+    this.length = this.set.length;
+  };
 
-    Set.prototype.prepend = function(node){
-      this.set.unshift(node);
-      this.length = this.set.length;
-    };
+  Set.prototype.remove = function (node) {
+    var index = this.set.indexOf(node);
+    if (index !== -1) {
+      this.set.splice(index, 1);
+    }
+    this.length = this.set.length;
+  };
 
-    Set.prototype.remove = function(node){
-      var index = this.set.indexOf(node);
-      if (index !== -1) {
-        this.set.splice(index, 1);
-      }
-      this.length = this.set.length;
-    };
+  Set.prototype.each = function (func) {
+    if (!func) {
+      return;
+    }
+    for (var n = 0; n < this.set.length; n++) {
+      var node = this.set[n];
+      func(node);
+    }
+    this.length = this.set.length;
+  };
 
-    Set.prototype.each = function(func){
-      if (!func) {
-        return;
-      }
-      for (var n=0;n<this.set.length;n++) {
-        var node = this.set[n];
-        func(node);
-      }
-      this.length = this.set.length;
-    };
+  //////////////////////////////////////////
+  // Some helpers
+  //////////////////////////////////////////
 
+  var getById = function (id) {
+    // Returns GameNode by ID
+    return _ids[id];
+  };
 
-    //////////////////////////////////////////
-    // Some helpers
-    //////////////////////////////////////////
+  var getByGestalt = function (gestalt) {
+    // Returns GameNodes by gestalt (first found)
+    return _.findWhere(Game._ids, { gestalt: gestalt });
+  };
 
-    var getById = function(id) {
-      // Returns GameNode by ID
-      return _ids[id];
-    };
+  var getAllByGestalt = function (gestalt) {
+    // Returns GameNodes by gestalt (all found)
+    return _.where(Game._ids, { gestalt: gestalt });
+  };
 
-    var getByGestalt = function(gestalt) {
-      // Returns GameNodes by gestalt (first found)
-      return _.findWhere(Game._ids, { gestalt: gestalt });
-    };
+  var eachByGestalt = function (gestalt, func) {
+    // Returns GameNodes by gestalt (all found)
+    if (func) {
+      _.each(_.where(Game._ids, { gestalt: gestalt }), function (v, k) {
+        func(v, k);
+      });
+    }
+  };
 
-    var getAllByGestalt = function(gestalt) {
-      // Returns GameNodes by gestalt (all found)
-      return _.where(Game._ids, { gestalt: gestalt });
-    };
+  var getByType = function (game_type) {
+    // Returns GameNodes by type
+    return _.where(Game._ids, { gameType: game_type });
+  };
 
-    var eachByGestalt = function(gestalt,func) {
-      // Returns GameNodes by gestalt (all found)
-      if (func) {
-        _.each(_.where(Game._ids, { gestalt: gestalt }),function(v,k){
-          func(v,k);
-        });
-      }
-    };
+  var getLastId = function (path) {
+    // Returns last ID of a Path, usally the ID of the GameNode itself
+    return path.split(setup.pathSeparator).pop();
+  };
 
-    var getByType = function(game_type) {
-      // Returns GameNodes by type
-      return _.where(Game._ids, { gameType: game_type });
-    };
-    
-    var getLastId = function(path) {
-      // Returns last ID of a Path, usally the ID of the GameNode itself
-      return path.split(setup.pathSeparator).pop();
-    };
+  var getByLastId = function (path) {
+    // Returns GameNode by parsing the paths last ID
+    return getById(getLastId(path));
+  };
 
-    var getByLastId = function(path) {
-      // Returns GameNode by parsing the paths last ID
-      return getById(getLastId(path));
-    };
+  var getParentId = function (path) {
+    // Returns the ID of the second last element of a path
+    var parts = path.split(setup.pathSeparator);
+    parts.pop();
+    return parts.pop();
+  };
 
-    var getParentId = function(path) {
-      // Returns the ID of the second last element of a path
-      var parts = path.split(setup.pathSeparator);
-      parts.pop();
-      return parts.pop();
-    };
+  var getParentFromPath = function (path) {
+    // Returns the parent GameNode from a Node's full path
+    return getById(getParentId(path));
+  };
 
-    var getParentFromPath = function(path) {
-      // Returns the parent GameNode from a Node's full path
-      return getById(getParentId(path));
-    };
+  var getFirstId = function (path) {
+    // Returns the root of a Path
+    return path.split(setup.pathSeparator)[0];
+  };
 
-    var getFirstId = function(path) {
-      // Returns the root of a Path
-      return path.split(setup.pathSeparator)[0];
-    };
+  var getByFirstId = function (path) {
+    // Returns the GameNode of the root of a path
+    return getById(getFirstId(path));
+  };
 
-    var getByFirstId = function(path) {
-      // Returns the GameNode of the root of a path
-      return getById(getFirstId(path));
-    };
+  var getGestalt = function (full_type) {
+    // Returns the the gestalt from a full type definition
+    return full_type.split(setup.typeSeparator)[1];
+  };
 
-    var getGestalt = function(full_type) {
-      // Returns the the gestalt from a full type definition
-      return full_type.split(setup.typeSeparator)[1];
-    };
-
-    var mergeData = function(type_data,instance_data) {
-      // Merges data objects, second argument overwrites the first ones and returns new merged object
-      var data = {};
-      _.extend(data,type_data);
-      _.extend(data,instance_data);
-      // If the type data is Project-like (has powerups and tokens) merge token amounts
-      if (instance_data && type_data && instance_data.hasOwnProperty('powerups') && type_data.hasOwnProperty('tokens') && instance_data.hasOwnProperty('tokens')) {
-        var tokens = [];
-        // No way around this: make a deep copy to avoid messing with token type_data
-        _.each(type_data.tokens,function(v,k){
-          tokens[k] = _.clone(v);
-        });
-        var instokens = instance_data.tokens;
-        _.each(tokens,function(t,k) {
-          var overwrite = _.findWhere(instokens, { gestalt: t.gestalt });
-          if (overwrite && overwrite.amount) {
-            t.amount = overwrite.amount;
-          }
-        });
-        data.tokens = tokens;
-      }
-      return data;
-    };
-
-    var convertPowerupType = function(game_type){
-      // This costs a beer dudes...
-      var convertCat = {
-        'UpgradePowerup':'upgrade',
-        'AdPowerup': 'ad',
-        'TeamMemberPowerup':'teammember'
-      }
-      return convertCat[game_type];
-    };
-
-    var getPowerupTypeFromGestalt = function(gestalt) {
-       var convertCat = {
-        'upgrade': 'UpgradePowerup',
-        'ad' : 'AdPowerup',
-        'teammember': 'TeamMemberPowerup',
-      }
-      var cat = undefined;
-      _.each(convertCat,function(v,k){
-        if (gestalt.substring(0, k.length) === k) {
-          cat = v;
+  var mergeData = function (type_data, instance_data) {
+    // Merges data objects, second argument overwrites the first ones and returns new merged object
+    var data = {};
+    _.extend(data, type_data);
+    _.extend(data, instance_data);
+    // If the type data is Project-like (has powerups and tokens) merge token amounts
+    if (
+      instance_data &&
+      type_data &&
+      instance_data.hasOwnProperty('powerups') &&
+      type_data.hasOwnProperty('tokens') &&
+      instance_data.hasOwnProperty('tokens')
+    ) {
+      var tokens = [];
+      // No way around this: make a deep copy to avoid messing with token type_data
+      _.each(type_data.tokens, function (v, k) {
+        tokens[k] = _.clone(v);
+      });
+      var instokens = instance_data.tokens;
+      _.each(tokens, function (t, k) {
+        var overwrite = _.findWhere(instokens, { gestalt: t.gestalt });
+        if (overwrite && overwrite.amount) {
+          t.amount = overwrite.amount;
         }
       });
-      return cat;
+      data.tokens = tokens;
+    }
+    return data;
+  };
+
+  var convertPowerupType = function (game_type) {
+    // This costs a beer dudes...
+    var convertCat = {
+      UpgradePowerup: 'upgrade',
+      AdPowerup: 'ad',
+      TeamMemberPowerup: 'teammember',
     };
+    return convertCat[game_type];
+  };
 
-    /////////////////////////////////////////////
-    // The APTicker (increments Action Points)
-    /////////////////////////////////////////////
-
-    // Written as Singleton, like original Ticker
-
-    var APTicker = {
-      interval: 0,
-      offset: 0,
-      start: function(offset){
-        if (!this.timeout) {
-          this.tick(offset);
-        }
-      },
-      reset: function(){
-        window.clearTimeout(this.timeout);
-        this.tick();
-      },
-      tick: function(offset){
-        var interval = this.interval;
-        if (offset) {
-          interval = interval - offset;
-          this.offset = offset;
-        } else {
-          this.offset = 0;
-        }
-        if (interval > 0) {
-          APTicker.lastTick = Date.now();
-          this.timeout = window.setTimeout(function(){
-            APTicker.listeners.each(function(node){
-              if (node.APTick) {
-                node.APTick();
-              }
-            });
-            APTicker.tick();
-          }, interval);
-        }
-      },
-      getRemainingTime: function(){
-        return new Date(this.lastTick + this.interval - this.offset - Date.now());
-      },
-      addListener: function(node) {
-        this.listeners.add(node);
-      },
-      removeListener: function(node) {
-        this.listeners.remove(node);
-      },
-      stop: function(){
-        window.clearTimeout(this.timeout);
-        this.timeout=undefined;
+  var getPowerupTypeFromGestalt = function (gestalt) {
+    var convertCat = {
+      upgrade: 'UpgradePowerup',
+      ad: 'AdPowerup',
+      teammember: 'TeamMemberPowerup',
+    };
+    var cat = undefined;
+    _.each(convertCat, function (v, k) {
+      if (gestalt.substring(0, k.length) === k) {
+        cat = v;
       }
-    };
-    APTicker.listeners = new Set();
+    });
+    return cat;
+  };
 
-    /////////////////////////////////////////////
-    // The AniTicker (increments Action Points)
-    /////////////////////////////////////////////
+  /////////////////////////////////////////////
+  // The APTicker (increments Action Points)
+  /////////////////////////////////////////////
 
-    // Written as Singleton, like original Ticker
+  // Written as Singleton, like original Ticker
 
-    var AniTicker = {
-      interval: 5000,
-      counter: 0,
-      start: function(){
-        AniTicker.counter = 0;
-        if (!this.timeout) {
-          this.tick();
-        }
-      },
-      reset: function(){
-        window.clearTimeout(this.timeout);
-        this.tick();
-      },
-      tick: function(){
-        if (this.interval > 0) {
-          this.timeout = window.setTimeout(function(){
-            var node = AniTicker.listeners.set[0];
-            AniTicker.interval = (Math.random()) * 1500 + 5000;
-
-            if (node) {
-              node.AniTick();
+  var APTicker = {
+    interval: 0,
+    offset: 0,
+    start: function (offset) {
+      if (!this.timeout) {
+        this.tick(offset);
+      }
+    },
+    reset: function () {
+      window.clearTimeout(this.timeout);
+      this.tick();
+    },
+    tick: function (offset) {
+      var interval = this.interval;
+      if (offset) {
+        interval = interval - offset;
+        this.offset = offset;
+      } else {
+        this.offset = 0;
+      }
+      if (interval > 0) {
+        APTicker.lastTick = Date.now();
+        this.timeout = window.setTimeout(function () {
+          APTicker.listeners.each(function (node) {
+            if (node.APTick) {
+              node.APTick();
             }
-            // only shuffle when all items were served (uses counter)
-            AniTicker.listeners.set = _.shuffle(AniTicker.listeners.set);
-            AniTicker.tick();
-          },this.interval);
+          });
+          APTicker.tick();
+        }, interval);
+      }
+    },
+    getRemainingTime: function () {
+      return new Date(this.lastTick + this.interval - this.offset - Date.now());
+    },
+    addListener: function (node) {
+      this.listeners.add(node);
+    },
+    removeListener: function (node) {
+      this.listeners.remove(node);
+    },
+    stop: function () {
+      window.clearTimeout(this.timeout);
+      this.timeout = undefined;
+    },
+  };
+  APTicker.listeners = new Set();
 
-          /* // Shuffle all Test
+  /////////////////////////////////////////////
+  // The AniTicker (increments Action Points)
+  /////////////////////////////////////////////
+
+  // Written as Singleton, like original Ticker
+
+  var AniTicker = {
+    interval: 5000,
+    counter: 0,
+    start: function () {
+      AniTicker.counter = 0;
+      if (!this.timeout) {
+        this.tick();
+      }
+    },
+    reset: function () {
+      window.clearTimeout(this.timeout);
+      this.tick();
+    },
+    tick: function () {
+      if (this.interval > 0) {
+        this.timeout = window.setTimeout(function () {
+          var node = AniTicker.listeners.set[0];
+          AniTicker.interval = Math.random() * 1500 + 5000;
+
+          if (node) {
+            node.AniTick();
+          }
+          // only shuffle when all items were served (uses counter)
+          AniTicker.listeners.set = _.shuffle(AniTicker.listeners.set);
+          AniTicker.tick();
+        }, this.interval);
+
+        /* // Shuffle all Test
           AniTicker.counter += 1;
           this.timeout = window.setTimeout(function(){
             var node = AniTicker.listeners.set[0];
@@ -348,1212 +351,1259 @@ var Game = function() {
             AniTicker.tick();
           },this.interval);
           */
-        }
-      },
-      addListener: function(node) {
-        if (node.AniTick) {
-          this.listeners.add(node);
-        }
-      },
-      removeListener: function(node) {
-        this.listeners.remove(node);
-      },
-      stop: function(){
-        window.clearTimeout(this.timeout);
-        this.timeout=undefined;
       }
-    };
-    AniTicker.listeners = new Set();
+    },
+    addListener: function (node) {
+      if (node.AniTick) {
+        this.listeners.add(node);
+      }
+    },
+    removeListener: function (node) {
+      this.listeners.remove(node);
+    },
+    stop: function () {
+      window.clearTimeout(this.timeout);
+      this.timeout = undefined;
+    },
+  };
+  AniTicker.listeners = new Set();
 
-    //////////////////////////////////////////
-    // The GameNode Base Class
-    //////////////////////////////////////////
+  //////////////////////////////////////////
+  // The GameNode Base Class
+  //////////////////////////////////////////
 
-    var GameNode = function(config) {
-      this.init(config);
-      return this;
-    };
+  var GameNode = function (config) {
+    this.init(config);
+    return this;
+  };
 
-    // RenderType and RenderData for the GameNode's main renderNode to match against Render API
-    GameNode.prototype.renderData = undefined;
-    GameNode.prototype.renderType = undefined;
+  // RenderType and RenderData for the GameNode's main renderNode to match against Render API
+  GameNode.prototype.renderData = undefined;
+  GameNode.prototype.renderType = undefined;
 
-    GameNode.prototype.toString = function() {
-      return sprintf('GameNode “%s”: %d children', this.renderType || this._id,
-      this.children.length);
-    };
+  GameNode.prototype.toString = function () {
+    return sprintf('GameNode “%s”: %d children', this.renderType || this._id, this.children.length);
+  };
 
-    GameNode.prototype.init = function(config) {
-      // Initialize GameNode and register it in Game _instances (Array) and _ids (Object)
-      // Set children property for tree-structure
-      // Set States registry of the GameNode
-      // Backlink to GameRoot for easy access to GameRoot API
-      // setAttrs expands the Object via generic setAttrs
-      // makeRenderConfig does the data crunching for the RenderAPI
-      // jq is the jquery wrapper of the GameNode
-      // initialize Event Handlers usually overwritten by the SubClasses
-      if (!config) {
-        config = {};
-      }
-      this._id = _instances.length;
-      this.id = config.id || "GameNode"+this._id;
-      add(this);
-      this.children = new Set();
-      this.states = {
-        idle:true
-      };
-      this.GameRoot = get(0);
-      this.setAttrs(config);
-      this.makeRenderConfig();
-      this.jq = $(this);
-      // init Event Handlers
-      this.initEventHandlers();
+  GameNode.prototype.init = function (config) {
+    // Initialize GameNode and register it in Game _instances (Array) and _ids (Object)
+    // Set children property for tree-structure
+    // Set States registry of the GameNode
+    // Backlink to GameRoot for easy access to GameRoot API
+    // setAttrs expands the Object via generic setAttrs
+    // makeRenderConfig does the data crunching for the RenderAPI
+    // jq is the jquery wrapper of the GameNode
+    // initialize Event Handlers usually overwritten by the SubClasses
+    if (!config) {
+      config = {};
+    }
+    this._id = _instances.length;
+    this.id = config.id || 'GameNode' + this._id;
+    add(this);
+    this.children = new Set();
+    this.states = {
+      idle: true,
     };
+    this.GameRoot = get(0);
+    this.setAttrs(config);
+    this.makeRenderConfig();
+    this.jq = $(this);
+    // init Event Handlers
+    this.initEventHandlers();
+  };
 
-    GameNode.prototype.remove = function(){
-      // Remove GameNode from all references and remove renderNodes
-      var gnode = this;
-      if (this.parentNode) {
-        this.parentNode.children.remove(this);
-      }
-      if (this.children) {
-        this.children.each(function(child){
-          child.parentNode = undefined;
-        });
-      }
-      if (this.renderNode) {
-        this.renderNode.remove();
-      }
-      if (this.renderMenu) {
-        this.renderMenu.remove();
-      }
-      if (this.renderPopup) {
-        this.renderPopup.close();
-      }
-      if (this.renderStatusbar) {
-        this.renderStatusbar.remove();
-      }
-      remove(this._id);
-    };
-
-    GameNode.prototype.addType = function(gestalt,data){
-      // Add a type to the typeRegistry data should have data.type_data
-      // If the game_type is also defined in typeSettings it will be merged and overwritte with data
-      var gnode = this;
-      var groot = gnode.GameRoot;
-      var nodeType = this.getType();
-      if (nodeType) {
-        if (data.game_type && data.type_data) {
-          if (typeSettings.hasOwnProperty(data.game_type)) {
-            data.type_data = mergeData(typeSettings[data.game_type].type_data,data.type_data);
-            data.type_data.gestalt = gestalt;
-            data.type_data.game_type = data.game_type;
-            // expand powerup tokens with their type data
-            if (data.type_data.tokens && data.type_data.tokens.length) {
-              _.each(data.type_data.tokens, function(v,k){
-                v.type_data = groot.getTypeData(v.gestalt);
-              });
-            }
-          }
-        return nodeType[gestalt] = data;
-        }
-      }
-    };
-
-    GameNode.prototype.getType = function(gestalt){
-      // Get (sub)type from node gestalt or return own type
-      if (gestalt) {
-        return this.GameRoot.getType(this.gestalt)[gestalt];
-      } else {
-        return this.GameRoot.getType(this.gestalt);
-      }
-    };
-    GameNode.prototype.getTypeData = function(gestalt){
-      // Get (sub)type from node gestalt or return own type
-      if (gestalt) {
-        return this.GameRoot.getType(this.gestalt)[gestalt].type_data;
-      } else {
-        return this.GameRoot.getType(this.gestalt).type_data;
-      }
-    };
-
-    GameNode.prototype.setState = function(state,value) {
-      // State change triggers event for renderNodes and renderPopups to listen to
-      // Note: The event is feedbacked to the GameNode. So Listener attached to the GameNode will also be triggered.
-      
-      // do nothing when state is the same
-      if (this.states[state] === value) {
-        return;
-      }
-      this.states[state] = value;
-      // TODO: Eventhook could be more generic but probably we only need feedback in the popup
-      this.trigger('local_states',[state,value]);
-      this.trigger('local_states_'+state,[value]);
-      if (this.renderNode) {
-        this.renderNode.trigger('states',[state,value]);
-        this.renderNode.trigger('states_'+state,[value]);
-      }
-      if (this.renderPopup) {
-        this.renderPopup.trigger('states',[state,value]);
-        this.renderPopup.trigger('states_'+state,[value]);
-      }
-    };
-
-    GameNode.prototype.setAttrs = function(attrs) {
-      // Set any attribute(s)
-      for (var key in attrs) {
-        if (attrs.hasOwnProperty(key)) {
-          this[key] = attrs[key];
-        }
-      }
-    };
-
-    GameNode.prototype.load = function() {
-      // FIXME: Do we need this?
-    };
-
-    GameNode.prototype.save = function() {
-      // FIXME: Do we need this?
-    };
-
-    GameNode.prototype.addChild = function(child) {
-      // The GameNode Tree: Append a child to the GameNode
-      if (!child) {
-        return false;
-      }
-      this.children.add(child);
-      child.parentNode = this;
-      return child;
-    };
-
-    GameNode.prototype.on = function(event,func) {
-      // Bind an jQuery Eventhandler to the GameNode
-      // Note: Most of the times this is called by the Renderer
-      // Important: any RenderNode.trigger() will feedback to the GameNode!
-      this.jq.on(event,func);
-    };
-    GameNode.prototype.off = function(event) {
-      // Unbind an jQuery Eventhandler from the GameNode
-      this.jq.off(event);
-    };
-    GameNode.prototype.trigger = function(event,params) {
-      // Trigger an jQuery Eventhandler from the GameNode
-      this.jq.trigger(event,params);
-    };
-
-    GameNode.prototype.initEventHandlers = function() {
-      // Bind specific eventhandlers (which get triggered by Render.Node)
-      // This is an example implementation and usually gets overwritten by the Subclasses
-      var gnode = this;
-      gnode.on('vclick',function(e) {
-        e.stopPropagation();
+  GameNode.prototype.remove = function () {
+    // Remove GameNode from all references and remove renderNodes
+    var gnode = this;
+    if (this.parentNode) {
+      this.parentNode.children.remove(this);
+    }
+    if (this.children) {
+      this.children.each(function (child) {
+        child.parentNode = undefined;
       });
-      if (this.extendEventHandlers) {
-        this.extendEventHandlers();
-      }
-    };
+    }
+    if (this.renderNode) {
+      this.renderNode.remove();
+    }
+    if (this.renderMenu) {
+      this.renderMenu.remove();
+    }
+    if (this.renderPopup) {
+      this.renderPopup.close();
+    }
+    if (this.renderStatusbar) {
+      this.renderStatusbar.remove();
+    }
+    remove(this._id);
+  };
 
-    GameNode.prototype.removeEventHandlers = function() {
-      // Stupidly removes all event handlers
-      this.off();
-    };
-
-    GameNode.prototype.makeRenderConfig = function() {
-      // Crunch data for render initialisation
-      // FIXME: this is mostly for data compatibility reasons,
-      // could be more streamlined
-      if (!this.renderData) { this.renderData = {}; }
-      var config = this.renderData.config || {};
-
-      //var data = mergeData(data.type_data,data.instance_data);
-      var data = this.data || {};
-      config.id = this.id;
-      config.name = data.name || config.name || this.id;
-
-
-      config.x = data.x || config.x;
-      config.y = data.y || config.y;
-
-      config.width = data.width || config.width;
-      config.height = data.height || config.height;
-
-      config.label = data.label || config.label;
-
-      config.zoomScale = data.zoom_scale || config.zoomScale;
-      config.perpSprite = data.perp_sprite || config.perpSprite;
-
-      config.perpBackground = data.perp_background || config.perpBackground;
-      //FIXME: supertoken check with is_supertoken, not gestaltinspection (though would work)
-      if (this.gestalt && this.gestalt.substring(0,10) === 'supertoken') {
-        config.perpBackground = data.perp_background2;
-      }
-      if (this.gestalt && this.gestalt.substring(0,6) === 'origin') {
-        this.is_origin = true;
-        config.no_render = true;
-      }
-      if (this.gestalt && this.gestalt.substring(0,5) === 'token') {
-        this.GameRoot.getTypeData(this.gestalt).is_supertoken = false;
-        this.data.is_supertoken = false;
-      }
-      if (config.perpBackground) {
-        _.each(config.perpBackground, function(v,k){
-          config[k]=v;
-        });
-      }
-
-      config.background = data.background || config.background;
-      config.RenderTemplate = data.RenderTemplate || config.RenderTemplate;
-
-      this.renderData.parentNode = this.renderNodeParent;
-      this.renderData.config = config;
-      return config;
-    };
-
-    GameNode.prototype.updateRenderNode = function(render) {
-      // Test Method: Updates the rendered GameNode to the stored config
-      // FIXME: this probably is pointless, better to reinit a specific node?
-      // Need to take care of tree structure and all render specific settings
-      if (!this.renderData && !render) {
-        return;
-      } else if (render) {
-        this.renderData = render;
-      }
-      if (this.renderData.hasOwnProperty('config')) {
-        this.renderNode.setAttrs(this.renderData.config);
-      }
-      this.renderNode.draw();
-    };
-
-    GameNode.prototype.render = function() {
-      // Renders GameNode or recursivly removes old RenderNodes and renders anew.
-      // FIXME: currently rerendering stuff has some problems with decorators etc...
-      // Maybe there's a better way to update stuff or re-init parts of the GameNode-Tree
-      if (this.renderNode) {
-        this.renderNode.remove();
-      }
-      var render = this.renderData;
-
-      if (render && render.config && !render.config.no_render) {
-        var node = new Render[this.renderType](render.config);
-        this.renderNode = node;
-        this.trigger('before_render');
-        node.gameNode = this;
-        // Put RenderNode in its place:
-        if (render.parentNode) {
-          var parentNode = Render.getById(render.parentNode);
-          if (parentNode) {
-            parentNode.addChild(node);
-          }
-        }
-
-        // Execute subclass specific render function
-        if (this.extendRender) {
-          this.extendRender();
-        }
-        // after_render is only triggered when node rendered for the first time
-        this.trigger('after_render');
-      }
-      // FIXME: Recursion, maybe we better get rid of it and do rendering on init and specific updates of the Tree
-      if (this.children.length) {
-        this.children.each(function(child) {
-          child.render();
-        });
-      }
-    };
-
-
-    //////////////////////////////////////////////////
-    // The Subclasses
-    //////////////////////////////////////////////////
-
-    ///////////////////////////////////
-    // The GameRoot of all Evil
-    // Currently only a single instance of GameRoot should be instantiated
-    // On Game.init GameRoot is exposed globally to app as app.game
-    // GameRoot (app.game) can be accessed in debug mode from the console
-    // TODO: better way to publish only those parts of the api that need to be global
-    ///////////////////////////////////
-
-    var GameRoot = function(config) {
-      // Initialize the typeRegistry
-      this.typeRegistry = {};
-      this.DBTokensLength = 0;
-      this.DBTokensLengthMax = 0;
-      this.DBTokens = {};
-      this.DBOriginTokens = {};
-      this.DBTokensAbsolute = {};
-      this.DBTokensCrossSum = 0;
-      this.IPerps = {};
-      this.NotificationQueue = [];
-      return this;
-    };
-    extend(GameRoot, GameNode);
-
-    GameRoot.prototype.renderType = "Stage";
-    
-    GameRoot.prototype.get = get;
-    
-    GameRoot.prototype.setup = setup;
-
-    GameRoot.prototype.ids = _ids;
-    GameRoot.prototype.getById = getById;
-
-    GameRoot.prototype.addType = function(gestalt,data){
-      // Add a type to the typeRegistry data should have data.type_data
-      // If the game_type is also defined in typeSettings it will be merged and overwritten with data
+  GameNode.prototype.addType = function (gestalt, data) {
+    // Add a type to the typeRegistry data should have data.type_data
+    // If the game_type is also defined in typeSettings it will be merged and overwritte with data
+    var gnode = this;
+    var groot = gnode.GameRoot;
+    var nodeType = this.getType();
+    if (nodeType) {
       if (data.game_type && data.type_data) {
         if (typeSettings.hasOwnProperty(data.game_type)) {
-          data.type_data = mergeData(typeSettings[data.game_type].type_data,data.type_data);
-        }
-      }
-      this.typeRegistry[gestalt] = data;
-      this.typeRegistry[gestalt].gestalt = gestalt;
-      this.typeRegistry[gestalt].game_type = data.game_type;
-      // FIXME: is_supertoken fix for export fail.
-      if (gestalt.substring(0,5) === 'token') {
-        this.typeRegistry[gestalt].type_data.is_supertoken = false;
-      }
-
-      return this.typeRegistry[gestalt];
-    };
-
-    GameRoot.prototype.addSubType = function(parent_gestalt,gestalt,data){
-      // Add a subtype to the typeRegistry data should have data.type_data
-      // If the game_type is also defined in typeSettings it will be merged and overwritten with data
-      var groot = this;
-      var parentType = groot.getType(parent_gestalt);
-      if (parentType) {
-        if (data.game_type && data.type_data) {
-          if (typeSettings.hasOwnProperty(data.game_type)) {
-            data.type_data = mergeData(typeSettings[data.game_type].type_data,data.type_data);
-            // expand powerup tokens with their type data
-            if (data.type_data.tokens && data.type_data.tokens.length) {
-              _.each(data.type_data.tokens, function(v,k){
-                v.type_data = groot.getTypeData(v.gestalt);
-              });
-            }
+          data.type_data = mergeData(typeSettings[data.game_type].type_data, data.type_data);
+          data.type_data.gestalt = gestalt;
+          data.type_data.game_type = data.game_type;
+          // expand powerup tokens with their type data
+          if (data.type_data.tokens && data.type_data.tokens.length) {
+            _.each(data.type_data.tokens, function (v, k) {
+              v.type_data = groot.getTypeData(v.gestalt);
+            });
           }
-        return parentType[gestalt] = data;
         }
+        return (nodeType[gestalt] = data);
       }
-    };
+    }
+  };
 
+  GameNode.prototype.getType = function (gestalt) {
+    // Get (sub)type from node gestalt or return own type
+    if (gestalt) {
+      return this.GameRoot.getType(this.gestalt)[gestalt];
+    } else {
+      return this.GameRoot.getType(this.gestalt);
+    }
+  };
+  GameNode.prototype.getTypeData = function (gestalt) {
+    // Get (sub)type from node gestalt or return own type
+    if (gestalt) {
+      return this.GameRoot.getType(this.gestalt)[gestalt].type_data;
+    } else {
+      return this.GameRoot.getType(this.gestalt).type_data;
+    }
+  };
 
-    GameRoot.prototype.removeType = function(gestalt){
-      // Remove a type from the typeRegistry
-      delete this.typeRegistry[gestalt];
-    };
-    GameRoot.prototype.getType = function(gestalt){
-      // Get type from the registry, Note on the structure: data.type_data
-      return this.typeRegistry[gestalt];
-    };
-    GameRoot.prototype.getTypeData = function(gestalt){
-      // Get type_data from the registry, Note on the structure: data.type_data
-      var type = this.getType(gestalt);
-      if (type) {
-        return type.type_data;
-      } else {
-        return undefined;
+  GameNode.prototype.setState = function (state, value) {
+    // State change triggers event for renderNodes and renderPopups to listen to
+    // Note: The event is feedbacked to the GameNode. So Listener attached to the GameNode will also be triggered.
+
+    // do nothing when state is the same
+    if (this.states[state] === value) {
+      return;
+    }
+    this.states[state] = value;
+    // TODO: Eventhook could be more generic but probably we only need feedback in the popup
+    this.trigger('local_states', [state, value]);
+    this.trigger('local_states_' + state, [value]);
+    if (this.renderNode) {
+      this.renderNode.trigger('states', [state, value]);
+      this.renderNode.trigger('states_' + state, [value]);
+    }
+    if (this.renderPopup) {
+      this.renderPopup.trigger('states', [state, value]);
+      this.renderPopup.trigger('states_' + state, [value]);
+    }
+  };
+
+  GameNode.prototype.setAttrs = function (attrs) {
+    // Set any attribute(s)
+    for (var key in attrs) {
+      if (attrs.hasOwnProperty(key)) {
+        this[key] = attrs[key];
       }
-    };
-    GameRoot.prototype.getTypes = function(game_type){
-      // Get all types with game_type from the registry
-      //return this.typeRegistry[gestalt];
-      return _.where(this.typeRegistry,{game_type:game_type});
-    };
-    GameRoot.prototype.getTypeFromGestalt = function(gestalt){
-      // Get all types with game_type from the registry
-      if (gestalt) {
-        return this.typeRegistry[gestalt].game_type;
-      } else {
-        return {};
-      }
-    };
+    }
+  };
 
-    GameRoot.prototype.getDBTokenAmount = function(gestalt){
-      if (this.DBTokens && this.DBTokens.hasOwnProperty(gestalt)) {
-        return this.DBTokens[gestalt];
-      } else {
-        return 0;
-      }
-    };
+  GameNode.prototype.load = function () {
+    // FIXME: Do we need this?
+  };
 
-    GameRoot.prototype.getDBTokensLength = function(){
-      // without origin tokens
-      return this.DBTokensLength = _.filter(_.keys(this.DBTokens),function(t){ return t.substring(0,6) !== 'origin' }).length;
+  GameNode.prototype.save = function () {
+    // FIXME: Do we need this?
+  };
+
+  GameNode.prototype.addChild = function (child) {
+    // The GameNode Tree: Append a child to the GameNode
+    if (!child) {
+      return false;
+    }
+    this.children.add(child);
+    child.parentNode = this;
+    return child;
+  };
+
+  GameNode.prototype.on = function (event, func) {
+    // Bind an jQuery Eventhandler to the GameNode
+    // Note: Most of the times this is called by the Renderer
+    // Important: any RenderNode.trigger() will feedback to the GameNode!
+    this.jq.on(event, func);
+  };
+  GameNode.prototype.off = function (event) {
+    // Unbind an jQuery Eventhandler from the GameNode
+    this.jq.off(event);
+  };
+  GameNode.prototype.trigger = function (event, params) {
+    // Trigger an jQuery Eventhandler from the GameNode
+    this.jq.trigger(event, params);
+  };
+
+  GameNode.prototype.initEventHandlers = function () {
+    // Bind specific eventhandlers (which get triggered by Render.Node)
+    // This is an example implementation and usually gets overwritten by the Subclasses
+    var gnode = this;
+    gnode.on('vclick', function (e) {
+      e.stopPropagation();
+    });
+    if (this.extendEventHandlers) {
+      this.extendEventHandlers();
+    }
+  };
+
+  GameNode.prototype.removeEventHandlers = function () {
+    // Stupidly removes all event handlers
+    this.off();
+  };
+
+  GameNode.prototype.makeRenderConfig = function () {
+    // Crunch data for render initialisation
+    // FIXME: this is mostly for data compatibility reasons,
+    // could be more streamlined
+    if (!this.renderData) {
+      this.renderData = {};
+    }
+    var config = this.renderData.config || {};
+
+    //var data = mergeData(data.type_data,data.instance_data);
+    var data = this.data || {};
+    config.id = this.id;
+    config.name = data.name || config.name || this.id;
+
+    config.x = data.x || config.x;
+    config.y = data.y || config.y;
+
+    config.width = data.width || config.width;
+    config.height = data.height || config.height;
+
+    config.label = data.label || config.label;
+
+    config.zoomScale = data.zoom_scale || config.zoomScale;
+    config.perpSprite = data.perp_sprite || config.perpSprite;
+
+    config.perpBackground = data.perp_background || config.perpBackground;
+    //FIXME: supertoken check with is_supertoken, not gestaltinspection (though would work)
+    if (this.gestalt && this.gestalt.substring(0, 10) === 'supertoken') {
+      config.perpBackground = data.perp_background2;
+    }
+    if (this.gestalt && this.gestalt.substring(0, 6) === 'origin') {
+      this.is_origin = true;
+      config.no_render = true;
+    }
+    if (this.gestalt && this.gestalt.substring(0, 5) === 'token') {
+      this.GameRoot.getTypeData(this.gestalt).is_supertoken = false;
+      this.data.is_supertoken = false;
+    }
+    if (config.perpBackground) {
+      _.each(config.perpBackground, function (v, k) {
+        config[k] = v;
+      });
     }
 
-    GameRoot.prototype.getDBTokensLengthMax = function(){
-      // without origin tokens
-      return this.DBTokensLengthMax = _.filter(_.where(this.typeRegistry,{ game_type: "TokenPerp" }), function(t){ 
-        return t.gestalt.substring(0,6) !== 'origin';
-      }).length;
+    config.background = data.background || config.background;
+    config.RenderTemplate = data.RenderTemplate || config.RenderTemplate;
+
+    this.renderData.parentNode = this.renderNodeParent;
+    this.renderData.config = config;
+    return config;
+  };
+
+  GameNode.prototype.updateRenderNode = function (render) {
+    // Test Method: Updates the rendered GameNode to the stored config
+    // FIXME: this probably is pointless, better to reinit a specific node?
+    // Need to take care of tree structure and all render specific settings
+    if (!this.renderData && !render) {
+      return;
+    } else if (render) {
+      this.renderData = render;
+    }
+    if (this.renderData.hasOwnProperty('config')) {
+      this.renderNode.setAttrs(this.renderData.config);
+    }
+    this.renderNode.draw();
+  };
+
+  GameNode.prototype.render = function () {
+    // Renders GameNode or recursivly removes old RenderNodes and renders anew.
+    // FIXME: currently rerendering stuff has some problems with decorators etc...
+    // Maybe there's a better way to update stuff or re-init parts of the GameNode-Tree
+    if (this.renderNode) {
+      this.renderNode.remove();
+    }
+    var render = this.renderData;
+
+    if (render && render.config && !render.config.no_render) {
+      var node = new Render[this.renderType](render.config);
+      this.renderNode = node;
+      this.trigger('before_render');
+      node.gameNode = this;
+      // Put RenderNode in its place:
+      if (render.parentNode) {
+        var parentNode = Render.getById(render.parentNode);
+        if (parentNode) {
+          parentNode.addChild(node);
+        }
+      }
+
+      // Execute subclass specific render function
+      if (this.extendRender) {
+        this.extendRender();
+      }
+      // after_render is only triggered when node rendered for the first time
+      this.trigger('after_render');
+    }
+    // FIXME: Recursion, maybe we better get rid of it and do rendering on init and specific updates of the Tree
+    if (this.children.length) {
+      this.children.each(function (child) {
+        child.render();
+      });
+    }
+  };
+
+  //////////////////////////////////////////////////
+  // The Subclasses
+  //////////////////////////////////////////////////
+
+  ///////////////////////////////////
+  // The GameRoot of all Evil
+  // Currently only a single instance of GameRoot should be instantiated
+  // On Game.init GameRoot is exposed globally to app as app.game
+  // GameRoot (app.game) can be accessed in debug mode from the console
+  // TODO: better way to publish only those parts of the api that need to be global
+  ///////////////////////////////////
+
+  var GameRoot = function (config) {
+    // Initialize the typeRegistry
+    this.typeRegistry = {};
+    this.DBTokensLength = 0;
+    this.DBTokensLengthMax = 0;
+    this.DBTokens = {};
+    this.DBOriginTokens = {};
+    this.DBTokensAbsolute = {};
+    this.DBTokensCrossSum = 0;
+    this.IPerps = {};
+    this.NotificationQueue = [];
+    return this;
+  };
+  extend(GameRoot, GameNode);
+
+  GameRoot.prototype.renderType = 'Stage';
+
+  GameRoot.prototype.get = get;
+
+  GameRoot.prototype.setup = setup;
+
+  GameRoot.prototype.ids = _ids;
+  GameRoot.prototype.getById = getById;
+
+  GameRoot.prototype.addType = function (gestalt, data) {
+    // Add a type to the typeRegistry data should have data.type_data
+    // If the game_type is also defined in typeSettings it will be merged and overwritten with data
+    if (data.game_type && data.type_data) {
+      if (typeSettings.hasOwnProperty(data.game_type)) {
+        data.type_data = mergeData(typeSettings[data.game_type].type_data, data.type_data);
+      }
+    }
+    this.typeRegistry[gestalt] = data;
+    this.typeRegistry[gestalt].gestalt = gestalt;
+    this.typeRegistry[gestalt].game_type = data.game_type;
+    // FIXME: is_supertoken fix for export fail.
+    if (gestalt.substring(0, 5) === 'token') {
+      this.typeRegistry[gestalt].type_data.is_supertoken = false;
     }
 
+    return this.typeRegistry[gestalt];
+  };
 
-    GameRoot.prototype.getDBTokensCrossSum = function(gestalt){
-      var DBTokens = this.DBTokens;
-      var sum = 0;
-      var count = 1;
-      _.each(DBTokens,function(t,k){
-        sum += t;
-        count += 1;
-      });
-      return sum / count;
-    };
-
-    GameRoot.prototype.compileOriginTokens = function(nodes){
-      var groot = this;
-      var origintokens = _.filter(nodes, function(n){ if (n.gestalt) { return n.gestalt.substring(0,6) === 'origin'; } else { return false; } });
-      _.each(origintokens, function(t,k){
-        var ot = groot.DBOriginTokens[t.gestalt] = {};
-        ot.gestalt = t.gestalt;
-        ot.data = groot.getTypeData(t.gestalt);
-        ot.amount = ot.data.amount = t.instance_data.amount;
-        ot.absoluteAmount = (groot.profiles_value * ot.amount) / 100;
-        ot.originGameNode = getByGestalt(ot.data.origin_gestalt);
-        ot.originGameType = ot.originGameNode.gameType;
-        if (ot.originGameType === "CityPerp") {
-          var citymax = ot.originGameNode.data.profiles_max;
-          ot.cityMaxAmount = (ot.amount/100) * groot.profiles_value / citymax;
-          //((float(amounts.get(origin_gestalt, 0))/100) * self.game_values.get('profiles_value')) / origin_data.get('type_data').get('profiles_max')
+  GameRoot.prototype.addSubType = function (parent_gestalt, gestalt, data) {
+    // Add a subtype to the typeRegistry data should have data.type_data
+    // If the game_type is also defined in typeSettings it will be merged and overwritten with data
+    var groot = this;
+    var parentType = groot.getType(parent_gestalt);
+    if (parentType) {
+      if (data.game_type && data.type_data) {
+        if (typeSettings.hasOwnProperty(data.game_type)) {
+          data.type_data = mergeData(typeSettings[data.game_type].type_data, data.type_data);
+          // expand powerup tokens with their type data
+          if (data.type_data.tokens && data.type_data.tokens.length) {
+            _.each(data.type_data.tokens, function (v, k) {
+              v.type_data = groot.getTypeData(v.gestalt);
+            });
+          }
         }
-      });
-    };
-
-
-    GameRoot.prototype.getOriginGestaltFromOriginTokenGestalt = function(origintokengestalt){
-      var origin = _.find(this.DBOriginTokens, function(ot){ return ot.originGameNode.gestalt === "city002" }) || {};
-      return origin.gestalt;
-    };
-
-    GameRoot.prototype.kill = function() {
-      console.warn('Killing Game');
-      clear();
-      delete app.game;
-    };
-
-    GameRoot.prototype.lock = function() {
-      // Lock the whole stage and turn off triggering of render Events
-      // TODO make stage spinner in Render and use proper method to unbind events
-      // Unlock currently wouldn't work since all events are destroyed
-      if (this.renderNode) {
-        this.renderNode.lock();
-        this.renderMenu.lock();
-        AniTicker.stop();
+        return (parentType[gestalt] = data);
       }
-      // FIXME for Popups
-      //this.renderNode.jdomelem.find('*').off();
-    };
-    GameRoot.prototype.unlock = function() {
-      // UnLock the whole stage
-      // TODO make stage spinner in Render and use proper method to unbind events
-      // Unlock currently wouldn't work since all events are destroyed
-      var groot = this;
-      if (groot.NotificationQueue && groot.NotificationQueue.length < 2) {
-        this.renderNode.unlock();
-        this.renderMenu.unlock();
-        AniTicker.start();
-      } else if (!groot.NotificationQueue) {
-        this.renderNode.unlock();
-        this.renderMenu.unlock();
-        AniTicker.start();
+    }
+  };
+
+  GameRoot.prototype.removeType = function (gestalt) {
+    // Remove a type from the typeRegistry
+    delete this.typeRegistry[gestalt];
+  };
+  GameRoot.prototype.getType = function (gestalt) {
+    // Get type from the registry, Note on the structure: data.type_data
+    return this.typeRegistry[gestalt];
+  };
+  GameRoot.prototype.getTypeData = function (gestalt) {
+    // Get type_data from the registry, Note on the structure: data.type_data
+    var type = this.getType(gestalt);
+    if (type) {
+      return type.type_data;
+    } else {
+      return undefined;
+    }
+  };
+  GameRoot.prototype.getTypes = function (game_type) {
+    // Get all types with game_type from the registry
+    //return this.typeRegistry[gestalt];
+    return _.where(this.typeRegistry, { game_type: game_type });
+  };
+  GameRoot.prototype.getTypeFromGestalt = function (gestalt) {
+    // Get all types with game_type from the registry
+    if (gestalt) {
+      return this.typeRegistry[gestalt].game_type;
+    } else {
+      return {};
+    }
+  };
+
+  GameRoot.prototype.getDBTokenAmount = function (gestalt) {
+    if (this.DBTokens && this.DBTokens.hasOwnProperty(gestalt)) {
+      return this.DBTokens[gestalt];
+    } else {
+      return 0;
+    }
+  };
+
+  GameRoot.prototype.getDBTokensLength = function () {
+    // without origin tokens
+    return (this.DBTokensLength = _.filter(_.keys(this.DBTokens), function (t) {
+      return t.substring(0, 6) !== 'origin';
+    }).length);
+  };
+
+  GameRoot.prototype.getDBTokensLengthMax = function () {
+    // without origin tokens
+    return (this.DBTokensLengthMax = _.filter(
+      _.where(this.typeRegistry, { game_type: 'TokenPerp' }),
+      function (t) {
+        return t.gestalt.substring(0, 6) !== 'origin';
       }
-      //this.renderNode.jdomelem.find('*').off();
-    };
+    ).length);
+  };
 
-    GameRoot.prototype.refresh = function() {
-      // Reload the game data and reinit the whole Game (like a page reload).
-      var groot = this;
-      groot.retryDelay = groot.retryDelay || 2000;
+  GameRoot.prototype.getDBTokensCrossSum = function (gestalt) {
+    var DBTokens = this.DBTokens;
+    var sum = 0;
+    var count = 1;
+    _.each(DBTokens, function (t, k) {
+      sum += t;
+      count += 1;
+    });
+    return sum / count;
+  };
 
-      groot.lock();
+  GameRoot.prototype.compileOriginTokens = function (nodes) {
+    var groot = this;
+    var origintokens = _.filter(nodes, function (n) {
+      if (n.gestalt) {
+        return n.gestalt.substring(0, 6) === 'origin';
+      } else {
+        return false;
+      }
+    });
+    _.each(origintokens, function (t, k) {
+      var ot = (groot.DBOriginTokens[t.gestalt] = {});
+      ot.gestalt = t.gestalt;
+      ot.data = groot.getTypeData(t.gestalt);
+      ot.amount = ot.data.amount = t.instance_data.amount;
+      ot.absoluteAmount = (groot.profiles_value * ot.amount) / 100;
+      ot.originGameNode = getByGestalt(ot.data.origin_gestalt);
+      ot.originGameType = ot.originGameNode.gameType;
+      if (ot.originGameType === 'CityPerp') {
+        var citymax = ot.originGameNode.data.profiles_max;
+        ot.cityMaxAmount = ((ot.amount / 100) * groot.profiles_value) / citymax;
+        //((float(amounts.get(origin_gestalt, 0))/100) * self.game_values.get('profiles_value')) / origin_data.get('type_data').get('profiles_max')
+      }
+    });
+  };
 
-      return app.remote.getSessionLocale().then(function(data) {
+  GameRoot.prototype.getOriginGestaltFromOriginTokenGestalt = function (origintokengestalt) {
+    var origin =
+      _.find(this.DBOriginTokens, function (ot) {
+        return ot.originGameNode.gestalt === 'city002';
+      }) || {};
+    return origin.gestalt;
+  };
+
+  GameRoot.prototype.kill = function () {
+    console.warn('Killing Game');
+    clear();
+    delete app.game;
+  };
+
+  GameRoot.prototype.lock = function () {
+    // Lock the whole stage and turn off triggering of render Events
+    // TODO make stage spinner in Render and use proper method to unbind events
+    // Unlock currently wouldn't work since all events are destroyed
+    if (this.renderNode) {
+      this.renderNode.lock();
+      this.renderMenu.lock();
+      AniTicker.stop();
+    }
+    // FIXME for Popups
+    //this.renderNode.jdomelem.find('*').off();
+  };
+  GameRoot.prototype.unlock = function () {
+    // UnLock the whole stage
+    // TODO make stage spinner in Render and use proper method to unbind events
+    // Unlock currently wouldn't work since all events are destroyed
+    var groot = this;
+    if (groot.NotificationQueue && groot.NotificationQueue.length < 2) {
+      this.renderNode.unlock();
+      this.renderMenu.unlock();
+      AniTicker.start();
+    } else if (!groot.NotificationQueue) {
+      this.renderNode.unlock();
+      this.renderMenu.unlock();
+      AniTicker.start();
+    }
+    //this.renderNode.jdomelem.find('*').off();
+  };
+
+  GameRoot.prototype.refresh = function () {
+    // Reload the game data and reinit the whole Game (like a page reload).
+    var groot = this;
+    groot.retryDelay = groot.retryDelay || 2000;
+
+    groot.lock();
+
+    return app.remote
+      .getSessionLocale()
+      .then(function (data) {
         var locale = data.result === 'de' ? 'de_AT' : 'en_US';
         i18n.setLocale(locale);
         var html = app.renderView('game.html');
         $('#dd-control').html(html);
-        return app.remote.loadGame().then(function(data) {
+        return app.remote.loadGame().then(function (data) {
           var Game = getGame();
           var gameData = data.result;
           app.version = gameData.version;
           Game.init(gameData);
         });
       })
-      .fail(function(data){
+      .fail(function (data) {
         if (groot.notificationPopup) {
           groot.notificationPopup.trigger('error');
-          window.setTimeout(function(){
+          window.setTimeout(function () {
             if (groot.notificationPopup) {
               groot.notificationPopup.render();
             }
-          },groot.retryDelay);
+          }, groot.retryDelay);
           groot.retryDelay += 1000;
           if (groot.retryDelay > 6000) {
-            document.location.href = "/";
+            document.location.href = '/';
           }
         }
       });
-    };
+  };
 
-    GameRoot.prototype.extendRender = function() {
-      if (this.renderMenu) {
-        this.renderMenu.remove();
-      }
-      var menu = new Render.MainMenu({
-        gameNode:this,
-        data:{
-          logo: {
-            frameSrc: 'MainSprites.png',
-            frameMap: {
-              normal: {x: 1, y: 819, width: 222, height: 40}
-            },
-            frame: 'normal',
-            className: 'MainMenuLogo'
+  GameRoot.prototype.extendRender = function () {
+    if (this.renderMenu) {
+      this.renderMenu.remove();
+    }
+    var menu = new Render.MainMenu({
+      gameNode: this,
+      data: {
+        logo: {
+          frameSrc: 'MainSprites.png',
+          frameMap: {
+            normal: { x: 1, y: 819, width: 222, height: 40 },
           },
-          userdata:this.userdata,
-          buttons:[]
+          frame: 'normal',
+          className: 'MainMenuLogo',
+        },
+        userdata: this.userdata,
+        buttons: [],
+      },
+    });
+
+    this.initStatusBar();
+    var statusbar = (this.renderStatusbar = new Render.Statusbar(this.data.status_bar));
+
+    var stage = this.renderNode;
+    stage.gameNode = this;
+    if (setup.debug) {
+      $(setup.renderContainer).addClass('debugmode');
+    }
+    $(setup.renderContainer).append(menu.domelem);
+    menu.initUI();
+    $(setup.renderContainer).append(stage.domelem);
+    this.renderNode = stage;
+    this.renderMenu = menu;
+    stage.addChild(statusbar);
+  };
+
+  function _showLangPicker(canDismiss) {
+    var $overlay = $(
+      '<div class="LangSelectOverlay" style="position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.75);z-index:9999;display:flex;align-items:center;justify-content:center;">' +
+        '<div class="LangPickerBox" style="background:#BFE7F5;border:3px solid #009FD9;border-radius:12px;padding:24px 32px;text-align:center;box-shadow:3px 3px 0px #009FD9,3px 3px 8px rgba(0,0,0,0.5);">' +
+        '<div style="font-family:Bowlby;color:#009FD9;font-size:20px;margin-bottom:16px;">Choose your language<br>Sprache wählen</div>' +
+        '<div style="display:flex;gap:16px;justify-content:center;">' +
+        '<div class="Button lang-pick" data-locale="en">🇺🇸🇬🇧🇦🇺 EN</div>' +
+        '<div class="Button lang-pick" data-locale="de">🇩🇪🇦🇹🇨🇭 DE</div>' +
+        '</div>' +
+        '</div>' +
+        '</div>'
+    );
+    $('body').append($overlay);
+    var picked = false;
+    $overlay.on('click touchend', '.lang-pick', function (e) {
+      e.stopPropagation();
+      e.preventDefault();
+      if (picked) {
+        return;
+      }
+      picked = true;
+      var chosen = $(this).data('locale');
+      $overlay.find('.lang-pick').addClass('disabled');
+      app.remote.setLocale(chosen).done(function () {
+        location.reload();
+      });
+    });
+    if (canDismiss) {
+      $overlay.on('click touchend', function (e) {
+        if (!$(e.target).closest('.LangPickerBox').length) {
+          e.preventDefault();
+          $overlay.remove();
         }
       });
+    }
+  }
 
-      this.initStatusBar();
-      var statusbar = this.renderStatusbar = new Render.Statusbar(this.data.status_bar);
+  GameRoot.prototype.initEventHandlers = function () {
+    var gnode = this;
 
-      var stage = this.renderNode;
-      stage.gameNode = this;
-      if (setup.debug) {
-        $(setup.renderContainer).addClass('debugmode');
-      }
-      $(setup.renderContainer).append(menu.domelem);
-      menu.initUI();
-      $(setup.renderContainer).append(stage.domelem);
-      this.renderNode = stage;
-      this.renderMenu = menu;
-      stage.addChild(statusbar);
-    };
+    // FIXME: This event should be renamed as we are out of the test phase – or are we?
+    gnode.on('saveCoordsQueue', function (e, path, pos) {
+      app.remote.setPerpCoordinates([[path, pos]]);
+    });
+    gnode.on('saveCoords', function (e, path, pos) {
+      app.remote.setPerpCoordinates([[path, pos]]);
+    });
 
-    function _showLangPicker(canDismiss) {
-      var $overlay = $(
-        '<div class="LangSelectOverlay" style="position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.75);z-index:9999;display:flex;align-items:center;justify-content:center;">' +
-          '<div class="LangPickerBox" style="background:#BFE7F5;border:3px solid #009FD9;border-radius:12px;padding:24px 32px;text-align:center;box-shadow:3px 3px 0px #009FD9,3px 3px 8px rgba(0,0,0,0.5);">' +
-            '<div style="font-family:Bowlby;color:#009FD9;font-size:20px;margin-bottom:16px;">Choose your language<br>Sprache wählen</div>' +
-            '<div style="display:flex;gap:16px;justify-content:center;">' +
-              '<div class="Button lang-pick" data-locale="en">🇺🇸🇬🇧🇦🇺 EN</div>' +
-              '<div class="Button lang-pick" data-locale="de">🇩🇪🇦🇹🇨🇭 DE</div>' +
-            '</div>' +
-          '</div>' +
-        '</div>'
-      );
-      $('body').append($overlay);
-      var picked = false;
-      $overlay.on('click touchend', '.lang-pick', function(e) {
-        e.stopPropagation();
-        e.preventDefault();
-        if (picked) { return; }
-        picked = true;
-        var chosen = $(this).data('locale');
-        $overlay.find('.lang-pick').addClass('disabled');
-        app.remote.setLocale(chosen).done(function() { location.reload(); });
+    gnode.on('switch_view', function (e, view_id) {
+      e.stopPropagation();
+      _.each(gnode.renderMenu.data.buttons, function (button) {
+        if (view_id !== button.id) {
+          getById(button.id).setState('active', false);
+        }
       });
-      if (canDismiss) {
-        $overlay.on('click touchend', function(e) {
-          if (!$(e.target).closest('.LangPickerBox').length) {
-            e.preventDefault();
-            $overlay.remove();
-          }
-        });
+      gnode.activeView = getById(view_id);
+      gnode.activeView.setState('active', true);
+      // Refresh the new view's scroller dimensions against the current
+      // stage (it may have been resized while a different tab was active),
+      // then recentre on its content. Without this, switching to Database
+      // leaves the camera wherever the previous view was scrolled.
+      var vm = gnode.activeView && gnode.activeView.renderNode;
+      if (vm && typeof vm.updateScroller === 'function') {
+        vm.updateScroller();
+      }
+      gnode._centerActiveView(true);
+    });
+
+    gnode.on('toggle_locale', function (e) {
+      e.stopPropagation();
+      _showLangPicker(true);
+    });
+
+    gnode.on('user_data', function (e) {
+      e.stopPropagation();
+      gnode.openGenericPopup({
+        data: {
+          title: 'About',
+          description: 'Data Dealer &mdash; webxdc port',
+        },
+        template: 'popup_user_data.html',
+      });
+    });
+
+    gnode.on('click_status.karma', function (e) {
+      var providedKarma = gnode.compileProvidedKarma();
+      gnode.openGenericPopup({
+        data: {
+          title: _._('karma_popup title'),
+          description: _._('karma_popup description'),
+          selectortitle: _._('karma_popup selector title'),
+          mainsprites_class: 'karma',
+          providedKarma: providedKarma,
+        },
+        template: 'popup_karma.html',
+      });
+    });
+
+    gnode.on('click_status.Profiles', function (e) {
+      gnode.openGenericPopup({
+        data: {
+          title: _._('sb_profiles title'),
+          subtitle: _.sprintf(
+            _._('sb_profiles subtitle %s from %s profiles'),
+            _.span(_.toKSNum(gnode.profiles_value)),
+            _.span(_.toKSNum(gnode.profiles_max))
+          ),
+          description: _._('sb_profiles description'),
+          mainsprites_class: 'Profiles',
+        },
+        template: 'popup_status.html',
+      });
+    });
+
+    gnode.on('click_status.Cash', function (e) {
+      gnode.openGenericPopup({
+        data: {
+          title: _._('sb_cash title'),
+          subtitle: _.sprintf(
+            _._('sb_cash subtitle <span class="highlight">$%s</span>'),
+            _.toKSNum(gnode.cash_value)
+          ),
+          description: _._('sb_cash description'),
+          mainsprites_class: 'Cash',
+        },
+        template: 'popup_status.html',
+      });
+    });
+
+    gnode.on('click_status.AP', function (e) {
+      gnode.openGenericPopup({
+        data: {
+          title: _._('sb_AP title'),
+          subtitle: _.sprintf(
+            _._('sb_AP subtitle %s/%s'),
+            _.span(_.toKSNum(gnode.ap_value)),
+            _.span(_.toKSNum(gnode.xp_level.ap_max))
+          ),
+          description: _._('sb_AP description'),
+          mainsprites_class: 'AP',
+        },
+        template: 'popup_status.html',
+      });
+    });
+
+    gnode.on('click_status.XP', function (e) {
+      gnode.openGenericPopup({
+        data: {
+          title: _._('sb_XP title'),
+          subtitle: _.sprintf(
+            _._('sb_XP subtitle Level %s'),
+            _.span(_.toKSNum(gnode.xp_level.number))
+          ),
+          description: _.sprintf(
+            _._('sb_XP description %s XP until next level'),
+            _.span(_.toKSNum(gnode.xp_level.xp_max - gnode.xp_value + 1))
+          ),
+          mainsprites_class: 'XP',
+        },
+        template: 'popup_status.html',
+      });
+    });
+
+    gnode.on('new_items', function (e, data) {
+      e.stopPropagation();
+      gnode.makeNotifications(data);
+    });
+  };
+
+  GameRoot.prototype.getParentTypes = function (gestalt) {
+    // returns the type_data of all perps where gestalt is provided
+    var types = _.filter(this.typeRegistry, function (t) {
+      return _.contains(t.type_data.provided_perps, gestalt);
+    });
+    if (types) {
+      return types;
+    } else {
+      return {};
+    }
+  };
+
+  GameRoot.prototype.getParentTypeData = function (gestalt) {
+    // returns the type_data of a perp where gestalt is provided
+    var type = _.find(this.typeRegistry, function (t) {
+      return _.contains(t.type_data.provided_perps, gestalt);
+    });
+    if (type) {
+      return type.type_data;
+    } else {
+      return {};
+    }
+  };
+
+  GameRoot.prototype.getParentType = function (gestalt) {
+    // returns the type_data of a perp where gestalt is provided
+    var type = _.find(this.typeRegistry, function (t) {
+      return _.contains(t.type_data.provided_perps, gestalt);
+    });
+    if (type) {
+      return type;
+    } else {
+      return {};
+    }
+  };
+
+  GameRoot.prototype.notification_level = 2;
+  GameRoot.prototype.makeNotifications = function (data) {
+    var gnode = this;
+    var groot = this;
+    var speed = 1;
+    if (setup.debug) {
+      speed = 0;
+    }
+    if (data.mission_complete) {
+      var mission = groot.Missions.getMission(data.mission_complete);
+      var n = mergeData({}, mission.data);
+      n.game_type = 'MissionComplete';
+      n.mission_decorator = _._('Mission complete!');
+      n.states = mission.states;
+      n.config = {
+        template: 'popup_mission_complete.html',
+        extendClass: 'Mission',
+        delay: 2500,
+        delayScript: 1000,
+      };
+      n.scriptedEvents = [];
+      n.scriptedEvents.push(function () {
+        groot.renderNode.FXMissionComplete();
+      });
+      gnode.cueNotification(n);
+    }
+    if (data.mission_active) {
+      // Only show the briefing if the player hasn't already dismissed it.
+      // The seen-flag is persisted via the dismissMissionBriefing op so it
+      // survives webxdc replay across reloads.
+      var seenBriefings = (groot.raw_data && groot.raw_data.mission_briefings_seen) || {};
+      if (!seenBriefings[data.mission_active]) {
+        var mission = groot.Missions.getMission(data.mission_active);
+        n = mergeData({}, mission.data);
+        n.game_type = 'MissionNew';
+        n.states = mission.states;
+        n.mission_decorator = _._('New Mission!');
+        n.mission = mission;
+        n.mission_active_gestalt = data.mission_active;
+        n.config = {
+          template: 'popup_mission.html',
+          extendClass: 'Mission',
+        };
+        gnode.cueNotification(n);
       }
     }
-
-    GameRoot.prototype.initEventHandlers = function() {
-      var gnode = this;
-
-      // FIXME: This event should be renamed as we are out of the test phase – or are we?
-      gnode.on('saveCoordsQueue', function(e,path,pos) {
-        app.remote.setPerpCoordinates([[path, pos]]);
+    if (data.levelup) {
+      var n = {};
+      n.game_type = 'LevelUp';
+      n.config = {
+        template: 'levelup.html',
+        extendClass: 'Tutorial',
+        placeBottom: true,
+        delay: 1200,
+      };
+      //n.nonblocking = 2000;
+      n.scriptedEvents = [];
+      n.scriptedEvents.push(function () {
+        groot.renderNode.FXLevelUpBling(data.levelup);
       });
-      gnode.on('saveCoords', function(e, path, pos) {
-        app.remote.setPerpCoordinates([[path, pos]]);
-      });
-
-
-      gnode.on('switch_view',function(e,view_id) {
-        e.stopPropagation();
-        _.each(gnode.renderMenu.data.buttons, function(button) {
-          if (view_id !== button.id) {
-            getById(button.id).setState('active',false);
-          }
-        });
-        gnode.activeView = getById(view_id);
-        gnode.activeView.setState('active',true);
-        // Refresh the new view's scroller dimensions against the current
-        // stage (it may have been resized while a different tab was active),
-        // then recentre on its content. Without this, switching to Database
-        // leaves the camera wherever the previous view was scrolled.
-        var vm = gnode.activeView && gnode.activeView.renderNode;
-        if (vm && typeof vm.updateScroller === 'function') {
-          vm.updateScroller();
-        }
-        gnode._centerActiveView(true);
-      });
-
-      gnode.on('toggle_locale',function(e) {
-        e.stopPropagation();
-        _showLangPicker(true);
-      });
-
-      gnode.on('user_data',function(e) {
-        e.stopPropagation();
-        gnode.openGenericPopup({
-          data: {
-            title: 'About',
-            description: 'Data Dealer &mdash; webxdc port'
-          },
-          template:'popup_user_data.html'
-        });
-      });
-
-      gnode.on('click_status.karma',function(e) {
-        var providedKarma = gnode.compileProvidedKarma();
-        gnode.openGenericPopup({
-          data: {
-            title: _._("karma_popup title"),
-            description: _._('karma_popup description'),
-            selectortitle: _._('karma_popup selector title'),
-            mainsprites_class: "karma",
-            providedKarma: providedKarma
-          },
-          template:'popup_karma.html'
-        });
-      });
-
-      gnode.on('click_status.Profiles',function(e) {
-        gnode.openGenericPopup({
-          data: {
-            title: _._("sb_profiles title"),
-            subtitle: _.sprintf(_._('sb_profiles subtitle %s from %s profiles'), _.span(_.toKSNum(gnode.profiles_value)), _.span(_.toKSNum(gnode.profiles_max))),
-            description: _._('sb_profiles description'),
-            mainsprites_class: "Profiles"
-          },
-          template:'popup_status.html'
-        });
-      });
-
-      gnode.on('click_status.Cash',function(e) {
-        gnode.openGenericPopup({
-          data: {
-            title: _._("sb_cash title"),
-            subtitle: _.sprintf(_._('sb_cash subtitle <span class="highlight">$%s</span>'), _.toKSNum(gnode.cash_value)),
-            description: _._('sb_cash description'),
-            mainsprites_class: "Cash"
-          },
-          template:'popup_status.html'
-        });
-      });
-
-      gnode.on('click_status.AP',function(e) {
-        gnode.openGenericPopup({
-          data: {
-            title: _._("sb_AP title"),
-            subtitle: _.sprintf(_._('sb_AP subtitle %s/%s'), _.span(_.toKSNum(gnode.ap_value)), _.span(_.toKSNum(gnode.xp_level.ap_max))),
-            description: _._('sb_AP description'),
-            mainsprites_class: "AP"
-          },
-          template:'popup_status.html'
-        });
-      });
-
-      gnode.on('click_status.XP',function(e) {
-        gnode.openGenericPopup({
-          data: {
-            title: _._("sb_XP title"),
-            subtitle: _.sprintf(_._('sb_XP subtitle Level %s'), _.span(_.toKSNum(gnode.xp_level.number))),
-            description: _.sprintf(_._('sb_XP description %s XP until next level'), _.span(_.toKSNum(gnode.xp_level.xp_max - gnode.xp_value + 1))),
-            mainsprites_class: "XP"
-          },
-          template:'popup_status.html'
-        });
-      });
-
-      gnode.on('new_items',function(e,data) {
-        e.stopPropagation();
-        gnode.makeNotifications(data);
-      });
-    };
-
-    GameRoot.prototype.getParentTypes = function(gestalt) {
-      // returns the type_data of all perps where gestalt is provided
-      var types = _.filter(this.typeRegistry, function(t){ return _.contains(t.type_data.provided_perps, gestalt); });
-      if (types) {
-        return types;
-      } else {
-        return {};
-      }
-    };
-
-    GameRoot.prototype.getParentTypeData = function(gestalt) {
-      // returns the type_data of a perp where gestalt is provided
-      var type = _.find(this.typeRegistry, function(t){ return _.contains(t.type_data.provided_perps, gestalt); });
-      if (type) {
-        return type.type_data;
-      } else {
-        return {};
-      }
-    };
-    
-    GameRoot.prototype.getParentType = function(gestalt) {
-      // returns the type_data of a perp where gestalt is provided
-      var type = _.find(this.typeRegistry, function(t){ return _.contains(t.type_data.provided_perps, gestalt); });
-      if (type) {
-        return type;
-      } else {
-        return {};
-      }
-    };
-
-    GameRoot.prototype.notification_level = 2;
-    GameRoot.prototype.makeNotifications = function(data) {
-      var gnode = this;
-      var groot = this;
-      var speed = 1;
-      if (setup.debug) { speed = 0 }
-      if (data.mission_complete) {
-        var mission = groot.Missions.getMission(data.mission_complete);
-        var n = mergeData({},mission.data);
-        n.game_type = "MissionComplete";
-        n.mission_decorator = _._('Mission complete!');
-        n.states = mission.states;
-        n.config = {
-          template: 'popup_mission_complete.html',
-          extendClass: 'Mission',
-          delay:2500,
-          delayScript:1000
-        };
-        n.scriptedEvents = [];
-        n.scriptedEvents.push(function(){
-          groot.renderNode.FXMissionComplete();
-        });
-        gnode.cueNotification(n);
-      }
-      if (data.mission_active) {
-        // Only show the briefing if the player hasn't already dismissed it.
-        // The seen-flag is persisted via the dismissMissionBriefing op so it
-        // survives webxdc replay across reloads.
-        var seenBriefings = (groot.raw_data && groot.raw_data.mission_briefings_seen) || {};
-        if (!seenBriefings[data.mission_active]) {
-          var mission = groot.Missions.getMission(data.mission_active);
-          n = mergeData({},mission.data);
-          n.game_type = "MissionNew";
-          n.states = mission.states;
-          n.mission_decorator = _._('New Mission!');
-          n.mission = mission;
-          n.mission_active_gestalt = data.mission_active;
-          n.config = {
-            template: 'popup_mission.html',
-            extendClass: 'Mission'
-          };
-          gnode.cueNotification(n);
-        }
-      }
-      if (data.levelup) {
+      gnode.cueNotification(n);
+    }
+    // FIXME: this turns off notifications during tutorials in general, currently only set by level
+    //if (data.perps && groot.states.tutorial_active !== true && groot.xp_level.number > 2) {
+    if (data.perps && groot.xp_level.number > groot.notification_level) {
+      _.each(data.perps, function (gestalt) {
         var n = {};
-        n.game_type = "LevelUp";
-        n.config = {
-          template: 'levelup.html',
-          extendClass: 'Tutorial',
-          placeBottom: true,
-          delay:1200
-        };
-        //n.nonblocking = 2000;
-        n.scriptedEvents = [];
-        n.scriptedEvents.push(function(){
-          groot.renderNode.FXLevelUpBling(data.levelup);
-        });
-        gnode.cueNotification(n);
-      }
-      // FIXME: this turns off notifications during tutorials in general, currently only set by level
-      //if (data.perps && groot.states.tutorial_active !== true && groot.xp_level.number > 2) {
-      if (data.perps && groot.xp_level.number > groot.notification_level) {
-        _.each(data.perps,function(gestalt){
-          var n = {};
-          n.config = n.config || {}
-          n.config.extendClass = 'NewItems';
-          var type = gnode.getType(gestalt);
-          n.game_type = type.game_type;
-          var tdata = gnode.getTypeData(gestalt);
-          if (type && tdata && !getByGestalt(gestalt)) {
-            var parentIsBuilt = false;
-            var parentTypes = gnode.getParentTypes(gestalt);
-            _.each(parentTypes, function(parentType){
-              var parentTypeData = parentType.type_data;
-              parentsBuilt = getAllByGestalt(parentType.gestalt).length;
-              parentIsBuilt = (parentIsBuilt) ? parentIsBuilt : parentsBuilt > 0;
-              n.perp = {data:tdata};
-              n.title = tdata.ntitle;
-              n.says = _._('Mark says:');
-              if (parentTypeData && parentTypeData.title) {
-                n.text = _.sprintf(tdata.ntext, _.span(parentTypeData.title));
-                eachByGestalt(parentType.gestalt, function(v,k) {
-                  if (v.renderNode) {
-                    v.markNewItems();
-                    v.checkProvidedByLevel();
-                    v.checkProvidedByRequiredPerps();
-                    v.highlightTabs = v.highlightTabs || [];
-                    v.highlightTabs.push(n.game_type);
-                  }
-                });
-              } else {
-                n.text = _.sprintf(tdata.ntext, _.span(tdata.title));
-              }
-            });
-            if (parentIsBuilt) {
-              gnode.cueNotification(n);
-            }
-          }
-        });
-      }
-      // Powerup Notifications
-      // FIXME same as by perps
-      //if (data.powerups && groot.states.tutorial_active !== true) {
-      if (data.powerups && groot.xp_level.number > groot.notification_level) {
-        // remap the response and prepare the types 'n' data.
-        var pow_register = {};
-        _.each(data.powerups,function(project_pows, projectgestalt){
-          var project = getByGestalt(projectgestalt);
-          if (project) {
-            _.each(project_pows, function(powerup){
-              var powgestalt = powerup.game_gestalt;
-              if (!project.getType(powgestalt)) {
-                project.addType(powgestalt,powerup);
-              }
-              var powerup_type = project.getType(powgestalt);
-              if (!pow_register.hasOwnProperty(powerup.game_gestalt)) {
-                pow_register[powerup.game_gestalt] = {};
-              }
-              var pow_reg = pow_register[powerup.game_gestalt];
-              pow_reg.game_type = powerup_type.game_type;
-              pow_reg.type_data = powerup_type.type_data;
-              pow_reg.projects = pow_reg.projects || [];
-              pow_reg.projects.push(project);
-              pow_reg.projects = _.uniq(pow_reg.projects, true);
-            });
-          }
-        });
-
-        _.each(pow_register,function(pow_reg, powgestalt){
-            var n = {};
-            n.config = {
-              extendClass: 'NewItems'
-            };
-            n.game_type = pow_reg.game_type;
-            n.perp = { data: pow_reg.type_data };
-            n.title = pow_reg.type_data.ntitle;;
-            var projectstext = "";
-            // add those decorators and make the projects notification text
-            _.each(pow_reg.projects, function(project, k) {
-              project.markNewItems();
-              project.highlightTabs = project.highlightTabs || [];
-              project.highlightTabs.push(n.game_type);
-              var sep = (k < pow_reg.projects.length -1 ) ? ", " : "";
-              projectstext = projectstext + project.data.title + sep;
-            });
-            n.says = _._('Mark says:');
-            n.text = _.sprintf(pow_reg.type_data.ntext, _.span( projectstext ));
-            // popup only if notification = true;
-            if (pow_reg.type_data.notification) {
-              gnode.cueNotification(n);
-            }
-        });
-      }
-      // Karmalizer Notification
-      if (data.karma) {
-        groot.compileProvidedKarma();
-        var gestalt = data.karma.gestalt;
-        var n = groot.getTypeData(gestalt);
-        n.selectortitle = _._('Choose your counter measures');
-        n.karma_dec = data.karma.dec;
-        n.button = _._('Do nothing');
-        n.config = {
-          template: 'popup_karma.html',
-          extendClass: 'Alert',
-          delay:650
-        };
-        n.providedKarma = groot.data.providedKarma;
+        n.config = n.config || {};
+        n.config.extendClass = 'NewItems';
         var type = gnode.getType(gestalt);
         n.game_type = type.game_type;
-        gnode.cueNotification(n);
-      }
-
-      // Simplemessage
-      if (data.simplemessage) {
-        var n = {};
-        n.game_type = "Story";
-        n.button = _._('Next');
-        n.description = data.simplemessage.text;
-        n.says = _._('Mark says:');
-        n.config = {
-          template: 'notification_tutorial.html',
-          extendClass: 'Tutorial',
-          placeBottom: true,
-          delay:0,
-        };
-        gnode.cueNotification(n);
-      }
-
-      // Tutorials and Missions
-      if (data.story && data.storyPerp) {
-        var n = {};
-        n.game_type = "Story";
-        n.button = _._('Next');
-        n.description = data.story.text;
-        n.says = _._('Mark says:');
-        n.scriptedEvents = [];
-        n.scriptedEvents.push(function() {
-          groot.trigger('switch_view',[data.storyPerp.ViewMap.id]);
-          groot.activeView.renderNode.scrollTo(data.storyPerp.renderNode.getPosition(),1000);
-        });
-        n.config = {
-          template: 'notification_tutorial.html',
-          extendClass: 'Tutorial',
-          placeBottom: true,
-          delay:0,
-        };
-        gnode.cueNotification(n);
-      }
-      if (data.tutorial) {
-        _.each(data.tutorial,function(tutorial){
-          var n = tutorial;
-          n.button = _._('Next');
-          n.says = _._('Mark says:');
-          n.config = {
-            template: 'notification_tutorial.html',
-            extendClass: 'Tutorial',
-            placeBottom: true,
-            delay:600 * speed,
-            delayScript:0
-          };
-          n.game_type = "Tutorial";
-          // TODO: handle/compile scripted events
-          // n.buyPerp
-          // n.buyParent
-          // n.buyPerpPos
-          // n.viewmap
-          // n.viewmapPos
-          // n.integrateProfileSet
-          var doadd = true;
-          // TODO: make sequence and add delays to actions.
-          // TODO: do not queue notifications with scripts already done.
-          n.scriptedEvents = [];
-          if (n.viewmap) {
-            n.config.delay = 0;
-            // FIXME: Hack for CMS fail
-            n.scriptedEvents.push(function() {
-              if (n.viewmap === "empire001") { n.viewmap = "Imperium"; }
-              if (n.viewmap === "database001") { n.viewmap = "Database"; }
-              groot.trigger('switch_view',[n.viewmap]);
-            });
-          }
-          if (n.viewmapPos) {
-            n.config.delay = (n.nodelay) ? 500 : 1000;
-            n.config.delay *= speed;
-            n.scriptedEvents.push(function() {
-              groot.activeView.renderNode.scrollTo({x:n.viewmapPos.x,y:n.viewmapPos.y},1000);
-            });
-          }
-          if (n.buyPerp && n.buyParent) {
-            var buyPerp = getByGestalt(n.buyPerp);
-            if (!buyPerp) {
-              n.config.delay = (n.nodelay) ? 500 : 3000;
-              n.config.delay *= speed;
-            } else {
-              n.config.delay = 650;
-              n.config.delay *= speed;
-            }
-            n.scriptedEvents.push(function() {
-              var parentNode = getByGestalt(n.buyParent);
-              if (parentNode) {
-                if (parentNode.renderNode.DecoratorNew) { parentNode.renderNode.DecoratorNew.remove(); }
-                var buyPerp = getByGestalt(n.buyPerp);
-                if (!buyPerp) {
-                  buyPerp = parentNode.BuyPerp(n.buyPerp,n.buyPerpPos);
-                } else {
-                  groot.activeView.renderNode.scrollTo({
-                    x: buyPerp.renderNode.getPosition().x,
-                    y: buyPerp.renderNode.getPosition().y - 40
-                  });
+        var tdata = gnode.getTypeData(gestalt);
+        if (type && tdata && !getByGestalt(gestalt)) {
+          var parentIsBuilt = false;
+          var parentTypes = gnode.getParentTypes(gestalt);
+          _.each(parentTypes, function (parentType) {
+            var parentTypeData = parentType.type_data;
+            parentsBuilt = getAllByGestalt(parentType.gestalt).length;
+            parentIsBuilt = parentIsBuilt ? parentIsBuilt : parentsBuilt > 0;
+            n.perp = { data: tdata };
+            n.title = tdata.ntitle;
+            n.says = _._('Mark says:');
+            if (parentTypeData && parentTypeData.title) {
+              n.text = _.sprintf(tdata.ntext, _.span(parentTypeData.title));
+              eachByGestalt(parentType.gestalt, function (v, k) {
+                if (v.renderNode) {
+                  v.markNewItems();
+                  v.checkProvidedByLevel();
+                  v.checkProvidedByRequiredPerps();
+                  v.highlightTabs = v.highlightTabs || [];
+                  v.highlightTabs.push(n.game_type);
                 }
-              }
-            });
+              });
+            } else {
+              n.text = _.sprintf(tdata.ntext, _.span(tdata.title));
+            }
+          });
+          if (parentIsBuilt) {
+            gnode.cueNotification(n);
           }
-          if (n.integrateProfileSet) {
-            n.config.delay = (n.nodelay) ? 500 : 5000;
-            n.config.delay *= speed;
-            n.scriptedEvents.push(function() {
-              var ps = _.find(groot.getDatabase().queue.set, function(ps){ return ps.origin.gestalt === "city002" });
-              if (ps) { groot.getDatabase().mergeCued(ps.psid); }
-            });
-          }
-          gnode.cueNotification(n);
-        });
-      }
-
-      // sort em by type!
-      var sort_types = [
-        'Error',
-        'Story',
-        'MissionComplete',
-        'LevelUp',
-        'Tutorial',
-        'Karmalizer',
-        'CityPerp',
-        'ProxyPerp',
-        'ProjectPerp',
-        'AgentPerp',
-        'ContactPerp',
-        'PusherPerp',
-        'ClientPerp',
-        'TokenPerp',
-        'UpgradePowerup',
-        'AdPowerup',
-        'TeamMemberPowerup',
-        'MissionNew'
-      ];
-      gnode.NotificationQueue = _.sortBy(gnode.NotificationQueue, function(ni){
-        return sort_types.indexOf(ni.game_type);
-      });
-      if (gnode.NotificationQueue.length) {
-        gnode.openNotification(gnode.NotificationQueue[0]);
-      }
-    };
-
-    GameRoot.prototype.cueNotification = function(notification) {
-      this.NotificationQueue.push(notification);
-    };
- 
-    GameRoot.prototype.startNotificationQueue = function() {
-    };
-
-
-    GameRoot.prototype.uncueNotification = function(notification) {
-      var index = this.NotificationQueue.indexOf(notification);
-      if (index !== -1) {
-        this.NotificationQueue.splice(index, 1);
-      }
-    };
-
-    GameRoot.prototype.compileProvidedKarma = function() {
-      var gnode = this;
-      var groot = this;
-      gnode.data.providedKarma = [];
-
-      _.each(groot.getTypes('Karmalauter'),function(v,k){
-        var karma = {};
-        karma.data = v.type_data;
-        karma.data.slot_background = gnode.data.slot_background;
-        karma.gestalt = v.gestalt;
-        // FIXME: lock level
-        if (karma.data.required_level > groot.xp_level.number) {
-          karma.locked = true;
         }
-        gnode.data.providedKarma.push(karma);
       });
-      gnode.data.providedKarma = _.sortBy(gnode.data.providedKarma, function(k){ return k.data.price; });
-      return gnode.data.providedKarma;
-    };
+    }
+    // Powerup Notifications
+    // FIXME same as by perps
+    //if (data.powerups && groot.states.tutorial_active !== true) {
+    if (data.powerups && groot.xp_level.number > groot.notification_level) {
+      // remap the response and prepare the types 'n' data.
+      var pow_register = {};
+      _.each(data.powerups, function (project_pows, projectgestalt) {
+        var project = getByGestalt(projectgestalt);
+        if (project) {
+          _.each(project_pows, function (powerup) {
+            var powgestalt = powerup.game_gestalt;
+            if (!project.getType(powgestalt)) {
+              project.addType(powgestalt, powerup);
+            }
+            var powerup_type = project.getType(powgestalt);
+            if (!pow_register.hasOwnProperty(powerup.game_gestalt)) {
+              pow_register[powerup.game_gestalt] = {};
+            }
+            var pow_reg = pow_register[powerup.game_gestalt];
+            pow_reg.game_type = powerup_type.game_type;
+            pow_reg.type_data = powerup_type.type_data;
+            pow_reg.projects = pow_reg.projects || [];
+            pow_reg.projects.push(project);
+            pow_reg.projects = _.uniq(pow_reg.projects, true);
+          });
+        }
+      });
 
+      _.each(pow_register, function (pow_reg, powgestalt) {
+        var n = {};
+        n.config = {
+          extendClass: 'NewItems',
+        };
+        n.game_type = pow_reg.game_type;
+        n.perp = { data: pow_reg.type_data };
+        n.title = pow_reg.type_data.ntitle;
+        var projectstext = '';
+        // add those decorators and make the projects notification text
+        _.each(pow_reg.projects, function (project, k) {
+          project.markNewItems();
+          project.highlightTabs = project.highlightTabs || [];
+          project.highlightTabs.push(n.game_type);
+          var sep = k < pow_reg.projects.length - 1 ? ', ' : '';
+          projectstext = projectstext + project.data.title + sep;
+        });
+        n.says = _._('Mark says:');
+        n.text = _.sprintf(pow_reg.type_data.ntext, _.span(projectstext));
+        // popup only if notification = true;
+        if (pow_reg.type_data.notification) {
+          gnode.cueNotification(n);
+        }
+      });
+    }
+    // Karmalizer Notification
+    if (data.karma) {
+      groot.compileProvidedKarma();
+      var gestalt = data.karma.gestalt;
+      var n = groot.getTypeData(gestalt);
+      n.selectortitle = _._('Choose your counter measures');
+      n.karma_dec = data.karma.dec;
+      n.button = _._('Do nothing');
+      n.config = {
+        template: 'popup_karma.html',
+        extendClass: 'Alert',
+        delay: 650,
+      };
+      n.providedKarma = groot.data.providedKarma;
+      var type = gnode.getType(gestalt);
+      n.game_type = type.game_type;
+      gnode.cueNotification(n);
+    }
 
-    GameRoot.prototype.BuyPerp = function(gestalt, placePos) {
-      // Wrapper for misc Buy operations
-      var gtype = this.getTypeFromGestalt(gestalt);
-      if (gtype === "CityPerp") {
-        var DBPerp = getByType('DatabasePerp');
-        if (DBPerp.length) {
-          DBPerp = DBPerp[0];
-        } else {
+    // Simplemessage
+    if (data.simplemessage) {
+      var n = {};
+      n.game_type = 'Story';
+      n.button = _._('Next');
+      n.description = data.simplemessage.text;
+      n.says = _._('Mark says:');
+      n.config = {
+        template: 'notification_tutorial.html',
+        extendClass: 'Tutorial',
+        placeBottom: true,
+        delay: 0,
+      };
+      gnode.cueNotification(n);
+    }
+
+    // Tutorials and Missions
+    if (data.story && data.storyPerp) {
+      var n = {};
+      n.game_type = 'Story';
+      n.button = _._('Next');
+      n.description = data.story.text;
+      n.says = _._('Mark says:');
+      n.scriptedEvents = [];
+      n.scriptedEvents.push(function () {
+        groot.trigger('switch_view', [data.storyPerp.ViewMap.id]);
+        groot.activeView.renderNode.scrollTo(data.storyPerp.renderNode.getPosition(), 1000);
+      });
+      n.config = {
+        template: 'notification_tutorial.html',
+        extendClass: 'Tutorial',
+        placeBottom: true,
+        delay: 0,
+      };
+      gnode.cueNotification(n);
+    }
+    if (data.tutorial) {
+      _.each(data.tutorial, function (tutorial) {
+        var n = tutorial;
+        n.button = _._('Next');
+        n.says = _._('Mark says:');
+        n.config = {
+          template: 'notification_tutorial.html',
+          extendClass: 'Tutorial',
+          placeBottom: true,
+          delay: 600 * speed,
+          delayScript: 0,
+        };
+        n.game_type = 'Tutorial';
+        // TODO: handle/compile scripted events
+        // n.buyPerp
+        // n.buyParent
+        // n.buyPerpPos
+        // n.viewmap
+        // n.viewmapPos
+        // n.integrateProfileSet
+        var doadd = true;
+        // TODO: make sequence and add delays to actions.
+        // TODO: do not queue notifications with scripts already done.
+        n.scriptedEvents = [];
+        if (n.viewmap) {
+          n.config.delay = 0;
+          // FIXME: Hack for CMS fail
+          n.scriptedEvents.push(function () {
+            if (n.viewmap === 'empire001') {
+              n.viewmap = 'Imperium';
+            }
+            if (n.viewmap === 'database001') {
+              n.viewmap = 'Database';
+            }
+            groot.trigger('switch_view', [n.viewmap]);
+          });
+        }
+        if (n.viewmapPos) {
+          n.config.delay = n.nodelay ? 500 : 1000;
+          n.config.delay *= speed;
+          n.scriptedEvents.push(function () {
+            groot.activeView.renderNode.scrollTo({ x: n.viewmapPos.x, y: n.viewmapPos.y }, 1000);
+          });
+        }
+        if (n.buyPerp && n.buyParent) {
+          var buyPerp = getByGestalt(n.buyPerp);
+          if (!buyPerp) {
+            n.config.delay = n.nodelay ? 500 : 3000;
+            n.config.delay *= speed;
+          } else {
+            n.config.delay = 650;
+            n.config.delay *= speed;
+          }
+          n.scriptedEvents.push(function () {
+            var parentNode = getByGestalt(n.buyParent);
+            if (parentNode) {
+              if (parentNode.renderNode.DecoratorNew) {
+                parentNode.renderNode.DecoratorNew.remove();
+              }
+              var buyPerp = getByGestalt(n.buyPerp);
+              if (!buyPerp) {
+                buyPerp = parentNode.BuyPerp(n.buyPerp, n.buyPerpPos);
+              } else {
+                groot.activeView.renderNode.scrollTo({
+                  x: buyPerp.renderNode.getPosition().x,
+                  y: buyPerp.renderNode.getPosition().y - 40,
+                });
+              }
+            }
+          });
+        }
+        if (n.integrateProfileSet) {
+          n.config.delay = n.nodelay ? 500 : 5000;
+          n.config.delay *= speed;
+          n.scriptedEvents.push(function () {
+            var ps = _.find(groot.getDatabase().queue.set, function (ps) {
+              return ps.origin.gestalt === 'city002';
+            });
+            if (ps) {
+              groot.getDatabase().mergeCued(ps.psid);
+            }
+          });
+        }
+        gnode.cueNotification(n);
+      });
+    }
+
+    // sort em by type!
+    var sort_types = [
+      'Error',
+      'Story',
+      'MissionComplete',
+      'LevelUp',
+      'Tutorial',
+      'Karmalizer',
+      'CityPerp',
+      'ProxyPerp',
+      'ProjectPerp',
+      'AgentPerp',
+      'ContactPerp',
+      'PusherPerp',
+      'ClientPerp',
+      'TokenPerp',
+      'UpgradePowerup',
+      'AdPowerup',
+      'TeamMemberPowerup',
+      'MissionNew',
+    ];
+    gnode.NotificationQueue = _.sortBy(gnode.NotificationQueue, function (ni) {
+      return sort_types.indexOf(ni.game_type);
+    });
+    if (gnode.NotificationQueue.length) {
+      gnode.openNotification(gnode.NotificationQueue[0]);
+    }
+  };
+
+  GameRoot.prototype.cueNotification = function (notification) {
+    this.NotificationQueue.push(notification);
+  };
+
+  GameRoot.prototype.startNotificationQueue = function () {};
+
+  GameRoot.prototype.uncueNotification = function (notification) {
+    var index = this.NotificationQueue.indexOf(notification);
+    if (index !== -1) {
+      this.NotificationQueue.splice(index, 1);
+    }
+  };
+
+  GameRoot.prototype.compileProvidedKarma = function () {
+    var gnode = this;
+    var groot = this;
+    gnode.data.providedKarma = [];
+
+    _.each(groot.getTypes('Karmalauter'), function (v, k) {
+      var karma = {};
+      karma.data = v.type_data;
+      karma.data.slot_background = gnode.data.slot_background;
+      karma.gestalt = v.gestalt;
+      // FIXME: lock level
+      if (karma.data.required_level > groot.xp_level.number) {
+        karma.locked = true;
+      }
+      gnode.data.providedKarma.push(karma);
+    });
+    gnode.data.providedKarma = _.sortBy(gnode.data.providedKarma, function (k) {
+      return k.data.price;
+    });
+    return gnode.data.providedKarma;
+  };
+
+  GameRoot.prototype.BuyPerp = function (gestalt, placePos) {
+    // Wrapper for misc Buy operations
+    var gtype = this.getTypeFromGestalt(gestalt);
+    if (gtype === 'CityPerp') {
+      var DBPerp = getByType('DatabasePerp');
+      if (DBPerp.length) {
+        DBPerp = DBPerp[0];
+      } else {
+        return;
+      }
+      return DBPerp.BuyCity(gestalt, placePos);
+    } else if (gtype === 'Karmalauter') {
+      //console.log('buy a karma?',gestalt);
+      return this.BuyKarma(gestalt);
+    } else {
+      //console.log('ERROR, computer says: can\'t buy',gestalt,gtype);
+      this.Error('The computer says NOOOO', data);
+    }
+  };
+
+  GameRoot.prototype.BuyKarma = function (bgestalt) {
+    var gnode = this;
+    var groot = this;
+
+    app.remote.buyKarma(bgestalt).done(function (data) {
+      if (data.result) {
+        if (data.result.error !== undefined) {
+          // Probably no cash
+          if (gnode.renderPopup && gnode.renderPopup.open) {
+            gnode.renderPopup.trigger('no_cash');
+          } else {
+            gnode.renderNode.FXNoCash();
+          }
           return;
         }
-        return DBPerp.BuyCity(gestalt, placePos);
-      } else if (gtype === "Karmalauter") {
-        //console.log('buy a karma?',gestalt);
-        return this.BuyKarma(gestalt);
-      } else {
-        //console.log('ERROR, computer says: can\'t buy',gestalt,gtype);
-        this.Error('The computer says NOOOO',data);
-      }
-    };
-    
-    GameRoot.prototype.BuyKarma = function(bgestalt) {
-      var gnode = this;
-      var groot = this;
-      
-      app.remote.buyKarma(bgestalt).done(function(data) {
-        if (data.result) {
-          if (data.result.error !== undefined) {
-            // Probably no cash
-            if (gnode.renderPopup && gnode.renderPopup.open) {
-              gnode.renderPopup.trigger('no_cash');
-            } else {
-              gnode.renderNode.FXNoCash();
-            }
-            return;
-          }
-          var karma_points = groot.getTypeData(bgestalt).karma_points;
-          var karma_value = groot.karma_value;
-          var karma_up = (karma_points + karma_value <= 100) ? karma_points : 100 - karma_value;
-          if (gnode.renderPopup) { 
-            gnode.renderPopup.trigger('popup_close'); 
-            groot.renderNode.FXKarmaBling(karma_up);
-          }
-          if (gnode.notificationPopup) { 
-            gnode.notificationPopup.trigger('popup_close'); 
-            groot.renderNode.FXKarmaBling(karma_up);
-
-          }
-          //TODO: Karma Up Animation?
-          groot.updateGameValues(data.result.game_values,data.result.levelup,data.result.missions);
-        } else if (data.result && data.result.error) {
-          if (popup) {
-            popup.trigger('error');
-          } 
-        } else {
-          // Server Error
-          gnode.Error('The computer says NOOOO',data);
+        var karma_points = groot.getTypeData(bgestalt).karma_points;
+        var karma_value = groot.karma_value;
+        var karma_up = karma_points + karma_value <= 100 ? karma_points : 100 - karma_value;
+        if (gnode.renderPopup) {
+          gnode.renderPopup.trigger('popup_close');
+          groot.renderNode.FXKarmaBling(karma_up);
         }
-      });
+        if (gnode.notificationPopup) {
+          gnode.notificationPopup.trigger('popup_close');
+          groot.renderNode.FXKarmaBling(karma_up);
+        }
+        //TODO: Karma Up Animation?
+        groot.updateGameValues(data.result.game_values, data.result.levelup, data.result.missions);
+      } else if (data.result && data.result.error) {
+        if (popup) {
+          popup.trigger('error');
+        }
+      } else {
+        // Server Error
+        gnode.Error('The computer says NOOOO', data);
+      }
+    });
+  };
+
+  GameNode.prototype.openGenericPopup = function (config) {
+    var gnode = config.gnode || this;
+    var groot = this.GameRoot;
+    var config = config || {};
+    var data = config.data || gnode.data;
+
+    gnode.popupTemplateData = {};
+    gnode.popupTemplateData.status_icons = gnode.GameRoot.data.status_icons;
+    gnode.popupTemplateData.states = config.states || {};
+    gnode.popupTemplateData.data = data;
+    //gnode.popupTemplateData.data.gestalt = 'Database';
+    //gnode.popupTemplateData.data.id = this.id;
+    gnode.popupTemplateData.groot = groot;
+    gnode.popupTemplateData.data = data;
+
+    var popupConfig = {
+      gameNode: this,
+      template: config.template || 'popup.html',
+      extendClass: config.extendClass || '',
+      templateData: gnode.popupTemplateData,
+      popupContainer: this,
     };
 
-    GameNode.prototype.openGenericPopup = function(config) {
-      var gnode = config.gnode || this;
-      var groot = this.GameRoot;
-      var config = config || {};
-      var data = config.data || gnode.data;
+    var popup = (this.renderPopup = new Render.Popup(popupConfig));
 
-      gnode.popupTemplateData = {};
-      gnode.popupTemplateData.status_icons = gnode.GameRoot.data.status_icons;
-      gnode.popupTemplateData.states = config.states || {};
-      gnode.popupTemplateData.data = data;
-      //gnode.popupTemplateData.data.gestalt = 'Database';
-      //gnode.popupTemplateData.data.id = this.id;
-      gnode.popupTemplateData.groot = groot;
-      gnode.popupTemplateData.data = data;
+    gnode.renderNode.addPopup(popup);
 
-      var popupConfig = {
-        gameNode: this,
-        template: config.template || 'popup.html',
-        extendClass: config.extendClass || "",
-        templateData: gnode.popupTemplateData,
-        popupContainer: this
-      };
+    gnode.initPopupEvents();
 
-      var popup = this.renderPopup = new Render.Popup(popupConfig);
-
-      gnode.renderNode.addPopup(popup);
-
-      gnode.initPopupEvents();
-      
-
-      /*
+    /*
       popup.on('button_click.MainButton',function(e) {
         e.stopPropagation();
         popup.close();
@@ -1566,702 +1616,750 @@ var Game = function() {
       });
       */
 
-      return popup;
-    };
+    return popup;
+  };
 
+  GameRoot.prototype.openNotification = function (notification) {
+    var gnode = this;
+    var groot = this;
+    var config = notification.config || {};
+    if (groot.notificationPopup) {
+      return;
+    }
+    var popupTemplateData = {};
+    popupTemplateData.status_icons = gnode.GameRoot.data.status_icons;
+    popupTemplateData.states = notification.states || {};
+    popupTemplateData.data = notification || {};
+    popupTemplateData.data.id = this.id;
+    popupTemplateData.groot = groot;
 
+    config.template = config.template || 'notification.html';
+    config.templateData = popupTemplateData;
+    config.popupContainer = this;
 
-    GameRoot.prototype.openNotification = function(notification) {
-      var gnode = this;
-      var groot = this;
-      var config = notification.config || {};
-      if (groot.notificationPopup) { return; }
-      var popupTemplateData = {};
-      popupTemplateData.status_icons = gnode.GameRoot.data.status_icons;
-      popupTemplateData.states = notification.states || {};
-      popupTemplateData.data = notification || {};
-      popupTemplateData.data.id = this.id;
-      popupTemplateData.groot = groot;
+    var popup = (gnode.notificationPopup = new Render.Popup(config));
+    // Tag the popup with the mission gestalt so the popup_close handler in
+    // initPopupEvents can persist the dismissal directly. Persisting in
+    // popup.callback (which only fires via popup.close(cb)) was unreliable
+    // — popup_close fires the moment the user clicks X, before the close
+    // animation/timeout chain that triggers the callback.
+    popup.notificationMission = notification.mission_active_gestalt;
+    //gnode.lock();
 
-      config.template = config.template || 'notification.html';
-      config.templateData = popupTemplateData;
-      config.popupContainer = this;
-
-      var popup = gnode.notificationPopup = new Render.Popup(config);
-      // Tag the popup with the mission gestalt so the popup_close handler in
-      // initPopupEvents can persist the dismissal directly. Persisting in
-      // popup.callback (which only fires via popup.close(cb)) was unreliable
-      // — popup_close fires the moment the user clicks X, before the close
-      // animation/timeout chain that triggers the callback.
-      popup.notificationMission = notification.mission_active_gestalt;
-      //gnode.lock();
-
-      window.setTimeout(function(){
-        if (notification.scriptedEvents && notification.scriptedEvents.length) {
-          _.each(notification.scriptedEvents,function(s){
-            s();
-          });
-        }
-      }, config.delayScript || 0);
-
-      window.setTimeout(function(){
-        gnode.renderNode.addPopup(popup);
-        gnode.initPopupEvents(popup);
-      }, config.delay || 0);
-
-      popup.callback = function(){
-        groot.uncueNotification(notification);
-        delete groot.notificationPopup;
-        if (groot.NotificationQueue.length) {
-          gnode.openNotification(groot.NotificationQueue[0]);
-        }
-      };
-
-      if (notification.nonblocking) {
-        window.setTimeout(function(){
-          popup.trigger('popup_close');
-        }, notification.nonblocking);
+    window.setTimeout(function () {
+      if (notification.scriptedEvents && notification.scriptedEvents.length) {
+        _.each(notification.scriptedEvents, function (s) {
+          s();
+        });
       }
-      return popup;
+    }, config.delayScript || 0);
+
+    window.setTimeout(function () {
+      gnode.renderNode.addPopup(popup);
+      gnode.initPopupEvents(popup);
+    }, config.delay || 0);
+
+    popup.callback = function () {
+      groot.uncueNotification(notification);
+      delete groot.notificationPopup;
+      if (groot.NotificationQueue.length) {
+        gnode.openNotification(groot.NotificationQueue[0]);
+      }
     };
 
+    if (notification.nonblocking) {
+      window.setTimeout(function () {
+        popup.trigger('popup_close');
+      }, notification.nonblocking);
+    }
+    return popup;
+  };
 
-    // The fullscreen button now resets zoom AND re-centers on the ViewMap's
-    // design home point — for Imperium that's where the seed places the
-    // Database (≈1024,800).  Falls back to a no-op if no ViewMap is active.
-    GameRoot.prototype.resetZoom = function() {
-      // activeView is only set after the first switch_view; on initial
-      // boot we need the same Imperium fallback as _centerActiveView.
-      var view = this.activeView || (this.getImperium && this.getImperium());
+  // The fullscreen button now resets zoom AND re-centers on the ViewMap's
+  // design home point — for Imperium that's where the seed places the
+  // Database (≈1024,800).  Falls back to a no-op if no ViewMap is active.
+  GameRoot.prototype.resetZoom = function () {
+    // activeView is only set after the first switch_view; on initial
+    // boot we need the same Imperium fallback as _centerActiveView.
+    var view = this.activeView || (this.getImperium && this.getImperium());
+    var vm = view && view.renderNode;
+    if (!vm || !vm.scroller || typeof vm.scroller.scrollTo !== 'function') return;
+    if (typeof vm.updateScroller === 'function') vm.updateScroller();
+    var vp = vm.parentNode;
+    if (!vp) return;
+    // Cancel any debounced re-center so it can't interrupt this animation
+    // 50ms in, which used to freeze zoom mid-tween (zoomTo+scrollTo issue
+    // a single __publish each, and the second one cancels the first).
+    clearTimeout(this._centerActiveViewTimer);
+    // scrollTo with an explicit zoom multiplies left/top by zoom internally
+    // and combines both into one __publish, so we get a single tween from
+    // (current zoom, current scroll) to (1.0, centered) instead of two
+    // animations fighting each other.
+    var sx = Math.max(0, vm.width / 2 - vp.width / 2);
+    var sy = Math.max(0, vm.height / 2 - vp.height / 2);
+    vm.scroller.scrollTo(sx, sy, true, 1);
+  };
+
+  // Re-centers the active ViewMap so the design home point sits in the
+  // middle of the visible viewport — used both at startup and from the
+  // reset-zoom button so the player isn't staring at empty space when
+  // the window is wider than the legacy 960×600 frame.
+  // Debounced: rapid callers during initial mount (fitToWindow → render
+  // after_render → tutorial switch_view) collapse into one scroll.
+  GameRoot.prototype._centerActiveView = function (animate) {
+    var self = this;
+    clearTimeout(self._centerActiveViewTimer);
+    self._centerActiveViewTimer = setTimeout(function () {
+      self._centerActiveViewTimer = null;
+      // activeView is set only after a switch_view; fall back to Imperium.
+      var view = self.activeView || (self.getImperium && self.getImperium());
       var vm = view && view.renderNode;
-      if (!vm || !vm.scroller || typeof vm.scroller.scrollTo !== 'function') return;
-      if (typeof vm.updateScroller === 'function') vm.updateScroller();
-      var vp = vm.parentNode;
-      if (!vp) return;
-      // Cancel any debounced re-center so it can't interrupt this animation
-      // 50ms in, which used to freeze zoom mid-tween (zoomTo+scrollTo issue
-      // a single __publish each, and the second one cancels the first).
-      clearTimeout(this._centerActiveViewTimer);
-      // scrollTo with an explicit zoom multiplies left/top by zoom internally
-      // and combines both into one __publish, so we get a single tween from
-      // (current zoom, current scroll) to (1.0, centered) instead of two
-      // animations fighting each other.
-      var sx = Math.max(0, vm.width  / 2 - vp.width  / 2);
-      var sy = Math.max(0, vm.height / 2 - vp.height / 2);
-      vm.scroller.scrollTo(sx, sy, true, 1);
-    };
+      if (!vm || !vm.scroller || !vm.parentNode) return;
+      var vw = vm.parentNode.width;
+      var vh = vm.parentNode.height;
+      var maxX = Math.max(0, vm.width - vw);
+      var maxY = Math.max(0, vm.height - vh);
+      var sx = Math.max(0, Math.min(maxX, vm.width / 2 - vw / 2));
+      var sy = Math.max(0, Math.min(maxY, vm.height / 2 - vh / 2));
+      vm.scroller.scrollTo(sx, sy, animate);
+    }, 50);
+  };
 
-    // Re-centers the active ViewMap so the design home point sits in the
-    // middle of the visible viewport — used both at startup and from the
-    // reset-zoom button so the player isn't staring at empty space when
-    // the window is wider than the legacy 960×600 frame.
-    // Debounced: rapid callers during initial mount (fitToWindow → render
-    // after_render → tutorial switch_view) collapse into one scroll.
-    GameRoot.prototype._centerActiveView = function(animate) {
-      var self = this;
-      clearTimeout(self._centerActiveViewTimer);
-      self._centerActiveViewTimer = setTimeout(function() {
-        self._centerActiveViewTimer = null;
-        // activeView is set only after a switch_view; fall back to Imperium.
-        var view = self.activeView || (self.getImperium && self.getImperium());
-        var vm = view && view.renderNode;
-        if (!vm || !vm.scroller || !vm.parentNode) return;
-        var vw = vm.parentNode.width;
-        var vh = vm.parentNode.height;
-        var maxX = Math.max(0, vm.width  - vw);
-        var maxY = Math.max(0, vm.height - vh);
-        var sx = Math.max(0, Math.min(maxX, vm.width  / 2 - vw / 2));
-        var sy = Math.max(0, Math.min(maxY, vm.height / 2 - vh / 2));
-        vm.scroller.scrollTo(sx, sy, animate);
-      }, 50);
-    };
+  // Size the renderable area to the current viewport.  Called on initial
+  // load and on window resize so the game fills the available space by
+  // default rather than sitting in a 960×600 letterbox.
+  GameRoot.prototype.fitToWindow = function () {
+    // The MainMenu is a sibling of the Stage in #GameContainer (not a
+    // child), so its height eats into the available viewport — without
+    // subtracting it the Stage pushes the page past the bottom edge.
+    var menuH =
+      this.renderMenu && this.renderMenu.jdomelem ? this.renderMenu.jdomelem.outerHeight() : 0;
+    this.setSize($(window).width(), $(window).height() - menuH);
+    // Refresh the scroller's viewport dimensions so the new stage size is
+    // reflected in clamping/zoom math. Without this, scrollTo and the
+    // +/- zoom buttons clamp against the previous viewport.
+    var view = this.activeView || (this.getImperium && this.getImperium());
+    var vm = view && view.renderNode;
+    if (vm && typeof vm.updateScroller === 'function') {
+      vm.updateScroller();
+    }
+    this._centerActiveView(false);
+  };
 
-    // Size the renderable area to the current viewport.  Called on initial
-    // load and on window resize so the game fills the available space by
-    // default rather than sitting in a 960×600 letterbox.
-    GameRoot.prototype.fitToWindow = function() {
-      // The MainMenu is a sibling of the Stage in #GameContainer (not a
-      // child), so its height eats into the available viewport — without
-      // subtracting it the Stage pushes the page past the bottom edge.
-      var menuH = (this.renderMenu && this.renderMenu.jdomelem)
-        ? this.renderMenu.jdomelem.outerHeight()
-        : 0;
-      this.setSize($(window).width(), $(window).height() - menuH);
-      // Refresh the scroller's viewport dimensions so the new stage size is
-      // reflected in clamping/zoom math. Without this, scrollTo and the
-      // +/- zoom buttons clamp against the previous viewport.
-      var view = this.activeView || (this.getImperium && this.getImperium());
-      var vm = view && view.renderNode;
-      if (vm && typeof vm.updateScroller === 'function') {
-        vm.updateScroller();
-      }
-      this._centerActiveView(false);
-    };
+  GameRoot.prototype.setSize = function (width, height) {
+    width = width || this.renderNode.width;
+    height = height || this.renderNode.height;
+    var maxwidth = this.getImperium().renderNode.width;
+    var maxheight = this.getImperium().renderNode.height;
+    width = width > maxwidth ? maxwidth : width;
+    width = width < this.data.width ? this.data.width : width;
+    height = height > maxheight ? maxheight : height;
+    height = height < this.data.height ? this.data.height : height;
+    this.renderNode.setSize({
+      width: width,
+      height: height,
+    });
+    this.renderMenu.setSize({
+      width: width,
+    });
+    this.renderStatusbar.render();
+    this.getDatabase().renderDBQueue.render();
+  };
 
-    GameRoot.prototype.setSize = function(width,height) {
-      width = width || this.renderNode.width;
-      height = height || this.renderNode.height;
-      var maxwidth = this.getImperium().renderNode.width;
-      var maxheight = this.getImperium().renderNode.height;
-      width = (width > maxwidth) ? maxwidth : width;
-      width = (width < this.data.width) ? this.data.width : width;
-      height = (height > maxheight) ? maxheight : height;
-      height = (height < this.data.height) ? this.data.height : height;
-      this.renderNode.setSize({
-        width:width,
-        height:height
-      });
-      this.renderMenu.setSize({
-        width:width
-      });
-      this.renderStatusbar.render();
-      this.getDatabase().renderDBQueue.render();
-    };
+  GameRoot.prototype.initStatusBar = function () {
+    this.data.status_bar.gameNode = this;
+    this.updateStatusBarValues();
+  };
 
-    GameRoot.prototype.initStatusBar = function() {
-      this.data.status_bar.gameNode = this;
-      this.updateStatusBarValues();
-    };
+  GameRoot.prototype.setLevel = function (levelnum, nolevelup) {
+    var lvl;
+    if (levelnum) {
+      lvl = this.getLevel(levelnum);
+    } else {
+      lvl = this.getLevel();
+    }
+    if (lvl !== this.getLevelByXP(this.xp_value)) {
+      this.xp_value = lvl.xp_min;
+    }
+    this.xp_level = lvl;
+    APTicker.interval = lvl.ap_inc_interval;
+    if (!nolevelup) {
+      APTicker.reset();
+    }
+    this.setAP();
+    this.setXP();
+    return this.xp_level;
+  };
 
-    GameRoot.prototype.setLevel = function(levelnum, nolevelup) {
-      var lvl;
-      if (levelnum) {
-        lvl = this.getLevel(levelnum);
-      } else {
-        lvl = this.getLevel();
-      }
-      if (lvl !== this.getLevelByXP(this.xp_value)) {
-        this.xp_value = lvl.xp_min;
-      }
-      this.xp_level = lvl;
-      APTicker.interval = lvl.ap_inc_interval;
-      if (!nolevelup) { 
-        APTicker.reset(); 
-      }
+  GameRoot.prototype.getLevel = function (level) {
+    if (level) {
+      return this.data.levels[level - 1];
+    } else {
+      return this.data.levels[this.data.game_values.xp_level - 1];
+    }
+  };
+  GameRoot.prototype.getLevelByXP = function (xp) {
+    if (!xp) {
+      return {};
+    }
+    var level = _.find(this.data.levels, function (lvl) {
+      return xp >= lvl.xp_min && xp <= lvl.xp_max;
+    });
+    return level;
+  };
+
+  GameRoot.prototype.APTick = function () {
+    if (this.xp_level.ap_max > this.ap_value) {
+      this.ap_value += this.xp_level.ap_inc_value;
       this.setAP();
-      this.setXP();
-      return this.xp_level;
-    };
+      // Remove No-AP decorators
+      this.renderNode.jdomelem.find('.Popup .no_AP').removeClass('no_AP disabled active');
+    }
+  };
 
-    GameRoot.prototype.getLevel = function(level) {
-      if (level) {
-        return this.data.levels[level-1];
-      } else {
-        return this.data.levels[this.data.game_values.xp_level-1];
+  GameRoot.prototype.updateStatusBarValues = function () {
+    // Map and evantually crunch game_values to statusbar values, without rendering
+    this.setProfiles();
+    this.setCash();
+    this.setAP();
+    this.setKarma();
+    this.setXP();
+  };
+
+  GameRoot.prototype.initGameValues = function () {
+    var gnode = this;
+    var gv = this.data.game_values; // FIXME: Added var; check for side-effects
+    this.ap_value = gv.ap_initial;
+    this.ap_offset = gv.ap_offset;
+    this.profiles_value = gv.profiles_value;
+    this.profiles_max = gv.profiles_max;
+    this.cash_value = gv.cash_value;
+    // cash_max was never initialised in the legacy code, so the cash-bar
+    // barsize divided by undefined → NaN. Pin to a sane large default so
+    // the bar fills meaningfully without overflowing once the player
+    // accumulates cash from client collections.
+    this.cash_max = gv.cash_max || 10000;
+    this.karma_value = gv.karma_value;
+    this.karma_max = 100;
+    this.xp_value = gv.xp_value;
+    this.setLevel(gv.xp_level, true);
+    APTicker.addListener(this);
+    APTicker.start(this.ap_offset);
+  };
+
+  GameRoot.prototype.updateGameValues = function (game_values, levelup, missions, silent) {
+    var groot = this;
+    var gv = game_values;
+    if (missions) {
+      groot.Missions.updateMissions(missions, game_values);
+      // FIXME: TESTING when mission completed, do not yet update game_values
+      //silent = true;
+    }
+    if (gv.profiles_max !== undefined) {
+      groot.profiles_max = gv.profiles_max;
+    }
+    if (gv.profiles_value !== undefined && gv.profiles_value !== groot.profiles_value) {
+      groot.setProfiles(gv.profiles_value, silent);
+    }
+    if (gv.cash_value !== undefined && gv.cash_value !== groot.cash_value) {
+      groot.setCash(gv.cash_value, silent);
+    }
+    if (gv.ap_increment) {
+      groot.useAP(gv.ap_increment, silent);
+    }
+    if (gv.karma_value !== undefined && gv.karma_value !== groot.karma_value) {
+      groot.setKarma(gv.karma_value, silent);
+    }
+    if (gv.xp_value !== undefined) {
+      groot.setXP(gv.xp_value, silent);
+    }
+    // ap_snapshot is the authoritative engine AP — sync the visible
+    // ap_value whenever it differs, not only on levelup. Without this,
+    // the statusbar AP bar shows stale text after every chargePerp /
+    // integrateCollected (handlers decrement ap_snapshot but Game.js
+    // never reapplied it pre-#120 follow-up).
+    if (gv.ap_snapshot !== undefined && gv.ap_snapshot !== groot.ap_value) {
+      groot.setAP(gv.ap_snapshot, silent);
+    }
+    // levelup-only side effects.
+    if (gv.ap_snapshot !== undefined && levelup === true && !silent) {
+      groot.getDatabase().checkNotifications();
+      groot.makeNotifications({ levelup: groot.xp_level.number });
+    }
+  };
+
+  GameRoot.prototype.useAP = function (inc) {
+    this.setAP(this.ap_value + inc);
+  };
+
+  var sb; // Added declaration; check for side-effects
+  GameRoot.prototype.setAP = function (num, silent) {
+    if (num !== undefined) {
+      this.ap_value = num;
+    }
+    if (this.ap_value > this.xp_level.ap_max) {
+      this.ap_value = this.xp_level.ap_max;
+    }
+    sb = this.data.status_bar;
+    // Only clip AP display: internally it can be -1 since that's the server's bonus
+    var clipap = this.ap_value < 0 ? 0 : this.ap_value;
+    sb.AP.val = this.ap_value < 0 ? 0 : this.ap_value;
+    sb.AP.max = this.xp_level.ap_max;
+    sb.AP.barsize = Math.min(
+      120,
+      Math.max(0, Math.round((sb.AP.val / this.xp_level.ap_max) * 120))
+    );
+    // Always invoke FXUpdate*: the Statusbar template binds the flat
+    // AP_val prop, which only refreshes inside FXUpdateAP. Skipping it
+    // on silent paths leaves the rendered DOM stale (issue #153).
+    if (this.renderStatusbar) {
+      this.renderStatusbar.FXUpdateAP(silent);
+    }
+  };
+
+  GameRoot.prototype.setCash = function (num, silent) {
+    if (num !== undefined) {
+      this.cash_value = num;
+    }
+    sb = this.data.status_bar;
+    sb.cash.val = this.cash_value;
+    sb.cash.barsize = Math.min(
+      120,
+      Math.max(0, Math.round((this.cash_value / this.cash_max) * 120))
+    );
+    if (this.renderStatusbar) {
+      this.renderStatusbar.FXUpdateCash(silent);
+    }
+  };
+
+  GameRoot.prototype.setProfiles = function (num, silent) {
+    if (num !== undefined) {
+      this.profiles_value = num;
+    }
+    if (this.profiles_value > this.profiles_max) {
+      this.profiles_value = this.profiles_max;
+    }
+    sb = this.data.status_bar;
+    sb.profiles.val = this.profiles_value;
+    sb.profiles.max = this.profiles_max;
+    sb.profiles.barsize = Math.min(
+      120,
+      Math.max(0, Math.round((this.profiles_value / this.profiles_max) * 120))
+    );
+    sb.profiles.crosssum = this.getDBTokensCrossSum();
+    this.getDBTokensLength();
+    sb.profiles.tokenslength = this.DBTokensLength;
+    sb.profiles.tokenslengthmax = this.DBTokensLengthMax;
+    if (this.renderStatusbar) {
+      this.renderStatusbar.FXUpdateProfiles(silent);
+    }
+  };
+
+  GameRoot.prototype.setKarma = function (num, silent) {
+    // FIXME TEST values
+    //num = 33;
+    if (num !== undefined) {
+      this.karma_value = num;
+    }
+    if (this.karma_value > this.karma_max) {
+      this.karma_value = this.karma_max;
+    }
+    if (this.karma_value < -this.karma_max) {
+      this.karma_value = -this.karma_max;
+    }
+
+    sb = this.data.status_bar;
+    sb.karma.val = this.karma_value;
+    sb.karma.max = this.karma_max || 100;
+    //var val_center = 50 - this.karma_value;
+    //FIXME: set to correct level not 50;
+    sb.karma.barsize = Math.min(
+      59,
+      Math.max(-59, Math.round((this.karma_value / this.karma_max) * 59))
+    );
+    if (this.renderStatusbar) {
+      this.renderStatusbar.FXUpdateKarma(silent);
+    }
+  };
+
+  GameRoot.prototype.setXP = function (num, silent) {
+    if (num !== undefined) {
+      if (num > this.xp_value) {
+        this.xp_value = num;
       }
+    }
+    if (this.xp_value > this.xp_level.xp_max) {
+      this.setLevel(this.getLevelByXP(this.xp_value).number);
+    }
+    if (this.xp_value < this.xp_level.xp_min) {
+      this.setLevel(this.getLevelByXP(this.xp_value).number);
+    }
+    sb = this.data.status_bar;
+    sb.XP.val = this.xp_value;
+    sb.XP.level = this.xp_level.number;
+    sb.XP.barsize = Math.min(
+      96,
+      Math.max(
+        0,
+        Math.round(
+          ((this.xp_value - this.xp_level.xp_min) / (this.xp_level.xp_max - this.xp_level.xp_min)) *
+            96
+        )
+      )
+    );
+    if (this.renderStatusbar) {
+      this.renderStatusbar.FXUpdateXP(silent);
+    }
+  };
+
+  ///////////////////////////////////////
+  // Loading a Game happens here:
+  //////////////////////////////////////
+
+  GameRoot.prototype.loadGame = function (data) {
+    // Clear if there are instances in the singleton
+    clear();
+    // Initialize the Game with self (reminder: there should only be one GameRoot!)
+    var game = this;
+    game.APTicker = APTicker;
+
+    if (setup.debug) {
+      app.Game = Game;
+    }
+
+    // Register all types (applies to all game_types)
+    _.each(data.type_registry, function (v, k) {
+      game.addType(k, v);
+    });
+
+    // Register dummy gestalt of GameRoot (needed for type_settings):
+    game.addType('GameRoot', {
+      game_type: 'GameRoot',
+      type_data: data.type_data || {},
+    });
+    game.addType('ProfileSet', {
+      game_type: 'ProfileSet',
+      type_data: {},
+    });
+
+    // Basic config of the GameRoot
+    var config = {
+      id: data._id,
+      userdata: data.user,
+      raw_data: data,
+      data: mergeData(game.getTypeData('GameRoot'), data),
+      gameType: 'GameRoot',
     };
-    GameRoot.prototype.getLevelByXP = function(xp) {
-      if (!xp) { return {}; }
-      var level = _.find(this.data.levels,function(lvl){
-        return ((xp >= lvl.xp_min) && (xp <= lvl.xp_max));
+    this.init(config);
+
+    // Seed display_name from webxdc.selfName on first boot; persisted as a delta
+    // so the name survives reloads without prompting the user again. The helper
+    // is non-mutating — we route the new name through setDisplayName so the
+    // reducer produces a fresh state instead of corrupting the live reference.
+    var newSelfName = webxdcIdentity.getMessengerDisplayNameChange(this.data.user);
+    if (newSelfName) {
+      app.remote.setDisplayName(newSelfName);
+    }
+
+    this.initGameValues();
+
+    this.makeRenderConfig();
+
+    // Make Main Tabs
+    _.each(['Imperium', 'Database'], function (v) {
+      game.addType(v, {
+        game_type: v,
+        type_data: data[v].type_data || {},
       });
-      return level;
-    };
+      var viewmap = new Game[v]({
+        id: data[v].game_id,
+        path: data[v].full_path,
+        data: mergeData(game.getTypeData(v), data[v].instance_data),
+        renderNodeParent: game.id,
+        gameType: v,
+      });
+      game[v] = viewmap;
+      game.addChild(viewmap);
+    });
 
+    // Make Missions Tab
+    game.addType('Missions', {
+      game_type: 'Missions',
+      type_data: {},
+    });
+    var viewmap = new Game.Missions({
+      id: 'Missions',
+      data: game.getTypeData('Missions'),
+      renderNodeParent: game.id,
+      gameType: 'Missions',
+    });
+    game.Missions = viewmap;
+    game.addChild(viewmap);
 
-    GameRoot.prototype.APTick = function() {
-      if (this.xp_level.ap_max > this.ap_value) {
-        this.ap_value += this.xp_level.ap_inc_value;
-        this.setAP();
-        // Remove No-AP decorators
-        this.renderNode.jdomelem.find('.Popup .no_AP').removeClass('no_AP disabled active');
+    // Make Topscores Tab
+    game.addType('Topscores', {
+      game_type: 'Topscores',
+      type_data: {},
+    });
+    game.addType('Topscore', {
+      game_type: 'Topscore',
+      type_data: {},
+    });
+
+    topscores = new Game.Topscores({
+      id: 'Topscores',
+      data: game.getTypeData('Topscores'),
+      renderNodeParent: game.id,
+      gameType: 'Topscores',
+    });
+    game.Topscores = topscores;
+    game.addChild(topscores);
+    _.each(topscores.data.type_titles, function (title, type) {
+      topscores.initTopscore(type);
+    });
+
+    // Fill DBTokens lookup table
+    _.each(_.where(game.raw_data.nodes, { game_type: 'TokenPerp' }), function (t) {
+      game.DBTokens[t.gestalt] = t.instance_data.amount;
+    });
+
+    game.getDBTokensLength();
+    game.getDBTokensLengthMax();
+
+    // Create Imperium and Database GameNode Tree Structure without recursion
+    var sortnodes = _.sortBy(data.nodes, function (elem) {
+      return elem.full_path;
+    });
+
+    // exclude origin tokens
+    sortnodes = _.filter(sortnodes, function (n) {
+      if (n.gestalt) {
+        return n.gestalt.substring(0, 6) !== 'origin';
+      } else {
+        return true;
+      }
+    });
+
+    _.each(sortnodes, function (datanode, k) {
+      var parentGameNode = getParentFromPath(datanode.full_path);
+      // get gestalt from full_type if not available:
+      if (!datanode.gestalt) {
+        datanode.gestalt = getGestalt(datanode.full_type);
+      }
+      // register dummy type when node not in typeRegistry:
+      if (!game.getType(datanode.gestalt)) {
+        game.addType(datanode.gestalt, {
+          game_type: datanode.game_type,
+          type_data: datanode.type_data,
+        });
+      }
+      var type_data = game.getTypeData(datanode.gestalt);
+      var node_data = mergeData(type_data, datanode.instance_data);
+      var perp = new Game[datanode.game_type]({
+        id: datanode.game_id,
+        gestalt: getGestalt(datanode.full_type),
+        path: datanode.full_path,
+        data: node_data,
+        // Render perps to first item in path (Imperium or Database)
+        renderNodeParent: getFirstId(datanode.full_path),
+        ViewMap: getByFirstId(datanode.full_path),
+        parentNode: parentGameNode,
+        gameType: datanode.game_type,
+      });
+      parentGameNode.addChild(perp);
+    });
+
+    _.each(data.nodes_charging, function (v) {
+      var gnode = getByLastId(v.path);
+      var timerconf = {
+        serverTime: game.raw_data.server_time.$date,
+        duration: gnode.data.charge_time,
+        // chargeEntry.charge_start is a plain epoch-ms number — no $date wrapper.
+        serverStart: v.charge_start,
+      };
+      gnode.setAttrs({ _loadTimer: timerconf });
+    });
+
+    _.each(data.nodes_collect, function (v) {
+      var gnode = getByLastId(v.path);
+      gnode.setAttrs({ _loadReady: true });
+    });
+
+    // register Missions...
+    game.Missions.initMissions(data);
+
+    _.each(data.db_queue, function (v) {
+      game.getDatabase().cue(v.profile_set, v.origin, v.collect_id);
+    });
+
+    // register Karmalizers and Karmalauters...
+    _.each(data.karmalauters, function (p, key) {
+      game.addType(p.type_data.gestalt, p);
+    });
+    _.each(data.karmalizers, function (p, key) {
+      game.addType(p.type_data.gestalt, p);
+    });
+
+    // compile origin tokens for Database
+    game.compileOriginTokens(data.nodes);
+
+    game.on('after_render', function () {
+      game.renderNode.show();
+      AniTicker.start();
+    });
+    game.on('before_render', function () {
+      game.renderNode.hide();
+    });
+
+    game.render();
+    // On first game start with no explicit locale choice, ask the player.
+    if (data.is_new_game && !data.locale_persisted) {
+      _showLangPicker(false);
+    }
+
+    // fitToWindow handles centring; the legacy is_new_game scrollTo would
+    // be immediately overwritten so we no longer set it here.
+    game.fitToWindow();
+    $(window)
+      .off('resize.gameFit')
+      .on(
+        'resize.gameFit',
+        _.debounce(function () {
+          game.fitToWindow();
+        }, 100)
+      );
+
+    return game;
+  };
+
+  GameRoot.prototype.getImperium = function () {
+    // FIXME: this is just a wrapper
+    return this.Imperium;
+  };
+
+  GameRoot.prototype.getDatabase = function () {
+    // FIXME: this is just a wrapper
+    return this.Database;
+  };
+
+  ///////////////////////////////////
+  // The ProfileSet
+  ///////////////////////////////////
+
+  var ProfileSet = function (config, tokens) {
+    // Used both as Template and cued Object in DBQueue
+    this.init(config);
+    var gnode = this;
+    var groot = this.GameRoot;
+
+    tokens = _.clone(tokens);
+    this.data = groot.getTypeData('ProfileSet');
+    var filter_is_query = this.filter_is_query;
+
+    if (this.convertTokens) {
+      _.each(tokens, function (t, k) {
+        tokens[k] = { gestalt: t };
+      });
+    }
+
+    this.tokens_map = {};
+    this.tokens_set = [];
+    var addtokens = [];
+    // Check if tokens is object with keys or array
+    if (tokens.length === undefined && gnode.origin) {
+      // Asuming its a token_map from the queue or collect
+      // FIXME: this messes with sorting, either we use a kind of sort key, or backend can give me an array!
+      _.each(tokens.tokens_map, function (v, k) {
+        var addme = {
+          gestalt: k,
+          amount: v.amount,
+          // collect_amount is profiles value here
+          collect_amount: gnode.profiles_value,
+        };
+        // exclude origin tokens
+        if (addme.gestalt.substring(0, 6) !== 'origin') {
+          addtokens.push(addme);
+        }
+      });
+      this.tokens_map = tokens.tokens_map;
+    } else {
+      // Asuming its from the source perp
+      // exclude origin tokens
+      addtokens = _.filter(tokens, function (n) {
+        if (n.gestalt) {
+          return n.gestalt.substring(0, 6) !== 'origin';
+        }
+      });
+      if (config.filter_is_query) {
+        var is_query = filter_is_query === 'blue';
+        addtokens = _.filter(tokens, function (n) {
+          {
+            return n.is_query === is_query;
+          }
+        });
       }
     }
 
-    GameRoot.prototype.updateStatusBarValues = function() {
-      // Map and evantually crunch game_values to statusbar values, without rendering
-      this.setProfiles();
-      this.setCash();
-      this.setAP();
-      this.setKarma();
-      this.setXP();
-    };
-
-    GameRoot.prototype.initGameValues = function() {
-      var gnode = this;
-      var gv = this.data.game_values; // FIXME: Added var; check for side-effects
-      this.ap_value = gv.ap_initial;
-      this.ap_offset = gv.ap_offset;
-      this.profiles_value = gv.profiles_value;
-      this.profiles_max = gv.profiles_max;
-      this.cash_value = gv.cash_value;
-      // cash_max was never initialised in the legacy code, so the cash-bar
-      // barsize divided by undefined → NaN. Pin to a sane large default so
-      // the bar fills meaningfully without overflowing once the player
-      // accumulates cash from client collections.
-      this.cash_max = gv.cash_max || 10000;
-      this.karma_value = gv.karma_value;
-      this.karma_max = 100;
-      this.xp_value = gv.xp_value;
-      this.setLevel(gv.xp_level, true);
-      APTicker.addListener(this);
-      APTicker.start(this.ap_offset);
-    };
-
-    GameRoot.prototype.updateGameValues = function(game_values,levelup,missions,silent) {
-      var groot = this;
-      var gv = game_values;
-      if (missions) {
-          groot.Missions.updateMissions(missions, game_values);
-          // FIXME: TESTING when mission completed, do not yet update game_values
-          //silent = true;
+    // We build and extend the token_set
+    _.each(addtokens, function (token, k) {
+      // don't mess with the original data
+      var t = _.extend({}, token);
+      t.data = groot.getTypeData(token.gestalt);
+      if (gnode.DBAmounts) {
+        t.database_amount = groot.DBTokens[token.gestalt] || 0;
+        t.database_absoluteAmount = groot.DBTokensAbsolute[token.gestalt] || 0;
       }
-      if (gv.profiles_max !== undefined) {
-        groot.profiles_max = gv.profiles_max;
-      }
-      if (gv.profiles_value !== undefined && gv.profiles_value !== groot.profiles_value) {
-        groot.setProfiles(gv.profiles_value,silent);
-      }
-      if (gv.cash_value !== undefined && gv.cash_value !== groot.cash_value) {
-        groot.setCash(gv.cash_value,silent);
-      }
-      if (gv.ap_increment) {
-        groot.useAP(gv.ap_increment,silent);
-      }
-      if (gv.karma_value !== undefined && gv.karma_value !== groot.karma_value) {
-        groot.setKarma(gv.karma_value,silent);
-      }
-      if (gv.xp_value !== undefined) {
-        groot.setXP(gv.xp_value,silent);
-      }
-      // ap_snapshot is the authoritative engine AP — sync the visible
-      // ap_value whenever it differs, not only on levelup. Without this,
-      // the statusbar AP bar shows stale text after every chargePerp /
-      // integrateCollected (handlers decrement ap_snapshot but Game.js
-      // never reapplied it pre-#120 follow-up).
-      if (gv.ap_snapshot !== undefined && gv.ap_snapshot !== groot.ap_value) {
-        groot.setAP(gv.ap_snapshot,silent);
-      }
-      // levelup-only side effects.
-      if (gv.ap_snapshot !== undefined && levelup === true && !silent) {
-        groot.getDatabase().checkNotifications();
-        groot.makeNotifications({levelup: groot.xp_level.number});
-      }
-    };
-
-    GameRoot.prototype.useAP = function(inc) {
-      this.setAP(this.ap_value + inc);
-    };
-
-    var sb; // Added declaration; check for side-effects
-    GameRoot.prototype.setAP = function(num,silent) {
-      if (num !== undefined) {
-        this.ap_value = num;
-      }
-      if (this.ap_value > this.xp_level.ap_max) {
-        this.ap_value = this.xp_level.ap_max;
-      }
-      sb = this.data.status_bar;
-      // Only clip AP display: internally it can be -1 since that's the server's bonus
-      var clipap = (this.ap_value < 0) ? 0 : this.ap_value
-      sb.AP.val = (this.ap_value < 0) ? 0 : this.ap_value;
-      sb.AP.max = this.xp_level.ap_max;
-      sb.AP.barsize = Math.min(120, Math.max(0, Math.round((sb.AP.val/this.xp_level.ap_max)*120)));
-      // Always invoke FXUpdate*: the Statusbar template binds the flat
-      // AP_val prop, which only refreshes inside FXUpdateAP. Skipping it
-      // on silent paths leaves the rendered DOM stale (issue #153).
-      if (this.renderStatusbar) { this.renderStatusbar.FXUpdateAP(silent); }
-    };
-
-    GameRoot.prototype.setCash = function(num,silent) {
-      if (num !== undefined) {
-        this.cash_value = num;
-      }
-      sb = this.data.status_bar;
-      sb.cash.val = this.cash_value;
-      sb.cash.barsize = Math.min(120, Math.max(0, Math.round((this.cash_value/this.cash_max)*120)));
-      if (this.renderStatusbar) { this.renderStatusbar.FXUpdateCash(silent); }
-    };
-
-    GameRoot.prototype.setProfiles = function(num,silent) {
-      if (num !== undefined) {
-        this.profiles_value = num;
-      }
-      if (this.profiles_value > this.profiles_max) {
-        this.profiles_value = this.profiles_max;
-      }
-      sb = this.data.status_bar;
-      sb.profiles.val = this.profiles_value;
-      sb.profiles.max = this.profiles_max;
-      sb.profiles.barsize = Math.min(120, Math.max(0, Math.round((this.profiles_value/this.profiles_max)*120)));
-      sb.profiles.crosssum = this.getDBTokensCrossSum();
-      this.getDBTokensLength();
-      sb.profiles.tokenslength = this.DBTokensLength;
-      sb.profiles.tokenslengthmax = this.DBTokensLengthMax;
-      if (this.renderStatusbar) { this.renderStatusbar.FXUpdateProfiles(silent); }
-    };
-
-    GameRoot.prototype.setKarma = function(num,silent) {
-      // FIXME TEST values
-      //num = 33;
-      if (num !== undefined) {
-        this.karma_value = num;
-      }
-      if (this.karma_value > this.karma_max) {
-        this.karma_value = this.karma_max;
-      }
-      if (this.karma_value < -this.karma_max) {
-        this.karma_value = -this.karma_max;
-      }
-
-      sb = this.data.status_bar;
-      sb.karma.val = this.karma_value;
-      sb.karma.max = this.karma_max || 100;
-      //var val_center = 50 - this.karma_value;
-      //FIXME: set to correct level not 50;
-      sb.karma.barsize = Math.min(59, Math.max(-59, Math.round((this.karma_value/this.karma_max)*59)));
-      if (this.renderStatusbar) { this.renderStatusbar.FXUpdateKarma(silent); }
-    };
-
-    GameRoot.prototype.setXP = function(num,silent) {
-      if (num !== undefined) {
-        if (num > this.xp_value) {
-          this.xp_value = num;
+      if (gnode.markNew) {
+        var seenMap = (groot.raw_data && groot.raw_data.tokens_seen) || {};
+        if (!groot.DBTokens.hasOwnProperty(token.gestalt) && !seenMap[token.gestalt]) {
+          t.new = true;
         }
       }
-      if (this.xp_value > this.xp_level.xp_max) {
-        this.setLevel(this.getLevelByXP(this.xp_value).number);
+      if (gnode.lockAmountZero && token.amount === 0) {
+        t.locked = true;
       }
-      if (this.xp_value < this.xp_level.xp_min) {
-        this.setLevel(this.getLevelByXP(this.xp_value).number);
+      if (gnode.lockNotInDB && !groot.DBTokens.hasOwnProperty(token.gestalt)) {
+        t.locked = true;
       }
-      sb = this.data.status_bar;
-      sb.XP.val = this.xp_value;
-      sb.XP.level = this.xp_level.number;
-      sb.XP.barsize = Math.min(96, Math.max(0, Math.round(((this.xp_value - this.xp_level.xp_min) / (this.xp_level.xp_max - this.xp_level.xp_min)) * 96)));
-      if (this.renderStatusbar) { this.renderStatusbar.FXUpdateXP(silent); }
-    };
-
-
-    ///////////////////////////////////////
-    // Loading a Game happens here:
-    //////////////////////////////////////
-
-    GameRoot.prototype.loadGame = function(data) {
-      // Clear if there are instances in the singleton
-      clear();
-      // Initialize the Game with self (reminder: there should only be one GameRoot!)
-      var game = this;
-      game.APTicker = APTicker;
-
-      if (setup.debug) {
-        app.Game = Game;
+      if (gnode.markUpgradeValues && gnode.lastUpgradeValues && !t.locked) {
+        var lastProfileValues = gnode.lastUpgradeValues.profiles_value;
+        var lastAmount = gnode.lastUpgradeValues.token_map[t.gestalt] || 0;
+        var lastAbsoluteAmount = (lastProfileValues * lastAmount) / 100;
+        var currentAbsoluteAmount = gnode.GameRoot.DBTokensAbsolute[t.gestalt];
+        t.diffAbsoluteAmount = currentAbsoluteAmount - lastAbsoluteAmount;
+        t.doneAbsoluteAmount = t.database_absoluteAmount - t.diffAbsoluteAmount;
+        t.diffAmount = 100 / (groot.profiles_value / t.diffAbsoluteAmount);
+        t.doneAmount = t.database_amount - t.diffAmount;
+      } else if (gnode.markUpgradeValues && !gnode.lastUpgradeValues && !t.locked) {
+        t.diffAbsoluteAmount = groot.DBTokensAbsolute[token.gestalt] || 0;
+        t.diffAmount = groot.DBTokens[token.gestalt] || 0;
+        t.doneAmount = 0;
+        t.doneAbsoluteAmount = 0;
       }
 
-      // Register all types (applies to all game_types)
-      _.each(data.type_registry,function(v,k){
-        game.addType(k,v);
-      });
-
-      // Register dummy gestalt of GameRoot (needed for type_settings):
-      game.addType('GameRoot',{
-        game_type: 'GameRoot',
-        type_data: data.type_data || {}
-      });
-      game.addType('ProfileSet',{
-        game_type: 'ProfileSet',
-        type_data:{}
-      });
-
-
-      // Basic config of the GameRoot
-      var config = {
-        "id": data._id,
-        "userdata": data.user,
-        "raw_data": data,
-        "data": mergeData(game.getTypeData('GameRoot'),data),
-        "gameType": "GameRoot"
-      };
-      this.init(config);
-
-      // Seed display_name from webxdc.selfName on first boot; persisted as a delta
-      // so the name survives reloads without prompting the user again. The helper
-      // is non-mutating — we route the new name through setDisplayName so the
-      // reducer produces a fresh state instead of corrupting the live reference.
-      var newSelfName = webxdcIdentity.getMessengerDisplayNameChange(this.data.user);
-      if (newSelfName) {
-        app.remote.setDisplayName(newSelfName);
+      // FIXME: Show origin data for debug reasons only
+      if (token.origin_gestalt) {
+        t.data = groot.getTypeData(token.origin_gestalt);
       }
-
-      this.initGameValues();
-
-      this.makeRenderConfig();
-
-
-      // Make Main Tabs
-      _.each(['Imperium', 'Database'],function(v){
-        game.addType(v,{
-          game_type: v,
-          type_data: data[v].type_data || {}
-        });
-        var viewmap = new Game[v]({
-          "id": data[v].game_id,
-          "path": data[v].full_path,
-          "data": mergeData(game.getTypeData(v),data[v].instance_data),
-          "renderNodeParent": game.id,
-          "gameType" : v
-        });
-        game[v] = viewmap;
-        game.addChild(viewmap);
-      });
-
-      // Make Missions Tab
-      game.addType('Missions',{
-        game_type: 'Missions',
-        type_data: {}
-      });
-      var viewmap = new Game.Missions({
-        "id": "Missions",
-        "data": game.getTypeData('Missions'),
-        "renderNodeParent": game.id,
-        "gameType" : 'Missions'
-      });
-      game.Missions = viewmap;
-      game.addChild(viewmap);
-
-      // Make Topscores Tab
-      game.addType('Topscores',{
-        game_type: 'Topscores',
-        type_data: {}
-      });
-      game.addType('Topscore',{
-        game_type: 'Topscore',
-        type_data: {}
-      });
-
-      topscores = new Game.Topscores({
-        "id": "Topscores",
-        "data": game.getTypeData('Topscores'),
-        "renderNodeParent": game.id,
-        "gameType" : 'Topscores'
-      });
-      game.Topscores = topscores;
-      game.addChild(topscores);
-      _.each(topscores.data.type_titles, function(title,type){
-        topscores.initTopscore(type);
-      });
-
-      // Fill DBTokens lookup table
-      _.each(_.where(game.raw_data.nodes,{game_type:"TokenPerp"}),function(t){
-        game.DBTokens[t.gestalt] = t.instance_data.amount;
-      });
-
-      game.getDBTokensLength();
-      game.getDBTokensLengthMax();
-
-      // Create Imperium and Database GameNode Tree Structure without recursion
-      var sortnodes = _.sortBy(data.nodes, function(elem){return elem.full_path;});
-
-      // exclude origin tokens
-      sortnodes = _.filter(sortnodes, function(n){ if (n.gestalt) { return n.gestalt.substring(0,6) !== 'origin'; } else { return true; }  });
-
-      _.each(sortnodes, function(datanode,k) {
-        var parentGameNode = getParentFromPath(datanode.full_path);
-        // get gestalt from full_type if not available:
-        if (!datanode.gestalt) {
-          datanode.gestalt = getGestalt(datanode.full_type);
-        }
-        // register dummy type when node not in typeRegistry:
-        if (!game.getType(datanode.gestalt)) {
-          game.addType(datanode.gestalt, {
-            game_type: datanode.game_type,
-            type_data: datanode.type_data
-          });
-        }
-        var type_data = game.getTypeData(datanode.gestalt);
-        var node_data = mergeData(type_data,datanode.instance_data);
-        var perp = new Game[datanode.game_type]({
-              "id": datanode.game_id,
-              "gestalt": getGestalt(datanode.full_type),
-              "path": datanode.full_path,
-              "data": node_data,
-              // Render perps to first item in path (Imperium or Database)
-              "renderNodeParent": getFirstId(datanode.full_path),
-              "ViewMap": getByFirstId(datanode.full_path),
-              "parentNode": parentGameNode,
-              "gameType": datanode.game_type
-        });
-        parentGameNode.addChild(perp);
-      });
-
-      _.each(data.nodes_charging, function(v) {
-        var gnode = getByLastId(v.path);
-        var timerconf = {
-          serverTime: game.raw_data.server_time.$date,
-          duration: gnode.data.charge_time,
-          // chargeEntry.charge_start is a plain epoch-ms number — no $date wrapper.
-          serverStart: v.charge_start
-        };
-        gnode.setAttrs({_loadTimer: timerconf});
-      });
-
-      _.each(data.nodes_collect, function(v) {
-        var gnode = getByLastId(v.path);
-        gnode.setAttrs({_loadReady: true});
-      });
-
-      // register Missions...
-      game.Missions.initMissions(data);
-
-      _.each(data.db_queue, function(v) {
-        game.getDatabase().cue(v.profile_set,v.origin,v.collect_id);
-      });
-
-      // register Karmalizers and Karmalauters...
-      _.each(data.karmalauters,function(p,key){
-        game.addType(p.type_data.gestalt,p);
-      });
-      _.each(data.karmalizers,function(p,key){
-        game.addType(p.type_data.gestalt,p);
-      });
-
-
-      // compile origin tokens for Database
-      game.compileOriginTokens(data.nodes);
-
-      game.on('after_render', function(){
-        game.renderNode.show();
-        AniTicker.start();
-      });
-      game.on('before_render', function(){
-        game.renderNode.hide();
-      });
-
-      game.render();
-      // On first game start with no explicit locale choice, ask the player.
-      if (data.is_new_game && !data.locale_persisted) {
-        _showLangPicker(false);
+      if (t.data) {
+        gnode.tokens_set.push(t);
       }
+    });
+    // sort when locked tokens are marked
 
-      // fitToWindow handles centring; the legacy is_new_game scrollTo would
-      // be immediately overwritten so we no longer set it here.
-      game.fitToWindow();
-      $(window).off('resize.gameFit').on('resize.gameFit',
-        _.debounce(function() { game.fitToWindow(); }, 100));
-
-      return game;
-    };
-
-
-    GameRoot.prototype.getImperium = function() {
-      // FIXME: this is just a wrapper
-      return this.Imperium;
-    };
-
-    GameRoot.prototype.getDatabase = function() {
-      // FIXME: this is just a wrapper
-      return this.Database;
-    };
-
-    ///////////////////////////////////
-    // The ProfileSet
-    ///////////////////////////////////
-
-    var ProfileSet = function(config,tokens) {
-      // Used both as Template and cued Object in DBQueue
-      this.init(config);
-      var gnode = this;
-      var groot = this.GameRoot;
-
-      tokens = _.clone(tokens);
-      this.data = groot.getTypeData("ProfileSet");
-      var filter_is_query = this.filter_is_query;
-      
-      if (this.convertTokens) {
-        _.each(tokens, function(t,k){
-           tokens[k] = { gestalt: t };
+    if (gnode.lockAmountZero || gnode.lockNotInDB || 0 === 0) {
+      var sorted = gnode.tokens_set;
+      // FIXME: sortBy Gestalt for messed up TokenSets from CMS/Backend (DBQueue and Clients)
+      if (gnode.sortByGestalt) {
+        sorted = _.sortBy(gnode.tokens_set, function (t) {
+          return t.gestalt;
         });
       }
-
-      this.tokens_map = {};
-      this.tokens_set = [];
-      var addtokens = [];
-      // Check if tokens is object with keys or array
-      if (tokens.length === undefined && gnode.origin) {
-        // Asuming its a token_map from the queue or collect
-        // FIXME: this messes with sorting, either we use a kind of sort key, or backend can give me an array!
-        _.each(tokens.tokens_map, function(v,k){
-          var addme = {
-            gestalt:k,
-            amount:v.amount,
-            // collect_amount is profiles value here
-            collect_amount:gnode.profiles_value
-          };
-          // exclude origin tokens
-          if (addme.gestalt.substring(0,6) !== 'origin') {
-            addtokens.push(addme);
-          }
-        });
-        this.tokens_map = tokens.tokens_map;
-      } else {
-        // Asuming its from the source perp
-        // exclude origin tokens
-        addtokens = _.filter(tokens, function(n){ if (n.gestalt) { return n.gestalt.substring(0,6) !== 'origin' } });
-        if (config.filter_is_query) {
-          var is_query = (filter_is_query==="blue");
-          addtokens = _.filter(tokens, function(n){ { return n.is_query === is_query  } });
-        }
-      }
-
-      // We build and extend the token_set
-      _.each(addtokens,function(token,k){
-        // don't mess with the original data
-        var t = _.extend({}, token);
-        t.data = groot.getTypeData(token.gestalt);
-        if (gnode.DBAmounts) {
-          t.database_amount = groot.DBTokens[token.gestalt] || 0;
-          t.database_absoluteAmount = groot.DBTokensAbsolute[token.gestalt] || 0;
-        }
-        if (gnode.markNew) {
-          var seenMap = (groot.raw_data && groot.raw_data.tokens_seen) || {};
-          if (!groot.DBTokens.hasOwnProperty(token.gestalt) && !seenMap[token.gestalt]) {
-            t.new = true;
-          }
-        }
-        if (gnode.lockAmountZero && token.amount === 0) {
-          t.locked = true;
-        }
-        if (gnode.lockNotInDB && !groot.DBTokens.hasOwnProperty(token.gestalt)) {
-          t.locked = true;
-        }
-        if (gnode.markUpgradeValues && gnode.lastUpgradeValues && !t.locked) {
-          var lastProfileValues = gnode.lastUpgradeValues.profiles_value;
-          var lastAmount = gnode.lastUpgradeValues.token_map[t.gestalt] || 0;
-          var lastAbsoluteAmount = (lastProfileValues * lastAmount) / 100;
-          var currentAbsoluteAmount = gnode.GameRoot.DBTokensAbsolute[t.gestalt];
-          t.diffAbsoluteAmount = currentAbsoluteAmount - lastAbsoluteAmount;
-          t.doneAbsoluteAmount = t.database_absoluteAmount - t.diffAbsoluteAmount;
-          t.diffAmount = 100 / (groot.profiles_value / t.diffAbsoluteAmount);
-          t.doneAmount = t.database_amount - t.diffAmount;
-        } else if (gnode.markUpgradeValues && !gnode.lastUpgradeValues && !t.locked) {
-          t.diffAbsoluteAmount = groot.DBTokensAbsolute[token.gestalt] || 0;
-          t.diffAmount = groot.DBTokens[token.gestalt] || 0;
-          t.doneAmount = 0;
-          t.doneAbsoluteAmount = 0;
-        }
-
-
-        // FIXME: Show origin data for debug reasons only
-        if (token.origin_gestalt) {
-          t.data = groot.getTypeData(token.origin_gestalt);
-        }
-        if (t.data) {
-          gnode.tokens_set.push(t);
-        }
+      var grouped = _.groupBy(sorted, function (t) {
+        return t.locked ? 1 : 0;
       });
-      // sort when locked tokens are marked
-
-      if (gnode.lockAmountZero || gnode.lockNotInDB || 0 === 0) {
-        var sorted = gnode.tokens_set;
-        // FIXME: sortBy Gestalt for messed up TokenSets from CMS/Backend (DBQueue and Clients)
-        if (gnode.sortByGestalt) { 
-          sorted = _.sortBy(gnode.tokens_set, function(t){ return t.gestalt; });
-        }
-        var grouped = _.groupBy(sorted, function(t){
-          return (t.locked) ? 1 : 0 ;
-        });
-        gnode.tokens_set = _.flatten(grouped);
-        /*
+      gnode.tokens_set = _.flatten(grouped);
+      /*
         gnode.tokens_set = _(gnode.tokens_set).sortBy(function(t,k){
           if (t.locked) {
             return k+gnode.tokens_set.length;
@@ -2271,904 +2369,950 @@ var Game = function() {
           }
         });
         */
-      }
-
-      return this;
-    };
-    extend(ProfileSet, GameNode);
-
-
-    ProfileSet.prototype.updateNewMarker = function(){
-      var ps = this;
-      var groot = this.GameRoot;
-      var seenMap = (groot.raw_data && groot.raw_data.tokens_seen) || {};
-      _.each(ps.tokens_set,function(token){
-        if (!groot.DBTokens.hasOwnProperty(token.gestalt) && !seenMap[token.gestalt]) {
-          token.new = true;
-        } else {
-          token.new = false;
-        }
-      });
-      if (ps.popupTemplateData) { ps.popupTemplateData.ProfileSet = ps };
-    };
-
-    ///////////////////////////////////
-    // The Imperium
-    ///////////////////////////////////
-
-    var Imperium = function(config) {
-      this.init(config);
-      this.ViewMap = this;
-      return this;
-    };
-
-    extend(Imperium, GameNode);
-
-    Imperium.prototype.renderType = "ViewMap";
-
-    Imperium.prototype.extendRender = function() {
-      this.setState('active',true);
-      // FIXME: name should be in data
-      //this.GameRoot.renderMenu.addButton(this.renderData.config.name, this.id, this.states);
-      this.GameRoot.renderMenu.addButton(_._('My Empire'), this.id, this.states);
-    };
-
-    Imperium.prototype.lock = function() {
-      this.renderNode.lock();
-    };
-
-    Imperium.prototype.unlock = function() {
-      this.renderNode.unlock();
-    };
-
-    ///////////////////////////////////
-    // The Database
-    ///////////////////////////////////
-
-    var Database = function(config) {
-      gnode = this;
-      groot = this.GameRoot;
-      this.ViewMap = this;
-      this.queue = new Set();
-      this.init(config);
-
-      return this;
-    };
-    extend(Database, GameNode);
-
-    Database.prototype.renderType = "ViewMap";
-
-    Database.prototype.compileSuperTokens = function() {
-      var gnode = this;
-      var groot = this.GameRoot;
-      // FIXME create buyable supertokens for DB
-      gnode.data.providedPerps = [];
-      gnode.data.buyToken_xp_level_min = 99999;
-      var buyable = _.filter(groot.typeRegistry,function(v){ 
-        if (v.type_data.is_buyable) {
-          gnode.data.buyToken_xp_level_min = (v.type_data.required_level < gnode.data.buyToken_xp_level_min) ? v.type_data.required_level : gnode.data.buyToken_xp_level_min;
-        }
-        return v.type_data.is_buyable && !groot.DBTokens.hasOwnProperty(v.gestalt);
-      });
-      _.each(buyable,function(t){
-        var provided = {};
-        //provided.locked = _.find(gnode.data.buyablePerps,function(v){ return v === t.gestalt }) === undefined;
-        provided.gestalt = t.gestalt;
-        provided.data = mergeData({},groot.getTypeData(t.gestalt));
-        provided.data.requiredTokens= [];
-        provided.locked = false;
-
-        _.each(provided.data.contained_tokens,function(v,k){
-          if (v.is_required === true) {
-            provided.data.requiredTokens.push(groot.getType(v.gestalt));
-            // check if all required tokens are there, else set to locked
-            if (!groot.DBTokens.hasOwnProperty(v.gestalt)) {
-              provided.locked = true;
-            } else if (groot.DBTokens[v.gestalt] === 0) {
-              provided.locked = true;
-            }
-          }
-        });
-        if (provided.data.required_level > groot.xp_level.number) {
-          provided.locked = true;
-        }
-        gnode.data.providedPerps.push(provided);
-      });
-      var sorted = _.sortBy(gnode.data.providedPerps, function(v){ return v.data.required_level; });
-      var grouped = _.groupBy(sorted, function(v){
-        return (v.locked) ? 1 : 0 ;
-      });
-      gnode.data.providedPerps = _.flatten(grouped);
     }
 
-    Database.prototype.openUpgradesPopup = function() {
-      var gnode = this;
-      // Popup instantiated for the first time
-      if (!gnode.popupTemplateData) {
-        gnode.popupTemplateData = {};
-        gnode.popupTemplateData.status_icons = gnode.GameRoot.data.status_icons;
-        gnode.popupTemplateData.states = {};
-        gnode.popupTemplateData.data = gnode.data;
-        gnode.popupTemplateData.data.gestalt = 'Database';
-        gnode.popupTemplateData.data.id = this.id;
-        gnode.popupTemplateData.data.title = _._("database_buytokens title");
-        gnode.popupTemplateData.data.subtitle = _._("database_buytokens subtitle");
-        gnode.popupTemplateData.data.description = _._("database_buytokens description");
-        gnode.popupTemplateData.data.selectortitle = _._("database_buytokens selector title");
-        gnode.popupTemplateData.data.mainsprites_class = "DBUpgrade";
-        gnode.popupTemplateData.groot = gnode.GameRoot;
+    return this;
+  };
+  extend(ProfileSet, GameNode);
+
+  ProfileSet.prototype.updateNewMarker = function () {
+    var ps = this;
+    var groot = this.GameRoot;
+    var seenMap = (groot.raw_data && groot.raw_data.tokens_seen) || {};
+    _.each(ps.tokens_set, function (token) {
+      if (!groot.DBTokens.hasOwnProperty(token.gestalt) && !seenMap[token.gestalt]) {
+        token.new = true;
+      } else {
+        token.new = false;
       }
+    });
+    if (ps.popupTemplateData) {
+      ps.popupTemplateData.ProfileSet = ps;
+    }
+  };
+
+  ///////////////////////////////////
+  // The Imperium
+  ///////////////////////////////////
+
+  var Imperium = function (config) {
+    this.init(config);
+    this.ViewMap = this;
+    return this;
+  };
+
+  extend(Imperium, GameNode);
+
+  Imperium.prototype.renderType = 'ViewMap';
+
+  Imperium.prototype.extendRender = function () {
+    this.setState('active', true);
+    // FIXME: name should be in data
+    //this.GameRoot.renderMenu.addButton(this.renderData.config.name, this.id, this.states);
+    this.GameRoot.renderMenu.addButton(_._('My Empire'), this.id, this.states);
+  };
+
+  Imperium.prototype.lock = function () {
+    this.renderNode.lock();
+  };
+
+  Imperium.prototype.unlock = function () {
+    this.renderNode.unlock();
+  };
+
+  ///////////////////////////////////
+  // The Database
+  ///////////////////////////////////
+
+  var Database = function (config) {
+    gnode = this;
+    groot = this.GameRoot;
+    this.ViewMap = this;
+    this.queue = new Set();
+    this.init(config);
+
+    return this;
+  };
+  extend(Database, GameNode);
+
+  Database.prototype.renderType = 'ViewMap';
+
+  Database.prototype.compileSuperTokens = function () {
+    var gnode = this;
+    var groot = this.GameRoot;
+    // FIXME create buyable supertokens for DB
+    gnode.data.providedPerps = [];
+    gnode.data.buyToken_xp_level_min = 99999;
+    var buyable = _.filter(groot.typeRegistry, function (v) {
+      if (v.type_data.is_buyable) {
+        gnode.data.buyToken_xp_level_min =
+          v.type_data.required_level < gnode.data.buyToken_xp_level_min
+            ? v.type_data.required_level
+            : gnode.data.buyToken_xp_level_min;
+      }
+      return v.type_data.is_buyable && !groot.DBTokens.hasOwnProperty(v.gestalt);
+    });
+    _.each(buyable, function (t) {
+      var provided = {};
+      //provided.locked = _.find(gnode.data.buyablePerps,function(v){ return v === t.gestalt }) === undefined;
+      provided.gestalt = t.gestalt;
+      provided.data = mergeData({}, groot.getTypeData(t.gestalt));
+      provided.data.requiredTokens = [];
+      provided.locked = false;
+
+      _.each(provided.data.contained_tokens, function (v, k) {
+        if (v.is_required === true) {
+          provided.data.requiredTokens.push(groot.getType(v.gestalt));
+          // check if all required tokens are there, else set to locked
+          if (!groot.DBTokens.hasOwnProperty(v.gestalt)) {
+            provided.locked = true;
+          } else if (groot.DBTokens[v.gestalt] === 0) {
+            provided.locked = true;
+          }
+        }
+      });
+      if (provided.data.required_level > groot.xp_level.number) {
+        provided.locked = true;
+      }
+      gnode.data.providedPerps.push(provided);
+    });
+    var sorted = _.sortBy(gnode.data.providedPerps, function (v) {
+      return v.data.required_level;
+    });
+    var grouped = _.groupBy(sorted, function (v) {
+      return v.locked ? 1 : 0;
+    });
+    gnode.data.providedPerps = _.flatten(grouped);
+  };
+
+  Database.prototype.openUpgradesPopup = function () {
+    var gnode = this;
+    // Popup instantiated for the first time
+    if (!gnode.popupTemplateData) {
+      gnode.popupTemplateData = {};
+      gnode.popupTemplateData.status_icons = gnode.GameRoot.data.status_icons;
+      gnode.popupTemplateData.states = {};
       gnode.popupTemplateData.data = gnode.data;
-
-      var popupConfig = {
-        gameNode: this,
-        template: 'popup.html',
-        templateData: gnode.popupTemplateData,
-        popupContainer: this
-      };
-
-      var popup = this.renderPopup = new Render.Popup(popupConfig);
-
-      gnode.renderNode.addPopup(popup);
-
-      gnode.initPopupEvents();
-
-      return popup;
-    };
-
-    Database.prototype.BuyPerp = function(bgestalt, placePos) {
-      return this.BuyToken(bgestalt,placePos);
+      gnode.popupTemplateData.data.gestalt = 'Database';
+      gnode.popupTemplateData.data.id = this.id;
+      gnode.popupTemplateData.data.title = _._('database_buytokens title');
+      gnode.popupTemplateData.data.subtitle = _._('database_buytokens subtitle');
+      gnode.popupTemplateData.data.description = _._('database_buytokens description');
+      gnode.popupTemplateData.data.selectortitle = _._('database_buytokens selector title');
+      gnode.popupTemplateData.data.mainsprites_class = 'DBUpgrade';
+      gnode.popupTemplateData.groot = gnode.GameRoot;
     }
+    gnode.popupTemplateData.data = gnode.data;
 
-    Database.prototype.BuyToken = function(bgestalt, placePos) {
-      // Buy Supertokens
-      var gnode = this;
-      var groot = this.GameRoot;
-      app.remote.buyPerp(gnode.path, bgestalt).done(function(data) {
-        if (data.result) {
-          if (data.result.error !== undefined) {
-            // Probably no cash
-            if (gnode.renderPopup && gnode.renderPopup.open) {
-              gnode.renderPopup.trigger('no_cash');
-            } else {
-              gnode.renderNode.FXNoCash();
-            }
-            return;
+    var popupConfig = {
+      gameNode: this,
+      template: 'popup.html',
+      templateData: gnode.popupTemplateData,
+      popupContainer: this,
+    };
+
+    var popup = (this.renderPopup = new Render.Popup(popupConfig));
+
+    gnode.renderNode.addPopup(popup);
+
+    gnode.initPopupEvents();
+
+    return popup;
+  };
+
+  Database.prototype.BuyPerp = function (bgestalt, placePos) {
+    return this.BuyToken(bgestalt, placePos);
+  };
+
+  Database.prototype.BuyToken = function (bgestalt, placePos) {
+    // Buy Supertokens
+    var gnode = this;
+    var groot = this.GameRoot;
+    app.remote.buyPerp(gnode.path, bgestalt).done(function (data) {
+      if (data.result) {
+        if (data.result.error !== undefined) {
+          // Probably no cash
+          if (gnode.renderPopup && gnode.renderPopup.open) {
+            gnode.renderPopup.trigger('no_cash');
+          } else {
+            gnode.renderNode.FXNoCash();
           }
-          if (gnode.renderPopup) { gnode.renderPopup.trigger('popup_close'); }
-          if (data.result.node) {
-            groot.updateGameValues(data.result.game_values,data.result.levelup,data.result.missions);
-            var node = data.result.node
-            var node_data = groot.getTypeData(bgestalt);
-            var perp = new Game[node.game_type]({
-              "id": node.game_id,
-              "gestalt": bgestalt,
-              "path": node.full_path,
-              noConnect:true,
-              "data": mergeData(node_data,node.instance_data),
-              // Render perps to first item in path (Imperium or Database)
-              "renderNodeParent": getFirstId("Database"),
-              "ViewMap": getByFirstId("Database"),
-              "gameType":node.game_type
-            });
-            gnode.addChild(perp);
-
-            var perpNode = gnode.renderNode;
-            var viewMap = getByFirstId("Database").renderNode;
-            var placePos = placePos || { 
-              x: viewMap.width/2,
-              y: viewMap.height/2
-            };
-            if (perp.data.contained_tokens.length) {
-              var firstContained = _.findWhere(perp.data.contained_tokens, {is_required:true});
-              if (firstContained) {
-                var placeNear = getByGestalt(firstContained.gestalt);
-                placePos = placeNear.renderNode.getPosition();
-              }
-            }
-            perp.renderData.config.placeRandom = placePos;
-            perp.renderData.config.hidden = true;
-
-            perp.render();
-            perp.renderNode.addDecorator(new Render.DecoratorNew({text: _._("New!"), extendClass: "NewPerp"}));
-            perp.renderNode.hide();
-            perp.renderNode.parentNode.scrollTo(perp.renderNode.getPosition());
-            groot.trigger('saveCoords', [perp.path, perp.renderNode.getPosition()]);
-            window.setTimeout(function(){
-              perp.renderNode.FXArise(function(){
-                  perp.renderNode.FXBounce(); 
-              });
-            },300);
-            // save coords to backend
-          } 
-        } else {
-          // Server Error
-          gnode.Error('The computer says NOOOO',data);
+          return;
         }
-      });
-    };
+        if (gnode.renderPopup) {
+          gnode.renderPopup.trigger('popup_close');
+        }
+        if (data.result.node) {
+          groot.updateGameValues(
+            data.result.game_values,
+            data.result.levelup,
+            data.result.missions
+          );
+          var node = data.result.node;
+          var node_data = groot.getTypeData(bgestalt);
+          var perp = new Game[node.game_type]({
+            id: node.game_id,
+            gestalt: bgestalt,
+            path: node.full_path,
+            noConnect: true,
+            data: mergeData(node_data, node.instance_data),
+            // Render perps to first item in path (Imperium or Database)
+            renderNodeParent: getFirstId('Database'),
+            ViewMap: getByFirstId('Database'),
+            gameType: node.game_type,
+          });
+          gnode.addChild(perp);
 
-    Database.prototype.extendRender = function() {
-      // FIXME: name should be in data
-      //this.GameRoot.renderMenu.addButton(this.renderData.config.name, this.id,this.states);
-      this.GameRoot.renderMenu.addButton(_._('Database'), this.id,this.states);
-      this.compileSuperTokens();
-      this.renderDBQueue = new Render.DBQueue({data:this.data,queue:this.queue});
-      this.renderDBQueue.gameNode = this;
-      this.renderNode.addChild(this.renderDBQueue,true);
-    };
+          var perpNode = gnode.renderNode;
+          var viewMap = getByFirstId('Database').renderNode;
+          var placePos = placePos || {
+            x: viewMap.width / 2,
+            y: viewMap.height / 2,
+          };
+          if (perp.data.contained_tokens.length) {
+            var firstContained = _.findWhere(perp.data.contained_tokens, { is_required: true });
+            if (firstContained) {
+              var placeNear = getByGestalt(firstContained.gestalt);
+              placePos = placeNear.renderNode.getPosition();
+            }
+          }
+          perp.renderData.config.placeRandom = placePos;
+          perp.renderData.config.hidden = true;
 
-    Database.prototype.lock = function() {
-      // TODO: Lock Profileset Queue etc...
-      this.renderNode.lock();
-    };
+          perp.render();
+          perp.renderNode.addDecorator(
+            new Render.DecoratorNew({ text: _._('New!'), extendClass: 'NewPerp' })
+          );
+          perp.renderNode.hide();
+          perp.renderNode.parentNode.scrollTo(perp.renderNode.getPosition());
+          groot.trigger('saveCoords', [perp.path, perp.renderNode.getPosition()]);
+          window.setTimeout(function () {
+            perp.renderNode.FXArise(function () {
+              perp.renderNode.FXBounce();
+            });
+          }, 300);
+          // save coords to backend
+        }
+      } else {
+        // Server Error
+        gnode.Error('The computer says NOOOO', data);
+      }
+    });
+  };
 
-    Database.prototype.unlock = function() {
-      // TODO: Unlock Profileset Queue etc...
-      this.renderNode.unlock();
-    };
+  Database.prototype.extendRender = function () {
+    // FIXME: name should be in data
+    //this.GameRoot.renderMenu.addButton(this.renderData.config.name, this.id,this.states);
+    this.GameRoot.renderMenu.addButton(_._('Database'), this.id, this.states);
+    this.compileSuperTokens();
+    this.renderDBQueue = new Render.DBQueue({ data: this.data, queue: this.queue });
+    this.renderDBQueue.gameNode = this;
+    this.renderNode.addChild(this.renderDBQueue, true);
+  };
 
-    Database.prototype.cue = function(profileset,path,collect_id) {
-      // Add a ProfileSet to the DB queue
-      // profileset has profiles_value (num) and token_map object with gestalt ids containing token amount
-      // path refers to the origin object
-      var ps = new ProfileSet({
+  Database.prototype.lock = function () {
+    // TODO: Lock Profileset Queue etc...
+    this.renderNode.lock();
+  };
+
+  Database.prototype.unlock = function () {
+    // TODO: Unlock Profileset Queue etc...
+    this.renderNode.unlock();
+  };
+
+  Database.prototype.cue = function (profileset, path, collect_id) {
+    // Add a ProfileSet to the DB queue
+    // profileset has profiles_value (num) and token_map object with gestalt ids containing token amount
+    // path refers to the origin object
+    var ps = new ProfileSet(
+      {
         psid: collect_id,
         origin: getByLastId(path),
-        profiles_value:profileset.profiles_value,
+        profiles_value: profileset.profiles_value,
         markNew: true,
-        sortByGestalt: true
-      },profileset);
+        sortByGestalt: true,
+      },
+      profileset
+    );
 
-      var q = this.queue;
-      q.prepend(ps);
+    var q = this.queue;
+    q.prepend(ps);
 
-      if (this.renderDBQueue) {
-        this.renderDBQueue.render();
+    if (this.renderDBQueue) {
+      this.renderDBQueue.render();
+    }
+    return ps;
+  };
+
+  Database.prototype.getToken = function (gestalt) {
+    return _.findWhere(this.children.set, { gestalt: gestalt });
+  };
+
+  Database.prototype.getCued = function (psid) {
+    var queue = this.queue;
+    var ps = _.findWhere(queue.set, { psid: psid });
+    return ps;
+  };
+
+  Database.prototype.mergeCued = function (psid) {
+    // Do the merging/integrate stuff
+    var gnode = this;
+    var groot = this.GameRoot;
+    var ps = this.getCued(psid);
+    var update_tokens = [];
+    var new_tokens = [];
+    var all_tokens;
+
+    // TODO: backend api call goes here, check for AP and give feedback in renderer etc...
+    //groot.useXP(1);
+
+    if (groot.ap_value < 1) {
+      if (gnode.renderPopup && gnode.renderPopup.open) {
+        gnode.renderPopup.trigger('no_AP');
+      } else {
+        gnode.renderDBQueue.jdomelem.find('.selected').removeClass('selected');
+        gnode.renderDBQueue.FXNoAP();
       }
-      return ps;
-    };
-
-    Database.prototype.getToken = function(gestalt) {
-      return _.findWhere(this.children.set,{gestalt:gestalt});
-    };
-
-    Database.prototype.getCued = function(psid) {
-      var queue = this.queue;
-      var ps = _.findWhere(queue.set, {psid : psid});
-      return ps;
-    };
-
-    Database.prototype.mergeCued = function(psid) {
-      // Do the merging/integrate stuff
-      var gnode = this;
-      var groot = this.GameRoot;
-      var ps = this.getCued(psid);
-      var update_tokens = [];
-      var new_tokens = [];
-      var all_tokens;
-
-      // TODO: backend api call goes here, check for AP and give feedback in renderer etc...
-      //groot.useXP(1);
-
-
-      if (groot.ap_value < 1) {
-        if (gnode.renderPopup && gnode.renderPopup.open) {
-          gnode.renderPopup.trigger('no_AP');
-        } else {
-          gnode.renderDBQueue.jdomelem.find('.selected').removeClass('selected');
-          gnode.renderDBQueue.FXNoAP();
-        }
-        return;
-      }
-
-      app.remote.integrateCollected(psid).done(function(data) {
-        if (data.result) {
-          // FIXME returned error 0
-          if (data.result.error !== undefined) {
-            // No AP
-            if (gnode.renderPopup && gnode.renderPopup.open) {
-              gnode.renderPopup.trigger('no_AP');
-            } else {
-              gnode.renderDBQueue.jdomelem.find('.selected').removeClass('selected');
-              gnode.renderDBQueue.FXNoAP();
-            }
-            return;
-          }
-          if (gnode.renderPopup) { gnode.renderPopup.trigger('popup_close'); }
-          var gv = data.result.game_values;
-          groot.setProfiles(data.result.game_values.profiles_value,true);
-          // Recompute game values + mission goals so integrate_profiles
-          // missions tick over right after DBTokensAbsolute is populated.
-          // setProfiles above already set profiles_value, so the inner
-          // setProfiles in updateGameValues is a no-op (guard by !== current).
-          groot.updateGameValues(data.result.game_values,data.result.levelup,data.result.missions,true);
-          var profiles_increment = data.result.result.increment;
-          var profiles_dup = data.result.result.dup;
-          
-          // FIXME: compile for checkNotifications
-          //gnode.compileSuperTokens();
-          gnode.checkNotifications();
-
-          // exclude origin tokens
-          all_tokens = _.filter(data.result.result.nodes, function(n){ if (n.gestalt) { return n.gestalt.substring(0,6) !== 'origin' } });
-
-          // compile origin tokens
-          groot.compileOriginTokens(data.result.result.nodes);
-
-          // update all token amounts and renderNode if they already exist
-          _.each(all_tokens, function(t){
-            var ti = getById(t.game_id);
-            if (ti) {
-              ti.setAmount(t.instance_data.amount);
-              var tir = Render.getById(t.game_id);
-              if (tir && !ps.tokens_map.hasOwnProperty(t.gestalt)) { 
-                //tir.DecoratorAmount.setAmount(t.instance_data.amount); 
-                ti.updateRenderAmount();
-              }
-              //ti.updateGear();
-            }
-          });
-          var triggerQueue = [];
-          _.each(ps.tokens_map,function(v,gestalt){
-            var token = gnode.getToken(gestalt);
-            if (token) {
-              // collect update tokens
-              update_tokens.push(token);
-            } else {
-              // create new tokens
-              var type = groot.getType(gestalt);
-              if (type.game_type === "TokenPerp") {
-                var token_instance = _.findWhere(all_tokens,{'gestalt':gestalt});
-                if (token_instance) {
-                  token = new Game.TokenPerp({
-                    "id": token_instance.game_id,
-                    "gestalt": gestalt,
-                    "path": token_instance.full_path,
-                    "data": mergeData(type.type_data,token_instance.instance_data),
-                    // Render perps to first item in path (Imperium or Database)
-                    "renderNodeParent": getFirstId("Database"),
-                    "ViewMap": getByFirstId("Database"),
-                    "gameType":type.game_type
-                  });
-                  gnode.addChild(token);
-                  triggerQueue.push(token);
-                  new_tokens.push(token);
-                }
-              }
-            }
-          });
-
-          var delay = 250;
-          var wait = 0;
-          _.each(update_tokens,function(t,k){
-            wait = wait + delay;
-            //var text = "+" + _.toKSNum(t.data.absoluteIncPerc) + "%";
-            var text = "+" + _.toKSNum(t.data.absoluteInc);
-            window.setTimeout(function(){
-              if (t.renderNode) {
-                t.renderNode.FXWheee({psid: psid, isnew: false, text: text});
-                //t.renderNode.DecoratorAmount.setAmount(); 
-              }
-            },wait);
-          });
-          delay = 250;
-          if (new_tokens.length) {
-            wait = 0;
-          }
-          _.each(new_tokens,function(t,k){
-            wait = wait + delay;
-            //var text = "+" + _.toKSNum(t.data.absoluteIncPerc) + "%";
-            var text = "+" + _.toKSNum(t.data.absoluteInc);
-            window.setTimeout(function(){
-              t.render();
-              t.renderNode.addDecorator(new Render.DecoratorNew({text: _._("New!"), extendClass: "NewToken"}));
-              t.renderNode.hide();
-              //t.renderNode.FXArise(function(){
-              t.renderNode.FXWheee({psid: psid, isnew: true, text: text});
-              //});
-              // save coords to backend
-              groot.trigger('saveCoordsQueue', [t.path,t.renderNode.getPosition()]);
-            },wait);
-          });
-
-          gnode.renderDBQueue.FXMerge(psid,profiles_increment,profiles_dup,wait);
-
-          // finally remove the ProfileSet GameNode
-          gnode.queue.remove(ps);
-          ps.remove();
-          groot.updateGameValues(data.result.game_values,data.result.levelup,data.result.missions);
-          groot.setProfiles();
-          window.setTimeout(function(){
-            _.each(triggerQueue,function(t){
-              t.trigger('after_create');
-            });
-
-            gnode.checkNotifications();
-            groot.updateGears();
-          },500 + wait);
-          window.setTimeout(function(){
-          },8000);
-
-          } else {
-            gnode.Error('The computer says NOOOO',data);
-          }
-        });
-    };
-
-    // TODO: Move this to GameRoot
-    GameRoot.prototype.updateGears = function() {
-      _.each(getByType('TokenPerp'), function(t){
-        t.updateGear();
-      });
-    };
-
-    Database.prototype.checkNotifications = function() {
-      // FIXME: this doesn't work;
-      var gnode = this;
-      var groot = this.GameRoot;
-      var change = false;
-      if (!gnode.data.providedPerps) {
-        gnode.compileSuperTokens();
-        return;
-      }
-      var before = _.pluck(_.where(gnode.data.providedPerps, {locked:false}),'gestalt');
-      gnode.compileSuperTokens();
-      var after = _.pluck(_.where(gnode.data.providedPerps, {locked:false}),'gestalt');
-      var newbuyable = _.difference(after,before);
-      if (newbuyable.length) {
-        groot.makeNotifications({
-          perps: newbuyable
-        });
-        groot.getDatabase().renderDBQueue.render();
-        groot.getDatabase().renderDBQueue.jdomelem.addClass('NewBuyable');
-      }
+      return;
     }
 
-    Database.prototype.openProfileSetPopup = function(ps) {
-      var gnode = this;
-      var origin = ps.origin;
-      ps.updateNewMarker();
-      // Popup instantiated for the first time
-      if (!ps.popupTemplateData) {
-        ps.popupTemplateData = {};
-        ps.popupTemplateData.ProfileSet = ps,
-        ps.popupTemplateData.states = origin.states;
-        ps.popupTemplateData.status_icons = gnode.GameRoot.data.status_icons;
-        ps.popupTemplateData.data = {};
-        ps.popupTemplateData.data.gestalt = origin.gestalt;
-        ps.popupTemplateData.data.id = origin.id;
-      }
-
-      // Update data with current gnode data
-      _.extend(ps.popupTemplateData.data, origin.data);
-
-      var popupConfig = {
-        gameNode: this,
-        template: 'popup_profileset.html',
-        templateData: ps.popupTemplateData,
-        popupContainer: this
-      };
-
-      var popup = this.renderPopup = new Render.Popup(popupConfig);
-
-      gnode.renderNode.addPopup(popup);
-
-      popup.on('button_click.MainButton',function(e) {
-        e.stopPropagation();
-        gnode.mergeCued(ps.psid);
-      });
-
-      popup.on('popup_close',function(e) {
-        e.stopPropagation();
-        popup.close();
-        delete gnode.renderPopup;
-      });
-
-      return popup;
-    };
-
-
-    Database.prototype.initEventHandlers = function() {
-      var gnode = this;
-
-      // FIXME MAKE POPUP for supertoken purchases
-
-      gnode.on('select_upgrades',function(e){
-        //gnode.fetchProvided(function(){
-          gnode.renderDBQueue.jdomelem.removeClass('NewBuyable');
-          gnode.compileSuperTokens();
-          gnode.openUpgradesPopup();
-        //});
-      });
-
-
-      gnode.on('profileset_click',function(e,psid){
-        var ps = gnode.getCued(psid);
-        gnode.openProfileSetPopup(ps);
-      });
-      gnode.on('profileset_shift_click',function(e,psid){
-        e.stopPropagation();
-        var ps = gnode.getCued(psid);
-        gnode.mergeCued(ps.psid);
-      });
-      gnode.on('popup_cancel',function(e,psid){
-        gnode.renderDBQueue.jdomelem.find('.selected').removeClass('selected');
-      });
-    };
-
-
-    ///////////////////////////////////
-    // The GamePerp Base Class
-    ///////////////////////////////////
-
-    var GamePerp = function(config) {
-      this.init(config);
-
-      return this;
-    };
-
-    extend(GamePerp, GameNode);
-
-    GamePerp.prototype.cableType = "in";
-    GamePerp.prototype.labelClass = undefined;
-    GamePerp.prototype.sticky = true;
-    GamePerp.prototype.popupTemplate = 'popup.html';
-
-    GamePerp.prototype.extendRender = function() {
-      var render = this.renderData || {};
-      var node = this.renderNode;
-      node.sticky = this.sticky;
-
-      // TODO: Some mixed Renderer rules, review/rewrite and split up to subclasses when we know how to better handle this
-      if (!this.noConnect && this.renderType === "Perp" && this.parentNode && this.parentNode.renderType === "Perp") {
-        this.parentNode.renderNode.cableTo(node,{mode:this.cableType});
-      }
-      if (render.config.label) {
-        node.addDecorator(new Render.DecoratorLabel({text:render.config.label,extendClass:this.labelClass}));
-      }
-      if (this._loadReady) {
-        this.markReady();
-        this._loadReady = undefined;
-      } else if (this._loadTimer) {
-        this.markTimer(this._loadTimer);
-        this._loadTimer = undefined;
-      }
-    };
-
-    GamePerp.prototype.markTimer = function(conf){
-      if (!conf) { return false; }
-      this.setState('idle',false);
-      this.setState('chargeRunning',true);
-      this.renderTimer = this.renderNode.addDecorator(new Render.DecoratorTimer({
-        duration: conf.duration,
-        serverTime: conf.serverTime,
-        serverStartTime: conf.serverStart
-      }));
-      this.renderTimer.FXSproing();
-    };
-
-    GamePerp.prototype.initEventHandlers = function() {
-      var gnode = this;
-      var groot = this.GameRoot;
-      gnode.on('dragend',function(e) {
-        e.stopPropagation();
-        // FIXME: Testing Save Coords...
-        gnode.GameRoot.trigger('saveCoordsQueue',[gnode.path,gnode.renderNode.getPosition()]);
-      });
-      gnode.on('vclick',function(e) {
-        e.stopPropagation();
-      });
-      gnode.on('vdblclick',function(e) {
-        e.stopPropagation();
-      });
-
-      gnode.on('after_buy after_create',function(e){
-        e.stopPropagation();
-        if (gnode.data.story) {
-          groot.makeNotifications({ story: gnode.data.story, storyPerp: gnode });
-        }
-      });
-
-
-      if (gnode.AniTick) {
-        gnode.on('states_chargeRunning', function(e,state) {
-          e.stopPropagation();
-          if (state) {
-            AniTicker.addListener(gnode);
+    app.remote.integrateCollected(psid).done(function (data) {
+      if (data.result) {
+        // FIXME returned error 0
+        if (data.result.error !== undefined) {
+          // No AP
+          if (gnode.renderPopup && gnode.renderPopup.open) {
+            gnode.renderPopup.trigger('no_AP');
           } else {
-            AniTicker.removeListener(gnode);
+            gnode.renderDBQueue.jdomelem.find('.selected').removeClass('selected');
+            gnode.renderDBQueue.FXNoAP();
+          }
+          return;
+        }
+        if (gnode.renderPopup) {
+          gnode.renderPopup.trigger('popup_close');
+        }
+        var gv = data.result.game_values;
+        groot.setProfiles(data.result.game_values.profiles_value, true);
+        // Recompute game values + mission goals so integrate_profiles
+        // missions tick over right after DBTokensAbsolute is populated.
+        // setProfiles above already set profiles_value, so the inner
+        // setProfiles in updateGameValues is a no-op (guard by !== current).
+        groot.updateGameValues(
+          data.result.game_values,
+          data.result.levelup,
+          data.result.missions,
+          true
+        );
+        var profiles_increment = data.result.result.increment;
+        var profiles_dup = data.result.result.dup;
+
+        // FIXME: compile for checkNotifications
+        //gnode.compileSuperTokens();
+        gnode.checkNotifications();
+
+        // exclude origin tokens
+        all_tokens = _.filter(data.result.result.nodes, function (n) {
+          if (n.gestalt) {
+            return n.gestalt.substring(0, 6) !== 'origin';
           }
         });
-      }
 
-      if (this.extendEventHandlers) {
-        this.extendEventHandlers();
+        // compile origin tokens
+        groot.compileOriginTokens(data.result.result.nodes);
+
+        // update all token amounts and renderNode if they already exist
+        _.each(all_tokens, function (t) {
+          var ti = getById(t.game_id);
+          if (ti) {
+            ti.setAmount(t.instance_data.amount);
+            var tir = Render.getById(t.game_id);
+            if (tir && !ps.tokens_map.hasOwnProperty(t.gestalt)) {
+              //tir.DecoratorAmount.setAmount(t.instance_data.amount);
+              ti.updateRenderAmount();
+            }
+            //ti.updateGear();
+          }
+        });
+        var triggerQueue = [];
+        _.each(ps.tokens_map, function (v, gestalt) {
+          var token = gnode.getToken(gestalt);
+          if (token) {
+            // collect update tokens
+            update_tokens.push(token);
+          } else {
+            // create new tokens
+            var type = groot.getType(gestalt);
+            if (type.game_type === 'TokenPerp') {
+              var token_instance = _.findWhere(all_tokens, { gestalt: gestalt });
+              if (token_instance) {
+                token = new Game.TokenPerp({
+                  id: token_instance.game_id,
+                  gestalt: gestalt,
+                  path: token_instance.full_path,
+                  data: mergeData(type.type_data, token_instance.instance_data),
+                  // Render perps to first item in path (Imperium or Database)
+                  renderNodeParent: getFirstId('Database'),
+                  ViewMap: getByFirstId('Database'),
+                  gameType: type.game_type,
+                });
+                gnode.addChild(token);
+                triggerQueue.push(token);
+                new_tokens.push(token);
+              }
+            }
+          }
+        });
+
+        var delay = 250;
+        var wait = 0;
+        _.each(update_tokens, function (t, k) {
+          wait = wait + delay;
+          //var text = "+" + _.toKSNum(t.data.absoluteIncPerc) + "%";
+          var text = '+' + _.toKSNum(t.data.absoluteInc);
+          window.setTimeout(function () {
+            if (t.renderNode) {
+              t.renderNode.FXWheee({ psid: psid, isnew: false, text: text });
+              //t.renderNode.DecoratorAmount.setAmount();
+            }
+          }, wait);
+        });
+        delay = 250;
+        if (new_tokens.length) {
+          wait = 0;
+        }
+        _.each(new_tokens, function (t, k) {
+          wait = wait + delay;
+          //var text = "+" + _.toKSNum(t.data.absoluteIncPerc) + "%";
+          var text = '+' + _.toKSNum(t.data.absoluteInc);
+          window.setTimeout(function () {
+            t.render();
+            t.renderNode.addDecorator(
+              new Render.DecoratorNew({ text: _._('New!'), extendClass: 'NewToken' })
+            );
+            t.renderNode.hide();
+            //t.renderNode.FXArise(function(){
+            t.renderNode.FXWheee({ psid: psid, isnew: true, text: text });
+            //});
+            // save coords to backend
+            groot.trigger('saveCoordsQueue', [t.path, t.renderNode.getPosition()]);
+          }, wait);
+        });
+
+        gnode.renderDBQueue.FXMerge(psid, profiles_increment, profiles_dup, wait);
+
+        // finally remove the ProfileSet GameNode
+        gnode.queue.remove(ps);
+        ps.remove();
+        groot.updateGameValues(data.result.game_values, data.result.levelup, data.result.missions);
+        groot.setProfiles();
+        window.setTimeout(function () {
+          _.each(triggerQueue, function (t) {
+            t.trigger('after_create');
+          });
+
+          gnode.checkNotifications();
+          groot.updateGears();
+        }, 500 + wait);
+        window.setTimeout(function () {}, 8000);
+      } else {
+        gnode.Error('The computer says NOOOO', data);
       }
+    });
+  };
+
+  // TODO: Move this to GameRoot
+  GameRoot.prototype.updateGears = function () {
+    _.each(getByType('TokenPerp'), function (t) {
+      t.updateGear();
+    });
+  };
+
+  Database.prototype.checkNotifications = function () {
+    // FIXME: this doesn't work;
+    var gnode = this;
+    var groot = this.GameRoot;
+    var change = false;
+    if (!gnode.data.providedPerps) {
+      gnode.compileSuperTokens();
+      return;
+    }
+    var before = _.pluck(_.where(gnode.data.providedPerps, { locked: false }), 'gestalt');
+    gnode.compileSuperTokens();
+    var after = _.pluck(_.where(gnode.data.providedPerps, { locked: false }), 'gestalt');
+    var newbuyable = _.difference(after, before);
+    if (newbuyable.length) {
+      groot.makeNotifications({
+        perps: newbuyable,
+      });
+      groot.getDatabase().renderDBQueue.render();
+      groot.getDatabase().renderDBQueue.jdomelem.addClass('NewBuyable');
+    }
+  };
+
+  Database.prototype.openProfileSetPopup = function (ps) {
+    var gnode = this;
+    var origin = ps.origin;
+    ps.updateNewMarker();
+    // Popup instantiated for the first time
+    if (!ps.popupTemplateData) {
+      ps.popupTemplateData = {};
+      (ps.popupTemplateData.ProfileSet = ps), (ps.popupTemplateData.states = origin.states);
+      ps.popupTemplateData.status_icons = gnode.GameRoot.data.status_icons;
+      ps.popupTemplateData.data = {};
+      ps.popupTemplateData.data.gestalt = origin.gestalt;
+      ps.popupTemplateData.data.id = origin.id;
+    }
+
+    // Update data with current gnode data
+    _.extend(ps.popupTemplateData.data, origin.data);
+
+    var popupConfig = {
+      gameNode: this,
+      template: 'popup_profileset.html',
+      templateData: ps.popupTemplateData,
+      popupContainer: this,
     };
 
+    var popup = (this.renderPopup = new Render.Popup(popupConfig));
 
-    ///////////////////////////////////
-    // GamePerp open a Popup
-    ///////////////////////////////////
+    gnode.renderNode.addPopup(popup);
 
-    GamePerp.prototype.updateTemplateData = function() {
-      var gnode = this;
-      var groot = this.GameRoot;
-      // Popup instantiated for the first time
-      if (!this.popupTemplateData) {
-        this.popupTemplateData = {};
-        this.popupTemplateData.states = gnode.states;
-        this.popupTemplateData.status_icons = gnode.GameRoot.data.status_icons;
-        this.popupTemplateData.data = {};
-        this.popupTemplateData.data.gestalt = this.gestalt;
-        this.popupTemplateData.data.id = this.id;
-        this.popupTemplateData.loading = true;
-        this.popupTemplateData.groot = groot;
+    popup.on('button_click.MainButton', function (e) {
+      e.stopPropagation();
+      gnode.mergeCued(ps.psid);
+    });
+
+    popup.on('popup_close', function (e) {
+      e.stopPropagation();
+      popup.close();
+      delete gnode.renderPopup;
+    });
+
+    return popup;
+  };
+
+  Database.prototype.initEventHandlers = function () {
+    var gnode = this;
+
+    // FIXME MAKE POPUP for supertoken purchases
+
+    gnode.on('select_upgrades', function (e) {
+      //gnode.fetchProvided(function(){
+      gnode.renderDBQueue.jdomelem.removeClass('NewBuyable');
+      gnode.compileSuperTokens();
+      gnode.openUpgradesPopup();
+      //});
+    });
+
+    gnode.on('profileset_click', function (e, psid) {
+      var ps = gnode.getCued(psid);
+      gnode.openProfileSetPopup(ps);
+    });
+    gnode.on('profileset_shift_click', function (e, psid) {
+      e.stopPropagation();
+      var ps = gnode.getCued(psid);
+      gnode.mergeCued(ps.psid);
+    });
+    gnode.on('popup_cancel', function (e, psid) {
+      gnode.renderDBQueue.jdomelem.find('.selected').removeClass('selected');
+    });
+  };
+
+  ///////////////////////////////////
+  // The GamePerp Base Class
+  ///////////////////////////////////
+
+  var GamePerp = function (config) {
+    this.init(config);
+
+    return this;
+  };
+
+  extend(GamePerp, GameNode);
+
+  GamePerp.prototype.cableType = 'in';
+  GamePerp.prototype.labelClass = undefined;
+  GamePerp.prototype.sticky = true;
+  GamePerp.prototype.popupTemplate = 'popup.html';
+
+  GamePerp.prototype.extendRender = function () {
+    var render = this.renderData || {};
+    var node = this.renderNode;
+    node.sticky = this.sticky;
+
+    // TODO: Some mixed Renderer rules, review/rewrite and split up to subclasses when we know how to better handle this
+    if (
+      !this.noConnect &&
+      this.renderType === 'Perp' &&
+      this.parentNode &&
+      this.parentNode.renderType === 'Perp'
+    ) {
+      this.parentNode.renderNode.cableTo(node, { mode: this.cableType });
+    }
+    if (render.config.label) {
+      node.addDecorator(
+        new Render.DecoratorLabel({ text: render.config.label, extendClass: this.labelClass })
+      );
+    }
+    if (this._loadReady) {
+      this.markReady();
+      this._loadReady = undefined;
+    } else if (this._loadTimer) {
+      this.markTimer(this._loadTimer);
+      this._loadTimer = undefined;
+    }
+  };
+
+  GamePerp.prototype.markTimer = function (conf) {
+    if (!conf) {
+      return false;
+    }
+    this.setState('idle', false);
+    this.setState('chargeRunning', true);
+    this.renderTimer = this.renderNode.addDecorator(
+      new Render.DecoratorTimer({
+        duration: conf.duration,
+        serverTime: conf.serverTime,
+        serverStartTime: conf.serverStart,
+      })
+    );
+    this.renderTimer.FXSproing();
+  };
+
+  GamePerp.prototype.initEventHandlers = function () {
+    var gnode = this;
+    var groot = this.GameRoot;
+    gnode.on('dragend', function (e) {
+      e.stopPropagation();
+      // FIXME: Testing Save Coords...
+      gnode.GameRoot.trigger('saveCoordsQueue', [gnode.path, gnode.renderNode.getPosition()]);
+    });
+    gnode.on('vclick', function (e) {
+      e.stopPropagation();
+    });
+    gnode.on('vdblclick', function (e) {
+      e.stopPropagation();
+    });
+
+    gnode.on('after_buy after_create', function (e) {
+      e.stopPropagation();
+      if (gnode.data.story) {
+        groot.makeNotifications({ story: gnode.data.story, storyPerp: gnode });
       }
-      // highlight Tabs in popups
-      this.popupTemplateData.highlightTabs = gnode.highlightTabs || [];
-      _.extend(this.popupTemplateData.data,this.data);
-      // FIXME: make this get game values method on groot
-      this.popupTemplateData.game_values = {
-        xp_level : groot.xp_level
-      };
+    });
+
+    if (gnode.AniTick) {
+      gnode.on('states_chargeRunning', function (e, state) {
+        e.stopPropagation();
+        if (state) {
+          AniTicker.addListener(gnode);
+        } else {
+          AniTicker.removeListener(gnode);
+        }
+      });
+    }
+
+    if (this.extendEventHandlers) {
+      this.extendEventHandlers();
+    }
+  };
+
+  ///////////////////////////////////
+  // GamePerp open a Popup
+  ///////////////////////////////////
+
+  GamePerp.prototype.updateTemplateData = function () {
+    var gnode = this;
+    var groot = this.GameRoot;
+    // Popup instantiated for the first time
+    if (!this.popupTemplateData) {
+      this.popupTemplateData = {};
+      this.popupTemplateData.states = gnode.states;
+      this.popupTemplateData.status_icons = gnode.GameRoot.data.status_icons;
+      this.popupTemplateData.data = {};
+      this.popupTemplateData.data.gestalt = this.gestalt;
+      this.popupTemplateData.data.id = this.id;
+      this.popupTemplateData.loading = true;
+      this.popupTemplateData.groot = groot;
+    }
+    // highlight Tabs in popups
+    this.popupTemplateData.highlightTabs = gnode.highlightTabs || [];
+    _.extend(this.popupTemplateData.data, this.data);
+    // FIXME: make this get game values method on groot
+    this.popupTemplateData.game_values = {
+      xp_level: groot.xp_level,
+    };
+  };
+
+  GamePerp.prototype.openPopup = function () {
+    var gnode = this;
+    var groot = this.GameRoot;
+    //gnode.renderNode.setFrame('active');
+
+    // Update TemplateData with current gnode data
+    gnode.updateTemplateData();
+
+    var popupConfig = {
+      // Fixme: gameNode only used for debug info on logo click
+      gameNode: this,
+      template: this.popupTemplate,
+      templateData: this.popupTemplateData,
+      popupContainer: this.ViewMap,
     };
 
-    GamePerp.prototype.openPopup = function() {
-      var gnode = this;
-      var groot = this.GameRoot;
-      //gnode.renderNode.setFrame('active');
+    var popup = (this.renderPopup = new Render.Popup(popupConfig));
 
-      // Update TemplateData with current gnode data
-      gnode.updateTemplateData();
+    gnode.ViewMap.renderNode.addPopup(popup);
 
-      var popupConfig = {
-        // Fixme: gameNode only used for debug info on logo click
-        gameNode: this,
-        template: this.popupTemplate,
-        templateData: this.popupTemplateData,
-        popupContainer: this.ViewMap
-      };
+    gnode.initPopupEvents();
 
-      var popup = this.renderPopup = new Render.Popup(popupConfig);
+    return popup;
+  };
 
-      gnode.ViewMap.renderNode.addPopup(popup);
+  GameNode.prototype.initPopupEvents = function (popup) {
+    var gnode = this;
+    var groot = this.GameRoot;
 
-      gnode.initPopupEvents();
+    var popup = popup || gnode.renderPopup;
 
-      return popup;
-    };
+    if (!popup) {
+      return;
+    }
 
-    GameNode.prototype.initPopupEvents = function(popup) {
-      var gnode = this;
-      var groot = this.GameRoot;
+    popup.on('button_click.MainButton', function (e) {
+      e.stopPropagation();
+      popup.trigger('popup_close');
+    });
 
-      var popup = popup || gnode.renderPopup;
+    popup.on('button_click.ChargeButton', function (e) {
+      e.stopPropagation();
+      gnode.Charge();
+    });
 
-      if (!popup) {
+    popup.on('button_click.CollectButton', function (e) {
+      e.stopPropagation();
+      gnode.collect();
+    });
+
+    popup.on('popup_close', function (e) {
+      e.stopPropagation();
+      if (popup.notificationMission) {
+        var gestalt = popup.notificationMission;
+        popup.notificationMission = null;
+        // No optimistic raw_data write: dismissMissionBriefing emits a
+        // delta whose listener echo lands synchronously in this tick
+        // (closes #116 race window under the #120 architectural fix).
+        if (app.remote && app.remote.dismissMissionBriefing) {
+          app.remote.dismissMissionBriefing(gestalt);
+        }
+      }
+      if (gnode.highlightTabs) {
+        gnode.highlightTabs = [];
+      }
+      if (gnode.renderNode && gnode.renderNode.DecoratorNew) {
+        _.each(getAllByGestalt(gnode.gestalt), function (gn) {
+          gn.renderNode.DecoratorNew.remove();
+        });
+      }
+      if (popup.callback) {
+        popup.close(popup.callback);
+      } else {
+        popup.close();
+      }
+      delete gnode.renderPopup;
+    });
+
+    popup.on('button_click.PowerupBuyButton', function (e, bgestalt, bslot) {
+      e.stopPropagation();
+      gnode.BuyPowerup(bgestalt, bslot);
+    });
+
+    popup.on('button_click.PowerupBuySlotsButton', function (e, bgestalt, bslot) {
+      e.stopPropagation();
+      gnode.BuySlots(bslot, bgestalt);
+    });
+
+    popup.on('button_click.PowerupSellButton', function (e, bgestalt, bslot) {
+      e.stopPropagation();
+      gnode.SellPowerup(bgestalt, bslot);
+    });
+
+    popup.on('popup_token_seen', function (e, gestalt) {
+      e.stopPropagation();
+      if (!gestalt) {
         return;
       }
-
-      popup.on('button_click.MainButton',function(e) {
-        e.stopPropagation();
-        popup.trigger('popup_close');
-      });
-
-      popup.on('button_click.ChargeButton',function(e) {
-        e.stopPropagation();
-        gnode.Charge();
-      });
-
-      popup.on('button_click.CollectButton',function(e) {
-        e.stopPropagation();
-        gnode.collect();
-      });
-
-      popup.on('popup_close',function(e) {
-        e.stopPropagation();
-        if (popup.notificationMission) {
-          var gestalt = popup.notificationMission;
-          popup.notificationMission = null;
-          // No optimistic raw_data write: dismissMissionBriefing emits a
-          // delta whose listener echo lands synchronously in this tick
-          // (closes #116 race window under the #120 architectural fix).
-          if (app.remote && app.remote.dismissMissionBriefing) {
-            app.remote.dismissMissionBriefing(gestalt);
-          }
-        }
-        if (gnode.highlightTabs) {
-          gnode.highlightTabs = [];
-        }
-        if (gnode.renderNode && gnode.renderNode.DecoratorNew) {
-          _.each(getAllByGestalt(gnode.gestalt), function(gn){
-            gn.renderNode.DecoratorNew.remove();
-          });
-        }
-        if (popup.callback) {
-          popup.close(popup.callback);
-        } else {
-          popup.close();
-        }
-        delete gnode.renderPopup;
-      });
-      
-      popup.on('button_click.PowerupBuyButton',function(e,bgestalt,bslot) {
-         e.stopPropagation();
-         gnode.BuyPowerup(bgestalt,bslot);
-      });
-
-      popup.on('button_click.PowerupBuySlotsButton',function(e,bgestalt,bslot) {
-         e.stopPropagation();
-         gnode.BuySlots(bslot, bgestalt);
-      });
-
-
-      popup.on('button_click.PowerupSellButton',function(e,bgestalt,bslot) {
-         e.stopPropagation();
-         gnode.SellPowerup(bgestalt,bslot);
-      });
-
-      popup.on('popup_token_seen',function(e,gestalt) {
-        e.stopPropagation();
-        if (!gestalt) { return; }
-        // No optimistic raw_data write: markTokenSeen emits a delta whose
-        // listener echo lands synchronously (closes #116 race window
-        // under the #120 architectural fix). The handler itself short-
-        // circuits when the gestalt is already in tokens_seen, so calling
-        // it twice is a no-op delta.
-        if (app.remote && app.remote.markTokenSeen) {
-          app.remote.markTokenSeen(gestalt);
-        }
-      });
-
-      popup.on('button_click.PerpBuyButton',function(e,bgestalt) {
-        e.stopPropagation();
-        var gtype = groot.getTypeFromGestalt(bgestalt);
-        if (gtype === "CityPerp") {
-          var DBPerp = getByType('DatabasePerp');
-          if (DBPerp.length) {
-            DBPerp = DBPerp[0];
-          } else {
-            return;
-          }
-          return DBPerp.BuyCity(bgestalt);
-        } else {
-           gnode.BuyPerp(bgestalt);
-        }
-      });
-
-      popup.on('button_click.UpgradeButton',function(e) {
-        e.stopPropagation();
-        gnode.Charge();
-      });
-
-      popup.jdomelem.on('click touchend','a.ml',function(e) {
-        e.stopPropagation();
-        e.preventDefault();
-        var link = $(this).attr('href');
-        // FIX for FF open link in external window to prevent socketloss
-        //document.location.href = link;
-        window.open(link);
-      });
-      
-      popup.jdomelem.on('click touchend','a.mln',function(e) {
-        e.stopPropagation();
-        e.preventDefault();
-        var link = $(this).attr('href');
-        window.open(link);
-      });
-
-      
-      popup.on('button_click.RefreshButton',function(e) {
-        e.stopPropagation();
-        gnode.GameRoot.refresh();
-      });
-
-    };
-
-    GamePerp.prototype.updatePopup = function() {
-      var gnode = this;
-
-      if (gnode.popupTemplateData) {
-        //gnode.popupTemplateData.loading = false;
+      // No optimistic raw_data write: markTokenSeen emits a delta whose
+      // listener echo lands synchronously (closes #116 race window
+      // under the #120 architectural fix). The handler itself short-
+      // circuits when the gestalt is already in tokens_seen, so calling
+      // it twice is a no-op delta.
+      if (app.remote && app.remote.markTokenSeen) {
+        app.remote.markTokenSeen(gestalt);
       }
+    });
 
-      // Update data with current gnode data
-      //_.extend(this.popupTemplateData.data,gnode.data);
-      gnode.updateTemplateData();
+    popup.on('button_click.PerpBuyButton', function (e, bgestalt) {
+      e.stopPropagation();
+      var gtype = groot.getTypeFromGestalt(bgestalt);
+      if (gtype === 'CityPerp') {
+        var DBPerp = getByType('DatabasePerp');
+        if (DBPerp.length) {
+          DBPerp = DBPerp[0];
+        } else {
+          return;
+        }
+        return DBPerp.BuyCity(bgestalt);
+      } else {
+        gnode.BuyPerp(bgestalt);
+      }
+    });
 
-      var popupConfig = {
-        gameNode: this,
-        template: this.popupTemplate,
-        templateData: this.popupTemplateData,
-        popupContainer: this.ViewMap
-      };
+    popup.on('button_click.UpgradeButton', function (e) {
+      e.stopPropagation();
+      gnode.Charge();
+    });
 
-      if (this.renderPopup) { this.renderPopup.remove(); }
-      var popup = this.renderPopup = new Render.Popup(popupConfig);
+    popup.jdomelem.on('click touchend', 'a.ml', function (e) {
+      e.stopPropagation();
+      e.preventDefault();
+      var link = $(this).attr('href');
+      // FIX for FF open link in external window to prevent socketloss
+      //document.location.href = link;
+      window.open(link);
+    });
 
-      gnode.ViewMap.renderNode.addPopup(popup);
+    popup.jdomelem.on('click touchend', 'a.mln', function (e) {
+      e.stopPropagation();
+      e.preventDefault();
+      var link = $(this).attr('href');
+      window.open(link);
+    });
 
-      gnode.initPopupEvents();
+    popup.on('button_click.RefreshButton', function (e) {
+      e.stopPropagation();
+      gnode.GameRoot.refresh();
+    });
+  };
 
-      return popup;
+  GamePerp.prototype.updatePopup = function () {
+    var gnode = this;
+
+    if (gnode.popupTemplateData) {
+      //gnode.popupTemplateData.loading = false;
+    }
+
+    // Update data with current gnode data
+    //_.extend(this.popupTemplateData.data,gnode.data);
+    gnode.updateTemplateData();
+
+    var popupConfig = {
+      gameNode: this,
+      template: this.popupTemplate,
+      templateData: this.popupTemplateData,
+      popupContainer: this.ViewMap,
     };
 
-    GamePerp.prototype.BuyPerp = function(bgestalt,placePos) {
-      var gnode = this;
-      var groot = this.GameRoot;
-      // TODO: backendcall and do purchase...
-      app.remote.buyPerp(gnode.path, bgestalt).done(function(data) {
-        if (data.result) {
-          if (data.result.error !== undefined) {
-            // Probably no cash
-            if (gnode.renderPopup && gnode.renderPopup.open) {
-              if (data.result.error === 2 || data.result === 2) {
-                gnode.renderPopup.trigger('no_cash');
-              } else if (gnode.gameType=== "ProxyPerp" && data.result.error === 3) {
-                gnode.renderPopup.trigger('error');
-                groot.makeNotifications({simplemessage:{text: _._('projectbuy_proxyslotsfull')}})
-              } else {
-                gnode.renderPopup.trigger('error');
-              }
+    if (this.renderPopup) {
+      this.renderPopup.remove();
+    }
+    var popup = (this.renderPopup = new Render.Popup(popupConfig));
+
+    gnode.ViewMap.renderNode.addPopup(popup);
+
+    gnode.initPopupEvents();
+
+    return popup;
+  };
+
+  GamePerp.prototype.BuyPerp = function (bgestalt, placePos) {
+    var gnode = this;
+    var groot = this.GameRoot;
+    // TODO: backendcall and do purchase...
+    app.remote.buyPerp(gnode.path, bgestalt).done(function (data) {
+      if (data.result) {
+        if (data.result.error !== undefined) {
+          // Probably no cash
+          if (gnode.renderPopup && gnode.renderPopup.open) {
+            if (data.result.error === 2 || data.result === 2) {
+              gnode.renderPopup.trigger('no_cash');
+            } else if (gnode.gameType === 'ProxyPerp' && data.result.error === 3) {
+              gnode.renderPopup.trigger('error');
+              groot.makeNotifications({
+                simplemessage: { text: _._('projectbuy_proxyslotsfull') },
+              });
             } else {
-              gnode.renderNode.FXNoCash();
+              gnode.renderPopup.trigger('error');
             }
-            return;
+          } else {
+            gnode.renderNode.FXNoCash();
           }
-          if (gnode.renderPopup) { gnode.renderPopup.trigger('popup_close'); }
-          if (data.result.node) {
-            groot.updateGameValues(data.result.game_values,data.result.levelup,data.result.missions);
-            var node = data.result.node
-            var node_data = groot.getTypeData(bgestalt);
-            var perp = new Game[node.game_type]({
-              "id": node.game_id,
-              "gestalt": bgestalt,
-              "path": node.full_path,
-              noConnect:true,
-              "data": mergeData(node_data,node.instance_data),
-              // Render perps to first item in path (Imperium or Database)
-              "renderNodeParent": getFirstId("Imperium"),
-              "ViewMap": getByFirstId("Imperium"),
-              "gameType":node.game_type
-            });
-            gnode.addChild(perp);
-            // FIXME: fishy but works?
-            var perpNode = gnode.renderNode;
-            var vector = gnode.parentNode.renderNode.getVectorTo(gnode.renderNode);
-            // golden ratio:
-            if (placePos) {
-            } else {
-              placePos = gnode.renderNode.getVectorPos(vector,0.61803398875);
-              perp.renderData.config.placeRandom = placePos;
-              perp.renderData.config.placeParentRadius = 320;
-            }
-
+          return;
+        }
+        if (gnode.renderPopup) {
+          gnode.renderPopup.trigger('popup_close');
+        }
+        if (data.result.node) {
+          groot.updateGameValues(
+            data.result.game_values,
+            data.result.levelup,
+            data.result.missions
+          );
+          var node = data.result.node;
+          var node_data = groot.getTypeData(bgestalt);
+          var perp = new Game[node.game_type]({
+            id: node.game_id,
+            gestalt: bgestalt,
+            path: node.full_path,
+            noConnect: true,
+            data: mergeData(node_data, node.instance_data),
+            // Render perps to first item in path (Imperium or Database)
+            renderNodeParent: getFirstId('Imperium'),
+            ViewMap: getByFirstId('Imperium'),
+            gameType: node.game_type,
+          });
+          gnode.addChild(perp);
+          // FIXME: fishy but works?
+          var perpNode = gnode.renderNode;
+          var vector = gnode.parentNode.renderNode.getVectorTo(gnode.renderNode);
+          // golden ratio:
+          if (placePos) {
+          } else {
+            placePos = gnode.renderNode.getVectorPos(vector, 0.61803398875);
             perp.renderData.config.placeRandom = placePos;
-            perp.renderData.config.placeParentRadius = 0;
-            perp.renderData.config.hidden = true;
+            perp.renderData.config.placeParentRadius = 320;
+          }
 
-            perp.render();
-            groot.trigger('saveCoords', [perp.path,perp.renderNode.getPosition()]);
-            perp.renderNode.addDecorator(new Render.DecoratorNew({text: _._("New!"), extendClass: "NewPerp"}));
-            perp.renderNode.hide();
-            perp.renderNode.parentNode.scrollTo(perp.renderNode.getPosition());
-            //perp.renderNode.hide();
-            window.setTimeout(function(){
-              perp.renderNode.FXArise(function(){
-                gnode.renderNode.cableAnimatedTo(perp.renderNode,{mode:perp.cableType},function(){ 
-                  if (perp.cableType == "in") {
-                    perp.renderNode.FXBounce(); 
-                  } else if (perp.cableType == "out") {
-                    gnode.renderNode.FXBounce(); 
+          perp.renderData.config.placeRandom = placePos;
+          perp.renderData.config.placeParentRadius = 0;
+          perp.renderData.config.hidden = true;
+
+          perp.render();
+          groot.trigger('saveCoords', [perp.path, perp.renderNode.getPosition()]);
+          perp.renderNode.addDecorator(
+            new Render.DecoratorNew({ text: _._('New!'), extendClass: 'NewPerp' })
+          );
+          perp.renderNode.hide();
+          perp.renderNode.parentNode.scrollTo(perp.renderNode.getPosition());
+          //perp.renderNode.hide();
+          window.setTimeout(function () {
+            perp.renderNode.FXArise(function () {
+              gnode.renderNode.cableAnimatedTo(
+                perp.renderNode,
+                { mode: perp.cableType },
+                function () {
+                  if (perp.cableType == 'in') {
+                    perp.renderNode.FXBounce();
+                  } else if (perp.cableType == 'out') {
+                    gnode.renderNode.FXBounce();
                   } else {
-                    gnode.renderNode.FXBounce(); 
-                    perp.renderNode.FXBounce(); 
+                    gnode.renderNode.FXBounce();
+                    perp.renderNode.FXBounce();
                   }
                   if (perp.data.provided_perps && perp.data.provided_perps.length) {
                     var n = {};
-                    if (perp.gameType === "PusherPerp") {
+                    if (perp.gameType === 'PusherPerp') {
                       n.perps = perp.getProvidedByRequiredPerps();
                     } else {
                       n.perps = perp.getProvidedByLevel();
@@ -3180,142 +3324,144 @@ var Game = function() {
                       perp.markNewItems();
                     }
                   }
-                });
-              });
-            },300);
-            // save coords to backend
-            perp.trigger('after_buy');
-            return perp;
-          } 
-        } else {
-          // Server Error
-          gnode.Error('The computer says NOOOO',data);
+                }
+              );
+            });
+          }, 300);
+          // save coords to backend
+          perp.trigger('after_buy');
+          return perp;
         }
-      });
-    };
+      } else {
+        // Server Error
+        gnode.Error('The computer says NOOOO', data);
+      }
+    });
+  };
 
-    // FIXME DEBUG: testpopup for each gameperp (gets overwritten)
-    GamePerp.prototype.extendEventHandlers = function() {
-      var gnode = this;
-      gnode.on('vclick',function(e,renderNode) {
-        e.stopPropagation();
-        var popup = this.openPopup();
-      });
-    };
+  // FIXME DEBUG: testpopup for each gameperp (gets overwritten)
+  GamePerp.prototype.extendEventHandlers = function () {
+    var gnode = this;
+    gnode.on('vclick', function (e, renderNode) {
+      e.stopPropagation();
+      var popup = this.openPopup();
+    });
+  };
 
+  ///////////////////////////////////
+  // The Top Scores
+  ///////////////////////////////////
 
+  var Topscores = function (config) {
+    var gnode = this;
+    var groot = this.GameRoot;
+    this.ViewMap = this;
+    this.queue = new Set();
+    this.init(config);
+    return this;
+  };
+  extend(Topscores, GameNode);
 
-    ///////////////////////////////////
-    // The Top Scores
-    ///////////////////////////////////
+  Topscores.prototype.renderType = 'ViewTab';
 
-    var Topscores = function(config) {
-      var gnode = this;
-      var groot = this.GameRoot;
-      this.ViewMap = this;
-      this.queue = new Set();
-      this.init(config);
-      return this;
-    };
-    extend(Topscores, GameNode);
+  Topscores.prototype.extendRender = function () {
+    this.GameRoot.renderMenu.addButton(_._('Topscores'), this.id, this.states);
+  };
 
-    Topscores.prototype.renderType = "ViewTab";
+  Topscores.prototype.initTopscore = function (type) {
+    var gnode = this;
+    var groot = this.GameRoot;
+    if (type === undefined) return;
 
-    Topscores.prototype.extendRender = function() {
-      this.GameRoot.renderMenu.addButton(_._('Topscores'), this.id,this.states);
-    };
+    score = new Game.Topscore({
+      id: 'Topscore' + type,
+      gestalt: 'topscore_' + type,
+      states: { complete: false, active: false },
+      scoretype: type,
+      data: groot.getTypeData('Topscore'),
+      renderNodeParent: getFirstId('Topscores'),
+      ViewMap: getByFirstId('Topscores'),
+      gameType: 'Topscore',
+    });
+    gnode.addChild(score);
+    score.render();
+    score.renderNode.hide();
+    return score;
+  };
 
-    Topscores.prototype.initTopscore = function(type) {
-      var gnode = this;
-      var groot = this.GameRoot;
-      if (type === undefined) return;
+  Topscores.prototype.updateScores = function () {
+    this.children.each(function (score) {
+      score.lastFetch = null;
+      score.fetchScore(score.scoretype, true);
+    });
+  };
 
-      score = new Game.Topscore({
-        "id": 'Topscore' + type,
-        "gestalt": 'topscore_'+ type,
-        "states" : { complete:false, active:false },
-        "scoretype": type,
-        "data": groot.getTypeData('Topscore'),
-        "renderNodeParent": getFirstId("Topscores"),
-        "ViewMap": getByFirstId("Topscores"),
-        "gameType": "Topscore"
-      });
-      gnode.addChild(score);
-      score.render();
-      score.renderNode.hide();
-      return score;
-    };
+  Topscores.prototype.extendEventHandlers = function () {
+    var gnode = this;
+    var groot = this.GameRoot;
 
-    Topscores.prototype.updateScores = function(){
-      this.children.each(function(score){
-        score.lastFetch = null;
-        score.fetchScore(score.scoretype, true);
-      });
-    };
-
-    Topscores.prototype.extendEventHandlers = function() {
-      var gnode = this;
-      var groot = this.GameRoot;
-
-      gnode.on('viewtab_selected',function(e,type) {
-        var all_hidden = true;
-        gnode.children.each(function(score){
-          score.fetchScore();
-          if (!score.renderNode.hidden) {
-            all_hidden = false;
-          }
-        });
-        var first = gnode.children.set[0];
-        if (first && all_hidden && gnode.children.length) {
-          first.renderNode.show();
-          gnode.renderNode.jdomelem.find('.ViewTabMenuButton[data-button-gestalt="' + first.scoretype + '"]').addClass('active');
-        }
-      });
-
-      gnode.on('button_click.ViewTabMenuButton',function(e,type) {
-        e.stopPropagation();
-        var score = getByGestalt('topscore_' + type);
-        gnode.children.each(function(ts){
-          ts.renderNode.hide();
-        });
-        score.renderNode.show();
+    gnode.on('viewtab_selected', function (e, type) {
+      var all_hidden = true;
+      gnode.children.each(function (score) {
         score.fetchScore();
+        if (!score.renderNode.hidden) {
+          all_hidden = false;
+        }
       });
-
-      // Live leaderboard refresh on every state.peers ref change.
-      // Topscores lives for the page lifetime; the unsubscribe is dropped.
-      if (bootMod && typeof bootMod.subscribePeersChanged === 'function') {
-        bootMod.subscribePeersChanged(function () {
-          gnode.updateScores();
-        });
+      var first = gnode.children.set[0];
+      if (first && all_hidden && gnode.children.length) {
+        first.renderNode.show();
+        gnode.renderNode.jdomelem
+          .find('.ViewTabMenuButton[data-button-gestalt="' + first.scoretype + '"]')
+          .addClass('active');
       }
-    };
+    });
 
+    gnode.on('button_click.ViewTabMenuButton', function (e, type) {
+      e.stopPropagation();
+      var score = getByGestalt('topscore_' + type);
+      gnode.children.each(function (ts) {
+        ts.renderNode.hide();
+      });
+      score.renderNode.show();
+      score.fetchScore();
+    });
 
-    //////////////////////////////////
+    // Live leaderboard refresh on every state.peers ref change.
+    // Topscores lives for the page lifetime; the unsubscribe is dropped.
+    if (bootMod && typeof bootMod.subscribePeersChanged === 'function') {
+      bootMod.subscribePeersChanged(function () {
+        gnode.updateScores();
+      });
+    }
+  };
 
-    var Topscore = function(config) {
-      this.init(config);
-      return this;
-    };
-    extend(Topscore, GameNode);
-    
-    Topscore.prototype.renderType = "TopscorePerp";
+  //////////////////////////////////
 
-    Topscore.prototype.fetchScore = function(type,force){
-      var gnode = this;
-      var groot = this.groot;
-      var type = type || gnode.scoretype;
-      var now = new Date();
-      // cache fetching for 30sec
-      if (!force && gnode.lastFetch && (now - gnode.lastFetch < 30000)) {
-        gnode.renderNode.jdomelem.removeClass('loading');
-        return;
-      }
-      app.remote.getRanking(type).done(function(data){
+  var Topscore = function (config) {
+    this.init(config);
+    return this;
+  };
+  extend(Topscore, GameNode);
+
+  Topscore.prototype.renderType = 'TopscorePerp';
+
+  Topscore.prototype.fetchScore = function (type, force) {
+    var gnode = this;
+    var groot = this.groot;
+    var type = type || gnode.scoretype;
+    var now = new Date();
+    // cache fetching for 30sec
+    if (!force && gnode.lastFetch && now - gnode.lastFetch < 30000) {
+      gnode.renderNode.jdomelem.removeClass('loading');
+      return;
+    }
+    app.remote
+      .getRanking(type)
+      .done(function (data) {
         if (data.result && data.result.error === undefined) {
           gnode.data = mergeData(gnode.data, data.result);
-          gnode.data.user_in_top = _.findWhere(gnode.data.top, {self:true}) !== undefined;
+          gnode.data.user_in_top = _.findWhere(gnode.data.top, { self: true }) !== undefined;
           gnode.renderNode.renderRank();
           gnode.renderNode.renderList();
           gnode.renderNode.jdomelem.removeClass('loading');
@@ -3324,618 +3470,663 @@ var Game = function() {
           console.error('getRanking failed', data);
         }
       })
-      .fail(function(data){
+      .fail(function (data) {
         console.error('getRanking failed', data);
       });
-    };
+  };
 
-    Topscore.prototype.extendEventHandlers = function() {
-      var gnode = this;
-      var groot = this.GameRoot;
-      var node = this.renderNode;
+  Topscore.prototype.extendEventHandlers = function () {
+    var gnode = this;
+    var groot = this.GameRoot;
+    var node = this.renderNode;
 
-      gnode.on('vclick',function(e,renderNode) {
-        e.stopPropagation();
-        gnode.renderNode.jdomelem.addClass('loading');
-        gnode.fetchScore();
-      });
-    };
+    gnode.on('vclick', function (e, renderNode) {
+      e.stopPropagation();
+      gnode.renderNode.jdomelem.addClass('loading');
+      gnode.fetchScore();
+    });
+  };
 
+  ///////////////////////////////////
+  // The Missions and Mission Classes
+  ///////////////////////////////////
 
-    ///////////////////////////////////
-    // The Missions and Mission Classes
-    ///////////////////////////////////
+  var Missions = function (config) {
+    gnode = this;
+    groot = this.GameRoot;
+    this.ViewMap = this;
+    this.queue = new Set();
+    this.init(config);
+    return this;
+  };
+  extend(Missions, GameNode);
 
-    var Missions = function(config) {
-      gnode = this;
-      groot = this.GameRoot;
-      this.ViewMap = this;
-      this.queue = new Set();
-      this.init(config);
-      return this;
-    };
-    extend(Missions, GameNode);
+  Missions.prototype.renderType = 'ViewTab';
 
-    Missions.prototype.renderType = "ViewTab";
+  Missions.prototype.extendRender = function () {
+    this.GameRoot.renderMenu.addButton(_._('Missions'), this.id, this.states);
+  };
 
-    Missions.prototype.extendRender = function() {
-      this.GameRoot.renderMenu.addButton(_._('Missions'), this.id,this.states);
-    };
-
-    Missions.prototype.extendEventHandlers = function() {
-      var mroot = this;
-      var groot = this.GameRoot;
-      mroot.on('states_active', function(e, params) {
-        if (!params || !app.remote || !app.remote.recheckMissions) { return; }
-        app.remote.recheckMissions().done(function(data) {
-          var r = data && data.result;
-          if (!r || !r.repaired) { return; }
-          if (r.missions.complete_missions && r.missions.complete_missions.length) {
-            groot.updateGameValues(r.game_values, r.levelup, r.missions, true);
-          } else {
-            // Goal flipped without finishing the mission — refresh rows only,
-            // skipping the reward/levelup popup machinery.
-            mroot.updateMissionGoals(r.missions.mission_data.mission_goals);
-          }
-        });
-      });
-    };
-
-    Missions.prototype.getMission = function(gestalt) {
-      return this.Missions[gestalt] || {};
-    };
-
-    Missions.prototype.initMissions = function(raw_data) {
-      // raw_data = rd = {}
-      // rd.mission_goals
-      // rd.missions = [missions+type_data]
-      // rd.active_missions
-      // rd.mission_goals = [object,...]
-      // TODO: how to compile completed missions?
-      var mroot = this;
-      var groot = this.GameRoot;
-      if (!mroot.Missions) {
-        mroot.Missions = {};
+  Missions.prototype.extendEventHandlers = function () {
+    var mroot = this;
+    var groot = this.GameRoot;
+    mroot.on('states_active', function (e, params) {
+      if (!params || !app.remote || !app.remote.recheckMissions) {
+        return;
       }
-
-      var active_missions = raw_data.active_missions;
-
-      raw_data.missions.reverse();
-
-      _.each(raw_data.missions,function(m,key){
-        groot.addType(m.type_data.gestalt,m);
+      app.remote.recheckMissions().done(function (data) {
+        var r = data && data.result;
+        if (!r || !r.repaired) {
+          return;
+        }
+        if (r.missions.complete_missions && r.missions.complete_missions.length) {
+          groot.updateGameValues(r.game_values, r.levelup, r.missions, true);
+        } else {
+          // Goal flipped without finishing the mission — refresh rows only,
+          // skipping the reward/levelup popup machinery.
+          mroot.updateMissionGoals(r.missions.mission_data.mission_goals);
+        }
       });
-      _.each(raw_data.missions,function(mission,key){
-        mission = new Game.Mission({
-          "id": mission.gestalt,
-          "gestalt": mission.gestalt,
-          "states" : { complete:false, active:false },
-          "data": groot.getTypeData(mission.gestalt),
-          "renderNodeParent": getFirstId("Missions"),
-          "ViewMap": getByFirstId("Missions"),
-          "gameType": "Mission"
-        });
-        mroot.Missions[mission.gestalt] = mission;
-        mroot.addChild(mission);
+    });
+  };
+
+  Missions.prototype.getMission = function (gestalt) {
+    return this.Missions[gestalt] || {};
+  };
+
+  Missions.prototype.initMissions = function (raw_data) {
+    // raw_data = rd = {}
+    // rd.mission_goals
+    // rd.missions = [missions+type_data]
+    // rd.active_missions
+    // rd.mission_goals = [object,...]
+    // TODO: how to compile completed missions?
+    var mroot = this;
+    var groot = this.GameRoot;
+    if (!mroot.Missions) {
+      mroot.Missions = {};
+    }
+
+    var active_missions = raw_data.active_missions;
+
+    raw_data.missions.reverse();
+
+    _.each(raw_data.missions, function (m, key) {
+      groot.addType(m.type_data.gestalt, m);
+    });
+    _.each(raw_data.missions, function (mission, key) {
+      mission = new Game.Mission({
+        id: mission.gestalt,
+        gestalt: mission.gestalt,
+        states: { complete: false, active: false },
+        data: groot.getTypeData(mission.gestalt),
+        renderNodeParent: getFirstId('Missions'),
+        ViewMap: getByFirstId('Missions'),
+        gameType: 'Mission',
       });
-      if (raw_data.mission_goals) {
-        mroot.updateMissionGoals(raw_data.mission_goals);
-      }
-      if (active_missions.length) {
-        _.each(active_missions, function(gestalt){
-          var active_mission = mroot.getMission(gestalt);
-          if (active_mission.setState) {
-              active_mission.setState('active', true);
-            _.each(active_mission.getBranch(), function(mission){
-              mission.setState('complete', true);
-              mission.setState('active', false);
-            });
-          }
-        });
-      } else {
-        // FIXME: all missions done, process all missions
-         _.each(mroot.Missions, function(mission){
+      mroot.Missions[mission.gestalt] = mission;
+      mroot.addChild(mission);
+    });
+    if (raw_data.mission_goals) {
+      mroot.updateMissionGoals(raw_data.mission_goals);
+    }
+    if (active_missions.length) {
+      _.each(active_missions, function (gestalt) {
+        var active_mission = mroot.getMission(gestalt);
+        if (active_mission.setState) {
+          active_mission.setState('active', true);
+          _.each(active_mission.getBranch(), function (mission) {
             mission.setState('complete', true);
             mission.setState('active', false);
-        });
-      }
-      mroot.checkProjectGoals();
-    };
-
-    Missions.prototype.getActiveMissions = function(){
-      var mroot = this;
-      var groot = this.GameRoot;
-      return _.filter(mroot.Missions, function(m){ return (m.states.active === true && m.states.complete === false); });
-    };
-
-    Missions.prototype.getVisibleMissions = function(){
-      var mroot = this;
-      var groot = this.GameRoot;
-      return _.filter(mroot.Missions, function(m){ return (m.states.active === true || m.states.complete === true); });
-    };
-
-    Missions.prototype.getCompletedMissions = function(){
-      var mroot = this;
-      var groot = this.GameRoot;
-      return _.filter(mroot.Missions, function(m){ return (m.states.active === false && m.states.complete === true); });
-    };
-
-    Missions.prototype.getNextMissions = function(){
-      var mroot = this;
-      var groot = this.GameRoot;
-      var next_missions = {};
-      var active_missions = _.each(mroot.getActiveMissions(), function(mission){
-        var next = mission.getNext();
-        if (next) { 
-          next_missions[next.gestalt] = next; 
+          });
         }
       });
-      return _(next_missions).values();
+    } else {
+      // FIXME: all missions done, process all missions
+      _.each(mroot.Missions, function (mission) {
+        mission.setState('complete', true);
+        mission.setState('active', false);
+      });
     }
+    mroot.checkProjectGoals();
+  };
 
+  Missions.prototype.getActiveMissions = function () {
+    var mroot = this;
+    var groot = this.GameRoot;
+    return _.filter(mroot.Missions, function (m) {
+      return m.states.active === true && m.states.complete === false;
+    });
+  };
 
-    Missions.prototype.checkProjectGoals = function(){
-      var mroot = this;
-      var groot = this.GameRoot;
-      var fetch_project_data = {};
-      var update_missions = [];
-      
-      var checkMission = function(mission) {
-        _.each(mission.data.goals, function(goal){
-          if (goal.project) {
-            fetch_project_data[goal.project] = mission;
-            update_missions.push(mission);
-          }
-        });
-      };
+  Missions.prototype.getVisibleMissions = function () {
+    var mroot = this;
+    var groot = this.GameRoot;
+    return _.filter(mroot.Missions, function (m) {
+      return m.states.active === true || m.states.complete === true;
+    });
+  };
 
-      _.each(mroot.getVisibleMissions(), checkMission);
-      _.each(mroot.getNextMissions(), checkMission);
+  Missions.prototype.getCompletedMissions = function () {
+    var mroot = this;
+    var groot = this.GameRoot;
+    return _.filter(mroot.Missions, function (m) {
+      return m.states.active === false && m.states.complete === true;
+    });
+  };
 
-      _.each(fetch_project_data, function(mission, gestalt){
-        groot.fetchProjectPowerupData(gestalt, function(){
-          // FIXME: gotta update all missions with the project in the goals,
-          // make this more light weight... best with deferred done callback?
-          //mission.updateRender();
-          _.each(update_missions,function(mission) {
-            mission.updateRender();
-          });
-          update_missions = _.without(update_missions, mission);
-        });
+  Missions.prototype.getNextMissions = function () {
+    var mroot = this;
+    var groot = this.GameRoot;
+    var next_missions = {};
+    var active_missions = _.each(mroot.getActiveMissions(), function (mission) {
+      var next = mission.getNext();
+      if (next) {
+        next_missions[next.gestalt] = next;
+      }
+    });
+    return _(next_missions).values();
+  };
+
+  Missions.prototype.checkProjectGoals = function () {
+    var mroot = this;
+    var groot = this.GameRoot;
+    var fetch_project_data = {};
+    var update_missions = [];
+
+    var checkMission = function (mission) {
+      _.each(mission.data.goals, function (goal) {
+        if (goal.project) {
+          fetch_project_data[goal.project] = mission;
+          update_missions.push(mission);
+        }
       });
     };
 
-    Missions.prototype.updateMissions = function(missions, game_values) {
-      var mroot = this;
-      var groot = this.GameRoot;
-      // missions is the mission data structure coming from the backend api
-      // missions = {} 
-      // missions.complete_missions = ['mission001',..]
-      // missions.mission_data = {}
-      // missions.mission_data.active_missions = ['mission001',...]
-      // missions.mission_data.missions_goals = [object,...]
-      // missions.mission_data.missions_goals[0] = {
-      //      amount: 6000,
-      //      current_amount: 2890,
-      //      goal_id: "52949c22182e75a93d9c61af",
-      //      mission: "mission001",
-      //      position: 1,
-      //      project: null,
-      //      target: "contact035",
-      //      workflow: "collect_profiles"
-      // }
-      // missions.updated_missions = ['mission001',..]
-      // missions.rewards = {
-      //  cash_value: 0
-      //  karma_value: 0
-      //  profile_sets: Array[0]
-      //  xp_value: 0
-      //}
-      if (missions.complete_missions) {
-        _.each(missions.complete_missions, function(gestalt){
-          mroot.getMission(gestalt).setState('active',false);
-          mroot.getMission(gestalt).setState('complete',true);
+    _.each(mroot.getVisibleMissions(), checkMission);
+    _.each(mroot.getNextMissions(), checkMission);
+
+    _.each(fetch_project_data, function (mission, gestalt) {
+      groot.fetchProjectPowerupData(gestalt, function () {
+        // FIXME: gotta update all missions with the project in the goals,
+        // make this more light weight... best with deferred done callback?
+        //mission.updateRender();
+        _.each(update_missions, function (mission) {
+          mission.updateRender();
         });
-      }
-      mroot.updateMissionGoals();
-      if (missions.mission_data && missions.mission_data.mission_goals) {
-        _.each(missions.mission_data.mission_goals, function(goal){
-          if (goal.complete) { groot.renderNode.FXMissionGoalComplete(); }
-        });
-        mroot.updateMissionGoals(missions.mission_data.mission_goals);
-      }
-      if (missions.mission_data && missions.mission_data.active_missions) {
-        _.each(missions.mission_data.active_missions, function(gestalt){
-          var am = mroot.getMission(gestalt);
-          mroot.getMission(gestalt).setState('active',true);
-        });
-      }
+        update_missions = _.without(update_missions, mission);
+      });
+    });
+  };
 
-      if (missions.rewards && missions.rewards.profile_sets) {
-        _.each(missions.rewards.profile_sets, function(ps){
-          groot.getDatabase().cue(ps.profile_set,ps.origin,ps.collect_id);
-        });
-      }
-
-      mroot.checkProjectGoals();
-
-      // TODO: check for notifications for complete and active missions
-      //groot.makeNotifications({ missions: missions, game_values: game_values });
-    };
-
-    Missions.prototype.updateMissionGoals = function(goals) {
-      var mroot = this;
-      if (goals) {
-        _.each(goals, function(goal){
-          var mission = mroot.Missions[goal.mission];
-          if (mission) {
-             mission.updateGoal(goal);
-          }
-        });
-      } else {
-        _.each(mroot.Missions, function(mission){
-          _.each(mission.data.goals, function(goal){
-            mission.updateGoal(goal);
-          });
-        });
-      }
-    };
-
-
-
-    ////////////////////////////////////
-
-    var Mission = function(config) {
-      this.init(config);
-      return this;
-    };
-    extend(Mission, GameNode);
-    
-    Mission.prototype.renderType = "MissionPerp";
-    Mission.prototype.popupTemplate = "popup_mission.html";
-    
-    Mission.prototype.getBranch = function(gestalt) {
-      var mroot = this.parentNode;
-      var branch = [];
-      var mission = this;
-      while (mission && mission.data && mission.data.required_mission) {
-        mission = mroot.getMission(mission.data.required_mission);
-        branch.push(mission);
-      }
-      return branch
+  Missions.prototype.updateMissions = function (missions, game_values) {
+    var mroot = this;
+    var groot = this.GameRoot;
+    // missions is the mission data structure coming from the backend api
+    // missions = {}
+    // missions.complete_missions = ['mission001',..]
+    // missions.mission_data = {}
+    // missions.mission_data.active_missions = ['mission001',...]
+    // missions.mission_data.missions_goals = [object,...]
+    // missions.mission_data.missions_goals[0] = {
+    //      amount: 6000,
+    //      current_amount: 2890,
+    //      goal_id: "52949c22182e75a93d9c61af",
+    //      mission: "mission001",
+    //      position: 1,
+    //      project: null,
+    //      target: "contact035",
+    //      workflow: "collect_profiles"
+    // }
+    // missions.updated_missions = ['mission001',..]
+    // missions.rewards = {
+    //  cash_value: 0
+    //  karma_value: 0
+    //  profile_sets: Array[0]
+    //  xp_value: 0
+    //}
+    if (missions.complete_missions) {
+      _.each(missions.complete_missions, function (gestalt) {
+        mroot.getMission(gestalt).setState('active', false);
+        mroot.getMission(gestalt).setState('complete', true);
+      });
+    }
+    mroot.updateMissionGoals();
+    if (missions.mission_data && missions.mission_data.mission_goals) {
+      _.each(missions.mission_data.mission_goals, function (goal) {
+        if (goal.complete) {
+          groot.renderNode.FXMissionGoalComplete();
+        }
+      });
+      mroot.updateMissionGoals(missions.mission_data.mission_goals);
+    }
+    if (missions.mission_data && missions.mission_data.active_missions) {
+      _.each(missions.mission_data.active_missions, function (gestalt) {
+        var am = mroot.getMission(gestalt);
+        mroot.getMission(gestalt).setState('active', true);
+      });
     }
 
-    Mission.prototype.getNext = function(gestalt) {
-      var mission = this;
-      var mroot = mission.parentNode;
-      gestalt = gestalt || this.gestalt;
-      return _.find(mroot.Missions, function(m){ return ( m.data.required_mission && m.data.required_mission === gestalt) });
-    };
-
-    Mission.prototype.updateRender = function() {
-      var mission = this;
-      if (mission.renderNode) { mission.renderNode.render(); }
-    };
-
-    Mission.prototype.updateGoal = function(goal) {
-      // TODO: take care of rendering
-      var mission = this;
-      var groot = this.GameRoot;
-      if (goal.mission = this.gestalt) {
-        // FIXME: if position equal to index of array -1 this could go faster ???
-        _.each(mission.data.goals, function(mission_goal,k) {
-          if (mission_goal.position === goal.position) {
-            if (goal.complete) {
-              if (!goal.amount) { goal.amount = 1; }
-              goal.current_amount = goal.amount;
-            }
-            if (goal.workflow === 'integrate_profiles') {
-              goal.current_amount = groot.DBTokensAbsolute[goal.target] || 0;
-              goal.current_amount = (goal.current_amount <= goal.amount) ? goal.current_amount : goal.amount;
-            }
-            mission.data.goals[k] = goal;
-          }
-        });
-        mission.updateRender();
-      }
-    };
-
-    Mission.prototype.openMissionPopup = function(){
-      var gnode = this;
-      var groot = this.GameRoot;
-      
-      groot.openGenericPopup({
-        states: gnode.states,
-        data: gnode.data,
-        template:'popup_mission.html',
-        extendClass: 'Mission'
+    if (missions.rewards && missions.rewards.profile_sets) {
+      _.each(missions.rewards.profile_sets, function (ps) {
+        groot.getDatabase().cue(ps.profile_set, ps.origin, ps.collect_id);
       });
-    };
+    }
 
-    Mission.prototype.checkTutorial = function() {
-      var gnode = this;
-      var groot = this.GameRoot;
-      var mroot = groot.Missions;
-      if (gnode.states.active && gnode.data.tutorial) {
-        // If the player already dismissed the mission briefing, the NPC coach
-        // intro has already been seen — skip re-queuing on reload.
-        var seenBriefings = (groot.raw_data && groot.raw_data.mission_briefings_seen) || {};
-        if (seenBriefings[gnode.gestalt]) { return false; }
-        groot.setState('tutorial_active',true);
-        // TODO: check each step for completion and delete everything before
-        var steps = gnode.data.tutorial;
-        var deletefrom = 0;
-        _.each(steps, function(step,k){
-          if (step.buyPerp && groot.IPerps.hasOwnProperty(step.buyPerp)) {
-            deletefrom = k;
-          }
-          if (step.integrateProfileSet && groot.getOriginGestaltFromOriginTokenGestalt(step.integrateProfileSet)) {
-            deletefrom = k;
-            step.nodelay = true;
-          }
-        });
-        steps = _.rest(steps, deletefrom);
+    mroot.checkProjectGoals();
 
-        groot.makeNotifications({
-          tutorial: steps
+    // TODO: check for notifications for complete and active missions
+    //groot.makeNotifications({ missions: missions, game_values: game_values });
+  };
+
+  Missions.prototype.updateMissionGoals = function (goals) {
+    var mroot = this;
+    if (goals) {
+      _.each(goals, function (goal) {
+        var mission = mroot.Missions[goal.mission];
+        if (mission) {
+          mission.updateGoal(goal);
+        }
+      });
+    } else {
+      _.each(mroot.Missions, function (mission) {
+        _.each(mission.data.goals, function (goal) {
+          mission.updateGoal(goal);
         });
-        return true;
-      } else {
+      });
+    }
+  };
+
+  ////////////////////////////////////
+
+  var Mission = function (config) {
+    this.init(config);
+    return this;
+  };
+  extend(Mission, GameNode);
+
+  Mission.prototype.renderType = 'MissionPerp';
+  Mission.prototype.popupTemplate = 'popup_mission.html';
+
+  Mission.prototype.getBranch = function (gestalt) {
+    var mroot = this.parentNode;
+    var branch = [];
+    var mission = this;
+    while (mission && mission.data && mission.data.required_mission) {
+      mission = mroot.getMission(mission.data.required_mission);
+      branch.push(mission);
+    }
+    return branch;
+  };
+
+  Mission.prototype.getNext = function (gestalt) {
+    var mission = this;
+    var mroot = mission.parentNode;
+    gestalt = gestalt || this.gestalt;
+    return _.find(mroot.Missions, function (m) {
+      return m.data.required_mission && m.data.required_mission === gestalt;
+    });
+  };
+
+  Mission.prototype.updateRender = function () {
+    var mission = this;
+    if (mission.renderNode) {
+      mission.renderNode.render();
+    }
+  };
+
+  Mission.prototype.updateGoal = function (goal) {
+    // TODO: take care of rendering
+    var mission = this;
+    var groot = this.GameRoot;
+    if ((goal.mission = this.gestalt)) {
+      // FIXME: if position equal to index of array -1 this could go faster ???
+      _.each(mission.data.goals, function (mission_goal, k) {
+        if (mission_goal.position === goal.position) {
+          if (goal.complete) {
+            if (!goal.amount) {
+              goal.amount = 1;
+            }
+            goal.current_amount = goal.amount;
+          }
+          if (goal.workflow === 'integrate_profiles') {
+            goal.current_amount = groot.DBTokensAbsolute[goal.target] || 0;
+            goal.current_amount =
+              goal.current_amount <= goal.amount ? goal.current_amount : goal.amount;
+          }
+          mission.data.goals[k] = goal;
+        }
+      });
+      mission.updateRender();
+    }
+  };
+
+  Mission.prototype.openMissionPopup = function () {
+    var gnode = this;
+    var groot = this.GameRoot;
+
+    groot.openGenericPopup({
+      states: gnode.states,
+      data: gnode.data,
+      template: 'popup_mission.html',
+      extendClass: 'Mission',
+    });
+  };
+
+  Mission.prototype.checkTutorial = function () {
+    var gnode = this;
+    var groot = this.GameRoot;
+    var mroot = groot.Missions;
+    if (gnode.states.active && gnode.data.tutorial) {
+      // If the player already dismissed the mission briefing, the NPC coach
+      // intro has already been seen — skip re-queuing on reload.
+      var seenBriefings = (groot.raw_data && groot.raw_data.mission_briefings_seen) || {};
+      if (seenBriefings[gnode.gestalt]) {
         return false;
       }
-    };
-
-    Mission.prototype.extendEventHandlers = function() {
-      var gnode = this;
-      var groot = this.GameRoot;
-      var mroot = groot.Missions;
-      var node = this.renderNode;
-      gnode.on('after_render',function(e) {
-        if (gnode.states.active) {
-          if (gnode.checkTutorial()) {
-            groot.makeNotifications({
-              mission_active: gnode.gestalt
-            });
-          }
+      groot.setState('tutorial_active', true);
+      // TODO: check each step for completion and delete everything before
+      var steps = gnode.data.tutorial;
+      var deletefrom = 0;
+      _.each(steps, function (step, k) {
+        if (step.buyPerp && groot.IPerps.hasOwnProperty(step.buyPerp)) {
+          deletefrom = k;
+        }
+        if (
+          step.integrateProfileSet &&
+          groot.getOriginGestaltFromOriginTokenGestalt(step.integrateProfileSet)
+        ) {
+          deletefrom = k;
+          step.nodelay = true;
         }
       });
+      steps = _.rest(steps, deletefrom);
 
-      gnode.on('states_active',function(e,params) {
-        e.stopPropagation();
-        if (!params) { return; }
-        gnode.checkTutorial();
-        groot.makeNotifications({
-          mission_active: gnode.gestalt
-        });
+      groot.makeNotifications({
+        tutorial: steps,
       });
+      return true;
+    } else {
+      return false;
+    }
+  };
 
-      gnode.on('local_states_complete',function(e,params) {
-        _.each(gnode.data.goals, function(goal){
-          goal.complete = true;
-          gnode.updateGoal(goal)
-        });
-      });
-
-      gnode.on('states_complete',function(e,params) {
-        e.stopPropagation();
-        if (!params) { return; }
-        if (gnode.data.tutorial) {
-          groot.setState('tutorial_active',false);
-        }
-        groot.makeNotifications({
-          mission_complete: gnode.gestalt
-        });
-      });
-
-      gnode.on('vclick',function(e,renderNode) {
-        e.stopPropagation();
-        gnode.openMissionPopup();
-      });
-    };
-
-    Mission.prototype.extendRender = function() {
-      var gnode = this;
-      if (!gnode.states.active && !gnode.states.complete) {
-        //gnode.renderNode.hide();
-      }
-    };
-
-
-    ///////////////////////////////////
-    // The Database Perp
-    ///////////////////////////////////
-
-    var DatabasePerp = function(config) {
-      this.init(config);
-      return this;
-    };
-
-    extend(DatabasePerp, GamePerp);
-
-    DatabasePerp.prototype.renderType = "Perp";
-
-    DatabasePerp.prototype.extendEventHandlers = function() {
-      var gnode = this;
-      gnode.on('vclick',function(e,renderNode) {
-        e.stopPropagation();
-        gnode.trigger('switch_view','Database');
-      });
-    };
-
-    DatabasePerp.prototype.BuyCity = function(bgestalt, placePos) {
-      var gnode = this;
-      var groot = this.GameRoot;
-      app.remote.buyPerp(gnode.path, bgestalt).done(function(data) {
-        if (data.result) {
-          if (data.result.error !== undefined) {
-            // Probably no cash
-            if (gnode.renderPopup && gnode.renderPopup.open) {
-              gnode.renderPopup.trigger('no_cash');
-            } else {
-              gnode.renderNode.FXNoCash();
-            }
-            return;
-          }
-          if (groot.renderPopup) { groot.renderPopup.trigger('popup_close'); }
-          _.each(getByType('CityPerp'),function(city){
-             if (city.renderPopup) { city.renderPopup.trigger('popup_close'); }
+  Mission.prototype.extendEventHandlers = function () {
+    var gnode = this;
+    var groot = this.GameRoot;
+    var mroot = groot.Missions;
+    var node = this.renderNode;
+    gnode.on('after_render', function (e) {
+      if (gnode.states.active) {
+        if (gnode.checkTutorial()) {
+          groot.makeNotifications({
+            mission_active: gnode.gestalt,
           });
-
-          if (data.result.node) {
-            groot.updateGameValues(data.result.game_values,data.result.levelup,data.result.missions);
-
-            var node = data.result.node
-            var node_data = groot.getTypeData(bgestalt);
-            var perp = new Game[node.game_type]({
-              "id": node.game_id,
-              "gestalt": bgestalt,
-              "path": node.full_path,
-              noConnect:true,
-              "data": mergeData(node_data,node.instance_data),
-              // Render perps to first item in path (Imperium or Database)
-              "renderNodeParent": getFirstId("Imperium"),
-              "ViewMap": getByFirstId("Imperium"),
-              "gameType":node.game_type
-            });
-            gnode.addChild(perp);
-            var perpNode = gnode.renderNode;
-            // place first city to a defined offset to the db, every other city on the opposite side of the first found city....
-            if (placePos) {
-            } else {
-              placePos = gnode.renderNode.getPosition();
-              placePos.x = placePos.x - 250;
-              placePos.y = placePos.y + 50;
-            }
-            if (gnode.children.set && gnode.children.set.length >= 2) {
-              var oppositeCity = _.findWhere(gnode.children.set,{gameType:"CityPerp"});
-              var vector = oppositeCity.renderNode.getVectorTo(gnode.renderNode);
-              placePos = gnode.renderNode.getVectorPos(vector,1);
-            }
-            perp.renderData.config.placeRandom = placePos;
-            perp.renderData.config.placeParentRadius = 400;
-            perp.renderData.config.hidden = true;
-
-            perp.render();
-            groot.trigger('saveCoords', [perp.path,perp.renderNode.getPosition()]);
-            perp.renderNode.addDecorator(new Render.DecoratorNew({text: _._("New!"), extendClass: "NewPerp"}));
-            perp.renderNode.hide();
-            perp.renderNode.parentNode.scrollTo(perp.renderNode.getPosition());
-            window.setTimeout(function(){
-              perp.renderNode.FXArise(function(){
-                gnode.renderNode.cableAnimatedTo(perp.renderNode,{mode:perp.cableType},function(){ 
-                  if (perp.cableType == "in") {
-                    perp.renderNode.FXBounce(); 
-                  } else if (perp.cableType == "out") {
-                    gnode.renderNode.FXBounce(); 
-                  } else {
-                    gnode.renderNode.FXBounce(); 
-                    perp.renderNode.FXBounce(); 
-                  }
-                });
-              });
-            },300);
-            
-            // put profileset in DBQueue
-            groot.getDatabase().cue(data.result.profile_set.profile_set, data.result.profile_set.origin, data.result.profile_set.collect_id);
-            perp.trigger('after_buy');
-            return perp;
-          } 
-        } else {
-          // Server Error
-          gnode.Error('The computer says NOOOO',data);
         }
+      }
+    });
+
+    gnode.on('states_active', function (e, params) {
+      e.stopPropagation();
+      if (!params) {
+        return;
+      }
+      gnode.checkTutorial();
+      groot.makeNotifications({
+        mission_active: gnode.gestalt,
       });
-    };
+    });
 
-    DatabasePerp.prototype.BuyPerp = DatabasePerp.prototype.BuyCity;
-
-    ///////////////////////////////////
-    // The City
-    ///////////////////////////////////
-
-    var CityPerp = function(config) {
-      this.init(config);
-      this.GameRoot.IPerps[this.gestalt] = true;
-      return this;
-    };
-
-    extend(CityPerp, GamePerp);
-
-    CityPerp.prototype.renderType = "Perp";
-    CityPerp.prototype.cableType = "inout";
-    CityPerp.prototype.popupTemplate = "popup_city.html";
-    CityPerp.prototype.textNewItems = _._('New Items!');
-
-    CityPerp.prototype.compileProvidedCities = function() {
-      var gnode = this;
-      var groot = this.GameRoot;
-      gnode.data.providedCities = [];
-      _.each(groot.getTypes('CityPerp'),function(p,key){
-        var city = {};
-        city.data = p.type_data;
-        city.gestalt = p.gestalt;
-        // FIXME: no game_type in template
-        city.data.is_city = true;
-        if (!getByGestalt(p.gestalt)) {
-          gnode.data.providedCities.push(city);
-          if (city.data.required_level <= groot.xp_level.number) {
-            gnode.data.buyablePerps.push(city.gestalt);
-          }
-        }
+    gnode.on('local_states_complete', function (e, params) {
+      _.each(gnode.data.goals, function (goal) {
+        goal.complete = true;
+        gnode.updateGoal(goal);
       });
-      return gnode.data.providedCities;
-    };
+    });
 
-    CityPerp.prototype.compileProvided = function(){
-      var gnode = this;
-      var groot = this.GameRoot;
-
-
-      var providedCache = {};
-      
-      providedCache.AgentPerp = _.filter(gnode.data.provided_perps,function(v){
-        return v.substring(0,5) === 'agent';
+    gnode.on('states_complete', function (e, params) {
+      e.stopPropagation();
+      if (!params) {
+        return;
+      }
+      if (gnode.data.tutorial) {
+        groot.setState('tutorial_active', false);
+      }
+      groot.makeNotifications({
+        mission_complete: gnode.gestalt,
       });
-      providedCache.ProxyPerp = _.filter(gnode.data.provided_perps,function(v){
-        return v.substring(0,5) === 'proxy';
-      });
-      providedCache.PusherPerp = _.filter(gnode.data.provided_perps,function(v){
-        return v.substring(0,6) === 'pusher';
-      });
+    });
 
-      providedCache.CityPerp = _.pluck(gnode.compileProvidedCities(),'gestalt');
+    gnode.on('vclick', function (e, renderNode) {
+      e.stopPropagation();
+      gnode.openMissionPopup();
+    });
+  };
 
-      gnode.data.providedTabs = {
-        AgentPerp: [],
-        PusherPerp: [],
-        ProxyPerp: [],
-        CityPerp: []
-      };
+  Mission.prototype.extendRender = function () {
+    var gnode = this;
+    if (!gnode.states.active && !gnode.states.complete) {
+      //gnode.renderNode.hide();
+    }
+  };
 
-      _.each(gnode.data.providedTabs,function(tab,k){
-        _.each(providedCache[k],function(p,key){
-          var perp = {};
-          var type_data = groot.getTypeData(p);
-          perp.data = type_data;
-          perp.gestalt = p;
-          perp.locked = _.find(gnode.data.buyablePerps,function(v){ return perp.gestalt === v }) === undefined;
-          // FIXME: this property should come from the backend and doesn't need to be set here.
-          if (!perp.data.max_instances) { 
-            perp.data.max_instances = 1;
-          }
-          if (perp.data.max_instances) {
-            if (getAllByGestalt(perp.gestalt).length >= perp.data.max_instances) {
-              perp.locked = true;
-              perp.bought = true;
-            }
-          }
-          if ( perp.locked && groot.IPerps.hasOwnProperty(perp.gestalt) ) {
-            perp.bought = true;
+  ///////////////////////////////////
+  // The Database Perp
+  ///////////////////////////////////
+
+  var DatabasePerp = function (config) {
+    this.init(config);
+    return this;
+  };
+
+  extend(DatabasePerp, GamePerp);
+
+  DatabasePerp.prototype.renderType = 'Perp';
+
+  DatabasePerp.prototype.extendEventHandlers = function () {
+    var gnode = this;
+    gnode.on('vclick', function (e, renderNode) {
+      e.stopPropagation();
+      gnode.trigger('switch_view', 'Database');
+    });
+  };
+
+  DatabasePerp.prototype.BuyCity = function (bgestalt, placePos) {
+    var gnode = this;
+    var groot = this.GameRoot;
+    app.remote.buyPerp(gnode.path, bgestalt).done(function (data) {
+      if (data.result) {
+        if (data.result.error !== undefined) {
+          // Probably no cash
+          if (gnode.renderPopup && gnode.renderPopup.open) {
+            gnode.renderPopup.trigger('no_cash');
           } else {
+            gnode.renderNode.FXNoCash();
+          }
+          return;
+        }
+        if (groot.renderPopup) {
+          groot.renderPopup.trigger('popup_close');
+        }
+        _.each(getByType('CityPerp'), function (city) {
+          if (city.renderPopup) {
+            city.renderPopup.trigger('popup_close');
+          }
+        });
+
+        if (data.result.node) {
+          groot.updateGameValues(
+            data.result.game_values,
+            data.result.levelup,
+            data.result.missions
+          );
+
+          var node = data.result.node;
+          var node_data = groot.getTypeData(bgestalt);
+          var perp = new Game[node.game_type]({
+            id: node.game_id,
+            gestalt: bgestalt,
+            path: node.full_path,
+            noConnect: true,
+            data: mergeData(node_data, node.instance_data),
+            // Render perps to first item in path (Imperium or Database)
+            renderNodeParent: getFirstId('Imperium'),
+            ViewMap: getByFirstId('Imperium'),
+            gameType: node.game_type,
+          });
+          gnode.addChild(perp);
+          var perpNode = gnode.renderNode;
+          // place first city to a defined offset to the db, every other city on the opposite side of the first found city....
+          if (placePos) {
+          } else {
+            placePos = gnode.renderNode.getPosition();
+            placePos.x = placePos.x - 250;
+            placePos.y = placePos.y + 50;
+          }
+          if (gnode.children.set && gnode.children.set.length >= 2) {
+            var oppositeCity = _.findWhere(gnode.children.set, { gameType: 'CityPerp' });
+            var vector = oppositeCity.renderNode.getVectorTo(gnode.renderNode);
+            placePos = gnode.renderNode.getVectorPos(vector, 1);
+          }
+          perp.renderData.config.placeRandom = placePos;
+          perp.renderData.config.placeParentRadius = 400;
+          perp.renderData.config.hidden = true;
+
+          perp.render();
+          groot.trigger('saveCoords', [perp.path, perp.renderNode.getPosition()]);
+          perp.renderNode.addDecorator(
+            new Render.DecoratorNew({ text: _._('New!'), extendClass: 'NewPerp' })
+          );
+          perp.renderNode.hide();
+          perp.renderNode.parentNode.scrollTo(perp.renderNode.getPosition());
+          window.setTimeout(function () {
+            perp.renderNode.FXArise(function () {
+              gnode.renderNode.cableAnimatedTo(
+                perp.renderNode,
+                { mode: perp.cableType },
+                function () {
+                  if (perp.cableType == 'in') {
+                    perp.renderNode.FXBounce();
+                  } else if (perp.cableType == 'out') {
+                    gnode.renderNode.FXBounce();
+                  } else {
+                    gnode.renderNode.FXBounce();
+                    perp.renderNode.FXBounce();
+                  }
+                }
+              );
+            });
+          }, 300);
+
+          // put profileset in DBQueue
+          groot
+            .getDatabase()
+            .cue(
+              data.result.profile_set.profile_set,
+              data.result.profile_set.origin,
+              data.result.profile_set.collect_id
+            );
+          perp.trigger('after_buy');
+          return perp;
+        }
+      } else {
+        // Server Error
+        gnode.Error('The computer says NOOOO', data);
+      }
+    });
+  };
+
+  DatabasePerp.prototype.BuyPerp = DatabasePerp.prototype.BuyCity;
+
+  ///////////////////////////////////
+  // The City
+  ///////////////////////////////////
+
+  var CityPerp = function (config) {
+    this.init(config);
+    this.GameRoot.IPerps[this.gestalt] = true;
+    return this;
+  };
+
+  extend(CityPerp, GamePerp);
+
+  CityPerp.prototype.renderType = 'Perp';
+  CityPerp.prototype.cableType = 'inout';
+  CityPerp.prototype.popupTemplate = 'popup_city.html';
+  CityPerp.prototype.textNewItems = _._('New Items!');
+
+  CityPerp.prototype.compileProvidedCities = function () {
+    var gnode = this;
+    var groot = this.GameRoot;
+    gnode.data.providedCities = [];
+    _.each(groot.getTypes('CityPerp'), function (p, key) {
+      var city = {};
+      city.data = p.type_data;
+      city.gestalt = p.gestalt;
+      // FIXME: no game_type in template
+      city.data.is_city = true;
+      if (!getByGestalt(p.gestalt)) {
+        gnode.data.providedCities.push(city);
+        if (city.data.required_level <= groot.xp_level.number) {
+          gnode.data.buyablePerps.push(city.gestalt);
+        }
+      }
+    });
+    return gnode.data.providedCities;
+  };
+
+  CityPerp.prototype.compileProvided = function () {
+    var gnode = this;
+    var groot = this.GameRoot;
+
+    var providedCache = {};
+
+    providedCache.AgentPerp = _.filter(gnode.data.provided_perps, function (v) {
+      return v.substring(0, 5) === 'agent';
+    });
+    providedCache.ProxyPerp = _.filter(gnode.data.provided_perps, function (v) {
+      return v.substring(0, 5) === 'proxy';
+    });
+    providedCache.PusherPerp = _.filter(gnode.data.provided_perps, function (v) {
+      return v.substring(0, 6) === 'pusher';
+    });
+
+    providedCache.CityPerp = _.pluck(gnode.compileProvidedCities(), 'gestalt');
+
+    gnode.data.providedTabs = {
+      AgentPerp: [],
+      PusherPerp: [],
+      ProxyPerp: [],
+      CityPerp: [],
+    };
+
+    _.each(gnode.data.providedTabs, function (tab, k) {
+      _.each(providedCache[k], function (p, key) {
+        var perp = {};
+        var type_data = groot.getTypeData(p);
+        perp.data = type_data;
+        perp.gestalt = p;
+        perp.locked =
+          _.find(gnode.data.buyablePerps, function (v) {
+            return perp.gestalt === v;
+          }) === undefined;
+        // FIXME: this property should come from the backend and doesn't need to be set here.
+        if (!perp.data.max_instances) {
+          perp.data.max_instances = 1;
+        }
+        if (perp.data.max_instances) {
+          if (getAllByGestalt(perp.gestalt).length >= perp.data.max_instances) {
+            perp.locked = true;
+            perp.bought = true;
+          }
+        }
+        if (perp.locked && groot.IPerps.hasOwnProperty(perp.gestalt)) {
+          perp.bought = true;
+        } else {
           if (perp.locked) {
             if (perp.data.required_providers && perp.data.required_providers.length) {
               perp.data.requiredProviders = [];
-              _.each(perp.data.required_providers,function(v,k){
+              _.each(perp.data.required_providers, function (v, k) {
                 var tdata = groot.getTypeData(v);
                 if (tdata && tdata.title) {
                   perp.data.requiredProviders.push(tdata.title);
@@ -3945,274 +4136,295 @@ var Game = function() {
           }
           gnode.data.providedPerps.push(perp);
           tab.push(perp);
-          }
-        });
-        var sorted = _.sortBy(tab, function(v){ return v.data.required_level; });
-        gnode.data.providedTabs[k] = sorted;
+        }
       });
-    };
-
-    CityPerp.prototype.extendEventHandlers = function(){
-      var gnode = this;
-      var groot = this.GameRoot;
-      
-      gnode.on('vclick',function(e,renderNode) {
-        e.stopPropagation();
-
-        // Empty the Tabs (later used for loader in popup)
-        gnode.data.providedTabs = {
-          agents: [],
-          pusher: [],
-          proxies: []
-        };
-
-        gnode.fetchProvided(function(){
-          gnode.compileProvided();
-          if (gnode.renderPopup) { 
-            gnode.updatePopup(); 
-          }
-        });
-        var popup = this.openPopup();
+      var sorted = _.sortBy(tab, function (v) {
+        return v.data.required_level;
       });
+      gnode.data.providedTabs[k] = sorted;
+    });
+  };
 
-    };
+  CityPerp.prototype.extendEventHandlers = function () {
+    var gnode = this;
+    var groot = this.GameRoot;
 
-    GameNode.prototype.fetchProvided = function(cb) {
-      var gnode = this;
-      gnode.data.providedPerps = [];
-      if (gnode.popupTemplateData) {
-        gnode.popupTemplateData.loading = true;
-      }
+    gnode.on('vclick', function (e, renderNode) {
+      e.stopPropagation();
 
-      app.remote.getProvidedPerps(gnode.path)
-      .done(function(data){
+      // Empty the Tabs (later used for loader in popup)
+      gnode.data.providedTabs = {
+        agents: [],
+        pusher: [],
+        proxies: [],
+      };
+
+      gnode.fetchProvided(function () {
+        gnode.compileProvided();
+        if (gnode.renderPopup) {
+          gnode.updatePopup();
+        }
+      });
+      var popup = this.openPopup();
+    });
+  };
+
+  GameNode.prototype.fetchProvided = function (cb) {
+    var gnode = this;
+    gnode.data.providedPerps = [];
+    if (gnode.popupTemplateData) {
+      gnode.popupTemplateData.loading = true;
+    }
+
+    app.remote
+      .getProvidedPerps(gnode.path)
+      .done(function (data) {
         if (data.result && data.result.buyable) {
           gnode.data.buyablePerps = data.result.buyable;
           if (gnode.popupTemplateData) {
             gnode.popupTemplateData.loading = false;
           }
-          if (cb) { cb(); }
+          if (cb) {
+            cb();
+          }
         }
       })
-      .fail(function(data){
-        if (cb) { cb(); }
+      .fail(function (data) {
+        if (cb) {
+          cb();
+        }
       });
-    }
+  };
 
-    ///////////////////////////////////
-    // The Agent
-    ///////////////////////////////////
+  ///////////////////////////////////
+  // The Agent
+  ///////////////////////////////////
 
-    var AgentPerp = function(config) {
-      this.init(config);
-      this.GameRoot.IPerps[this.gestalt] = true;
-      return this;
-    };
+  var AgentPerp = function (config) {
+    this.init(config);
+    this.GameRoot.IPerps[this.gestalt] = true;
+    return this;
+  };
 
-    extend(AgentPerp, GamePerp);
+  extend(AgentPerp, GamePerp);
 
-    AgentPerp.prototype.renderType = "Perp";
-    AgentPerp.prototype.cableType = "in";
-    AgentPerp.prototype.popupTemplate = 'popup_agent.html';
-    AgentPerp.prototype.textNewItems = _._('New Contacts!');
+  AgentPerp.prototype.renderType = 'Perp';
+  AgentPerp.prototype.cableType = 'in';
+  AgentPerp.prototype.popupTemplate = 'popup_agent.html';
+  AgentPerp.prototype.textNewItems = _._('New Contacts!');
 
-    AgentPerp.prototype.extendEventHandlers = function(){
-      var gnode = this;
-      var groot = this.GameRoot;
+  AgentPerp.prototype.extendEventHandlers = function () {
+    var gnode = this;
+    var groot = this.GameRoot;
 
-      gnode.compileProvided();
+    gnode.compileProvided();
 
-      gnode.on('after_render',function(e,renderNode) {
-        gnode.checkProvidedByLevel();
+    gnode.on('after_render', function (e, renderNode) {
+      gnode.checkProvidedByLevel();
+    });
+
+    gnode.on('vclick', function (e, renderNode) {
+      e.stopPropagation();
+      gnode.fetchProvided(function () {
+        gnode.compileProvided();
+        if (gnode.renderPopup) {
+          gnode.updatePopup();
+        }
       });
+      var popup = this.openPopup();
+    });
+  };
 
-      gnode.on('vclick',function(e,renderNode) {
-        e.stopPropagation();
-        gnode.fetchProvided(function(){
-          gnode.compileProvided();
-          if (gnode.renderPopup) { gnode.updatePopup(); }
-        });
-        var popup = this.openPopup();
-      });
-    };
+  // FIXME: move this to the GamePerp section
 
-    // FIXME: move this to the GamePerp section
-    
-    GamePerp.prototype.markNewItems = function(){
-      /* FIXME? no decorator when max_slots is full?
+  GamePerp.prototype.markNewItems = function () {
+    /* FIXME? no decorator when max_slots is full?
       if (this.data && this.data.max_slots) {
         if (this.children.length >= this.data.max_slots) {
           return;
         }
       }
       */
-      var text = this.textNewItems || _._("New Items!");
-      this.renderNode.addDecorator(new Render.DecoratorNew({ text:text, arrow:true }));
-    };
- 
-    GamePerp.prototype.checkProvidedByRequiredPerps = function(){
-      // checks for provided perps by required providers
-      var gnode = this;
-      var groot = this.GameRoot;
-      _.each(gnode.data.provided_perps,function(gestalt,key){
-        var type = groot.getType(gestalt);
-        if (type.type_data.required_providers && !groot.IPerps.hasOwnProperty(gestalt)) {
-          _.each(type.type_data.required_providers, function(provided){
-            if (groot.IPerps.hasOwnProperty(provided)) {
-              gnode.markNewItems();
-            }
-          });
-        }
-      });
-    };
+    var text = this.textNewItems || _._('New Items!');
+    this.renderNode.addDecorator(new Render.DecoratorNew({ text: text, arrow: true }));
+  };
 
-    GamePerp.prototype.getProvidedByRequiredPerps = function(){
-      // returns all provided perps by required providers
-      var gnode = this;
-      var groot = this.GameRoot;
-      var perps = [];
-      _.each(gnode.data.provided_perps,function(gestalt,key){
-        var type = groot.getType(gestalt);
-        if (type.type_data.required_providers && !groot.IPerps.hasOwnProperty(gestalt)) {
-          _.each(type.type_data.required_providers, function(provided){
-            if (groot.IPerps.hasOwnProperty(provided)) {
-              perps.push(gestalt);
-            }
-          });
-        }
-      });
-      return perps;
-    };
-
-    GamePerp.prototype.checkProvidedByLevel = function(){
-      // checks for same level
-      var gnode = this;
-      var groot = this.GameRoot;
-      _.each(gnode.data.provided_perps,function(gestalt,key){
-        var type = groot.getType(gestalt);
-        if (type.type_data.required_level === groot.xp_level.number && !groot.IPerps.hasOwnProperty(gestalt)) {
-          gnode.markNewItems();
-        }
-      });
-    };
-
-    GamePerp.prototype.getProvidedByLevel = function(){
-      // returns all available perp gestalten
-      var gnode = this;
-      var groot = this.GameRoot;
-      var perps = [];
-      _.each(gnode.data.provided_perps,function(gestalt,key){
-        var type = groot.getType(gestalt);
-        if (type.type_data.required_level <= groot.xp_level.number && !groot.IPerps.hasOwnProperty(gestalt)) {
-          perps.push(gestalt);
-        }
-      });
-      return perps;
-    };
-
-
-    GamePerp.prototype.compileProvided = function(){
-      var gnode = this;
-      var groot = this.GameRoot;
-      gnode.data.providedPerps = [];
-      if (gnode.data.buyablePerps === undefined) {
-        return;
-      }
-      _.each(gnode.data.provided_perps,function(p,key){
-        var perp = {};
-        var type_data = groot.getTypeData(p);
-        perp.data = type_data;
-        perp.gestalt = p;
-        // Already-owned perps shouldn't appear in the buy dialog at all —
-        // backend `provided_perps` is a static list per-provider, so the
-        // UI is the only place that knows about ownership.
-        if (groot.IPerps.hasOwnProperty(perp.gestalt)) {
-          return;
-        }
-        perp.locked = _.find(gnode.data.buyablePerps,function(v){ return perp.gestalt === v }) === undefined;
-        if (perp.locked && perp.data.required_level && !perp.data.required_providers && perp.data.required_level <= groot.xp_level.number) {
-          perp.locked = false;
-        }
-        if (perp.locked) {
-          if (perp.data.required_providers && perp.data.required_providers.length) {
-            perp.data.requiredProviders = [];
-            _.each(perp.data.required_providers,function(v,k){
-              var tdata = groot.getTypeData(v);
-              if (tdata && tdata.title) {
-                perp.data.requiredProviders.push(tdata.title);
-              }
-            });
+  GamePerp.prototype.checkProvidedByRequiredPerps = function () {
+    // checks for provided perps by required providers
+    var gnode = this;
+    var groot = this.GameRoot;
+    _.each(gnode.data.provided_perps, function (gestalt, key) {
+      var type = groot.getType(gestalt);
+      if (type.type_data.required_providers && !groot.IPerps.hasOwnProperty(gestalt)) {
+        _.each(type.type_data.required_providers, function (provided) {
+          if (groot.IPerps.hasOwnProperty(provided)) {
+            gnode.markNewItems();
           }
-        }
-        gnode.data.providedPerps.push(perp);
-      });
-      var sorted = _.sortBy(gnode.data.providedPerps, function(v){ return v.data.required_level; });
-      var grouped = _.groupBy(sorted,function(v){
-        return (v.locked) ? 1 : 0 ;
-      });
-      gnode.data.providedPerps = _.flatten(grouped);
-    };
+        });
+      }
+    });
+  };
 
+  GamePerp.prototype.getProvidedByRequiredPerps = function () {
+    // returns all provided perps by required providers
+    var gnode = this;
+    var groot = this.GameRoot;
+    var perps = [];
+    _.each(gnode.data.provided_perps, function (gestalt, key) {
+      var type = groot.getType(gestalt);
+      if (type.type_data.required_providers && !groot.IPerps.hasOwnProperty(gestalt)) {
+        _.each(type.type_data.required_providers, function (provided) {
+          if (groot.IPerps.hasOwnProperty(provided)) {
+            perps.push(gestalt);
+          }
+        });
+      }
+    });
+    return perps;
+  };
 
-    ///////////////////////////////////
-    // The Contact
-    ///////////////////////////////////
+  GamePerp.prototype.checkProvidedByLevel = function () {
+    // checks for same level
+    var gnode = this;
+    var groot = this.GameRoot;
+    _.each(gnode.data.provided_perps, function (gestalt, key) {
+      var type = groot.getType(gestalt);
+      if (
+        type.type_data.required_level === groot.xp_level.number &&
+        !groot.IPerps.hasOwnProperty(gestalt)
+      ) {
+        gnode.markNewItems();
+      }
+    });
+  };
 
-    var ContactPerp = function(config) {
-      this.init(config);
-      this.GameRoot.IPerps[this.gestalt] = true;
-      return this;
-    };
+  GamePerp.prototype.getProvidedByLevel = function () {
+    // returns all available perp gestalten
+    var gnode = this;
+    var groot = this.GameRoot;
+    var perps = [];
+    _.each(gnode.data.provided_perps, function (gestalt, key) {
+      var type = groot.getType(gestalt);
+      if (
+        type.type_data.required_level <= groot.xp_level.number &&
+        !groot.IPerps.hasOwnProperty(gestalt)
+      ) {
+        perps.push(gestalt);
+      }
+    });
+    return perps;
+  };
 
-    extend(ContactPerp, GamePerp);
-
-    ContactPerp.prototype.renderType = "Perp";
-    ContactPerp.prototype.popupTemplate = "popup_contact.html";
-    ContactPerp.prototype.cableType = "in";
-    ContactPerp.prototype.sticky = false;
-
-    ContactPerp.prototype.extendEventHandlers = function() {
-      var gnode = this;
-      var groot = this.GameRoot;
-
-      gnode.on('vshiftclick',function(e,renderNode) {
-        e.stopPropagation();
-        gnode.Charge();
-      });
-      gnode.on('vclick',function(e,renderNode) {
-
-        e.stopPropagation();
-        // FIXME: Prepare data move this to own function
-        gnode.data.ProfileSet = new ProfileSet({ markNew:true },gnode.data.tokens);
-
-        var popup = this.openPopup();
-
-      });
-      gnode.on('node_ready',function(e,result) {
-        e.stopPropagation();
-        // FIXME result has no meaning here?! since A) event can be triggered by non-socket-io b) markready takes no argument.
-        //gnode.markReady(result);
-        //onsole.log('node_ready',result);
-        gnode.markReady();
-      });
-
-    };
-
-    ContactPerp.prototype.Charge = function() {
-      var gnode = this;
-      var groot = this.GameRoot;
-      // No request when not enough cash
-      if (gnode.data.charge_cost > groot.cash_value) {
-        // No cash
-        if (gnode.renderPopup && gnode.renderPopup.open) {
-          gnode.renderPopup.trigger('no_cash');
-        } else {
-          gnode.renderNode.FXNoCash();
-        }
+  GamePerp.prototype.compileProvided = function () {
+    var gnode = this;
+    var groot = this.GameRoot;
+    gnode.data.providedPerps = [];
+    if (gnode.data.buyablePerps === undefined) {
+      return;
+    }
+    _.each(gnode.data.provided_perps, function (p, key) {
+      var perp = {};
+      var type_data = groot.getTypeData(p);
+      perp.data = type_data;
+      perp.gestalt = p;
+      // Already-owned perps shouldn't appear in the buy dialog at all —
+      // backend `provided_perps` is a static list per-provider, so the
+      // UI is the only place that knows about ownership.
+      if (groot.IPerps.hasOwnProperty(perp.gestalt)) {
         return;
       }
-      if (!gnode.states.chargeRunning && gnode.states.idle) {
-        app.remote.chargePerp(gnode.path).done(function(data) {
+      perp.locked =
+        _.find(gnode.data.buyablePerps, function (v) {
+          return perp.gestalt === v;
+        }) === undefined;
+      if (
+        perp.locked &&
+        perp.data.required_level &&
+        !perp.data.required_providers &&
+        perp.data.required_level <= groot.xp_level.number
+      ) {
+        perp.locked = false;
+      }
+      if (perp.locked) {
+        if (perp.data.required_providers && perp.data.required_providers.length) {
+          perp.data.requiredProviders = [];
+          _.each(perp.data.required_providers, function (v, k) {
+            var tdata = groot.getTypeData(v);
+            if (tdata && tdata.title) {
+              perp.data.requiredProviders.push(tdata.title);
+            }
+          });
+        }
+      }
+      gnode.data.providedPerps.push(perp);
+    });
+    var sorted = _.sortBy(gnode.data.providedPerps, function (v) {
+      return v.data.required_level;
+    });
+    var grouped = _.groupBy(sorted, function (v) {
+      return v.locked ? 1 : 0;
+    });
+    gnode.data.providedPerps = _.flatten(grouped);
+  };
+
+  ///////////////////////////////////
+  // The Contact
+  ///////////////////////////////////
+
+  var ContactPerp = function (config) {
+    this.init(config);
+    this.GameRoot.IPerps[this.gestalt] = true;
+    return this;
+  };
+
+  extend(ContactPerp, GamePerp);
+
+  ContactPerp.prototype.renderType = 'Perp';
+  ContactPerp.prototype.popupTemplate = 'popup_contact.html';
+  ContactPerp.prototype.cableType = 'in';
+  ContactPerp.prototype.sticky = false;
+
+  ContactPerp.prototype.extendEventHandlers = function () {
+    var gnode = this;
+    var groot = this.GameRoot;
+
+    gnode.on('vshiftclick', function (e, renderNode) {
+      e.stopPropagation();
+      gnode.Charge();
+    });
+    gnode.on('vclick', function (e, renderNode) {
+      e.stopPropagation();
+      // FIXME: Prepare data move this to own function
+      gnode.data.ProfileSet = new ProfileSet({ markNew: true }, gnode.data.tokens);
+
+      var popup = this.openPopup();
+    });
+    gnode.on('node_ready', function (e, result) {
+      e.stopPropagation();
+      // FIXME result has no meaning here?! since A) event can be triggered by non-socket-io b) markready takes no argument.
+      //gnode.markReady(result);
+      //onsole.log('node_ready',result);
+      gnode.markReady();
+    });
+  };
+
+  ContactPerp.prototype.Charge = function () {
+    var gnode = this;
+    var groot = this.GameRoot;
+    // No request when not enough cash
+    if (gnode.data.charge_cost > groot.cash_value) {
+      // No cash
+      if (gnode.renderPopup && gnode.renderPopup.open) {
+        gnode.renderPopup.trigger('no_cash');
+      } else {
+        gnode.renderNode.FXNoCash();
+      }
+      return;
+    }
+    if (!gnode.states.chargeRunning && gnode.states.idle) {
+      app.remote
+        .chargePerp(gnode.path)
+        .done(function (data) {
           if (data.result) {
             if (data.result.error) {
               // Error 1 = no AP (energy), Error 3 = no cash
@@ -4231,72 +4443,91 @@ var Game = function() {
               }
               return;
             }
-            if (gnode.renderPopup) { gnode.renderPopup.trigger('popup_close'); }
+            if (gnode.renderPopup) {
+              gnode.renderPopup.trigger('popup_close');
+            }
             // TODO game_values
             var gv = data.result.game_values;
-            groot.updateGameValues(data.result.game_values,data.result.levelup,data.result.missions);
+            groot.updateGameValues(
+              data.result.game_values,
+              data.result.levelup,
+              data.result.missions
+            );
             gnode.renderNode.FXCharge();
             gnode.markTimer({
               duration: data.result.duration,
               serverTime: 0,
-              serverStartTime: 0
+              serverStartTime: 0,
             });
           } else {
-            gnode.Error('The computer says NOOOO',data);
+            gnode.Error('The computer says NOOOO', data);
           }
         })
-        .fail(function(data){
-            gnode.Error('The computer says NOOOO',data);
+        .fail(function (data) {
+          gnode.Error('The computer says NOOOO', data);
         });
-      }
-    };
+    }
+  };
 
-
-    ContactPerp.prototype.collect = function() {
-      var gperp = this;
-      var gnode = this;
-      var groot = this.GameRoot;
-      var deco = this.renderReady;
-      var popup = this.renderPopup;
-      if (groot.ap_value < 1) {
-        if (popup) {
-          popup.trigger('no_AP');
-        } else {
-          deco.FXNoAP();
-        }
-        return;
+  ContactPerp.prototype.collect = function () {
+    var gperp = this;
+    var gnode = this;
+    var groot = this.GameRoot;
+    var deco = this.renderReady;
+    var popup = this.renderPopup;
+    if (groot.ap_value < 1) {
+      if (popup) {
+        popup.trigger('no_AP');
+      } else {
+        deco.FXNoAP();
       }
-      deco.setClickable(false);
-      deco.setFrame('active');
-      deco.FXPulse();
-      //var amount = _.toKSNum(Math.round(Math.random()*100000));
-      app.remote.collectPerp(gperp.path).done(function(data) {
+      return;
+    }
+    deco.setClickable(false);
+    deco.setFrame('active');
+    deco.FXPulse();
+    //var amount = _.toKSNum(Math.round(Math.random()*100000));
+    app.remote
+      .collectPerp(gperp.path)
+      .done(function (data) {
         // FIXME: It would be better if data.result was in a predefined state to prevent testing for both, undefined _and_ null...
         if (data.result && data.result.result) {
           var amount = data.result.result.profile_set.profiles_value;
-          
-          if (popup) { popup.trigger('popup_close'); }
-          groot.updateGameValues(data.result.game_values,data.result.levelup,data.result.missions);
+
+          if (popup) {
+            popup.trigger('popup_close');
+          }
+          groot.updateGameValues(
+            data.result.game_values,
+            data.result.levelup,
+            data.result.missions
+          );
           if (data.result.karma_incident) {
             // Karmalizer
             var karma_dec = data.result.game_values.karma_value - groot.karma_value;
             groot.makeNotifications({
               karma: {
                 gestalt: data.result.karma_incident,
-                dec: karma_dec
-              }
+                dec: karma_dec,
+              },
             });
           }
 
-          deco.FXBling({text: _.toKSNum(amount), extendClass: "ProfileBling"});
-          deco.FXSuck(function() {
+          deco.FXBling({ text: _.toKSNum(amount), extendClass: 'ProfileBling' });
+          deco.FXSuck(function () {
             gperp.renderNode.FXDataOut();
-            gperp.renderReady=undefined;
+            gperp.renderReady = undefined;
           });
           // Add to DB Queue
           //groot.getDatabase().cue(data.result.result.profile_set, data.result.result.origin, data.result.result.collect_id);
-          groot.getDatabase().cue(data.result.result.profile_set, data.result.result.origin, data.result.result.collect_id);
-          gperp.setState('idle',true);
+          groot
+            .getDatabase()
+            .cue(
+              data.result.result.profile_set,
+              data.result.result.origin,
+              data.result.result.collect_id
+            );
+          gperp.setState('idle', true);
         } else if (data.result && data.result.error) {
           if (popup) {
             popup.trigger('no_AP');
@@ -4309,33 +4540,35 @@ var Game = function() {
           console.warn('collect failed');
         } else {
           // ERROR
-          gperp.Error('The computer says NOOOO',data);
+          gperp.Error('The computer says NOOOO', data);
         }
       })
-      .fail(function(data){
-          deco.FXError();
-          deco.FXStop();
-          deco.setClickable(true);
-          deco.setFrame('normal');
+      .fail(function (data) {
+        deco.FXError();
+        deco.FXStop();
+        deco.setClickable(true);
+        deco.setFrame('normal');
       });
-    };
+  };
 
-    ContactPerp.prototype.markReady = function() {
-      var gperp = this;
-      var groot = this.GameRoot;
-      gperp.setState('idle',false);
-      gperp.setState('chargeRunning',false);
-      if (gperp.renderTimer) { gperp.renderTimer.FXPuff(); }
-      var deco = this.renderReady = this.renderNode.addDecorator(new Render.DecoratorReady());
-      deco.FXSproing();
-      deco.on('vclick',function(e,renderNode) {
-        e.stopPropagation();
-        gperp.collect();
-        // No Request when no AP
-      });
-    };
+  ContactPerp.prototype.markReady = function () {
+    var gperp = this;
+    var groot = this.GameRoot;
+    gperp.setState('idle', false);
+    gperp.setState('chargeRunning', false);
+    if (gperp.renderTimer) {
+      gperp.renderTimer.FXPuff();
+    }
+    var deco = (this.renderReady = this.renderNode.addDecorator(new Render.DecoratorReady()));
+    deco.FXSproing();
+    deco.on('vclick', function (e, renderNode) {
+      e.stopPropagation();
+      gperp.collect();
+      // No Request when no AP
+    });
+  };
 
-    /*
+  /*
     ContactPerp.prototype.AniTick = function() {
       if (this.renderNode) {
         this.renderNode.FXBounce();
@@ -4343,67 +4576,65 @@ var Game = function() {
     };
     */
 
+  ///////////////////////////////////
+  // The Pusher
+  ///////////////////////////////////
 
-    ///////////////////////////////////
-    // The Pusher
-    ///////////////////////////////////
+  var PusherPerp = function (config) {
+    this.init(config);
+    this.GameRoot.IPerps[this.gestalt] = true;
+    return this;
+  };
 
-    var PusherPerp = function(config) {
-      this.init(config);
-      this.GameRoot.IPerps[this.gestalt] = true;
-      return this;
-    };
+  extend(PusherPerp, GamePerp);
 
-    extend(PusherPerp, GamePerp);
+  PusherPerp.prototype.renderType = 'Perp';
+  PusherPerp.prototype.cableType = 'out';
+  PusherPerp.prototype.labelClass = 'client';
+  PusherPerp.prototype.popupTemplate = 'popup_pusher.html';
+  PusherPerp.prototype.textNewItems = _._('New Clients!');
 
-    PusherPerp.prototype.renderType = "Perp";
-    PusherPerp.prototype.cableType = "out";
-    PusherPerp.prototype.labelClass = "client";
-    PusherPerp.prototype.popupTemplate = 'popup_pusher.html';
-    PusherPerp.prototype.textNewItems = _._('New Clients!');
+  PusherPerp.prototype.extendEventHandlers = function () {
+    var gnode = this;
+    var groot = this.GameRoot;
 
-    PusherPerp.prototype.extendEventHandlers = function(){
-      var gnode = this;
-      var groot = this.GameRoot;
+    gnode.compileProvided();
 
-      gnode.compileProvided();
+    gnode.on('after_render', function (e, renderNode) {
+      gnode.checkProvidedByRequiredPerps();
+    });
 
-      gnode.on('after_render',function(e,renderNode) {
-        gnode.checkProvidedByRequiredPerps();
+    gnode.on('vclick', function (e, renderNode) {
+      e.stopPropagation();
+      gnode.fetchProvided(function () {
+        gnode.compileProvided();
+        if (gnode.renderPopup) {
+          gnode.updatePopup();
+        }
       });
+      var popup = this.openPopup();
+    });
+  };
 
-      gnode.on('vclick',function(e,renderNode) {
-        e.stopPropagation();
-        gnode.fetchProvided(function(){
-          gnode.compileProvided();
-          if (gnode.renderPopup) { gnode.updatePopup(); }
-        });
-        var popup = this.openPopup();
-      });
-    };
+  ///////////////////////////////////
+  // The Client (former Customer)
+  ///////////////////////////////////
 
+  var ClientPerp = function (config) {
+    this.init(config);
+    this.GameRoot.IPerps[this.gestalt] = true;
+    return this;
+  };
 
+  extend(ClientPerp, GamePerp);
 
-    ///////////////////////////////////
-    // The Client (former Customer)
-    ///////////////////////////////////
+  ClientPerp.prototype.renderType = 'Perp';
+  ClientPerp.prototype.cableType = 'out';
+  ClientPerp.prototype.labelClass = 'client';
+  ClientPerp.prototype.sticky = false;
+  ClientPerp.prototype.popupTemplate = 'popup_client.html';
 
-    var ClientPerp = function(config) {
-      this.init(config);
-      this.GameRoot.IPerps[this.gestalt] = true;
-      return this;
-    };
-
-    extend(ClientPerp, GamePerp);
-
-    ClientPerp.prototype.renderType = "Perp";
-    ClientPerp.prototype.cableType = "out";
-    ClientPerp.prototype.labelClass = "client";
-    ClientPerp.prototype.sticky = false;
-    ClientPerp.prototype.popupTemplate = 'popup_client.html';
-
-
-/* NEW
+  /* NEW
 
 class CollectableClient(CollectablePerpBase):
 
@@ -4427,30 +4658,27 @@ class CollectableClient(CollectablePerpBase):
 
 */
 
+  ClientPerp.prototype.AniTick = function () {
+    if (this.renderNode) {
+      this.renderNode.FXDataIn();
+    }
+  };
 
+  ClientPerp.prototype.getKarmaPenalty = function () {
+    var gnode = this;
+    var groot = this.GameRoot;
+    var karma = groot.karma_value;
+    var karma_factor = (karma + 100) / 200 + 0.5;
+    karma_factor = karma_factor > 1 ? 1 : karma_factor;
+    if (karma_factor < 1) {
+      gnode.data.karma_penalty = true;
+    } else {
+      gnode.data.karma_penalty = false;
+    }
+    return karma_factor;
+  };
 
-    ClientPerp.prototype.AniTick = function() {
-      if (this.renderNode) {
-        this.renderNode.FXDataIn();
-      }
-    };
-
-    ClientPerp.prototype.getKarmaPenalty = function(){
-      var gnode = this;
-      var groot = this.GameRoot;
-      var karma = groot.karma_value;
-      var karma_factor = (karma + 100)/200 + 0.5;
-      karma_factor = (karma_factor > 1) ? 1 : karma_factor;
-      if (karma_factor < 1) {
-        gnode.data.karma_penalty = true;
-      } else {
-        gnode.data.karma_penalty = false;
-      }
-      return karma_factor;
-    };
-    
-    
-/*
+  /*
      def getPerpChargeData(self):
         db_state = self.getDBAmounts()
         token_amounts = [float(db_state.get(token['gestalt'], 0) * token['amount'])/10000 for token in self.node_type_data['consumed_tokens']]
@@ -4463,101 +4691,126 @@ class CollectableClient(CollectablePerpBase):
         return {'collect_cash': result}, self.getCost()
 */
 
+  ClientPerp.prototype.getIncome = function (nopenalty) {
+    var groot = this.GameRoot;
+    var gnode = this;
+    var base_income = gnode.data.income_base;
+    var base_income_factor = gnode.data.income_factor;
+    var consumed_tokens = gnode.data.consumed_tokens;
+    var db_profiles = groot.DBTokens;
+    var sum = [];
+    _.each(consumed_tokens, function (token, k) {
+      sum.push((groot.getDBTokenAmount(token.gestalt) * token.amount) / 10000);
+    });
+    var amount = 0;
+    amount = _.reduce(
+      sum,
+      function (memo, num) {
+        return memo + num;
+      },
+      0
+    );
+    var db_fill_factor = groot.getDBFactorNormalized();
+    var karma_penalty_factor = nopenalty ? 1 : gnode.getKarmaPenalty();
+    amount = Math.pow(amount * db_fill_factor, 0.6);
+    //var result = parseInt( karma_penalty_factor * Math.round( (base_income + (amount * base_income * (base_income_factor/1000))) /10 ) * 10 );
+    var result = parseInt(
+      karma_penalty_factor *
+        Math.round(base_income + amount * base_income * (base_income_factor / 1000))
+    );
+    return result;
+  };
 
-    ClientPerp.prototype.getIncome = function(nopenalty){
-      var groot = this.GameRoot;
-      var gnode = this;
-      var base_income = gnode.data.income_base;
-      var base_income_factor = gnode.data.income_factor;
-      var consumed_tokens = gnode.data.consumed_tokens;
-      var db_profiles = groot.DBTokens;
-      var sum = [];
-      _.each(consumed_tokens,function(token,k){
-        sum.push( (groot.getDBTokenAmount(token.gestalt) * token.amount )/10000 );
-      });
-      var amount=0;
-      amount = _.reduce(sum, function(memo, num){ return memo + num; }, 0);
-      var db_fill_factor = groot.getDBFactorNormalized();
-      var karma_penalty_factor = (nopenalty) ? 1 : gnode.getKarmaPenalty();
-      amount = Math.pow((amount * db_fill_factor), 0.6);
-      //var result = parseInt( karma_penalty_factor * Math.round( (base_income + (amount * base_income * (base_income_factor/1000))) /10 ) * 10 );
-      var result = parseInt( karma_penalty_factor * Math.round( (base_income + (amount * base_income * (base_income_factor/1000)))) );
-      return result;
-    }
+  GameRoot.prototype.getCityOriginAmounts = function () {
+    var cities = _.where(this.DBOriginTokens, { originGameType: 'CityPerp' });
+    var city_amounts = {};
+    _.each(cities, function (c) {
+      city_amounts[c.gestalt] = c.cityMaxAmount;
+    });
+    return city_amounts;
+  };
 
-    GameRoot.prototype.getCityOriginAmounts = function(){
-      var cities = _.where(this.DBOriginTokens,{ originGameType : "CityPerp" });
-      var city_amounts = {}
-      _.each(cities, function(c){
-        city_amounts[c.gestalt] = c.cityMaxAmount;
-      });
-      return city_amounts;
-    };
+  GameRoot.prototype.getDBFactorNormalized = function () {
+    var cityamounts = this.getCityOriginAmounts();
+    return _.reduce(
+      _.values(cityamounts),
+      function (memo, num) {
+        return memo + num;
+      },
+      0
+    );
+  };
 
-    GameRoot.prototype.getDBFactorNormalized = function(){
-      var cityamounts = this.getCityOriginAmounts()
-      return _.reduce(_.values(cityamounts), function(memo, num){ return memo + num; }, 0);
-    };
+  ClientPerp.prototype.extendEventHandlers = function () {
+    var gnode = this;
 
+    gnode.on('vshiftclick', function (e, renderNode) {
+      e.stopPropagation();
+      gnode.Charge();
+    });
 
-    ClientPerp.prototype.extendEventHandlers = function() {
-      var gnode = this;
+    gnode.on('vclick', function (e, renderNode) {
+      e.stopPropagation();
 
-      gnode.on('vshiftclick',function(e,renderNode) {
-        e.stopPropagation();
-        gnode.Charge();
-      });
+      // FIXME: Compile some data, move to extra method
+      //gnode.data.ProfileSet = new ProfileSet({ convertTokens:true, DBAmounts:true, lockNotInDB:true }, gnode.data.provided_tokens);
+      gnode.data.ProfileSet = new ProfileSet(
+        { DBAmounts: true, lockNotInDB: true, filter_is_query: 'blue', sortByGestalt: true },
+        gnode.data.consumed_tokens
+      );
+      gnode.data.ConsumedProfileSet = new ProfileSet(
+        { lockNotInDB: true, DBAmounts: true, filter_is_query: 'orange', sortByGestalt: true },
+        gnode.data.consumed_tokens
+      );
+      gnode.data.income = gnode.getIncome();
+      gnode.data.income_nopenalty = gnode.getIncome(true);
 
-      gnode.on('vclick',function(e,renderNode) {
-        e.stopPropagation();
+      var popup = this.openPopup();
+    });
 
-        // FIXME: Compile some data, move to extra method
-        //gnode.data.ProfileSet = new ProfileSet({ convertTokens:true, DBAmounts:true, lockNotInDB:true }, gnode.data.provided_tokens);
-        gnode.data.ProfileSet = new ProfileSet({  DBAmounts:true, lockNotInDB:true, filter_is_query: "blue", sortByGestalt:true }, gnode.data.consumed_tokens);
-        gnode.data.ConsumedProfileSet = new ProfileSet({ lockNotInDB:true, DBAmounts:true, filter_is_query: "orange", sortByGestalt:true }, gnode.data.consumed_tokens);
-        gnode.data.income = gnode.getIncome();
-        gnode.data.income_nopenalty = gnode.getIncome(true);
+    gnode.on('node_ready', function (e, result) {
+      e.stopPropagation();
+      gnode.markReady();
+    });
+  };
 
-        var popup = this.openPopup();
-
-      });
-      
-      gnode.on('node_ready',function(e,result) {
-        e.stopPropagation();
-        gnode.markReady();
-      });
-
-    };
-
-    ClientPerp.prototype.collect = function() {
-      var gperp = this;
-      var gnode = this;
-      var groot = this.GameRoot;
-      var deco = gperp.renderReady;
-      // No Request when no AP
-      var popup = gperp.renderPopup;
-      // No Request when no AP
-      if (groot.ap_value < 1) {
-        if (popup) {
-          popup.trigger('no_AP');
-        } else {
-          deco.FXNoAP();
-        }
-        return;
+  ClientPerp.prototype.collect = function () {
+    var gperp = this;
+    var gnode = this;
+    var groot = this.GameRoot;
+    var deco = gperp.renderReady;
+    // No Request when no AP
+    var popup = gperp.renderPopup;
+    // No Request when no AP
+    if (groot.ap_value < 1) {
+      if (popup) {
+        popup.trigger('no_AP');
+      } else {
+        deco.FXNoAP();
       }
-      deco.setClickable(false);
-      deco.setFrame('active');
-      deco.FXPulse();
-      //var amount = _.toKSNum(Math.round(Math.random()*100000));
-      app.remote.collectPerp(gperp.path).done(function(data) {
+      return;
+    }
+    deco.setClickable(false);
+    deco.setFrame('active');
+    deco.FXPulse();
+    //var amount = _.toKSNum(Math.round(Math.random()*100000));
+    app.remote
+      .collectPerp(gperp.path)
+      .done(function (data) {
         // FIXME: It would be better if data.result was in a predefined state to prevent testing for both, undefined _and_ null...
         if (data.result && data.result.result) {
           var amount = data.result.result.cash;
 
-          if (popup) { popup.trigger('popup_close'); }
+          if (popup) {
+            popup.trigger('popup_close');
+          }
 
-          groot.updateGameValues(data.result.game_values,data.result.levelup,data.result.missions);
-          deco.FXBling({text:'$' + _.toKSNum(amount), extendClass: "MoneyBling",wait:600});
+          groot.updateGameValues(
+            data.result.game_values,
+            data.result.levelup,
+            data.result.missions
+          );
+          deco.FXBling({ text: '$' + _.toKSNum(amount), extendClass: 'MoneyBling', wait: 600 });
 
           if (data.result.karma_incident) {
             // Karmalizer
@@ -4565,17 +4818,17 @@ class CollectableClient(CollectablePerpBase):
             groot.makeNotifications({
               karma: {
                 gestalt: data.result.karma_incident,
-                dec: karma_dec
-              }
+                dec: karma_dec,
+              },
             });
           }
-          deco.FXKatsching(function() {
+          deco.FXKatsching(function () {
             gperp.renderReady.remove();
-            gperp.renderReady=undefined;
+            gperp.renderReady = undefined;
             delete gperp.renderReady;
           });
 
-          gperp.setState('idle',true);
+          gperp.setState('idle', true);
         } else if (data.result && data.result.error) {
           if (popup) {
             popup.trigger('error');
@@ -4588,52 +4841,53 @@ class CollectableClient(CollectablePerpBase):
           console.warn('collect failed', data.result.error);
         } else {
           // ERROR
-          gperp.Error('The computer says NOOOO',data);
+          gperp.Error('The computer says NOOOO', data);
         }
       })
-      .fail(function(data){
-          deco.FXError();
-          deco.FXStop();
-          deco.setClickable(true);
-          deco.setFrame('normal');
+      .fail(function (data) {
+        deco.FXError();
+        deco.FXStop();
+        deco.setClickable(true);
+        deco.setFrame('normal');
       });
-    };
+  };
 
+  ClientPerp.prototype.markReady = function () {
+    var gperp = this;
+    var groot = this.GameRoot;
+    gperp.setState('idle', false);
+    gperp.setState('chargeRunning', false);
+    if (gperp.renderTimer) {
+      gperp.renderTimer.FXPuff();
+    }
 
+    var deco = (gperp.renderReady = new Render.DecoratorReady({ mode: 'money' }));
+    gperp.renderNode.addDecorator(deco);
+    deco.FXSproing();
 
+    deco.on('vclick', function (e, renderNode) {
+      e.stopPropagation();
+      gperp.collect();
+    });
+  };
 
-    ClientPerp.prototype.markReady = function() {
-      var gperp = this;
-      var groot = this.GameRoot;
-      gperp.setState('idle',false);
-      gperp.setState('chargeRunning',false);
-      if (gperp.renderTimer) { gperp.renderTimer.FXPuff(); }
-
-      var deco = gperp.renderReady = new Render.DecoratorReady({mode:"money"});
-      gperp.renderNode.addDecorator(deco);
-      deco.FXSproing();
-
-      deco.on('vclick',function(e,renderNode) {
-        e.stopPropagation();
-        gperp.collect();
-      });
-    };
-
-    ClientPerp.prototype.Charge = function() {
-      var gnode = this;
-      var groot = this.GameRoot;
-      // No request when not enough cash
-      if (groot.ap_value < 1) {
-        // No AP
-        if (gnode.renderPopup && gnode.renderPopup.open) {
-          gnode.renderPopup.trigger('no_AP');
-        } else {
-          gnode.renderNode.FXNoAP();
-        }
-        return;
+  ClientPerp.prototype.Charge = function () {
+    var gnode = this;
+    var groot = this.GameRoot;
+    // No request when not enough cash
+    if (groot.ap_value < 1) {
+      // No AP
+      if (gnode.renderPopup && gnode.renderPopup.open) {
+        gnode.renderPopup.trigger('no_AP');
+      } else {
+        gnode.renderNode.FXNoAP();
       }
-      if (!gnode.states.chargeRunning && gnode.states.idle) {
-        app.remote.chargePerp(gnode.path).done(function(data) {
+      return;
+    }
+    if (!gnode.states.chargeRunning && gnode.states.idle) {
+      app.remote
+        .chargePerp(gnode.path)
+        .done(function (data) {
           if (data.result) {
             if (data.result.error) {
               // No AP
@@ -4644,137 +4898,149 @@ class CollectableClient(CollectablePerpBase):
               }
               return;
             }
-            if (gnode.renderPopup) { gnode.renderPopup.trigger('popup_close'); }
+            if (gnode.renderPopup) {
+              gnode.renderPopup.trigger('popup_close');
+            }
 
             gnode.renderNode.FXDataIn();
             // TODO game_values
             var gv = data.result.game_values;
-            groot.updateGameValues(data.result.game_values,data.result.levelup,data.result.missions);
+            groot.updateGameValues(
+              data.result.game_values,
+              data.result.levelup,
+              data.result.missions
+            );
             gnode.renderNode.FXCharge('AP');
             gnode.markTimer({
               duration: data.result.duration,
               serverTime: 0,
-              serverStartTime: 0
+              serverStartTime: 0,
             });
           } else {
-            gnode.Error('The computer says NOOOO',data);
+            gnode.Error('The computer says NOOOO', data);
           }
         })
-        .fail(function(data){
-            gnode.Error('The computer says NOOOO',data);
+        .fail(function (data) {
+          gnode.Error('The computer says NOOOO', data);
         });
-      }
-    };
+    }
+  };
 
-    ///////////////////////////////////
-    // The Proxy
-    ///////////////////////////////////
+  ///////////////////////////////////
+  // The Proxy
+  ///////////////////////////////////
 
-    var ProxyPerp = function(config) {
-      this.init(config);
-      this.GameRoot.IPerps[this.gestalt] = true;
-      return this;
-    };
+  var ProxyPerp = function (config) {
+    this.init(config);
+    this.GameRoot.IPerps[this.gestalt] = true;
+    return this;
+  };
 
-    extend(ProxyPerp, GamePerp);
+  extend(ProxyPerp, GamePerp);
 
-    ProxyPerp.prototype.renderType = "Perp";
-    ProxyPerp.prototype.cableType = "in";
-    ProxyPerp.prototype.popupTemplate = 'popup_proxy.html';
-    ProxyPerp.prototype.textNewItems = _._('New Ventures!');
+  ProxyPerp.prototype.renderType = 'Perp';
+  ProxyPerp.prototype.cableType = 'in';
+  ProxyPerp.prototype.popupTemplate = 'popup_proxy.html';
+  ProxyPerp.prototype.textNewItems = _._('New Ventures!');
 
-    ProxyPerp.prototype.extendEventHandlers = function(){
-      var gnode = this;
-      var groot = this.GameRoot;
-      
-      gnode.compileProvided();
+  ProxyPerp.prototype.extendEventHandlers = function () {
+    var gnode = this;
+    var groot = this.GameRoot;
 
-      gnode.on('after_render',function(e,renderNode) {
-        gnode.checkProvidedByLevel();
-      });
+    gnode.compileProvided();
 
-      gnode.on('vclick',function(e,renderNode) {
-        e.stopPropagation();
-        gnode.data.used_slots = gnode.children.set.length;
-        gnode.fetchProvided(function(){
-          gnode.compileProvided();
-          if (gnode.renderPopup) { gnode.updatePopup(); }
-        });
-        var popup = this.openPopup();
-      });
+    gnode.on('after_render', function (e, renderNode) {
+      gnode.checkProvidedByLevel();
+    });
 
-      gnode.on('after_render', function(){
-        gnode.updateRenderSlotStatus();
-      });
-
-    };
-    
-    ProxyPerp.prototype.updateRenderSlotStatus = function(){
-      var gnode = this;
-      var node = gnode.renderNode;
+    gnode.on('vclick', function (e, renderNode) {
+      e.stopPropagation();
       gnode.data.used_slots = gnode.children.set.length;
-      if (gnode.data.used_slots < gnode.data.max_slots) {
-        node.addDecorator(new Render.DecoratorLabel({text: gnode.data.label + "<br />"+ gnode.data.used_slots +"/"+ gnode.data.max_slots }));
-      } else {
-        node.addDecorator(new Render.DecoratorLabel({text: gnode.data.label }));
-      }
-
-    };
-
-
-    ///////////////////////////////////
-    // The Project
-    ///////////////////////////////////
-
-    var ProjectPerp = function(config) {
-      this.init(config);
-      this.GameRoot.IPerps[this.gestalt] = true;
-      return this;
-    };
-
-    extend(ProjectPerp, GamePerp);
-
-    ProjectPerp.prototype.renderType = "Perp";
-    ProjectPerp.prototype.cableType = "in";
-    ProjectPerp.prototype.sticky = false;
-    ProjectPerp.prototype.popupTemplate = "popup_project.html";
-    ProjectPerp.prototype.textNewItems = _._('New Powerups!');
-
-    ProjectPerp.prototype.compileProfileSet = function() {
-      var gnode = this;
-      gnode.data.ProfileSet = new ProfileSet({markNew:true, lockAmountZero:true}, gnode.data.tokens);
-    };
-
-    ProjectPerp.prototype.extendEventHandlers = function() {
-      var gnode = this;
-      var groot = this.GameRoot;
-
-
-      gnode.on('vshiftclick',function(e,renderNode) {
-        e.stopPropagation();
-        gnode.Charge();
+      gnode.fetchProvided(function () {
+        gnode.compileProvided();
+        if (gnode.renderPopup) {
+          gnode.updatePopup();
+        }
       });
+      var popup = this.openPopup();
+    });
 
-      gnode.on('vclick',function(e,renderNode) {
-        e.stopPropagation();
+    gnode.on('after_render', function () {
+      gnode.updateRenderSlotStatus();
+    });
+  };
 
-        var popup = this.openPopup();
-        
-        gnode.fetchPowerups(function(){
-          gnode.compilePowerups();
-          gnode.compileProfileSet();
-          if (gnode.renderPopup) { gnode.updatePopup(); }
-        });
+  ProxyPerp.prototype.updateRenderSlotStatus = function () {
+    var gnode = this;
+    var node = gnode.renderNode;
+    gnode.data.used_slots = gnode.children.set.length;
+    if (gnode.data.used_slots < gnode.data.max_slots) {
+      node.addDecorator(
+        new Render.DecoratorLabel({
+          text: gnode.data.label + '<br />' + gnode.data.used_slots + '/' + gnode.data.max_slots,
+        })
+      );
+    } else {
+      node.addDecorator(new Render.DecoratorLabel({ text: gnode.data.label }));
+    }
+  };
 
+  ///////////////////////////////////
+  // The Project
+  ///////////////////////////////////
+
+  var ProjectPerp = function (config) {
+    this.init(config);
+    this.GameRoot.IPerps[this.gestalt] = true;
+    return this;
+  };
+
+  extend(ProjectPerp, GamePerp);
+
+  ProjectPerp.prototype.renderType = 'Perp';
+  ProjectPerp.prototype.cableType = 'in';
+  ProjectPerp.prototype.sticky = false;
+  ProjectPerp.prototype.popupTemplate = 'popup_project.html';
+  ProjectPerp.prototype.textNewItems = _._('New Powerups!');
+
+  ProjectPerp.prototype.compileProfileSet = function () {
+    var gnode = this;
+    gnode.data.ProfileSet = new ProfileSet(
+      { markNew: true, lockAmountZero: true },
+      gnode.data.tokens
+    );
+  };
+
+  ProjectPerp.prototype.extendEventHandlers = function () {
+    var gnode = this;
+    var groot = this.GameRoot;
+
+    gnode.on('vshiftclick', function (e, renderNode) {
+      e.stopPropagation();
+      gnode.Charge();
+    });
+
+    gnode.on('vclick', function (e, renderNode) {
+      e.stopPropagation();
+
+      var popup = this.openPopup();
+
+      gnode.fetchPowerups(function () {
+        gnode.compilePowerups();
+        gnode.compileProfileSet();
+        if (gnode.renderPopup) {
+          gnode.updatePopup();
+        }
       });
+    });
 
-      gnode.on('node_ready',function(e,result) {
-        e.stopPropagation();
-        gnode.markReady();
-      });
-    };
+    gnode.on('node_ready', function (e, result) {
+      e.stopPropagation();
+      gnode.markReady();
+    });
+  };
 
-    /*
+  /*
     ProjectPerp.prototype.AniTick = function() {
       if (this.renderNode) {
         this.renderNode.FXBounce();
@@ -4782,227 +5048,252 @@ class CollectableClient(CollectablePerpBase):
     };
     */
 
-    ProjectPerp.prototype.fetchPowerups = function(cb) {
-      this.GameRoot.fetchProjectPowerupData(this.gestalt,cb);
-      return;
-      var gnode = this;
-        // Register Powerups in typeRegistry if opend for the first time move this to compilePowerupsa
-        if (!gnode.data.powerups_compiled) {
-          app.remote.getPowerups(gnode.gestalt,app.version)
-          .done(function(data){
-            _.each(data.result,function(v,k){
-              gnode.addType(v.game_gestalt, v);
-            });
-            if (gnode.renderPopup) {
-              // FIXME: get rid of caching flag for now?
-              gnode.renderPopup.templateData.cached = true;
-              // FIXME: only update tabs don't redraw everything
-              //gnode.compilePowerups();
-              //gnode.updatePopup();
-              if (cb) { cb(); }
-            }
-          });
+  ProjectPerp.prototype.fetchPowerups = function (cb) {
+    this.GameRoot.fetchProjectPowerupData(this.gestalt, cb);
+    return;
+    var gnode = this;
+    // Register Powerups in typeRegistry if opend for the first time move this to compilePowerupsa
+    if (!gnode.data.powerups_compiled) {
+      app.remote.getPowerups(gnode.gestalt, app.version).done(function (data) {
+        _.each(data.result, function (v, k) {
+          gnode.addType(v.game_gestalt, v);
+        });
+        if (gnode.renderPopup) {
+          // FIXME: get rid of caching flag for now?
+          gnode.renderPopup.templateData.cached = true;
+          // FIXME: only update tabs don't redraw everything
+          //gnode.compilePowerups();
+          //gnode.updatePopup();
+          if (cb) {
+            cb();
+          }
+        }
+      });
+    } else {
+      if (cb) {
+        cb();
+      }
+    }
+  };
+
+  GameRoot.prototype.fetchProjectPowerupData = function (project_gestalt, cb) {
+    var groot = this;
+    var gnode = getByGestalt(project_gestalt);
+    // Register Powerups in typeRegistry
+    if (gnode && !gnode.data.powerupsCached) {
+      app.remote.getPowerups(project_gestalt, app.version).done(function (data) {
+        _.each(data.result, function (v, k) {
+          groot.addSubType(project_gestalt, v.game_gestalt, v);
+        });
+        if (gnode.renderPopup) {
+          gnode.renderPopup.templateData.cached = true;
+        }
+        gnode.data.powerupsCached = true;
+        if (cb) {
+          cb();
+        }
+      });
+    } else if (gnode && gnode.renderPopup && gnode.renderPopup.templateData) {
+      gnode.renderPopup.templateData.cached = true;
+      if (cb) {
+        cb();
+      }
+    } else {
+      app.remote.getPowerups(project_gestalt, app.version).done(function (data) {
+        _.each(data.result, function (v, k) {
+          groot.addSubType(project_gestalt, v.game_gestalt, v);
+        });
+        if (cb) {
+          cb();
+        }
+      });
+    }
+  };
+
+  ProjectPerp.prototype.compilePowerups = function () {
+    var gnode = this;
+    var powerups = {};
+    if (gnode.data) {
+      _.each(gnode.data.provided_ads, function (powerup) {
+        powerup.data = mergeData(gnode.getType(powerup.gestalt).type_data, powerup.instance_data);
+        powerup.game_type = gnode.getType(powerup.gestalt).game_type;
+      });
+      _.each(gnode.data.provided_upgrades, function (powerup) {
+        powerup.data = mergeData(gnode.getType(powerup.gestalt).type_data, powerup.instance_data);
+        powerup.game_type = gnode.getType(powerup.gestalt).game_type;
+      });
+      _.each(gnode.data.provided_teammembers, function (powerup) {
+        powerup.data = mergeData(gnode.getType(powerup.gestalt).type_data, powerup.instance_data);
+        powerup.game_type = gnode.getType(powerup.gestalt).game_type;
+      });
+      _.each(gnode.data.powerups, function (powerup) {
+        gnode.removeProvidedPowerup(powerup.gestalt);
+        if (gnode.getType(powerup.gestalt)) {
+          powerup.data = mergeData(gnode.getType(powerup.gestalt).type_data, powerup.instance_data);
+          powerup.game_type = gnode.getType(powerup.gestalt).game_type;
         } else {
-          if (cb) { cb(); }
-        }
-    };
-
-    GameRoot.prototype.fetchProjectPowerupData = function(project_gestalt,cb) {
-      var groot = this;
-      var gnode = getByGestalt(project_gestalt);
-      // Register Powerups in typeRegistry
-      if (gnode && !gnode.data.powerupsCached) {
-        app.remote.getPowerups(project_gestalt,app.version)
-        .done(function(data){
-          _.each(data.result,function(v,k){
-            groot.addSubType(project_gestalt, v.game_gestalt, v);
-          });
-          if (gnode.renderPopup) {
-            gnode.renderPopup.templateData.cached = true;
-          }
-          gnode.data.powerupsCached = true;
-          if (cb) { cb(); }
-        });
-      } 
-      else if (gnode && gnode.renderPopup && gnode.renderPopup.templateData) {
-        gnode.renderPopup.templateData.cached = true;
-        if (cb) { cb(); }
-      } else {
-        app.remote.getPowerups(project_gestalt,app.version)
-        .done(function(data){
-          _.each(data.result,function(v,k){
-            groot.addSubType(project_gestalt, v.game_gestalt, v);
-          });
-          if (cb) { cb(); }
-        });
-      }
-    };
-
-    ProjectPerp.prototype.compilePowerups = function() {
-      var gnode = this;
-      var powerups = {};
-      if (gnode.data) {
-        _.each(gnode.data.provided_ads,function(powerup){
-          powerup.data = mergeData(gnode.getType(powerup.gestalt).type_data,powerup.instance_data);
-          powerup.game_type = gnode.getType(powerup.gestalt).game_type;
-        });
-        _.each(gnode.data.provided_upgrades,function(powerup){
-          powerup.data = mergeData(gnode.getType(powerup.gestalt).type_data,powerup.instance_data);
-          powerup.game_type = gnode.getType(powerup.gestalt).game_type;
-        });
-        _.each(gnode.data.provided_teammembers,function(powerup){
-          powerup.data = mergeData(gnode.getType(powerup.gestalt).type_data,powerup.instance_data);
-          powerup.game_type = gnode.getType(powerup.gestalt).game_type;
-        });
-        _.each(gnode.data.powerups,function(powerup){
-          gnode.removeProvidedPowerup(powerup.gestalt);
-          if (gnode.getType(powerup.gestalt)) {
-            powerup.data = mergeData(gnode.getType(powerup.gestalt).type_data,powerup.instance_data);
-            powerup.game_type = gnode.getType(powerup.gestalt).game_type;
-          } else { 
-            console.warn('Error no type_data',powerup.gestalt);
-          }
-        });
-      }
-
-      _.each(['UpgradePowerup','AdPowerup','TeamMemberPowerup'],function(game_type){
-        var pcat = convertPowerupType(game_type);
-        if (!powerups[game_type]) {
-          // init powerup slots
-          powerups[game_type] = {
-            slots : [],
-            provided : [],
-            typelower:pcat,
-            slots_left:gnode.data['max_'+pcat+'_slots']- gnode.data[pcat+'_slots']
-          };
-          var slotslen = 0;
-          var provided = [];
-          if (game_type === 'UpgradePowerup') {
-            slotslen = gnode.data.upgrade_slots;
-            powerups[game_type].provided = _.filter(gnode.data.provided_upgrades, function(p){ return p.bought !== true });
-          }
-          else if (game_type === 'AdPowerup') {
-            slotslen = gnode.data.ad_slots;
-            powerups[game_type].provided = _.filter(gnode.data.provided_ads, function(p){ return p.bought !== true });
-          }
-          else if (game_type === 'TeamMemberPowerup') {
-            slotslen = gnode.data.teammember_slots;
-            powerups[game_type].provided = _.filter(gnode.data.provided_teammembers, function(p){ return p.bought !== true });
-          }
-          // adding slots to override default game inconsistencies
-          var slots = [];
-          var pagesize = 10;
-          var pages = Math.ceil(slotslen/pagesize);
-          _.each(_.range(0,slotslen),function(v){
-            slots[v] = 'free';
-          });
-          // TODO: only add locked if slots < max_length of slots
-          if (powerups[game_type].slots_left>0) {
-            slots.push('locked');
-          }
-          powerups[game_type].slots = slots;
+          console.warn('Error no type_data', powerup.gestalt);
         }
       });
-      _.each(gnode.data.powerups,function(p){
-        // No game type? abort.
-        if (!p.game_type) { 
-          return;
+    }
+
+    _.each(['UpgradePowerup', 'AdPowerup', 'TeamMemberPowerup'], function (game_type) {
+      var pcat = convertPowerupType(game_type);
+      if (!powerups[game_type]) {
+        // init powerup slots
+        powerups[game_type] = {
+          slots: [],
+          provided: [],
+          typelower: pcat,
+          slots_left: gnode.data['max_' + pcat + '_slots'] - gnode.data[pcat + '_slots'],
+        };
+        var slotslen = 0;
+        var provided = [];
+        if (game_type === 'UpgradePowerup') {
+          slotslen = gnode.data.upgrade_slots;
+          powerups[game_type].provided = _.filter(gnode.data.provided_upgrades, function (p) {
+            return p.bought !== true;
+          });
+        } else if (game_type === 'AdPowerup') {
+          slotslen = gnode.data.ad_slots;
+          powerups[game_type].provided = _.filter(gnode.data.provided_ads, function (p) {
+            return p.bought !== true;
+          });
+        } else if (game_type === 'TeamMemberPowerup') {
+          slotslen = gnode.data.teammember_slots;
+          powerups[game_type].provided = _.filter(gnode.data.provided_teammembers, function (p) {
+            return p.bought !== true;
+          });
         }
-        // test if slot is free - THIS SHOULD NOT HAPPEN!
-        if (powerups[p.game_type].slots[p.slot] === 'free') {
-          powerups[p.game_type].slots[p.slot] = p;
+        // adding slots to override default game inconsistencies
+        var slots = [];
+        var pagesize = 10;
+        var pages = Math.ceil(slotslen / pagesize);
+        _.each(_.range(0, slotslen), function (v) {
+          slots[v] = 'free';
+        });
+        // TODO: only add locked if slots < max_length of slots
+        if (powerups[game_type].slots_left > 0) {
+          slots.push('locked');
         }
-      });
+        powerups[game_type].slots = slots;
+      }
+    });
+    _.each(gnode.data.powerups, function (p) {
+      // No game type? abort.
+      if (!p.game_type) {
+        return;
+      }
+      // test if slot is free - THIS SHOULD NOT HAPPEN!
+      if (powerups[p.game_type].slots[p.slot] === 'free') {
+        powerups[p.game_type].slots[p.slot] = p;
+      }
+    });
     gnode.data.powerups_compiled = powerups;
-    };
-    
-    ProjectPerp.prototype.removeProvidedPowerup = function(bgestalt) {
-      // Does not actually remove powerup but flags as bought
-      var gnode = this;
-      var provided = {
-        provided_ads: gnode.data.provided_ads,
-        provided_upgrades: gnode.data.provided_upgrades,
-        provided_teammembers: gnode.data.provided_teammembers
-      };
-      _.each(provided,function(p,key){
-        var deleteme = _.findWhere(p,{gestalt:bgestalt});
-        if (deleteme) {
-          deleteme.bought = true;
-          //gnode.data[key] = _.without(p, deleteme);
-        }
-      });
-    };
+  };
 
-    ProjectPerp.prototype.addProvidedPowerup = function(bgestalt) {
-      // Does not actually add powerup but unflags as bought
-      var gnode = this;
-      var provided = {
-        provided_ads: gnode.data.provided_ads,
-        provided_upgrades: gnode.data.provided_upgrades,
-        provided_teammembers: gnode.data.provided_teammembers
-      };
-      _.each(provided,function(p,key){
-        var addme = _.findWhere(p,{gestalt:bgestalt});
-        if (addme) {
-          addme.bought = false;
-        }
-      });
+  ProjectPerp.prototype.removeProvidedPowerup = function (bgestalt) {
+    // Does not actually remove powerup but flags as bought
+    var gnode = this;
+    var provided = {
+      provided_ads: gnode.data.provided_ads,
+      provided_upgrades: gnode.data.provided_upgrades,
+      provided_teammembers: gnode.data.provided_teammembers,
     };
-
-    GameNode.prototype.Error = function(errormsg,data){
-      // TODO: consolidate Error Codes on Backend and parse them with this function
-      // try to display an error or fallback to game root
-      var gnode = this;
-      var groot = this.GameRoot;
-      if (gnode.renderPopup && gnode.renderPopup.open) {
-        gnode.renderPopup.trigger('error');
-      } else if (gnode.renderNode) {
-        gnode.renderNode.FXError();
-      } else if (groot) {
-        groot.renderNode.FXError();
-      } 
-      if (setup.debug) {
-        console.error(errormsg,data);
+    _.each(provided, function (p, key) {
+      var deleteme = _.findWhere(p, { gestalt: bgestalt });
+      if (deleteme) {
+        deleteme.bought = true;
+        //gnode.data[key] = _.without(p, deleteme);
       }
+    });
+  };
+
+  ProjectPerp.prototype.addProvidedPowerup = function (bgestalt) {
+    // Does not actually add powerup but unflags as bought
+    var gnode = this;
+    var provided = {
+      provided_ads: gnode.data.provided_ads,
+      provided_upgrades: gnode.data.provided_upgrades,
+      provided_teammembers: gnode.data.provided_teammembers,
     };
+    _.each(provided, function (p, key) {
+      var addme = _.findWhere(p, { gestalt: bgestalt });
+      if (addme) {
+        addme.bought = false;
+      }
+    });
+  };
 
-    GameNode.prototype.NoCash = function(){
-      var gnode = this;
-      if (gnode.renderPopup && gnode.renderPopup.open) {
-        gnode.renderPopup.trigger('no_cash');
-      } else {
-        gnode.renderNode.FXNoCash();
-      }
-    };
+  GameNode.prototype.Error = function (errormsg, data) {
+    // TODO: consolidate Error Codes on Backend and parse them with this function
+    // try to display an error or fallback to game root
+    var gnode = this;
+    var groot = this.GameRoot;
+    if (gnode.renderPopup && gnode.renderPopup.open) {
+      gnode.renderPopup.trigger('error');
+    } else if (gnode.renderNode) {
+      gnode.renderNode.FXError();
+    } else if (groot) {
+      groot.renderNode.FXError();
+    }
+    if (setup.debug) {
+      console.error(errormsg, data);
+    }
+  };
 
-    GameNode.prototype.NoAP = function(){
-      var gnode = this;
-      if (gnode.renderPopup && gnode.renderPopup.open) {
-        gnode.renderPopup.trigger('no_AP');
-      } else {
-        gnode.renderNode.FXNoAP();
-      }
-    };
+  GameNode.prototype.NoCash = function () {
+    var gnode = this;
+    if (gnode.renderPopup && gnode.renderPopup.open) {
+      gnode.renderPopup.trigger('no_cash');
+    } else {
+      gnode.renderNode.FXNoCash();
+    }
+  };
 
-    ProjectPerp.prototype.BuyPowerup = function(bgestalt,bslot) {
-      var gnode = this;
-      var groot = this.GameRoot;
-      // TODO: backendcall and do purchase...
-      if (bgestalt === undefined || bslot === undefined) {
-        gnode.Error('Buy powerup is missing parameters');
-        return;
-      }
-      if (bgestalt.split(':')[0]==='buyslots') {
-        gnode.BuySlots(bslot,bgestalt);
-        return;
-      }
-      app.remote.buyPowerup(gnode.path, bslot, bgestalt).done(function(data) {
+  GameNode.prototype.NoAP = function () {
+    var gnode = this;
+    if (gnode.renderPopup && gnode.renderPopup.open) {
+      gnode.renderPopup.trigger('no_AP');
+    } else {
+      gnode.renderNode.FXNoAP();
+    }
+  };
+
+  ProjectPerp.prototype.BuyPowerup = function (bgestalt, bslot) {
+    var gnode = this;
+    var groot = this.GameRoot;
+    // TODO: backendcall and do purchase...
+    if (bgestalt === undefined || bslot === undefined) {
+      gnode.Error('Buy powerup is missing parameters');
+      return;
+    }
+    if (bgestalt.split(':')[0] === 'buyslots') {
+      gnode.BuySlots(bslot, bgestalt);
+      return;
+    }
+    app.remote
+      .buyPowerup(gnode.path, bslot, bgestalt)
+      .done(function (data) {
         if (data.result) {
           if (data.result.error !== undefined) {
-            var buyErrors = { 0: 'node or powerup type not found', 1: 'slot already occupied', 3: 'insufficient cash' };
-            var buyDetail = (data.result.error === 3) ? ' (cash: ' + groot.cash_value + ')' : '';
-            console.log('[BuyPowerup] failed:', (buyErrors[data.result.error] || ('unknown error ' + data.result.error)) + buyDetail,
-              '| path:', gnode.path, '| slot:', bslot, '| gestalt:', bgestalt, data);
+            var buyErrors = {
+              0: 'node or powerup type not found',
+              1: 'slot already occupied',
+              3: 'insufficient cash',
+            };
+            var buyDetail = data.result.error === 3 ? ' (cash: ' + groot.cash_value + ')' : '';
+            console.log(
+              '[BuyPowerup] failed:',
+              (buyErrors[data.result.error] || 'unknown error ' + data.result.error) + buyDetail,
+              '| path:',
+              gnode.path,
+              '| slot:',
+              bslot,
+              '| gestalt:',
+              bgestalt,
+              data
+            );
             if (data.result.error === 3) {
               gnode.NoCash();
             } else {
@@ -5010,92 +5301,124 @@ class CollectableClient(CollectablePerpBase):
             }
             return;
           }
-          groot.updateGameValues(data.result.game_values,data.result.levelup,data.result.missions);
-          gnode.data = mergeData(gnode.data,data.result.node.instance_data);
+          groot.updateGameValues(
+            data.result.game_values,
+            data.result.levelup,
+            data.result.missions
+          );
+          gnode.data = mergeData(gnode.data, data.result.node.instance_data);
           gnode.removeProvidedPowerup(bgestalt);
           gnode.compilePowerups();
           gnode.compileProfileSet();
-          gnode.renderPopup.trigger('close_powerup',function(){
+          gnode.renderPopup.trigger('close_powerup', function () {
             // NOTE: close_powerup has callback with timeout
             gnode.updatePopupGracefully(bslot, bgestalt);
           });
-
         } else {
           // Server Error
-          gnode.Error('The computer says NOOOO',data);
+          gnode.Error('The computer says NOOOO', data);
         }
       })
-      .fail(function(data){
+      .fail(function (data) {
         if (data.error && data.error.message) {
-          gnode.Error(data.error.message,data);
+          gnode.Error(data.error.message, data);
         } else {
-          gnode.Error('The computer says NOOOO',data);
+          gnode.Error('The computer says NOOOO', data);
         }
       });
-    };
+  };
 
-    ProjectPerp.prototype.SellPowerup = function(bgestalt,bslot) {
-      var gnode = this;
-      var groot = this.GameRoot;
-      // TODO: backendcall and do purchase...
+  ProjectPerp.prototype.SellPowerup = function (bgestalt, bslot) {
+    var gnode = this;
+    var groot = this.GameRoot;
+    // TODO: backendcall and do purchase...
 
-      app.remote.sellPowerup(gnode.path, parseInt(bslot), bgestalt).done(function(data) {
+    app.remote
+      .sellPowerup(gnode.path, parseInt(bslot), bgestalt)
+      .done(function (data) {
         if (data.result) {
           if (data.result.error !== undefined) {
-            gnode.Error('The computer says NOOOO',data);
+            gnode.Error('The computer says NOOOO', data);
             return;
           }
-          groot.updateGameValues(data.result.game_values,data.result.levelup,data.result.missions);
+          groot.updateGameValues(
+            data.result.game_values,
+            data.result.levelup,
+            data.result.missions
+          );
           //gnode.data = mergeData(gnode.data, data.result.node.instance_data);
           gnode.data = mergeData(groot.getTypeData(gnode.gestalt), data.result.node.instance_data);
           gnode.addProvidedPowerup(bgestalt);
           gnode.compilePowerups();
           gnode.compileProfileSet();
-          gnode.renderPopup.trigger('close_powerup',function(){
+          gnode.renderPopup.trigger('close_powerup', function () {
             gnode.updatePopupGracefully(bslot, bgestalt, true);
           });
         } else {
           // Server Error
-          gnode.Error('The computer says NOOOO',data);
+          gnode.Error('The computer says NOOOO', data);
         }
       })
-      .fail(function(data){
+      .fail(function (data) {
         if (data.error && data.error.message) {
-          gnode.Error(data.error.message,data);
+          gnode.Error(data.error.message, data);
         } else {
-          gnode.Error('The computer says NOOOO',data);
+          gnode.Error('The computer says NOOOO', data);
         }
       });
-    };
+  };
 
+  ProjectPerp.prototype.BuySlots = function (num, bgestalt) {
+    var pcat = convertPowerupType(bgestalt.split(':')[1]);
+    num = parseInt(num, 10) || 1;
 
-    ProjectPerp.prototype.BuySlots = function(num,bgestalt) {
-      var pcat = convertPowerupType(bgestalt.split(':')[1]);
-      num = parseInt(num, 10) || 1;
+    var gnode = this;
+    var groot = this.GameRoot;
 
-      var gnode = this;
-      var groot = this.GameRoot;
+    var slotKey = pcat + '_slots';
+    var maxKey = 'max_' + pcat + '_slots';
+    var currentSlots = gnode.data[slotKey] || 0;
+    var maxSlots = gnode.data[maxKey];
+    if (maxSlots != null && currentSlots + num > maxSlots) {
+      console.log(
+        '[BuySlots] blocked: max slots reached (have ' +
+          currentSlots +
+          ', max ' +
+          maxSlots +
+          ', tried to add ' +
+          num +
+          ')'
+      );
+      gnode.Error('Max slots reached', {});
+      return;
+    }
 
-      var slotKey = pcat + '_slots';
-      var maxKey  = 'max_' + pcat + '_slots';
-      var currentSlots = gnode.data[slotKey] || 0;
-      var maxSlots = gnode.data[maxKey];
-      if (maxSlots != null && currentSlots + num > maxSlots) {
-        console.log('[BuySlots] blocked: max slots reached (have ' + currentSlots + ', max ' + maxSlots + ', tried to add ' + num + ')');
-        gnode.Error('Max slots reached', {});
-        return;
-      }
-
-      app.remote.buySlots(gnode.path, pcat, num).done(function(data) {
+    app.remote
+      .buySlots(gnode.path, pcat, num)
+      .done(function (data) {
         if (data.result) {
           if (data.result.error !== undefined) {
-            var slotErrors = { 0: 'node or slot type not found', 2: 'max slots already reached', 3: 'insufficient cash' };
+            var slotErrors = {
+              0: 'node or slot type not found',
+              2: 'max slots already reached',
+              3: 'insufficient cash',
+            };
             var slotDetails = {
               2: ' (have ' + currentSlots + ', max ' + maxSlots + ', tried to add ' + num + ')',
-              3: ' (cash: ' + groot.cash_value + ')'
+              3: ' (cash: ' + groot.cash_value + ')',
             };
-            console.log('[BuySlots] failed:', (slotErrors[data.result.error] || ('unknown error ' + data.result.error)) + (slotDetails[data.result.error] || ''),
-              '| path:', gnode.path, '| type:', pcat, '| num:', num, data);
+            console.log(
+              '[BuySlots] failed:',
+              (slotErrors[data.result.error] || 'unknown error ' + data.result.error) +
+                (slotDetails[data.result.error] || ''),
+              '| path:',
+              gnode.path,
+              '| type:',
+              pcat,
+              '| num:',
+              num,
+              data
+            );
             if (data.result.error === 2) {
               gnode.Error('Max slots reached', data);
             } else {
@@ -5103,70 +5426,78 @@ class CollectableClient(CollectablePerpBase):
             }
             return;
           }
-          groot.updateGameValues(data.result.game_values,data.result.levelup,data.result.missions);
-          gnode.data = mergeData(gnode.data,data.result.node.instance_data);
+          groot.updateGameValues(
+            data.result.game_values,
+            data.result.levelup,
+            data.result.missions
+          );
+          gnode.data = mergeData(gnode.data, data.result.node.instance_data);
           gnode.compilePowerups();
           // FIXME: do this gracefully
-          gnode.renderPopup.trigger('close_powerup',function(){
+          gnode.renderPopup.trigger('close_powerup', function () {
             gnode.updatePopup();
           });
         } else {
           // Server Error
-          gnode.Error('The computer says NOOOO',data);
+          gnode.Error('The computer says NOOOO', data);
         }
       })
-      .fail(function(data){
+      .fail(function (data) {
         if (data.error && data.error.message) {
-          gnode.Error(data.error.message,data);
+          gnode.Error(data.error.message, data);
         } else {
-          gnode.Error('The computer says NOOOO',data);
+          gnode.Error('The computer says NOOOO', data);
         }
       });
-    };
+  };
 
-    ProjectPerp.prototype.updatePopupGracefully = function(bslot, bgestalt, selling) {
-      var gnode = this;
-      var pcat = getPowerupTypeFromGestalt(bgestalt);
-      gnode.updateTemplateData();
-      if (gnode.popupTemplateData) {
-        gnode.popupTemplateData.loading = false;
-      }
+  ProjectPerp.prototype.updatePopupGracefully = function (bslot, bgestalt, selling) {
+    var gnode = this;
+    var pcat = getPowerupTypeFromGestalt(bgestalt);
+    gnode.updateTemplateData();
+    if (gnode.popupTemplateData) {
+      gnode.popupTemplateData.loading = false;
+    }
 
-      if (!gnode.renderPopup) { return; }
-      
-      var popup = gnode.renderPopup;
-      popup.renderDataTab();
-      popup.renderPowerupSelectors(pcat);
+    if (!gnode.renderPopup) {
+      return;
+    }
 
-      var jpop = gnode.renderPopup.jdomelem;
-      var jtab = jpop.find('.PopupTab[data-tab="'+ pcat +'"]');
-      if (!selling) {
-        // Buying a Powerup
-        var slot = jtab.find('.Powerup.free[data-button-data="'+bslot+'"]');
-        slot.removeAttr('data-subpop-id');
-        var powerup = _.findWhere(gnode.data.powerups,{gestalt:bgestalt});
-        var jpowerup = _.renderView('powerup.html', {  powerup: powerup,
-                           slot: bslot,
-                           key: pcat+bslot,
-                           updating: true
-                         });
-        jtab.find('.Subpop[data-subpop-id="' + pcat+bslot + '"]').remove();
-        var jpowerupSubpop = _.renderView('subpop_powerup.html', {  powerup: powerup,
-                           slot: bslot,
-                           key: pcat+bslot,
-                         });
-        jtab.find('.SubpopContainer').append(jpowerupSubpop);
+    var popup = gnode.renderPopup;
+    popup.renderDataTab();
+    popup.renderPowerupSelectors(pcat);
 
-        var parsed = $.parseHTML(jpowerup);
-        slot.addClass('updating hide ');
-        window.setTimeout(function(){
-          slot.replaceWith(parsed);
-          slot = jtab.find('.Powerup.updating[data-button-data="'+bslot+'"]');
-          window.setTimeout(function(){
-            slot.removeClass('updating').addClass('taken new');
-          },400);
-        },400);
-        /*
+    var jpop = gnode.renderPopup.jdomelem;
+    var jtab = jpop.find('.PopupTab[data-tab="' + pcat + '"]');
+    if (!selling) {
+      // Buying a Powerup
+      var slot = jtab.find('.Powerup.free[data-button-data="' + bslot + '"]');
+      slot.removeAttr('data-subpop-id');
+      var powerup = _.findWhere(gnode.data.powerups, { gestalt: bgestalt });
+      var jpowerup = _.renderView('powerup.html', {
+        powerup: powerup,
+        slot: bslot,
+        key: pcat + bslot,
+        updating: true,
+      });
+      jtab.find('.Subpop[data-subpop-id="' + pcat + bslot + '"]').remove();
+      var jpowerupSubpop = _.renderView('subpop_powerup.html', {
+        powerup: powerup,
+        slot: bslot,
+        key: pcat + bslot,
+      });
+      jtab.find('.SubpopContainer').append(jpowerupSubpop);
+
+      var parsed = $.parseHTML(jpowerup);
+      slot.addClass('updating hide ');
+      window.setTimeout(function () {
+        slot.replaceWith(parsed);
+        slot = jtab.find('.Powerup.updating[data-button-data="' + bslot + '"]');
+        window.setTimeout(function () {
+          slot.removeClass('updating').addClass('taken new');
+        }, 400);
+      }, 400);
+      /*
         window.setTimeout(function(){
           slot = jtab.find('.Powerup.updating[data-button-data="'+bslot+'"]');
           slot.find('.PowerupBackground').delay(400).fadeOut(150,function(){
@@ -5174,68 +5505,86 @@ class CollectableClient(CollectablePerpBase):
           }).fadeIn(250);
         },800);
         */
+    } else {
+      // Selling a Powerup
+      //gnode.updatePopup();
+      var slot = jtab.find('.Powerup.taken[data-button-data="' + bslot + '"]');
+      slot.removeAttr('data-subpop-id');
+      var jpowerup = _.renderView('powerup_free.html', {
+        slot: bslot,
+        slot_background: gnode.data.slot_background,
+        pkey: pcat,
+        data: gnode.popupTemplateData.data,
+        typelower: convertPowerupType(pcat),
+        updating: true,
+      });
+      var parsed = $.parseHTML(jpowerup);
+      slot.addClass('updating hide');
+      window.setTimeout(function () {
+        slot.replaceWith(parsed);
+        slot = jtab.find('.Powerup.updating[data-button-data="' + bslot + '"]');
+        window.setTimeout(function () {
+          slot.removeClass('updating').addClass('free');
+        }, 400);
+      }, 400);
+      /*
+        window.setTimeout(function(){
+          slot = jtab.find('.Powerup.updating[data-button-data="'+bslot+'"]');
+          slot.find('.PowerupBackground').delay(400).fadeOut(150,function(){
+            slot.removeClass('updating').addClass('free');
+          }).fadeIn(250);
+        },800);
+        */
+    }
+  };
+
+  ProjectPerp.prototype.Charge = function () {
+    var gnode = this;
+    var groot = this.GameRoot;
+    // Client-side pre-checks before issuing the engine call.
+    if (gnode.data.charge_cost > groot.cash_value) {
+      console.log(
+        '[Charge] blocked: insufficient cash (have ' +
+          groot.cash_value +
+          ', need ' +
+          gnode.data.charge_cost +
+          ')'
+      );
+      if (gnode.renderPopup && gnode.renderPopup.open) {
+        gnode.renderPopup.trigger('no_cash');
       } else {
-        // Selling a Powerup
-        //gnode.updatePopup();
-        var slot = jtab.find('.Powerup.taken[data-button-data="'+bslot+'"]');
-        slot.removeAttr('data-subpop-id');
-        var jpowerup = _.renderView('powerup_free.html', {  
-                           slot: bslot,
-                           slot_background: gnode.data.slot_background,
-                           pkey: pcat,
-                           data: gnode.popupTemplateData.data,
-                           typelower: convertPowerupType(pcat),
-                           updating: true
-                         });
-        var parsed = $.parseHTML(jpowerup);
-        slot.addClass('updating hide');
-        window.setTimeout(function(){
-          slot.replaceWith(parsed);
-          slot = jtab.find('.Powerup.updating[data-button-data="'+bslot+'"]');
-          window.setTimeout(function(){
-            slot.removeClass('updating').addClass('free');
-          },400);
-        },400);
-        /*
-        window.setTimeout(function(){
-          slot = jtab.find('.Powerup.updating[data-button-data="'+bslot+'"]');
-          slot.find('.PowerupBackground').delay(400).fadeOut(150,function(){
-            slot.removeClass('updating').addClass('free');
-          }).fadeIn(250);
-        },800);
-        */
-
+        gnode.renderNode.FXNoCash();
       }
-    };
-
-    ProjectPerp.prototype.Charge = function() {
-      var gnode = this;
-      var groot = this.GameRoot;
-      // Client-side pre-checks before issuing the engine call.
-      if (gnode.data.charge_cost > groot.cash_value) {
-        console.log('[Charge] blocked: insufficient cash (have ' + groot.cash_value + ', need ' + gnode.data.charge_cost + ')');
-        if (gnode.renderPopup && gnode.renderPopup.open) {
-          gnode.renderPopup.trigger('no_cash');
-        } else {
-          gnode.renderNode.FXNoCash();
-        }
-        return;
-      }
-      if (groot.ap_value < 1) {
-        console.log('[Charge] blocked: insufficient AP (have ' + groot.ap_value + ')');
-        gnode.NoAP();
-        return;
-      }
-      if (!gnode.states.chargeRunning && gnode.states.idle) {
-        // FIXME: rename Remote Call
-        app.remote.chargePerp(gnode.path).done(function(data) {
+      return;
+    }
+    if (groot.ap_value < 1) {
+      console.log('[Charge] blocked: insufficient AP (have ' + groot.ap_value + ')');
+      gnode.NoAP();
+      return;
+    }
+    if (!gnode.states.chargeRunning && gnode.states.idle) {
+      // FIXME: rename Remote Call
+      app.remote
+        .chargePerp(gnode.path)
+        .done(function (data) {
           if (data.result) {
             if (data.result.error !== undefined) {
-              var chargeErrors = { 1: 'insufficient AP', 2: 'already charging', 3: 'insufficient cash' };
+              var chargeErrors = {
+                1: 'insufficient AP',
+                2: 'already charging',
+                3: 'insufficient cash',
+              };
               var chargeDetail = '';
               if (data.result.error === 1) chargeDetail = ' (AP: ' + groot.ap_value + ')';
-              else if (data.result.error === 3) chargeDetail = ' (cash: ' + groot.cash_value + ', need: ' + gnode.data.charge_cost + ')';
-              console.log('[Charge] failed:', (chargeErrors[data.result.error] || ('unknown error ' + data.result.error)) + chargeDetail, data);
+              else if (data.result.error === 3)
+                chargeDetail =
+                  ' (cash: ' + groot.cash_value + ', need: ' + gnode.data.charge_cost + ')';
+              console.log(
+                '[Charge] failed:',
+                (chargeErrors[data.result.error] || 'unknown error ' + data.result.error) +
+                  chargeDetail,
+                data
+              );
               if (data.result.error === 3) {
                 if (gnode.renderPopup && gnode.renderPopup.open) {
                   gnode.renderPopup.trigger('no_cash');
@@ -5247,70 +5596,90 @@ class CollectableClient(CollectablePerpBase):
               }
               return;
             }
-            if (gnode.renderPopup) { gnode.renderPopup.trigger('popup_close'); }
+            if (gnode.renderPopup) {
+              gnode.renderPopup.trigger('popup_close');
+            }
             var gv = data.result.game_values;
-            groot.updateGameValues(data.result.game_values,data.result.levelup,data.result.missions);
+            groot.updateGameValues(
+              data.result.game_values,
+              data.result.levelup,
+              data.result.missions
+            );
 
             gnode.renderNode.FXCharge();
             gnode.markTimer({
               duration: data.result.duration,
               serverTime: 0,
-              serverStartTime: 0
+              serverStartTime: 0,
             });
           } else {
             // Server Error
-            gnode.Error('The computer says NOOOO',data);
+            gnode.Error('The computer says NOOOO', data);
           }
         })
-        .fail(function(data){
-            gnode.Error('The computer says NOOOO',data);
+        .fail(function (data) {
+          gnode.Error('The computer says NOOOO', data);
         });
-      }
-    };
+    }
+  };
 
-    ProjectPerp.prototype.collect = function() {
-      var gperp = this;
-      var gnode = this;
-      var groot = this.GameRoot;
-      var deco = this.renderReady;
-      var popup = gperp.renderPopup;
-      // No Request when no AP
-      if (groot.ap_value < 1) {
-        if (popup) {
-          popup.trigger('no_AP');
-        } else {
-          deco.FXNoAP();
-        }
-        return;
+  ProjectPerp.prototype.collect = function () {
+    var gperp = this;
+    var gnode = this;
+    var groot = this.GameRoot;
+    var deco = this.renderReady;
+    var popup = gperp.renderPopup;
+    // No Request when no AP
+    if (groot.ap_value < 1) {
+      if (popup) {
+        popup.trigger('no_AP');
+      } else {
+        deco.FXNoAP();
       }
-      deco.setClickable(false);
-      deco.setFrame('active');
-      deco.FXPulse();
-      app.remote.collectPerp(gperp.path).done(function(data) {
+      return;
+    }
+    deco.setClickable(false);
+    deco.setFrame('active');
+    deco.FXPulse();
+    app.remote
+      .collectPerp(gperp.path)
+      .done(function (data) {
         // FIXME: It would be better if data.result was in a predefined state to prevent testing for both, undefined _and_ null...
         if (data.result && data.result.result) {
           var amount = data.result.result.profile_set.profiles_value;
-          if (popup) { popup.trigger('popup_close'); }
+          if (popup) {
+            popup.trigger('popup_close');
+          }
 
-          groot.updateGameValues(data.result.game_values,data.result.levelup,data.result.missions);
+          groot.updateGameValues(
+            data.result.game_values,
+            data.result.levelup,
+            data.result.missions
+          );
           if (data.result.karma_incident) {
             // Karmalizer
             var karma_dec = data.result.game_values.karma_value - groot.karma_value;
             groot.makeNotifications({
               karma: {
                 gestalt: data.result.karma_incident,
-                karma_value: karma_dec
-              }
+                karma_value: karma_dec,
+              },
             });
           }
-          deco.FXBling({text: _.toKSNum(amount), extendClass: "ProfileBling"});
-          deco.FXSuck(function() {
+          deco.FXBling({ text: _.toKSNum(amount), extendClass: 'ProfileBling' });
+          deco.FXSuck(function () {
             gperp.renderNode.FXDataOut();
-            gperp.renderReady=undefined;
+            gperp.renderReady = undefined;
           });
           // Add to DB Queue
-          groot.getDatabase().cue(data.result.result.profile_set, data.result.result.origin, data.result.result.collect_id);
-          gperp.setState('idle',true);
+          groot
+            .getDatabase()
+            .cue(
+              data.result.result.profile_set,
+              data.result.result.origin,
+              data.result.result.collect_id
+            );
+          gperp.setState('idle', true);
         } else if (data.result && data.result.error) {
           if (popup) {
             popup.trigger('no_AP');
@@ -5323,207 +5692,228 @@ class CollectableClient(CollectablePerpBase):
           //console.log('collect failed');
         } else {
           // ERROR
-          gperp.Error('The computer says NOOOO',data);
+          gperp.Error('The computer says NOOOO', data);
         }
       })
-      .fail(function(data){
-          deco.FXError();
-          deco.FXStop();
-          deco.setClickable(true);
-          deco.setFrame('normal');
+      .fail(function (data) {
+        deco.FXError();
+        deco.FXStop();
+        deco.setClickable(true);
+        deco.setFrame('normal');
       });
-    };
+  };
 
+  ProjectPerp.prototype.markReady = function () {
+    var gperp = this;
+    var groot = this.GameRoot;
+    gperp.setState('idle', false);
+    gperp.setState('chargeRunning', false);
+    if (gperp.renderTimer) {
+      gperp.renderTimer.FXPuff();
+    }
+    var deco = (this.renderReady = this.renderNode.addDecorator(new Render.DecoratorReady()));
+    deco.FXSproing();
+    deco.on('vclick', function (e, renderNode) {
+      e.stopPropagation();
+      gperp.collect();
+    });
+  };
 
-    ProjectPerp.prototype.markReady = function() {
-      var gperp = this;
-      var groot = this.GameRoot;
-      gperp.setState('idle',false);
-      gperp.setState('chargeRunning',false);
-      if (gperp.renderTimer) { gperp.renderTimer.FXPuff(); }
-      var deco = this.renderReady = this.renderNode.addDecorator(new Render.DecoratorReady());
-      deco.FXSproing();
-      deco.on('vclick',function(e,renderNode) {
-        e.stopPropagation();
-        gperp.collect();
+  ///////////////////////////////////
+  // The Token
+  ///////////////////////////////////
+
+  var TokenPerp = function (config) {
+    this.init(config);
+    if (config && config.data && config.data.amount) {
+      this.setAmount(config.data.amount);
+    } else {
+      this.setAmount(0);
+    }
+    return this;
+  };
+
+  extend(TokenPerp, GamePerp);
+
+  TokenPerp.prototype.renderType = 'Perp';
+  TokenPerp.prototype.cableType = 'in';
+  TokenPerp.prototype.popupTemplate = 'popup_token.html';
+
+  TokenPerp.prototype.setAmount = function (amount) {
+    var groot = this.GameRoot;
+    var absoluteAmount = (groot.profiles_value * amount) / 100;
+    if (this.data.absoluteAmount) {
+      this.data.previousAbsoluteAmount = this.data.absoluteAmount;
+    } else {
+      // FIXME: only true if new, not if game loaded
+      this.data.previousAbsoluteAmount = 0;
+    }
+    this.data.absoluteAmount = absoluteAmount;
+    this.amount = this.data.amount = amount;
+    this.data.absoluteInc = this.data.absoluteAmount - this.data.previousAbsoluteAmount;
+    this.data.absoluteIncPerc = (100 / this.data.absoluteAmount) * this.data.absoluteInc;
+    groot.DBTokens[this.gestalt] = amount;
+    groot.DBTokensAbsolute[this.gestalt] = absoluteAmount;
+  };
+
+  TokenPerp.prototype.updateRenderAmount = function () {
+    this.renderNode.DecoratorAmount.setAmount(this.data.amount);
+  };
+
+  TokenPerp.prototype.updateGear = function () {
+    var gnode = this;
+    if (gnode.data.contained_tokens.length === 0 || gnode.renderNode === undefined) {
+      return;
+    }
+    gnode.makeProfileSet();
+    var node = this.renderNode;
+    var av = gnode.getUpgradeAverage();
+    var frame = av > 0 ? 'normal' : 'inactive';
+    if (!node.DecoratorGear === undefined) {
+      node.addDecorator(new Render.DecoratorGear());
+    }
+    node.DecoratorGear.setFrame(frame);
+  };
+
+  TokenPerp.prototype.getUpgradeAverage = function () {
+    var gnode = this;
+    gnode.setState('zeroresult', true);
+    if (!gnode.data.ProfileSet) {
+      return 0;
+    }
+    var amounts = [];
+    _.each(gnode.data.ProfileSet.tokens_set, function (token) {
+      if (!token.locked && token.diffAmount !== undefined) {
+        amounts.push(token.diffAmount);
+      }
+    });
+    var len = amounts.length || 1;
+    gnode.data.upgradeAverage =
+      Math.round(
+        (_.reduce(
+          amounts,
+          function (memo, num) {
+            return memo + num;
+          },
+          0
+        ) /
+          len) *
+          100
+      ) / 100;
+    if (gnode.data.upgradeAverage > 0) {
+      gnode.setState('zeroresult', false);
+    }
+    return gnode.data.upgradeAverage;
+  };
+
+  TokenPerp.prototype.extendRender = function () {
+    var render = this.renderData || {};
+    var gnode = this;
+    var groot = this.GameRoot;
+    var node = this.renderNode;
+    node.sticky = this.sticky;
+
+    if (render.config.label) {
+      node.addDecorator(
+        new Render.DecoratorLabel({
+          text: render.config.label,
+          extendClass: this.labelClass,
+          offsetToParent: { x: 0, y: 6 },
+        })
+      );
+    }
+    var amount = this.data.amount || 0;
+
+    node.addDecorator(new Render.DecoratorAmount({ amount: amount, decoratedNode: node }));
+
+    if (this.data.contained_tokens && this.data.contained_tokens.length) {
+      node.addDecorator(new Render.DecoratorGear());
+      gnode.updateGear();
+    }
+
+    if (this._loadReady) {
+      this.markReady();
+      this._loadReady = undefined;
+    } else if (this._loadTimer) {
+      this.markTimer(this._loadTimer);
+      this._loadTimer = undefined;
+    }
+
+    if (gnode.states.idle === false && gnode.data.contained_tokens.length) {
+      _.each(gnode.data.contained_tokens, function (t) {
+        var ct = getByGestalt(t.gestalt);
+        if (ct && ct.renderNode) {
+          gnode.renderNode.cableTo(ct.renderNode, {
+            cableMaxLength: 1920,
+            mode: 'in',
+            noWobble: true,
+          });
+        }
       });
-    };
+    }
+  };
 
+  TokenPerp.prototype.makeProfileSet = function () {
+    var gnode = this;
+    gnode.data.ProfileSet = new ProfileSet(
+      {
+        lockNotInDB: true,
+        DBAmounts: true,
+        markUpgradeValues: true,
+        lastUpgradeValues: gnode.data.last_upgrade_values,
+      },
+      gnode.data.contained_tokens
+    );
+  };
 
-    ///////////////////////////////////
-    // The Token
-    ///////////////////////////////////
+  TokenPerp.prototype.extendEventHandlers = function () {
+    var gnode = this;
 
-    var TokenPerp = function(config) {
-      this.init(config);
-      if (config && config.data && config.data.amount) {
-        this.setAmount(config.data.amount);
+    gnode.on('vshiftclick', function (e, renderNode) {
+      e.stopPropagation();
+      if (gnode.data.contained_tokens.length) {
+        gnode.Charge();
+      }
+    });
+
+    gnode.on('vclick', function (e, renderNode) {
+      e.stopPropagation();
+      if (gnode.data.contained_tokens) {
+        var lastUpgradeValues = gnode.data.last_upgrade_values;
+        gnode.makeProfileSet();
+      }
+      var popup = this.openPopup();
+    });
+
+    gnode.on('node_ready', function (e, result) {
+      e.stopPropagation();
+      // FIXME result has no meaning here?! since A) event can be triggered by non-socket-io b) markready takes no argument.
+      //gnode.markReady(result);
+      //console.log('node_ready',result);
+      gnode.data.last_upgrade_values = result.last_upgrade_data;
+      gnode.markReady();
+    });
+  };
+
+  TokenPerp.prototype.Charge = function () {
+    var gnode = this;
+    var rnode = this.renderNode;
+    var groot = this.GameRoot;
+    // No request when not enough AP
+    if (groot.ap_value < 1) {
+      // No AP
+      if (gnode.renderPopup && gnode.renderPopup.open) {
+        gnode.renderPopup.trigger('no_AP');
       } else {
-        this.setAmount(0);
+        gnode.renderNode.FXNoAP();
       }
-      return this;
-    };
-
-    extend(TokenPerp, GamePerp);
-
-    TokenPerp.prototype.renderType = "Perp";
-    TokenPerp.prototype.cableType = "in";
-    TokenPerp.prototype.popupTemplate = "popup_token.html";
-
-    TokenPerp.prototype.setAmount = function(amount) {
-      var groot = this.GameRoot;
-      var absoluteAmount = (groot.profiles_value * amount) / 100;
-      if (this.data.absoluteAmount) {
-        this.data.previousAbsoluteAmount = this.data.absoluteAmount;
-      } else {
-        // FIXME: only true if new, not if game loaded
-        this.data.previousAbsoluteAmount = 0;
-      }
-      this.data.absoluteAmount = absoluteAmount;
-      this.amount = this.data.amount = amount;
-      this.data.absoluteInc = this.data.absoluteAmount - this.data.previousAbsoluteAmount;
-      this.data.absoluteIncPerc = (100/this.data.absoluteAmount) * this.data.absoluteInc;
-      groot.DBTokens[this.gestalt] = amount;
-      groot.DBTokensAbsolute[this.gestalt] = absoluteAmount;
-    };
-
-    TokenPerp.prototype.updateRenderAmount = function() {
-      this.renderNode.DecoratorAmount.setAmount(this.data.amount);
-    };
-
-    TokenPerp.prototype.updateGear = function() {
-      var gnode = this;
-      if (gnode.data.contained_tokens.length === 0 || gnode.renderNode === undefined) {
-        return;
-      }
-      gnode.makeProfileSet();
-      var node = this.renderNode;
-      var av = gnode.getUpgradeAverage();
-      var frame = (av > 0) ? "normal" : "inactive";
-      if (!node.DecoratorGear === undefined) {
-        node.addDecorator(new Render.DecoratorGear());
-      } 
-      node.DecoratorGear.setFrame(frame);
-    };
-
-    TokenPerp.prototype.getUpgradeAverage = function() {
-      var gnode = this;
-      gnode.setState('zeroresult', true);
-      if (!gnode.data.ProfileSet) {
-        return 0;
-      }
-      var amounts = [];
-      _.each(gnode.data.ProfileSet.tokens_set, function(token){
-        if (!token.locked && token.diffAmount !== undefined) {
-          amounts.push(token.diffAmount);
-        }
-      });
-      var len = amounts.length || 1;
-      gnode.data.upgradeAverage = Math.round((_.reduce(amounts, function(memo, num){ return memo + num; }, 0) / len) * 100 ) / 100;
-      if (gnode.data.upgradeAverage > 0) {
-        gnode.setState('zeroresult', false);
-      }
-      return gnode.data.upgradeAverage;
-    };
-
-    TokenPerp.prototype.extendRender = function() {
-      var render = this.renderData || {};
-      var gnode = this;
-      var groot = this.GameRoot;
-      var node = this.renderNode;
-      node.sticky = this.sticky;
-
-      if (render.config.label) {
-        node.addDecorator(new Render.DecoratorLabel({text: render.config.label, extendClass: this.labelClass, offsetToParent: {x: 0,y: 6}}));
-      }
-      var amount = this.data.amount || 0;
-
-      node.addDecorator(new Render.DecoratorAmount({amount:amount,decoratedNode:node}));
-      
-      if (this.data.contained_tokens && this.data.contained_tokens.length) {
-        node.addDecorator(new Render.DecoratorGear());
-        gnode.updateGear();
-      }
-
-      if (this._loadReady) {
-        this.markReady();
-        this._loadReady = undefined;
-      } else if (this._loadTimer) {
-        this.markTimer(this._loadTimer);
-        this._loadTimer = undefined;
-      }
-
-      if (gnode.states.idle === false && gnode.data.contained_tokens.length) {
-        _.each(gnode.data.contained_tokens,function(t){
-          var ct = getByGestalt(t.gestalt);
-          if (ct && ct.renderNode) {
-            gnode.renderNode.cableTo(ct.renderNode, {cableMaxLength:1920,mode:'in',noWobble:true});
-          }
-        });
-      }
-
-
-    };
-
-    TokenPerp.prototype.makeProfileSet = function() {
-      var gnode = this;
-      gnode.data.ProfileSet = new ProfileSet({
-        lockNotInDB:true, 
-        DBAmounts:true, 
-        markUpgradeValues: true, 
-        lastUpgradeValues: gnode.data.last_upgrade_values 
-      }, gnode.data.contained_tokens);
-    };
-
-    TokenPerp.prototype.extendEventHandlers = function() {
-      var gnode = this;
-      
-      gnode.on('vshiftclick',function(e,renderNode) {
-        e.stopPropagation();
-        if (gnode.data.contained_tokens.length) {
-          gnode.Charge();
-        }
-      });
-
-      gnode.on('vclick',function(e,renderNode) {
-        e.stopPropagation();
-        if (gnode.data.contained_tokens) {
-          var lastUpgradeValues = gnode.data.last_upgrade_values;
-          gnode.makeProfileSet();
-        }
-        var popup = this.openPopup();
-      });
-      
-      gnode.on('node_ready',function(e,result) {
-        e.stopPropagation();
-        // FIXME result has no meaning here?! since A) event can be triggered by non-socket-io b) markready takes no argument.
-        //gnode.markReady(result);
-        //console.log('node_ready',result);
-        gnode.data.last_upgrade_values = result.last_upgrade_data;
-        gnode.markReady();
-      });
-      
-    };
-
-
-    TokenPerp.prototype.Charge = function() {
-      var gnode = this;
-      var rnode = this.renderNode;
-      var groot = this.GameRoot;
-      // No request when not enough AP
-      if (groot.ap_value < 1) {
-        // No AP
-        if (gnode.renderPopup && gnode.renderPopup.open) {
-          gnode.renderPopup.trigger('no_AP');
-        } else {
-          gnode.renderNode.FXNoAP();
-        }
-        return;
-      }
-      if (!gnode.states.chargeRunning && gnode.states.idle && !gnode.states.zeroresult) {
-
-        //console.log('charge');
-        app.remote.chargePerp(gnode.path).done(function(data) {
+      return;
+    }
+    if (!gnode.states.chargeRunning && gnode.states.idle && !gnode.states.zeroresult) {
+      //console.log('charge');
+      app.remote
+        .chargePerp(gnode.path)
+        .done(function (data) {
           if (data.result) {
             if (data.result.error) {
               // No AP
@@ -5534,80 +5924,95 @@ class CollectableClient(CollectablePerpBase):
               }
               return;
             }
-            if (gnode.renderPopup) { gnode.renderPopup.trigger('popup_close'); }
+            if (gnode.renderPopup) {
+              gnode.renderPopup.trigger('popup_close');
+            }
 
-            groot.updateGameValues(data.result.game_values,data.result.levelup,data.result.missions);
+            groot.updateGameValues(
+              data.result.game_values,
+              data.result.levelup,
+              data.result.missions
+            );
             gnode.renderNode.FXCharge('AP');
 
             rnode.DecoratorGear.remove();
             gnode.markTimer({
               duration: data.result.duration,
               serverTime: 0,
-              serverStartTime: 0
+              serverStartTime: 0,
             });
 
             var wait = 300;
-            
-            _.each(gnode.data.contained_tokens,function(t){
+
+            _.each(gnode.data.contained_tokens, function (t) {
               var ct = getByGestalt(t.gestalt);
               if (ct && ct.renderNode) {
-                window.setTimeout(function(){
-                  var cable = gnode.renderNode.cableAnimatedTo(ct.renderNode, {cableMaxLength:1920,mode:'in',noWobble:true});
-                  window.setTimeout(function(){
-                    cable.FXDataIn(function(){
+                window.setTimeout(function () {
+                  var cable = gnode.renderNode.cableAnimatedTo(ct.renderNode, {
+                    cableMaxLength: 1920,
+                    mode: 'in',
+                    noWobble: true,
+                  });
+                  window.setTimeout(function () {
+                    cable.FXDataIn(function () {
                       gnode.renderNode.FXBounce();
                     });
-                  },wait+400);
-                },wait);
-                wait = wait+150;
+                  }, wait + 400);
+                }, wait);
+                wait = wait + 150;
               }
             });
-
           } else {
-            gnode.Error('The computer says NOOOO',data);
+            gnode.Error('The computer says NOOOO', data);
           }
         })
-        .fail(function(data){
-            gnode.Error('The computer says NOOOO',data);
+        .fail(function (data) {
+          gnode.Error('The computer says NOOOO', data);
         });
-      }
+    }
+  };
 
-    };
+  TokenPerp.prototype.collect = function () {
+    var gperp = this;
+    var groot = this.GameRoot;
+    var deco = this.renderReady;
+    if (groot.ap_value < 1) {
+      deco.FXNoAP();
+      return;
+    }
 
-    TokenPerp.prototype.collect = function() {
-      var gperp = this;
-      var groot = this.GameRoot;
-      var deco = this.renderReady;
-      if (groot.ap_value < 1) {
-        deco.FXNoAP();
-        return;
-      }
+    var popup = gperp.renderPopup;
+    deco.setClickable(false);
+    deco.setFrame('active');
+    deco.FXPulse();
 
-      var popup = gperp.renderPopup;
-      deco.setClickable(false);
-      deco.setFrame('active');
-      deco.FXPulse();
-
-      app.remote.collectPerp(gperp.path).done(function(data) {
+    app.remote
+      .collectPerp(gperp.path)
+      .done(function (data) {
         if (data.result && data.result.result) {
-
-          if (popup) { popup.trigger('popup_close'); }
+          if (popup) {
+            popup.trigger('popup_close');
+          }
           // FIXME: compile for checkNotifications
           groot.getDatabase().compileSuperTokens();
           var amount = data.result.result.token_upgraded_amount;
           gperp.setAmount(amount);
-          groot.updateGameValues(data.result.game_values,data.result.levelup,data.result.missions);
+          groot.updateGameValues(
+            data.result.game_values,
+            data.result.levelup,
+            data.result.missions
+          );
           //deco.FXBling({text: _.toKSNum(gperp.data.absoluteIncPerc) + "%", extendClass: "ProfileBling"});
-          deco.FXSuck(function() {
+          deco.FXSuck(function () {
             //gperp.renderNode.DecoratorGear.show();
             gperp.renderNode.addDecorator(new Render.DecoratorGear());
             gperp.updateGear();
             gperp.renderNode.DecoratorGear.FXSproing();
-            gperp.renderReady=undefined;
-            window.setTimeout(function(){
+            gperp.renderReady = undefined;
+            window.setTimeout(function () {
               groot.getDatabase().checkNotifications();
               groot.updateGears();
-            },2000);
+            }, 2000);
           });
           var wait = 0;
 
@@ -5621,32 +6026,32 @@ class CollectableClient(CollectablePerpBase):
             }
           });
           */
-          
+
           // FX WITH CABLES
-          _.each(gperp.data.contained_tokens,function(t){
+          _.each(gperp.data.contained_tokens, function (t) {
             var ct = getByGestalt(t.gestalt);
             if (ct && ct.renderNode) {
               //window.setTimeout(function(){
-                //ct.renderNode.FXDataOut();
-                window.setTimeout(function(){
-                  gperp.renderNode.cableAnimatedRemove(ct.renderNode);
-                },wait+200);
+              //ct.renderNode.FXDataOut();
+              window.setTimeout(function () {
+                gperp.renderNode.cableAnimatedRemove(ct.renderNode);
+              }, wait + 200);
               //},wait);
-              wait = wait+200;
+              wait = wait + 200;
             }
           });
           // FIXME when previous was 0 there's something wrong here...
           //var text = "+" + _.toKSNum(gperp.data.absoluteIncPerc) + "%";
-          var text = "+" + _.toKSNum(gperp.data.absoluteInc);
-          window.setTimeout(function(){
-            gperp.renderNode.FXSpinner({text: text,duration:wait},function(){
+          var text = '+' + _.toKSNum(gperp.data.absoluteInc);
+          window.setTimeout(function () {
+            gperp.renderNode.FXSpinner({ text: text, duration: wait }, function () {
               gperp.updateRenderAmount();
-              //gperp.renderNode.DecoratorAmount.setAmount(gperp.data.amount); 
+              //gperp.renderNode.DecoratorAmount.setAmount(gperp.data.amount);
             });
-          },800);
+          }, 800);
           // FIXME Merge to DB
 
-          gperp.setState('idle',true);
+          gperp.setState('idle', true);
         } else if (data.result && data.result.error) {
           deco.FXNoAP();
           deco.FXStop();
@@ -5655,85 +6060,85 @@ class CollectableClient(CollectablePerpBase):
           //console.log('collect failed');
         } else {
           // ERROR
-          gperp.Error('The computer says NOOOO',data);
+          gperp.Error('The computer says NOOOO', data);
         }
       })
-      .fail(function(data){
-          deco.FXError();
-          deco.FXStop();
-          deco.setClickable(true);
-          deco.setFrame('normal');
+      .fail(function (data) {
+        deco.FXError();
+        deco.FXStop();
+        deco.setClickable(true);
+        deco.setFrame('normal');
       });
-    };
+  };
 
+  TokenPerp.prototype.markReady = function () {
+    var gperp = this;
+    var groot = this.GameRoot;
+    gperp.setState('idle', false);
+    gperp.setState('chargeRunning', false);
+    if (gperp.renderTimer) {
+      gperp.renderTimer.FXPuff();
+    }
+    var deco = (this.renderReady = this.renderNode.addDecorator(
+      new Render.DecoratorReady({ mode: 'gear' })
+    ));
+    deco.FXSproing();
+    deco.on('vclick', function (e, renderNode) {
+      e.stopPropagation();
+      gperp.collect();
+    });
+  };
 
+  ///////////////////////////////////
+  // The Supertoken
+  ///////////////////////////////////
 
-    TokenPerp.prototype.markReady = function() {
-      var gperp = this;
-      var groot = this.GameRoot;
-      gperp.setState('idle',false);
-      gperp.setState('chargeRunning',false);
-      if (gperp.renderTimer) { gperp.renderTimer.FXPuff(); }
-      var deco = this.renderReady = this.renderNode.addDecorator(new Render.DecoratorReady({mode:'gear'}));
-      deco.FXSproing();
-      deco.on('vclick',function(e,renderNode) {
-        e.stopPropagation();
-        gperp.collect();
-      });
-    };
+  var SupertokenPerp = function (config) {
+    this.init(config);
+    return this;
+  };
 
+  extend(SupertokenPerp, GamePerp);
 
+  SupertokenPerp.prototype.renderType = 'Perp';
+  TokenPerp.prototype.cableType = 'inout';
 
-    ///////////////////////////////////
-    // The Supertoken
-    ///////////////////////////////////
+  ////////////////////////////////////////////
+  // The API Publisher
+  ////////////////////////////////////////////
 
-    var SupertokenPerp = function(config) {
-      this.init(config);
-      return this;
-    };
+  var Game = {
+    get: get,
+    getById: getById,
+    getByType: getByType,
+    getByGestalt: getByGestalt,
+    getAllByGestalt: getAllByGestalt,
+    eachByGestalt: eachByGestalt,
+    APTicker: APTicker,
+    init: init,
+    _instances: _instances,
+    _ids: _ids,
+    GameNode: GameNode,
+    GameRoot: GameRoot,
+    Mission: Mission,
+    Missions: Missions,
+    Topscores: Topscores,
+    Topscore: Topscore,
+    Imperium: Imperium,
+    Database: Database,
+    DatabasePerp: DatabasePerp,
+    CityPerp: CityPerp,
+    AgentPerp: AgentPerp,
+    ContactPerp: ContactPerp,
+    PusherPerp: PusherPerp,
+    ClientPerp: ClientPerp,
+    TokenPerp: TokenPerp,
+    ProxyPerp: ProxyPerp,
+    ProjectPerp: ProjectPerp,
+    SupertokenPerp: SupertokenPerp,
+  };
 
-    extend(SupertokenPerp, GamePerp);
-
-    SupertokenPerp.prototype.renderType = "Perp";
-    TokenPerp.prototype.cableType = "inout";
-    
-    ////////////////////////////////////////////
-    // The API Publisher
-    ////////////////////////////////////////////
-
-    var Game = {
-      get : get,
-      getById : getById,
-      getByType : getByType,
-      getByGestalt : getByGestalt,
-      getAllByGestalt : getAllByGestalt,
-      eachByGestalt : eachByGestalt,
-      APTicker : APTicker,
-      init:init,
-      _instances:_instances,
-      _ids:_ids,
-      GameNode:GameNode,
-      GameRoot:GameRoot,
-      Mission:Mission,
-      Missions:Missions,
-      Topscores:Topscores,
-      Topscore:Topscore,
-      Imperium:Imperium,
-      Database:Database,
-      DatabasePerp:DatabasePerp,
-      CityPerp:CityPerp,
-      AgentPerp:AgentPerp,
-      ContactPerp:ContactPerp,
-      PusherPerp:PusherPerp,
-      ClientPerp:ClientPerp,
-      TokenPerp:TokenPerp,
-      ProxyPerp:ProxyPerp,
-      ProjectPerp:ProjectPerp,
-      SupertokenPerp:SupertokenPerp
-    };
-
-    return Game;
+  return Game;
 };
 
 var game;

--- a/scripts/Game.js
+++ b/scripts/Game.js
@@ -1,15 +1,15 @@
 // @ts-nocheck — strict-TS quarantine; remove when this file is migrated to TS (issue #147)
+import { getRender } from './Render.js';
 // Vendor libs ($, _, sprintf) are read off globalThis at factory-body
 // time, not at module-evaluation time, so this module can be bundled
 // alongside scripts that run before vendor `<script>` tags execute.
 import appModule from './app.js';
-import setup from './setup.js';
-import utilDefault from './util.js';
-import { getTypeSettings } from './type_settings.js';
-import webxdcIdentity from './webxdc-identity.js';
 import * as bootMod from './boot.js';
 import i18n from './i18n.js';
-import { getRender } from './Render.js';
+import setup from './setup.js';
+import { getTypeSettings } from './type_settings.js';
+import utilDefault from './util.js';
+import webxdcIdentity from './webxdc-identity.js';
 
 var Game = function () {
   var _ = globalThis._;
@@ -79,6 +79,7 @@ var Game = function () {
   // The Set
   ////////////////////////////////
 
+  // biome-ignore lint/suspicious/noShadowRestrictedNames: legacy collection class predates ES6 Set
   var Set = function (set) {
     if (!set) {
       set = [];
@@ -413,8 +414,6 @@ var Game = function () {
   };
 
   GameNode.prototype.remove = function () {
-    // Remove GameNode from all references and remove renderNodes
-    var gnode = this;
     if (this.parentNode) {
       this.parentNode.children.remove(this);
     }
@@ -439,10 +438,7 @@ var Game = function () {
   };
 
   GameNode.prototype.addType = function (gestalt, data) {
-    // Add a type to the typeRegistry data should have data.type_data
-    // If the game_type is also defined in typeSettings it will be merged and overwritte with data
-    var gnode = this;
-    var groot = gnode.GameRoot;
+    var groot = this.GameRoot;
     var nodeType = this.getType();
     if (nodeType) {
       if (data.game_type && data.type_data) {
@@ -544,10 +540,7 @@ var Game = function () {
   };
 
   GameNode.prototype.initEventHandlers = function () {
-    // Bind specific eventhandlers (which get triggered by Render.Node)
-    // This is an example implementation and usually gets overwritten by the Subclasses
-    var gnode = this;
-    gnode.on('vclick', function (e) {
+    this.on('vclick', function (e) {
       e.stopPropagation();
     });
     if (this.extendEventHandlers) {
@@ -859,15 +852,11 @@ var Game = function () {
     //this.renderNode.jdomelem.find('*').off();
   };
   GameRoot.prototype.unlock = function () {
-    // UnLock the whole stage
-    // TODO make stage spinner in Render and use proper method to unbind events
-    // Unlock currently wouldn't work since all events are destroyed
-    var groot = this;
-    if (groot.NotificationQueue && groot.NotificationQueue.length < 2) {
+    if (this.NotificationQueue && this.NotificationQueue.length < 2) {
       this.renderNode.unlock();
       this.renderMenu.unlock();
       AniTicker.start();
-    } else if (!groot.NotificationQueue) {
+    } else if (!this.NotificationQueue) {
       this.renderNode.unlock();
       this.renderMenu.unlock();
       AniTicker.start();
@@ -1827,7 +1816,6 @@ var Game = function () {
   };
 
   GameRoot.prototype.initGameValues = function () {
-    var gnode = this;
     var gv = this.data.game_values; // FIXME: Added var; check for side-effects
     this.ap_value = gv.ap_initial;
     this.ap_offset = gv.ap_offset;
@@ -1848,43 +1836,42 @@ var Game = function () {
   };
 
   GameRoot.prototype.updateGameValues = function (game_values, levelup, missions, silent) {
-    var groot = this;
     var gv = game_values;
     if (missions) {
-      groot.Missions.updateMissions(missions, game_values);
+      this.Missions.updateMissions(missions, game_values);
       // FIXME: TESTING when mission completed, do not yet update game_values
       //silent = true;
     }
     if (gv.profiles_max !== undefined) {
-      groot.profiles_max = gv.profiles_max;
+      this.profiles_max = gv.profiles_max;
     }
-    if (gv.profiles_value !== undefined && gv.profiles_value !== groot.profiles_value) {
-      groot.setProfiles(gv.profiles_value, silent);
+    if (gv.profiles_value !== undefined && gv.profiles_value !== this.profiles_value) {
+      this.setProfiles(gv.profiles_value, silent);
     }
-    if (gv.cash_value !== undefined && gv.cash_value !== groot.cash_value) {
-      groot.setCash(gv.cash_value, silent);
+    if (gv.cash_value !== undefined && gv.cash_value !== this.cash_value) {
+      this.setCash(gv.cash_value, silent);
     }
     if (gv.ap_increment) {
-      groot.useAP(gv.ap_increment, silent);
+      this.useAP(gv.ap_increment, silent);
     }
-    if (gv.karma_value !== undefined && gv.karma_value !== groot.karma_value) {
-      groot.setKarma(gv.karma_value, silent);
+    if (gv.karma_value !== undefined && gv.karma_value !== this.karma_value) {
+      this.setKarma(gv.karma_value, silent);
     }
     if (gv.xp_value !== undefined) {
-      groot.setXP(gv.xp_value, silent);
+      this.setXP(gv.xp_value, silent);
     }
     // ap_snapshot is the authoritative engine AP — sync the visible
     // ap_value whenever it differs, not only on levelup. Without this,
     // the statusbar AP bar shows stale text after every chargePerp /
     // integrateCollected (handlers decrement ap_snapshot but Game.js
     // never reapplied it pre-#120 follow-up).
-    if (gv.ap_snapshot !== undefined && gv.ap_snapshot !== groot.ap_value) {
-      groot.setAP(gv.ap_snapshot, silent);
+    if (gv.ap_snapshot !== undefined && gv.ap_snapshot !== this.ap_value) {
+      this.setAP(gv.ap_snapshot, silent);
     }
     // levelup-only side effects.
     if (gv.ap_snapshot !== undefined && levelup === true && !silent) {
-      groot.getDatabase().checkNotifications();
-      groot.makeNotifications({ levelup: groot.xp_level.number });
+      this.getDatabase().checkNotifications();
+      this.makeNotifications({ levelup: this.xp_level.number });
     }
   };
 
@@ -2293,9 +2280,7 @@ var Game = function () {
       if (config.filter_is_query) {
         var is_query = filter_is_query === 'blue';
         addtokens = _.filter(tokens, function (n) {
-          {
-            return n.is_query === is_query;
-          }
+          return n.is_query === is_query;
         });
       }
     }
@@ -2347,6 +2332,7 @@ var Game = function () {
     });
     // sort when locked tokens are marked
 
+    // biome-ignore lint/suspicious/noSelfCompare: legacy always-true guard, removal is a separate refactor
     if (gnode.lockAmountZero || gnode.lockNotInDB || 0 === 0) {
       var sorted = gnode.tokens_set;
       // FIXME: sortBy Gestalt for messed up TokenSets from CMS/Backend (DBQueue and Clients)
@@ -2376,18 +2362,17 @@ var Game = function () {
   extend(ProfileSet, GameNode);
 
   ProfileSet.prototype.updateNewMarker = function () {
-    var ps = this;
     var groot = this.GameRoot;
     var seenMap = (groot.raw_data && groot.raw_data.tokens_seen) || {};
-    _.each(ps.tokens_set, function (token) {
+    _.each(this.tokens_set, function (token) {
       if (!groot.DBTokens.hasOwnProperty(token.gestalt) && !seenMap[token.gestalt]) {
         token.new = true;
       } else {
         token.new = false;
       }
     });
-    if (ps.popupTemplateData) {
-      ps.popupTemplateData.ProfileSet = ps;
+    if (this.popupTemplateData) {
+      this.popupTemplateData.ProfileSet = this;
     }
   };
 
@@ -2486,36 +2471,35 @@ var Game = function () {
   };
 
   Database.prototype.openUpgradesPopup = function () {
-    var gnode = this;
     // Popup instantiated for the first time
-    if (!gnode.popupTemplateData) {
-      gnode.popupTemplateData = {};
-      gnode.popupTemplateData.status_icons = gnode.GameRoot.data.status_icons;
-      gnode.popupTemplateData.states = {};
-      gnode.popupTemplateData.data = gnode.data;
-      gnode.popupTemplateData.data.gestalt = 'Database';
-      gnode.popupTemplateData.data.id = this.id;
-      gnode.popupTemplateData.data.title = _._('database_buytokens title');
-      gnode.popupTemplateData.data.subtitle = _._('database_buytokens subtitle');
-      gnode.popupTemplateData.data.description = _._('database_buytokens description');
-      gnode.popupTemplateData.data.selectortitle = _._('database_buytokens selector title');
-      gnode.popupTemplateData.data.mainsprites_class = 'DBUpgrade';
-      gnode.popupTemplateData.groot = gnode.GameRoot;
+    if (!this.popupTemplateData) {
+      this.popupTemplateData = {};
+      this.popupTemplateData.status_icons = this.GameRoot.data.status_icons;
+      this.popupTemplateData.states = {};
+      this.popupTemplateData.data = this.data;
+      this.popupTemplateData.data.gestalt = 'Database';
+      this.popupTemplateData.data.id = this.id;
+      this.popupTemplateData.data.title = _._('database_buytokens title');
+      this.popupTemplateData.data.subtitle = _._('database_buytokens subtitle');
+      this.popupTemplateData.data.description = _._('database_buytokens description');
+      this.popupTemplateData.data.selectortitle = _._('database_buytokens selector title');
+      this.popupTemplateData.data.mainsprites_class = 'DBUpgrade';
+      this.popupTemplateData.groot = this.GameRoot;
     }
-    gnode.popupTemplateData.data = gnode.data;
+    this.popupTemplateData.data = this.data;
 
     var popupConfig = {
       gameNode: this,
       template: 'popup.html',
-      templateData: gnode.popupTemplateData,
+      templateData: this.popupTemplateData,
       popupContainer: this,
     };
 
     var popup = (this.renderPopup = new Render.Popup(popupConfig));
 
-    gnode.renderNode.addPopup(popup);
+    this.renderNode.addPopup(popup);
 
-    gnode.initPopupEvents();
+    this.initPopupEvents();
 
     return popup;
   };
@@ -2829,17 +2813,15 @@ var Game = function () {
   };
 
   Database.prototype.checkNotifications = function () {
-    // FIXME: this doesn't work;
-    var gnode = this;
     var groot = this.GameRoot;
     var change = false;
-    if (!gnode.data.providedPerps) {
-      gnode.compileSuperTokens();
+    if (!this.data.providedPerps) {
+      this.compileSuperTokens();
       return;
     }
-    var before = _.pluck(_.where(gnode.data.providedPerps, { locked: false }), 'gestalt');
-    gnode.compileSuperTokens();
-    var after = _.pluck(_.where(gnode.data.providedPerps, { locked: false }), 'gestalt');
+    var before = _.pluck(_.where(this.data.providedPerps, { locked: false }), 'gestalt');
+    this.compileSuperTokens();
+    var after = _.pluck(_.where(this.data.providedPerps, { locked: false }), 'gestalt');
     var newbuyable = _.difference(after, before);
     if (newbuyable.length) {
       groot.makeNotifications({
@@ -3023,13 +3005,12 @@ var Game = function () {
   ///////////////////////////////////
 
   GamePerp.prototype.updateTemplateData = function () {
-    var gnode = this;
     var groot = this.GameRoot;
     // Popup instantiated for the first time
     if (!this.popupTemplateData) {
       this.popupTemplateData = {};
-      this.popupTemplateData.states = gnode.states;
-      this.popupTemplateData.status_icons = gnode.GameRoot.data.status_icons;
+      this.popupTemplateData.states = this.states;
+      this.popupTemplateData.status_icons = this.GameRoot.data.status_icons;
       this.popupTemplateData.data = {};
       this.popupTemplateData.data.gestalt = this.gestalt;
       this.popupTemplateData.data.id = this.id;
@@ -3037,7 +3018,7 @@ var Game = function () {
       this.popupTemplateData.groot = groot;
     }
     // highlight Tabs in popups
-    this.popupTemplateData.highlightTabs = gnode.highlightTabs || [];
+    this.popupTemplateData.highlightTabs = this.highlightTabs || [];
     _.extend(this.popupTemplateData.data, this.data);
     // FIXME: make this get game values method on groot
     this.popupTemplateData.game_values = {
@@ -3046,12 +3027,11 @@ var Game = function () {
   };
 
   GamePerp.prototype.openPopup = function () {
-    var gnode = this;
     var groot = this.GameRoot;
     //gnode.renderNode.setFrame('active');
 
     // Update TemplateData with current gnode data
-    gnode.updateTemplateData();
+    this.updateTemplateData();
 
     var popupConfig = {
       // Fixme: gameNode only used for debug info on logo click
@@ -3063,9 +3043,9 @@ var Game = function () {
 
     var popup = (this.renderPopup = new Render.Popup(popupConfig));
 
-    gnode.ViewMap.renderNode.addPopup(popup);
+    this.ViewMap.renderNode.addPopup(popup);
 
-    gnode.initPopupEvents();
+    this.initPopupEvents();
 
     return popup;
   };
@@ -3197,15 +3177,13 @@ var Game = function () {
   };
 
   GamePerp.prototype.updatePopup = function () {
-    var gnode = this;
-
-    if (gnode.popupTemplateData) {
+    if (this.popupTemplateData) {
       //gnode.popupTemplateData.loading = false;
     }
 
     // Update data with current gnode data
     //_.extend(this.popupTemplateData.data,gnode.data);
-    gnode.updateTemplateData();
+    this.updateTemplateData();
 
     var popupConfig = {
       gameNode: this,
@@ -3219,9 +3197,9 @@ var Game = function () {
     }
     var popup = (this.renderPopup = new Render.Popup(popupConfig));
 
-    gnode.ViewMap.renderNode.addPopup(popup);
+    this.ViewMap.renderNode.addPopup(popup);
 
-    gnode.initPopupEvents();
+    this.initPopupEvents();
 
     return popup;
   };
@@ -3302,9 +3280,9 @@ var Game = function () {
                 perp.renderNode,
                 { mode: perp.cableType },
                 function () {
-                  if (perp.cableType == 'in') {
+                  if (perp.cableType === 'in') {
                     perp.renderNode.FXBounce();
-                  } else if (perp.cableType == 'out') {
+                  } else if (perp.cableType === 'out') {
                     gnode.renderNode.FXBounce();
                   } else {
                     gnode.renderNode.FXBounce();
@@ -3341,8 +3319,7 @@ var Game = function () {
 
   // FIXME DEBUG: testpopup for each gameperp (gets overwritten)
   GamePerp.prototype.extendEventHandlers = function () {
-    var gnode = this;
-    gnode.on('vclick', function (e, renderNode) {
+    this.on('vclick', function (e, renderNode) {
       e.stopPropagation();
       var popup = this.openPopup();
     });
@@ -3353,7 +3330,6 @@ var Game = function () {
   ///////////////////////////////////
 
   var Topscores = function (config) {
-    var gnode = this;
     var groot = this.GameRoot;
     this.ViewMap = this;
     this.queue = new Set();
@@ -3369,7 +3345,6 @@ var Game = function () {
   };
 
   Topscores.prototype.initTopscore = function (type) {
-    var gnode = this;
     var groot = this.GameRoot;
     if (type === undefined) return;
 
@@ -3383,7 +3358,7 @@ var Game = function () {
       ViewMap: getByFirstId('Topscores'),
       gameType: 'Topscore',
     });
-    gnode.addChild(score);
+    this.addChild(score);
     score.render();
     score.renderNode.hide();
     return score;
@@ -3592,34 +3567,30 @@ var Game = function () {
   };
 
   Missions.prototype.getActiveMissions = function () {
-    var mroot = this;
     var groot = this.GameRoot;
-    return _.filter(mroot.Missions, function (m) {
+    return _.filter(this.Missions, function (m) {
       return m.states.active === true && m.states.complete === false;
     });
   };
 
   Missions.prototype.getVisibleMissions = function () {
-    var mroot = this;
     var groot = this.GameRoot;
-    return _.filter(mroot.Missions, function (m) {
+    return _.filter(this.Missions, function (m) {
       return m.states.active === true || m.states.complete === true;
     });
   };
 
   Missions.prototype.getCompletedMissions = function () {
-    var mroot = this;
     var groot = this.GameRoot;
-    return _.filter(mroot.Missions, function (m) {
+    return _.filter(this.Missions, function (m) {
       return m.states.active === false && m.states.complete === true;
     });
   };
 
   Missions.prototype.getNextMissions = function () {
-    var mroot = this;
     var groot = this.GameRoot;
     var next_missions = {};
-    var active_missions = _.each(mroot.getActiveMissions(), function (mission) {
+    var active_missions = _.each(this.getActiveMissions(), function (mission) {
       var next = mission.getNext();
       if (next) {
         next_missions[next.gestalt] = next;
@@ -3629,7 +3600,6 @@ var Game = function () {
   };
 
   Missions.prototype.checkProjectGoals = function () {
-    var mroot = this;
     var groot = this.GameRoot;
     var fetch_project_data = {};
     var update_missions = [];
@@ -3643,8 +3613,8 @@ var Game = function () {
       });
     };
 
-    _.each(mroot.getVisibleMissions(), checkMission);
-    _.each(mroot.getNextMissions(), checkMission);
+    _.each(this.getVisibleMissions(), checkMission);
+    _.each(this.getNextMissions(), checkMission);
 
     _.each(fetch_project_data, function (mission, gestalt) {
       groot.fetchProjectPowerupData(gestalt, function () {
@@ -3760,8 +3730,7 @@ var Game = function () {
   };
 
   Mission.prototype.getNext = function (gestalt) {
-    var mission = this;
-    var mroot = mission.parentNode;
+    var mroot = this.parentNode;
     gestalt = gestalt || this.gestalt;
     return _.find(mroot.Missions, function (m) {
       return m.data.required_mission && m.data.required_mission === gestalt;
@@ -3769,9 +3738,8 @@ var Game = function () {
   };
 
   Mission.prototype.updateRender = function () {
-    var mission = this;
-    if (mission.renderNode) {
-      mission.renderNode.render();
+    if (this.renderNode) {
+      this.renderNode.render();
     }
   };
 
@@ -3802,31 +3770,29 @@ var Game = function () {
   };
 
   Mission.prototype.openMissionPopup = function () {
-    var gnode = this;
     var groot = this.GameRoot;
 
     groot.openGenericPopup({
-      states: gnode.states,
-      data: gnode.data,
+      states: this.states,
+      data: this.data,
       template: 'popup_mission.html',
       extendClass: 'Mission',
     });
   };
 
   Mission.prototype.checkTutorial = function () {
-    var gnode = this;
     var groot = this.GameRoot;
     var mroot = groot.Missions;
-    if (gnode.states.active && gnode.data.tutorial) {
+    if (this.states.active && this.data.tutorial) {
       // If the player already dismissed the mission briefing, the NPC coach
       // intro has already been seen — skip re-queuing on reload.
       var seenBriefings = (groot.raw_data && groot.raw_data.mission_briefings_seen) || {};
-      if (seenBriefings[gnode.gestalt]) {
+      if (seenBriefings[this.gestalt]) {
         return false;
       }
       groot.setState('tutorial_active', true);
       // TODO: check each step for completion and delete everything before
-      var steps = gnode.data.tutorial;
+      var steps = this.data.tutorial;
       var deletefrom = 0;
       _.each(steps, function (step, k) {
         if (step.buyPerp && groot.IPerps.hasOwnProperty(step.buyPerp)) {
@@ -3904,8 +3870,7 @@ var Game = function () {
   };
 
   Mission.prototype.extendRender = function () {
-    var gnode = this;
-    if (!gnode.states.active && !gnode.states.complete) {
+    if (!this.states.active && !this.states.complete) {
       //gnode.renderNode.hide();
     }
   };
@@ -4005,9 +3970,9 @@ var Game = function () {
                 perp.renderNode,
                 { mode: perp.cableType },
                 function () {
-                  if (perp.cableType == 'in') {
+                  if (perp.cableType === 'in') {
                     perp.renderNode.FXBounce();
-                  } else if (perp.cableType == 'out') {
+                  } else if (perp.cableType === 'out') {
                     gnode.renderNode.FXBounce();
                   } else {
                     gnode.renderNode.FXBounce();
@@ -4266,11 +4231,9 @@ var Game = function () {
   };
 
   GamePerp.prototype.getProvidedByRequiredPerps = function () {
-    // returns all provided perps by required providers
-    var gnode = this;
     var groot = this.GameRoot;
     var perps = [];
-    _.each(gnode.data.provided_perps, function (gestalt, key) {
+    _.each(this.data.provided_perps, function (gestalt, key) {
       var type = groot.getType(gestalt);
       if (type.type_data.required_providers && !groot.IPerps.hasOwnProperty(gestalt)) {
         _.each(type.type_data.required_providers, function (provided) {
@@ -4299,11 +4262,9 @@ var Game = function () {
   };
 
   GamePerp.prototype.getProvidedByLevel = function () {
-    // returns all available perp gestalten
-    var gnode = this;
     var groot = this.GameRoot;
     var perps = [];
-    _.each(gnode.data.provided_perps, function (gestalt, key) {
+    _.each(this.data.provided_perps, function (gestalt, key) {
       var type = groot.getType(gestalt);
       if (
         type.type_data.required_level <= groot.xp_level.number &&
@@ -4471,7 +4432,6 @@ var Game = function () {
 
   ContactPerp.prototype.collect = function () {
     var gperp = this;
-    var gnode = this;
     var groot = this.GameRoot;
     var deco = this.renderReady;
     var popup = this.renderPopup;
@@ -4665,15 +4625,14 @@ class CollectableClient(CollectablePerpBase):
   };
 
   ClientPerp.prototype.getKarmaPenalty = function () {
-    var gnode = this;
     var groot = this.GameRoot;
     var karma = groot.karma_value;
     var karma_factor = (karma + 100) / 200 + 0.5;
     karma_factor = karma_factor > 1 ? 1 : karma_factor;
     if (karma_factor < 1) {
-      gnode.data.karma_penalty = true;
+      this.data.karma_penalty = true;
     } else {
-      gnode.data.karma_penalty = false;
+      this.data.karma_penalty = false;
     }
     return karma_factor;
   };
@@ -4693,10 +4652,9 @@ class CollectableClient(CollectablePerpBase):
 
   ClientPerp.prototype.getIncome = function (nopenalty) {
     var groot = this.GameRoot;
-    var gnode = this;
-    var base_income = gnode.data.income_base;
-    var base_income_factor = gnode.data.income_factor;
-    var consumed_tokens = gnode.data.consumed_tokens;
+    var base_income = this.data.income_base;
+    var base_income_factor = this.data.income_factor;
+    var consumed_tokens = this.data.consumed_tokens;
     var db_profiles = groot.DBTokens;
     var sum = [];
     _.each(consumed_tokens, function (token, k) {
@@ -4711,10 +4669,10 @@ class CollectableClient(CollectablePerpBase):
       0
     );
     var db_fill_factor = groot.getDBFactorNormalized();
-    var karma_penalty_factor = nopenalty ? 1 : gnode.getKarmaPenalty();
-    amount = Math.pow(amount * db_fill_factor, 0.6);
+    var karma_penalty_factor = nopenalty ? 1 : this.getKarmaPenalty();
+    amount = (amount * db_fill_factor) ** 0.6;
     //var result = parseInt( karma_penalty_factor * Math.round( (base_income + (amount * base_income * (base_income_factor/1000))) /10 ) * 10 );
-    var result = parseInt(
+    var result = Number.parseInt(
       karma_penalty_factor *
         Math.round(base_income + amount * base_income * (base_income_factor / 1000))
     );
@@ -4776,7 +4734,6 @@ class CollectableClient(CollectablePerpBase):
 
   ClientPerp.prototype.collect = function () {
     var gperp = this;
-    var gnode = this;
     var groot = this.GameRoot;
     var deco = gperp.renderReady;
     // No Request when no AP
@@ -4971,17 +4928,16 @@ class CollectableClient(CollectablePerpBase):
   };
 
   ProxyPerp.prototype.updateRenderSlotStatus = function () {
-    var gnode = this;
-    var node = gnode.renderNode;
-    gnode.data.used_slots = gnode.children.set.length;
-    if (gnode.data.used_slots < gnode.data.max_slots) {
+    var node = this.renderNode;
+    this.data.used_slots = this.children.set.length;
+    if (this.data.used_slots < this.data.max_slots) {
       node.addDecorator(
         new Render.DecoratorLabel({
-          text: gnode.data.label + '<br />' + gnode.data.used_slots + '/' + gnode.data.max_slots,
+          text: this.data.label + '<br />' + this.data.used_slots + '/' + this.data.max_slots,
         })
       );
     } else {
-      node.addDecorator(new Render.DecoratorLabel({ text: gnode.data.label }));
+      node.addDecorator(new Render.DecoratorLabel({ text: this.data.label }));
     }
   };
 
@@ -5004,10 +4960,9 @@ class CollectableClient(CollectablePerpBase):
   ProjectPerp.prototype.textNewItems = _._('New Powerups!');
 
   ProjectPerp.prototype.compileProfileSet = function () {
-    var gnode = this;
-    gnode.data.ProfileSet = new ProfileSet(
+    this.data.ProfileSet = new ProfileSet(
       { markNew: true, lockAmountZero: true },
-      gnode.data.tokens
+      this.data.tokens
     );
   };
 
@@ -5051,6 +5006,7 @@ class CollectableClient(CollectablePerpBase):
   ProjectPerp.prototype.fetchPowerups = function (cb) {
     this.GameRoot.fetchProjectPowerupData(this.gestalt, cb);
     return;
+    // biome-ignore lint/correctness/noUnreachable: legacy dead code, kept as reference for future re-enable
     var gnode = this;
     // Register Powerups in typeRegistry if opend for the first time move this to compilePowerupsa
     if (!gnode.data.powerups_compiled) {
@@ -5193,12 +5149,10 @@ class CollectableClient(CollectablePerpBase):
   };
 
   ProjectPerp.prototype.removeProvidedPowerup = function (bgestalt) {
-    // Does not actually remove powerup but flags as bought
-    var gnode = this;
     var provided = {
-      provided_ads: gnode.data.provided_ads,
-      provided_upgrades: gnode.data.provided_upgrades,
-      provided_teammembers: gnode.data.provided_teammembers,
+      provided_ads: this.data.provided_ads,
+      provided_upgrades: this.data.provided_upgrades,
+      provided_teammembers: this.data.provided_teammembers,
     };
     _.each(provided, function (p, key) {
       var deleteme = _.findWhere(p, { gestalt: bgestalt });
@@ -5210,12 +5164,10 @@ class CollectableClient(CollectablePerpBase):
   };
 
   ProjectPerp.prototype.addProvidedPowerup = function (bgestalt) {
-    // Does not actually add powerup but unflags as bought
-    var gnode = this;
     var provided = {
-      provided_ads: gnode.data.provided_ads,
-      provided_upgrades: gnode.data.provided_upgrades,
-      provided_teammembers: gnode.data.provided_teammembers,
+      provided_ads: this.data.provided_ads,
+      provided_upgrades: this.data.provided_upgrades,
+      provided_teammembers: this.data.provided_teammembers,
     };
     _.each(provided, function (p, key) {
       var addme = _.findWhere(p, { gestalt: bgestalt });
@@ -5226,14 +5178,11 @@ class CollectableClient(CollectablePerpBase):
   };
 
   GameNode.prototype.Error = function (errormsg, data) {
-    // TODO: consolidate Error Codes on Backend and parse them with this function
-    // try to display an error or fallback to game root
-    var gnode = this;
     var groot = this.GameRoot;
-    if (gnode.renderPopup && gnode.renderPopup.open) {
-      gnode.renderPopup.trigger('error');
-    } else if (gnode.renderNode) {
-      gnode.renderNode.FXError();
+    if (this.renderPopup && this.renderPopup.open) {
+      this.renderPopup.trigger('error');
+    } else if (this.renderNode) {
+      this.renderNode.FXError();
     } else if (groot) {
       groot.renderNode.FXError();
     }
@@ -5243,20 +5192,18 @@ class CollectableClient(CollectablePerpBase):
   };
 
   GameNode.prototype.NoCash = function () {
-    var gnode = this;
-    if (gnode.renderPopup && gnode.renderPopup.open) {
-      gnode.renderPopup.trigger('no_cash');
+    if (this.renderPopup && this.renderPopup.open) {
+      this.renderPopup.trigger('no_cash');
     } else {
-      gnode.renderNode.FXNoCash();
+      this.renderNode.FXNoCash();
     }
   };
 
   GameNode.prototype.NoAP = function () {
-    var gnode = this;
-    if (gnode.renderPopup && gnode.renderPopup.open) {
-      gnode.renderPopup.trigger('no_AP');
+    if (this.renderPopup && this.renderPopup.open) {
+      this.renderPopup.trigger('no_AP');
     } else {
-      gnode.renderNode.FXNoAP();
+      this.renderNode.FXNoAP();
     }
   };
 
@@ -5334,7 +5281,7 @@ class CollectableClient(CollectablePerpBase):
     // TODO: backendcall and do purchase...
 
     app.remote
-      .sellPowerup(gnode.path, parseInt(bslot), bgestalt)
+      .sellPowerup(gnode.path, Number.parseInt(bslot), bgestalt)
       .done(function (data) {
         if (data.result) {
           if (data.result.error !== undefined) {
@@ -5370,7 +5317,7 @@ class CollectableClient(CollectablePerpBase):
 
   ProjectPerp.prototype.BuySlots = function (num, bgestalt) {
     var pcat = convertPowerupType(bgestalt.split(':')[1]);
-    num = parseInt(num, 10) || 1;
+    num = Number.parseInt(num, 10) || 1;
 
     var gnode = this;
     var groot = this.GameRoot;
@@ -5452,28 +5399,27 @@ class CollectableClient(CollectablePerpBase):
   };
 
   ProjectPerp.prototype.updatePopupGracefully = function (bslot, bgestalt, selling) {
-    var gnode = this;
     var pcat = getPowerupTypeFromGestalt(bgestalt);
-    gnode.updateTemplateData();
-    if (gnode.popupTemplateData) {
-      gnode.popupTemplateData.loading = false;
+    this.updateTemplateData();
+    if (this.popupTemplateData) {
+      this.popupTemplateData.loading = false;
     }
 
-    if (!gnode.renderPopup) {
+    if (!this.renderPopup) {
       return;
     }
 
-    var popup = gnode.renderPopup;
+    var popup = this.renderPopup;
     popup.renderDataTab();
     popup.renderPowerupSelectors(pcat);
 
-    var jpop = gnode.renderPopup.jdomelem;
+    var jpop = this.renderPopup.jdomelem;
     var jtab = jpop.find('.PopupTab[data-tab="' + pcat + '"]');
     if (!selling) {
       // Buying a Powerup
       var slot = jtab.find('.Powerup.free[data-button-data="' + bslot + '"]');
       slot.removeAttr('data-subpop-id');
-      var powerup = _.findWhere(gnode.data.powerups, { gestalt: bgestalt });
+      var powerup = _.findWhere(this.data.powerups, { gestalt: bgestalt });
       var jpowerup = _.renderView('powerup.html', {
         powerup: powerup,
         slot: bslot,
@@ -5512,9 +5458,9 @@ class CollectableClient(CollectablePerpBase):
       slot.removeAttr('data-subpop-id');
       var jpowerup = _.renderView('powerup_free.html', {
         slot: bslot,
-        slot_background: gnode.data.slot_background,
+        slot_background: this.data.slot_background,
         pkey: pcat,
-        data: gnode.popupTemplateData.data,
+        data: this.popupTemplateData.data,
         typelower: convertPowerupType(pcat),
         updating: true,
       });
@@ -5625,7 +5571,6 @@ class CollectableClient(CollectablePerpBase):
 
   ProjectPerp.prototype.collect = function () {
     var gperp = this;
-    var gnode = this;
     var groot = this.GameRoot;
     var deco = this.renderReady;
     var popup = gperp.renderPopup;
@@ -5761,13 +5706,12 @@ class CollectableClient(CollectablePerpBase):
   };
 
   TokenPerp.prototype.updateGear = function () {
-    var gnode = this;
-    if (gnode.data.contained_tokens.length === 0 || gnode.renderNode === undefined) {
+    if (this.data.contained_tokens.length === 0 || this.renderNode === undefined) {
       return;
     }
-    gnode.makeProfileSet();
+    this.makeProfileSet();
     var node = this.renderNode;
-    var av = gnode.getUpgradeAverage();
+    var av = this.getUpgradeAverage();
     var frame = av > 0 ? 'normal' : 'inactive';
     if (!node.DecoratorGear === undefined) {
       node.addDecorator(new Render.DecoratorGear());
@@ -5776,19 +5720,18 @@ class CollectableClient(CollectablePerpBase):
   };
 
   TokenPerp.prototype.getUpgradeAverage = function () {
-    var gnode = this;
-    gnode.setState('zeroresult', true);
-    if (!gnode.data.ProfileSet) {
+    this.setState('zeroresult', true);
+    if (!this.data.ProfileSet) {
       return 0;
     }
     var amounts = [];
-    _.each(gnode.data.ProfileSet.tokens_set, function (token) {
+    _.each(this.data.ProfileSet.tokens_set, function (token) {
       if (!token.locked && token.diffAmount !== undefined) {
         amounts.push(token.diffAmount);
       }
     });
     var len = amounts.length || 1;
-    gnode.data.upgradeAverage =
+    this.data.upgradeAverage =
       Math.round(
         (_.reduce(
           amounts,
@@ -5800,10 +5743,10 @@ class CollectableClient(CollectablePerpBase):
           len) *
           100
       ) / 100;
-    if (gnode.data.upgradeAverage > 0) {
-      gnode.setState('zeroresult', false);
+    if (this.data.upgradeAverage > 0) {
+      this.setState('zeroresult', false);
     }
-    return gnode.data.upgradeAverage;
+    return this.data.upgradeAverage;
   };
 
   TokenPerp.prototype.extendRender = function () {
@@ -5854,15 +5797,14 @@ class CollectableClient(CollectablePerpBase):
   };
 
   TokenPerp.prototype.makeProfileSet = function () {
-    var gnode = this;
-    gnode.data.ProfileSet = new ProfileSet(
+    this.data.ProfileSet = new ProfileSet(
       {
         lockNotInDB: true,
         DBAmounts: true,
         markUpgradeValues: true,
-        lastUpgradeValues: gnode.data.last_upgrade_values,
+        lastUpgradeValues: this.data.last_upgrade_values,
       },
-      gnode.data.contained_tokens
+      this.data.contained_tokens
     );
   };
 

--- a/scripts/LocalEngine.ts
+++ b/scripts/LocalEngine.ts
@@ -10,15 +10,15 @@
 // resetGame is intentionally absent — in webxdc, reset = re-share the .xdc.
 // Remaining handlers are stubs that return a rejected Promise.
 
-import { getState, setState } from './boot.js';
-import { applyDelta } from './state.js';
-import type { LocalState, Delta, GameValues, GameNode, MissionGoal } from './state.js';
-import { materialize } from './materializer.js';
-import { now as clockNow } from './clock.js';
 import rulesetDe from '../data/ruleset_3.de.json' with { type: 'json' };
 import rulesetEn from '../data/ruleset_3.en.json' with { type: 'json' };
 import i18nDe from '../i18n/de_AT.json' with { type: 'json' };
 import i18nEn from '../i18n/en_US.json' with { type: 'json' };
+import { getState, setState } from './boot.js';
+import { now as clockNow } from './clock.js';
+import { materialize } from './materializer.js';
+import { applyDelta } from './state.js';
+import type { Delta, GameNode, GameValues, LocalState, MissionGoal } from './state.js';
 
 // ---------------------------------------------------------------------------
 // Local types
@@ -770,6 +770,7 @@ function _mkDelta(addr: string, op: string, args: unknown[], result: unknown): D
 // ---------------------------------------------------------------------------
 
 // Printable Unicode, 1–30 chars; no ASCII control chars (< 0x20) or DEL (0x7f).
+// biome-ignore lint/suspicious/noControlCharactersInRegex: intentional char-class exclusion for control chars
 var DISPLAY_NAME_RE = /^[^\x00-\x1f\x7f]{1,30}$/;
 
 function validateDisplayName(name: unknown): name is string {
@@ -1259,7 +1260,7 @@ export function buySlots(
   slotType: string,
   num: number | string
 ): Promise<{ result: { error: number } | Record<string, unknown> }> {
-  var nNum = parseInt(String(num), 10) || 1;
+  var nNum = Number.parseInt(String(num), 10) || 1;
   var r = _resolveNode(perpPath);
   if (!r) return Promise.resolve({ result: { error: 0 } });
   var state = r.state,
@@ -1276,7 +1277,7 @@ export function buySlots(
   // function works on plain `number` values.
   var currentSlots: number =
     _readNumber(node.instance_data, slotKey) ?? _readNumber(perpTypeData, slotKey) ?? 0;
-  var maxSlots: number = _readNumber(perpTypeData, maxKey) ?? Infinity;
+  var maxSlots: number = _readNumber(perpTypeData, maxKey) ?? Number.POSITIVE_INFINITY;
 
   if (currentSlots + nNum > maxSlots) return Promise.resolve({ result: { error: 2 } });
 
@@ -2244,7 +2245,7 @@ function _handleKarmaIncident(gv: GameValues, ruleset: Ruleset): KarmaIncident |
   var karma = (gv && gv.karma_value) || 0;
   if (karma >= 0) return null;
 
-  var factor = Math.pow(-karma / 100, 0.5) + 0.05;
+  var factor = (-karma / 100) ** 0.5 + 0.05;
   if (_rng() >= factor) return null;
 
   var level = (gv && gv.xp_level) || 1;
@@ -2423,6 +2424,7 @@ export function collectPerp(
     last_seen_ts: Math.max(now, ms.last_seen_ts || 0),
   });
 
+  // biome-ignore lint/suspicious/noImplicitAnyLet: typed on first assignment below
   var collectMissionResult;
   if (gameType === 'ContactPerp') {
     collectMissionResult = _advanceCollectProfilesMissions(

--- a/scripts/LocalEngine.ts
+++ b/scripts/LocalEngine.ts
@@ -257,7 +257,7 @@ function _readNumber(rec: object | undefined, key: string): number | undefined {
 
 function _getRuleset(): Ruleset {
   var state = getState();
-  var locale: Locale = (state && state.locale === 'en') ? 'en' : 'de';
+  var locale: Locale = state && state.locale === 'en' ? 'en' : 'de';
   return (locale === 'en' ? rulesetEn : rulesetDe) as unknown as Ruleset;
 }
 
@@ -337,10 +337,10 @@ export function setSendAchievement(fn: AchievementSender): void {
 // Locale-aware format-string lookup.  Replaces %s tokens left-to-right.
 function _t(msgid: string, ...subs: unknown[]): string {
   var state = getState();
-  var locale: Locale = (state && state.locale === 'en') ? 'en' : 'de';
+  var locale: Locale = state && state.locale === 'en' ? 'en' : 'de';
   var table = (locale === 'en' ? i18nEn : i18nDe) as unknown as I18nTable;
   var entry = table[msgid];
-  var tmpl: string = (entry && entry[1]) ? entry[1] : msgid;
+  var tmpl: string = entry && entry[1] ? entry[1] : msgid;
   for (var i = 0; i < subs.length; i++) {
     tmpl = tmpl.replace('%s', String(subs[i]));
   }
@@ -356,7 +356,7 @@ function triggerAchievement(
 ): void {
   var state = getState();
   var addr = state ? state.addr : '';
-  var name = state ? (state.display_name || addr) : addr;
+  var name = state ? state.display_name || addr : addr;
   // kind: 'achievement' is the top-level discriminator for webxdc consumers.
   // achievement_kind carries the subtype (mission_done, levelup, joined, …).
   var payload: AchievementPayload = {
@@ -367,7 +367,9 @@ function triggerAchievement(
     ts: clockNow(),
   };
   if (extraPayload) Object.assign(payload, extraPayload);
-  if (_sendAchievementFn) { _sendAchievementFn({ info: info, payload: payload }); }
+  if (_sendAchievementFn) {
+    _sendAchievementFn({ info: info, payload: payload });
+  }
   if (typeof webxdc !== 'undefined' && webxdc) {
     webxdc.sendUpdate({ info: info, payload: payload }, '');
   }
@@ -401,15 +403,15 @@ function _djb2(str: string): number {
 }
 
 function _seededRand(seed: number): number {
-  var s = (seed >>> 0);
+  var s = seed >>> 0;
   s = (Math.imul(1664525, s) + 1013904223) >>> 0;
-  return s / 0xFFFFFFFF;
+  return s / 0xffffffff;
 }
 
 function _getVariatedAmount(baseAmount: number, ts: number, path: string): number {
-  var seed = ((ts & 0xFFFFFFFF) ^ _djb2(path)) >>> 0;
-  var rand = _seededRand(seed);        // uniform 0..1
-  var variation = rand * 0.1 - 0.05;  // map to −0.05…+0.05 (±5%)
+  var seed = ((ts & 0xffffffff) ^ _djb2(path)) >>> 0;
+  var rand = _seededRand(seed); // uniform 0..1
+  var variation = rand * 0.1 - 0.05; // map to −0.05…+0.05 (±5%)
   return Math.round(baseAmount * (1 + variation));
 }
 
@@ -422,7 +424,7 @@ function _getVariatedAmount(baseAmount: number, ts: number, path: string): numbe
  * Returns webxdc.selfAddr (or 'local' in non-webxdc environments).
  */
 export function getToken(): Promise<{ result: string }> {
-  var addr = (typeof webxdc !== 'undefined' && webxdc) ? webxdc.selfAddr : '';
+  var addr = typeof webxdc !== 'undefined' && webxdc ? webxdc.selfAddr : '';
   return Promise.resolve({ result: addr || 'local' });
 }
 
@@ -441,7 +443,7 @@ export function ping(): Promise<{ result: 'pong' }> {
  */
 export function getSessionLocale(): Promise<{ result: Locale }> {
   var state = getState();
-  var locale: Locale = (state && state.locale === 'en') ? 'en' : 'de';
+  var locale: Locale = state && state.locale === 'en' ? 'en' : 'de';
   return Promise.resolve({ result: locale });
 }
 
@@ -500,10 +502,12 @@ export function loadGame(): Promise<{ result: ReturnType<typeof _buildLoadGameRe
   var startupRepair = _repairStuckMissionGoals(seededState);
   if (startupRepair && startupRepair.missions) {
     var startupGv = _applyRewardsToGv(seededState.game_values || {}, startupRepair.rewards);
-    _persistDelta(_mkDelta(seededState.addr, 'recheckMissions', [], {
-      game_values: startupGv,
-      missions: startupRepair.missions,
-    }));
+    _persistDelta(
+      _mkDelta(seededState.addr, 'recheckMissions', [], {
+        game_values: startupGv,
+        missions: startupRepair.missions,
+      })
+    );
     seededState = getState();
   }
 
@@ -550,7 +554,7 @@ function _buildLoadGameResponse(state: LocalState, now: number, isNewGame: boole
   var gv = state.game_values || {};
   var gameValues = Object.assign({}, gv, {
     ap_initial: typeof gv.ap_snapshot === 'number' ? gv.ap_snapshot : 0,
-    ap_offset: 0
+    ap_offset: 0,
   });
 
   return {
@@ -561,23 +565,23 @@ function _buildLoadGameResponse(state: LocalState, now: number, isNewGame: boole
     // GameRoot.getLevelByXP (Game.js:1704).
     type_data: {
       levels: ruleset.levels,
-      game_values: gameValues
+      game_values: gameValues,
     },
     user: {
       auth_username: state.addr,
-      display_name: state.display_name || ''
+      display_name: state.display_name || '',
     },
     Imperium: {
       game_id: 'Imperium',
       full_path: 'Imperium',
       instance_data: {},
-      type_data: {}
+      type_data: {},
     },
     Database: {
       game_id: 'Database',
       full_path: 'Database',
       instance_data: {},
-      type_data: {}
+      type_data: {},
     },
     nodes: state.nodes || [],
     nodes_charging: state.nodes_charging || [],
@@ -596,7 +600,7 @@ function _buildLoadGameResponse(state: LocalState, now: number, isNewGame: boole
     // dismissMissionBriefing / markTokenSeen think the gestalt is already
     // seen and skip the delta commit, so the dismissal never persists).
     mission_briefings_seen: Object.assign({}, state.mission_briefings_seen || {}),
-    tokens_seen: Object.assign({}, state.tokens_seen || {})
+    tokens_seen: Object.assign({}, state.tokens_seen || {}),
   };
 }
 
@@ -673,7 +677,11 @@ export function getPowerups(
 // forward-facing field. Unknown types fall back to 'xp' with a console.warn.
 type RankingField = 'cash' | 'profiles' | 'xp' | 'level' | 'spent';
 const _RANKING_FIELDS: Record<RankingField, true> = {
-  cash: true, profiles: true, xp: true, level: true, spent: true,
+  cash: true,
+  profiles: true,
+  xp: true,
+  level: true,
+  spent: true,
 };
 
 function _isRankingField(s: string): s is RankingField {
@@ -710,19 +718,21 @@ export function getRanking(
     };
   });
 
-  rows.sort(function (a, b) { return b.value - a.value; });
+  rows.sort(function (a, b) {
+    return b.value - a.value;
+  });
 
   var selfIdx = -1;
   for (var i = 0; i < rows.length; i++) {
     var row = rows[i];
-    if (row && row.self) { selfIdx = i; break; }
+    if (row && row.self) {
+      selfIdx = i;
+      break;
+    }
   }
 
   var n = rows.length;
-  var userRank = n === 0 ? 0
-    : selfIdx < 0 ? 0
-    : n === 1 ? 1
-    : 1 - selfIdx / (n - 1);
+  var userRank = n === 0 ? 0 : selfIdx < 0 ? 0 : n === 1 ? 1 : 1 - selfIdx / (n - 1);
 
   return Promise.resolve({ result: { top: rows, user_rank: userRank } });
 }
@@ -746,12 +756,12 @@ export function getRanking(
  */
 function _mkDelta(addr: string, op: string, args: unknown[], result: unknown): Delta {
   return {
-    kind:   'delta',
-    addr:   addr,
-    op:     op,
-    args:   args as unknown[] as never[],
+    kind: 'delta',
+    addr: addr,
+    op: op,
+    args: args as unknown[] as never[],
     result: result as unknown,
-    ts:     clockNow(),
+    ts: clockNow(),
   } as Delta;
 }
 
@@ -821,7 +831,7 @@ export function setPerpCoordinates(updates: unknown): Promise<{ result: 1 }> {
     var entry = updates[i];
     if (!Array.isArray(entry) || entry.length < 2) continue;
     var path = entry[0];
-    var pos  = entry[1];
+    var pos = entry[1];
     if (typeof path !== 'string' || !pos || typeof pos !== 'object') continue;
     coordMap[path] = pos;
   }
@@ -897,14 +907,15 @@ export function buyKarma(
 
   if (levelup) newGv.ap_snapshot = newLevel.ap_max;
 
-  _persistDelta(_mkDelta(state.addr, 'buyKarma', [karmalauterGestalt],
-    { game_values: newGv }));
+  _persistDelta(_mkDelta(state.addr, 'buyKarma', [karmalauterGestalt], { game_values: newGv }));
 
   // Achievements
   var _bkDisplayName = state.display_name || state.addr;
   if (levelup) {
-    triggerAchievement('levelup',
-      _t('achievement_levelup', _bkDisplayName, String(newLevel.number)));
+    triggerAchievement(
+      'levelup',
+      _t('achievement_levelup', _bkDisplayName, String(newLevel.number))
+    );
   }
   var _bkOldKarma = gv.karma_value || 0;
   if (_bkOldKarma !== 100 && newKarma === 100) {
@@ -937,14 +948,17 @@ function _resolveNode(perpPath: string): ResolvedNode | null {
   var nodeIdx = -1;
   for (var i = 0; i < state.nodes.length; i++) {
     var n0 = state.nodes[i];
-    if (n0 && n0.full_path === perpPath) { nodeIdx = i; break; }
+    if (n0 && n0.full_path === perpPath) {
+      nodeIdx = i;
+      break;
+    }
   }
   if (nodeIdx === -1) return null;
   var node = state.nodes[nodeIdx];
   if (!node) return null;
   var ft = node.full_type || '';
   var colon = ft.indexOf(':');
-  var perpGestalt = colon >= 0 ? ft.slice(colon + 1) : (node.gestalt || '');
+  var perpGestalt = colon >= 0 ? ft.slice(colon + 1) : node.gestalt || '';
   var perpTypeDef = _getRuleset().perps[perpGestalt];
   if (!perpTypeDef || !perpTypeDef.type_data) return null;
   return { state: state, nodeIdx: nodeIdx, node: node, perpTypeData: perpTypeDef.type_data };
@@ -999,9 +1013,9 @@ function _computeModifiers(perpTypeData: PerpTypeData, powerups: PowerupDef[]): 
     if (!pu || !pu.gestalt) continue;
     var puDef = defByGestalt[pu.gestalt];
     if (puDef) {
-      chargeCost    += puDef.charge_cost_modifier    || 0;
+      chargeCost += puDef.charge_cost_modifier || 0;
       collectAmount += puDef.collect_amount_modifier || 0;
-      collectRisk   += puDef.collect_risk_modifier   || 0;
+      collectRisk += puDef.collect_risk_modifier || 0;
     }
   }
   return { charge_cost: chargeCost, collect_amount: collectAmount, collect_risk: collectRisk };
@@ -1045,7 +1059,10 @@ export function buyPowerup(
 ): Promise<{ result: { error: number } | Record<string, unknown> }> {
   var r = _resolveNode(perpPath);
   if (!r) return Promise.resolve({ result: { error: 0 } });
-  var state = r.state, nodeIdx = r.nodeIdx, node = r.node, perpTypeData = r.perpTypeData;
+  var state = r.state,
+    nodeIdx = r.nodeIdx,
+    node = r.node,
+    perpTypeData = r.perpTypeData;
 
   var puDef = _findPowerupDef(perpTypeData, gestalt);
   if (!puDef) return Promise.resolve({ result: { error: 0 } });
@@ -1070,20 +1087,20 @@ export function buyPowerup(
   var mods = _computeModifiers(perpTypeData, newPowerups);
 
   var newInstanceData = Object.assign({}, node.instance_data, {
-    powerups:       newPowerups,
-    charge_cost:    mods.charge_cost,
+    powerups: newPowerups,
+    charge_cost: mods.charge_cost,
     collect_amount: mods.collect_amount,
-    collect_risk:   mods.collect_risk,
-    tokens:         perpTypeData.tokens || [],
+    collect_risk: mods.collect_risk,
+    tokens: perpTypeData.tokens || [],
   });
 
   var newXp = (state.game_values.xp_value || 0) + (perpTypeData.xp_inc || 1);
   var levelup = _checkLevelup(state.game_values.xp_level || 1, newXp);
 
   var newGameValues: GameValues = Object.assign({}, state.game_values, {
-    cash_value:  cashValue - price,
-    cash_spent:  (state.game_values.cash_spent  || 0) + price,
-    xp_value:    newXp,
+    cash_value: cashValue - price,
+    cash_spent: (state.game_values.cash_spent || 0) + price,
+    xp_value: newXp,
     karma_value: (state.game_values.karma_value || 0) + 1,
   });
   if (levelup) newGameValues.xp_level = _getLevelByXP(newXp);
@@ -1096,32 +1113,40 @@ export function buyPowerup(
   newGameValues = _applyRewardsToGv(newGameValues, puMissionResult.rewards);
 
   var responseNode = {
-    game_id: node.game_id, game_type: node.game_type,
-    full_path: node.full_path, instance_data: newInstanceData,
+    game_id: node.game_id,
+    game_type: node.game_type,
+    full_path: node.full_path,
+    instance_data: newInstanceData,
   };
   var result = {
-    node: responseNode, game_values: newGameValues, levelup: levelup,
+    node: responseNode,
+    game_values: newGameValues,
+    levelup: levelup,
     missions: puMissionResult.missions || null,
   };
 
-  _persistDelta(_mkDelta(state.addr, 'buyPowerup',
-    [perpPath, slot, gestalt], result));
+  _persistDelta(_mkDelta(state.addr, 'buyPowerup', [perpPath, slot, gestalt], result));
 
   // Achievements
   var _bpuDisplayName = state.display_name || state.addr;
   if (levelup) {
-    triggerAchievement('levelup',
-      _t('achievement_levelup', _bpuDisplayName, String(newGameValues.xp_level)));
+    triggerAchievement(
+      'levelup',
+      _t('achievement_levelup', _bpuDisplayName, String(newGameValues.xp_level))
+    );
   }
-  var _bpuCompletedMissions = (puMissionResult.missions && puMissionResult.missions.complete_missions) || [];
+  var _bpuCompletedMissions =
+    (puMissionResult.missions && puMissionResult.missions.complete_missions) || [];
   for (var _bpuMi = 0; _bpuMi < _bpuCompletedMissions.length; _bpuMi++) {
     var mGestalt = _bpuCompletedMissions[_bpuMi];
     if (typeof mGestalt !== 'string') continue;
     var _bpuMDef = _findMissionDef(_getRuleset(), mGestalt);
     var _bpuMTitle = (_bpuMDef && _bpuMDef.type_data && _bpuMDef.type_data.title) || mGestalt;
-    triggerAchievement('mission_done',
+    triggerAchievement(
+      'mission_done',
       _t('achievement_mission_done', _bpuDisplayName, _bpuMTitle),
-      { mission: mGestalt });
+      { mission: mGestalt }
+    );
   }
   var _bpuOldKarma = state.game_values.karma_value || 0;
   var _bpuNewKarma = newGameValues.karma_value || 0;
@@ -1150,30 +1175,38 @@ export function sellPowerup(
 ): Promise<{ result: { error: number } | Record<string, unknown> }> {
   var r = _resolveNode(perpPath);
   if (!r) return Promise.resolve({ result: { error: 0 } });
-  var state = r.state, nodeIdx = r.nodeIdx, node = r.node, perpTypeData = r.perpTypeData;
+  var state = r.state,
+    nodeIdx = r.nodeIdx,
+    node = r.node,
+    perpTypeData = r.perpTypeData;
 
   var idata: NodeInstanceData = node.instance_data || {};
   var powerups: PowerupDef[] = idata.powerups || [];
   var puEntry: PowerupDef | null = null;
   for (var i = 0; i < powerups.length; i++) {
     var p0 = powerups[i];
-    if (p0 && p0.slot === slot) { puEntry = p0; break; }
+    if (p0 && p0.slot === slot) {
+      puEntry = p0;
+      break;
+    }
   }
   if (!puEntry) return Promise.resolve({ result: { error: 1 } });
 
   var puDef = puEntry.gestalt ? _findPowerupDef(perpTypeData, puEntry.gestalt) : null;
-  var price = puDef ? (puDef.price || 0) : 0;
+  var price = puDef ? puDef.price || 0 : 0;
   var refund = Math.floor(price * 0.75);
 
-  var newPowerups: PowerupDef[] = powerups.filter(function (p) { return p && p.slot !== slot; });
+  var newPowerups: PowerupDef[] = powerups.filter(function (p) {
+    return p && p.slot !== slot;
+  });
   var mods = _computeModifiers(perpTypeData, newPowerups);
 
   var newInstanceData = Object.assign({}, node.instance_data, {
-    powerups:       newPowerups,
-    charge_cost:    mods.charge_cost,
+    powerups: newPowerups,
+    charge_cost: mods.charge_cost,
     collect_amount: mods.collect_amount,
-    collect_risk:   mods.collect_risk,
-    tokens:         perpTypeData.tokens || [],
+    collect_risk: mods.collect_risk,
+    tokens: perpTypeData.tokens || [],
   });
 
   var newXp = (state.game_values.xp_value || 0) + 1;
@@ -1181,7 +1214,7 @@ export function sellPowerup(
 
   var newGameValues: GameValues = Object.assign({}, state.game_values, {
     cash_value: (state.game_values.cash_value || 0) + refund,
-    xp_value:   newXp,
+    xp_value: newXp,
   });
   if (levelup) newGameValues.xp_level = _getLevelByXP(newXp);
 
@@ -1189,18 +1222,21 @@ export function sellPowerup(
   newNodes[nodeIdx] = Object.assign({}, node, { instance_data: newInstanceData });
 
   var responseNode = {
-    game_id: node.game_id, game_type: node.game_type,
-    full_path: node.full_path, instance_data: newInstanceData,
+    game_id: node.game_id,
+    game_type: node.game_type,
+    full_path: node.full_path,
+    instance_data: newInstanceData,
   };
   var result = { node: responseNode, game_values: newGameValues, levelup: levelup };
 
-  _persistDelta(_mkDelta(state.addr, 'sellPowerup',
-    [perpPath, slot, gestalt], result));
+  _persistDelta(_mkDelta(state.addr, 'sellPowerup', [perpPath, slot, gestalt], result));
 
   if (levelup) {
     var _spDisplayName = state.display_name || state.addr;
-    triggerAchievement('levelup',
-      _t('achievement_levelup', _spDisplayName, String(newGameValues.xp_level)));
+    triggerAchievement(
+      'levelup',
+      _t('achievement_levelup', _spDisplayName, String(newGameValues.xp_level))
+    );
   }
 
   return Promise.resolve({ result: result });
@@ -1226,9 +1262,12 @@ export function buySlots(
   var nNum = parseInt(String(num), 10) || 1;
   var r = _resolveNode(perpPath);
   if (!r) return Promise.resolve({ result: { error: 0 } });
-  var state = r.state, nodeIdx = r.nodeIdx, node = r.node, perpTypeData = r.perpTypeData;
+  var state = r.state,
+    nodeIdx = r.nodeIdx,
+    node = r.node,
+    perpTypeData = r.perpTypeData;
   var slotKey = slotType + '_slots';
-  var maxKey  = 'max_' + slotType + '_slots';
+  var maxKey = 'max_' + slotType + '_slots';
 
   // PerpTypeData / NodeInstanceData both whitelist their typed fields and
   // fall through to `[key: string]: unknown` for the long tail. The slot
@@ -1236,9 +1275,7 @@ export function buySlots(
   // open-ended portion — read once via _readNumber and the rest of the
   // function works on plain `number` values.
   var currentSlots: number =
-    _readNumber(node.instance_data, slotKey) ??
-    _readNumber(perpTypeData, slotKey) ??
-    0;
+    _readNumber(node.instance_data, slotKey) ?? _readNumber(perpTypeData, slotKey) ?? 0;
   var maxSlots: number = _readNumber(perpTypeData, maxKey) ?? Infinity;
 
   if (currentSlots + nNum > maxSlots) return Promise.resolve({ result: { error: 2 } });
@@ -1262,7 +1299,7 @@ export function buySlots(
   var newGameValues: GameValues = Object.assign({}, state.game_values, {
     cash_value: cashValue - totalCost,
     cash_spent: (state.game_values.cash_spent || 0) + totalCost,
-    xp_value:   newXp,
+    xp_value: newXp,
   });
   if (levelup) newGameValues.xp_level = _getLevelByXP(newXp);
 
@@ -1270,18 +1307,21 @@ export function buySlots(
   newNodes[nodeIdx] = Object.assign({}, node, { instance_data: newInstanceData });
 
   var responseNode = {
-    game_id: node.game_id, game_type: node.game_type,
-    full_path: node.full_path, instance_data: newInstanceData,
+    game_id: node.game_id,
+    game_type: node.game_type,
+    full_path: node.full_path,
+    instance_data: newInstanceData,
   };
   var result = { node: responseNode, game_values: newGameValues, levelup: levelup };
 
-  _persistDelta(_mkDelta(state.addr, 'buySlots',
-    [perpPath, slotType, nNum], result));
+  _persistDelta(_mkDelta(state.addr, 'buySlots', [perpPath, slotType, nNum], result));
 
   if (levelup) {
     var _bsDisplayName = state.display_name || state.addr;
-    triggerAchievement('levelup',
-      _t('achievement_levelup', _bsDisplayName, String(newGameValues.xp_level)));
+    triggerAchievement(
+      'levelup',
+      _t('achievement_levelup', _bsDisplayName, String(newGameValues.xp_level))
+    );
   }
 
   return Promise.resolve({ result: result });
@@ -1323,19 +1363,21 @@ export function buyPerp(
 ): Promise<{ result: { error: number } | BuyPerpPayload }> {
   var state = getState();
   var ruleset = _getRuleset();
-  var allTypes: Record<string, PerpDef> = Object.assign(
-    {}, ruleset.perps, ruleset.tokens
-  );
+  var allTypes: Record<string, PerpDef> = Object.assign({}, ruleset.perps, ruleset.tokens);
 
   var perpDef = allTypes[gestalt];
-  if (!perpDef) { return Promise.resolve({ result: { error: 1 } }); }
+  if (!perpDef) {
+    return Promise.resolve({ result: { error: 1 } });
+  }
   var typeData: PerpTypeData = perpDef.type_data || {};
   var gameType = perpDef.game_type || '';
 
   var gv = state.game_values || {};
   var currentLevel = gv.xp_level || 1;
   var requiredLevel = typeData.required_level != null ? typeData.required_level : 1;
-  if (currentLevel < requiredLevel) { return Promise.resolve({ result: { error: 1 } }); }
+  if (currentLevel < requiredLevel) {
+    return Promise.resolve({ result: { error: 1 } });
+  }
 
   // Roots ("Imperium", "Database") are always valid.  Other paths are checked
   // against state.nodes; if not found we still allow the call (single-tenant,
@@ -1345,14 +1387,17 @@ export function buyPerp(
     var nodes = state.nodes || [];
     for (var ni = 0; ni < nodes.length; ni++) {
       var pn = nodes[ni];
-      if (pn && pn.full_path === parentPath) { parentNode = pn; break; }
+      if (pn && pn.full_path === parentPath) {
+        parentNode = pn;
+        break;
+      }
     }
   }
 
   // Only validate provided_perps when we can resolve the parent's type definition.
-  var parentGestalt = parentNode ? (parentNode.gestalt || '') : '';
+  var parentGestalt = parentNode ? parentNode.gestalt || '' : '';
   var parentTypeDef = parentGestalt ? allTypes[parentGestalt] : null;
-  var parentTypeData: PerpTypeData | null = parentTypeDef ? (parentTypeDef.type_data || {}) : null;
+  var parentTypeData: PerpTypeData | null = parentTypeDef ? parentTypeDef.type_data || {} : null;
 
   if (parentTypeData && Array.isArray(parentTypeData.provided_perps)) {
     if (parentTypeData.provided_perps.indexOf(gestalt) === -1) {
@@ -1367,14 +1412,20 @@ export function buyPerp(
     var allNodes = state.nodes || [];
     for (var ci = 0; ci < allNodes.length; ci++) {
       var an = allNodes[ci];
-      if (an && an.full_path.indexOf(childPrefix) === 0) { childCount++; }
+      if (an && an.full_path.indexOf(childPrefix) === 0) {
+        childCount++;
+      }
     }
-    if (childCount >= maxSlots) { return Promise.resolve({ result: { error: 3 } }); }
+    if (childCount >= maxSlots) {
+      return Promise.resolve({ result: { error: 3 } });
+    }
   }
 
   var price = typeof typeData.price === 'number' ? typeData.price : 0;
   var cashValue = gv.cash_value || 0;
-  if (cashValue < price) { return Promise.resolve({ result: { error: 2 } }); }
+  if (cashValue < price) {
+    return Promise.resolve({ result: { error: 2 } });
+  }
 
   var newFullPath = parentPath + '.' + gestalt;
   var stateNodes = state.nodes || [];
@@ -1411,7 +1462,8 @@ export function buyPerp(
   if (levelup) {
     newGv = Object.assign({}, newGv, { xp_level: newLevel });
     var levelInfo = ruleset.levels[newLevel - 1] as
-      (LevelEntry & { ap_inc_value?: number; ap_inc_interval?: number }) | undefined;
+      | (LevelEntry & { ap_inc_value?: number; ap_inc_interval?: number })
+      | undefined;
     if (levelInfo) {
       newGv = Object.assign({}, newGv, {
         ap_inc_value: levelInfo.ap_inc_value,
@@ -1432,11 +1484,10 @@ export function buyPerp(
   // profile_set for project*/contact*/city* gestalts:
   // initial data batch pushed to db_queue; city-buy path also read by Game.js:3816.
   var profileSetPayload: BuyPerpProfileSetPayload | null = null;
-  var isProfileGestalt = (
+  var isProfileGestalt =
     gestalt.indexOf('project') === 0 ||
     gestalt.indexOf('contact') === 0 ||
-    gestalt.indexOf('city') === 0
-  );
+    gestalt.indexOf('city') === 0;
   if (isProfileGestalt) {
     var collectId = 'cq_' + nodeCounter;
     var tokensMap: Record<string, { amount: number }> = {};
@@ -1447,11 +1498,18 @@ export function buyPerp(
         tokensMap[tk.gestalt] = { amount: tk.amount || 0 };
       }
     }
-    var profilesValue: number = typeof typeData.profileset_size === 'number'
-      ? typeData.profileset_size
-      : (typeof typeData.collect_amount === 'number' ? typeData.collect_amount : 0);
+    var profilesValue: number =
+      typeof typeData.profileset_size === 'number'
+        ? typeData.profileset_size
+        : typeof typeData.collect_amount === 'number'
+          ? typeData.collect_amount
+          : 0;
     var generatedProfileSet = { profiles_value: profilesValue, tokens_map: tokensMap };
-    profileSetPayload = { profile_set: generatedProfileSet, origin: newFullPath, collect_id: collectId };
+    profileSetPayload = {
+      profile_set: generatedProfileSet,
+      origin: newFullPath,
+      collect_id: collectId,
+    };
   }
 
   var payload: BuyPerpPayload = {
@@ -1461,25 +1519,30 @@ export function buyPerp(
     node_counter: nodeCounter,
     missions: missionResult.missions || null,
   };
-  if (profileSetPayload) { payload.profile_set = profileSetPayload; }
+  if (profileSetPayload) {
+    payload.profile_set = profileSetPayload;
+  }
 
   _persistDelta(_mkDelta(state.addr, 'buyPerp', [parentPath, gestalt], payload));
 
   // Achievements
   var _bpDisplayName = state.display_name || state.addr;
   if (levelup) {
-    triggerAchievement('levelup',
-      _t('achievement_levelup', _bpDisplayName, String(newGv.xp_level)));
+    triggerAchievement(
+      'levelup',
+      _t('achievement_levelup', _bpDisplayName, String(newGv.xp_level))
+    );
   }
-  var _bpCompletedMissions = (missionResult.missions && missionResult.missions.complete_missions) || [];
+  var _bpCompletedMissions =
+    (missionResult.missions && missionResult.missions.complete_missions) || [];
   for (var _bpMi = 0; _bpMi < _bpCompletedMissions.length; _bpMi++) {
     var mGestalt = _bpCompletedMissions[_bpMi];
     if (typeof mGestalt !== 'string') continue;
     var _bpMDef = _findMissionDef(_getRuleset(), mGestalt);
     var _bpMTitle = (_bpMDef && _bpMDef.type_data && _bpMDef.type_data.title) || mGestalt;
-    triggerAchievement('mission_done',
-      _t('achievement_mission_done', _bpDisplayName, _bpMTitle),
-      { mission: mGestalt });
+    triggerAchievement('mission_done', _t('achievement_mission_done', _bpDisplayName, _bpMTitle), {
+      mission: mGestalt,
+    });
   }
 
   return Promise.resolve({ result: payload });
@@ -1514,9 +1577,14 @@ function _completeGoal(goal: MissionGoal): MissionGoal {
 
 // Returns the same array reference when nothing changed so callers can use
 // reference equality to detect whether any repairs were made.
-function _autoCompleteBuyPerpGoals(goals: MissionGoal[], nodes: GameNode[] | undefined): MissionGoal[] {
+function _autoCompleteBuyPerpGoals(
+  goals: MissionGoal[],
+  nodes: GameNode[] | undefined
+): MissionGoal[] {
   var owned: Record<string, true> = {};
-  (nodes || []).forEach(function (n) { if (n.gestalt) owned[n.gestalt] = true; });
+  (nodes || []).forEach(function (n) {
+    if (n.gestalt) owned[n.gestalt] = true;
+  });
   var changed = false;
   var result = goals.map(function (g) {
     if (g.workflow !== 'buy_perp' || g.complete || !owned[g.target]) return g;
@@ -1652,9 +1720,15 @@ function _completeMissionsIfReady(
   var ruleset = _getRuleset();
   var completed: string[] = [];
   var stillActive = activeMissions.filter(function (mGestalt) {
-    var goals = updatedGoals.filter(function (g) { return g.mission === mGestalt; });
+    var goals = updatedGoals.filter(function (g) {
+      return g.mission === mGestalt;
+    });
     if (!goals.length) return true;
-    if (goals.every(function (g) { return g.complete; })) {
+    if (
+      goals.every(function (g) {
+        return g.complete;
+      })
+    ) {
       completed.push(mGestalt);
       return false;
     }
@@ -1682,8 +1756,12 @@ function _completeMissionsIfReady(
   }
 
   var updatedMissions = activeMissions.filter(function (m) {
-    var goals = updatedGoals.filter(function (g) { return g.mission === m; });
-    return goals.some(function (g) { return g.current_amount > 0 || g.complete; });
+    var goals = updatedGoals.filter(function (g) {
+      return g.mission === m;
+    });
+    return goals.some(function (g) {
+      return g.current_amount > 0 || g.complete;
+    });
   });
 
   return {
@@ -1710,7 +1788,9 @@ function _repairStuckMissionGoals(state: LocalState): MissionAdvanceResult | nul
   if (!goals.length || !activeMissions.length) return null;
 
   var activeSet: Record<string, true> = {};
-  activeMissions.forEach(function (m) { activeSet[m] = true; });
+  activeMissions.forEach(function (m) {
+    activeSet[m] = true;
+  });
 
   var changed = false;
   var updatedGoals = goals.map(function (goal) {
@@ -1759,11 +1839,10 @@ function _collectMissionRewards(ruleset: Ruleset, completedGestalts: string[]): 
 function _applyRewardsToGv(gv: GameValues, rewards: RewardSet | undefined): GameValues {
   if (!rewards) return gv;
   return Object.assign({}, gv, {
-    cash_value:   (gv.cash_value   || 0) + (rewards.cash_value   || 0),
-    xp_value:     (gv.xp_value     || 0) + (rewards.xp_value     || 0),
-    karma_value:  Math.max(-100, Math.min(100,
-                  (gv.karma_value  || 0) + (rewards.karma_value || 0))),
-    profiles_max: (gv.profiles_max || 0) + (rewards.profiles_max || 0)
+    cash_value: (gv.cash_value || 0) + (rewards.cash_value || 0),
+    xp_value: (gv.xp_value || 0) + (rewards.xp_value || 0),
+    karma_value: Math.max(-100, Math.min(100, (gv.karma_value || 0) + (rewards.karma_value || 0))),
+    profiles_max: (gv.profiles_max || 0) + (rewards.profiles_max || 0),
   });
 }
 
@@ -1791,7 +1870,10 @@ function _advanceChargePerpMissions(state: LocalState, gestalt: string): Mission
   return _completeMissionsIfReady(updatedGoals, activeMissions);
 }
 
-function _advanceBuyPowerupMissions(state: LocalState, powerupGestalt: string): MissionAdvanceResult {
+function _advanceBuyPowerupMissions(
+  state: LocalState,
+  powerupGestalt: string
+): MissionAdvanceResult {
   var activeMissions = state.active_missions || [];
   var missionGoals = state.mission_goals || [];
 
@@ -1815,7 +1897,10 @@ function _advanceBuyPowerupMissions(state: LocalState, powerupGestalt: string): 
   return _completeMissionsIfReady(updatedGoals, activeMissions);
 }
 
-function _advanceUpgradeTokenMissions(state: LocalState, tokenGestalt: string): MissionAdvanceResult {
+function _advanceUpgradeTokenMissions(
+  state: LocalState,
+  tokenGestalt: string
+): MissionAdvanceResult {
   var activeMissions = state.active_missions || [];
   var missionGoals = state.mission_goals || [];
 
@@ -1911,21 +1996,24 @@ export function chargePerp(
   path: string
 ): Promise<{ result: { error: number } | Record<string, unknown> }> {
   var rawState = getState();
-  var now      = clockNow();
-  var ruleset  = _getRuleset();
+  var now = clockNow();
+  var ruleset = _getRuleset();
 
   // Materialize before reading game_values so AP regen ticks accumulated
   // since the last handler call are visible. Without this, the UI's
   // APTicker can show 1 AP while state.ap_snapshot still says 0, and
   // chargePerp would refuse the action despite the visible bar.
-  var mat   = materialize(rawState, now);
+  var mat = materialize(rawState, now);
   var state = mat.state;
 
-  var nodes   = state.nodes || [];
+  var nodes = state.nodes || [];
   var nodeIdx = -1;
   for (var i = 0; i < nodes.length; i++) {
     var n0 = nodes[i];
-    if (n0 && n0.full_path === path) { nodeIdx = i; break; }
+    if (n0 && n0.full_path === path) {
+      nodeIdx = i;
+      break;
+    }
   }
   if (nodeIdx < 0) return Promise.resolve({ result: { error: 1 } });
 
@@ -1933,7 +2021,7 @@ export function chargePerp(
   if (!node) return Promise.resolve({ result: { error: 1 } });
   var gestalt = node.gestalt || _gestaltFrom(node.full_type) || '';
   var perpDef: PerpDef | undefined = gestalt
-    ? (ruleset.perps[gestalt] || ruleset.tokens[gestalt])
+    ? ruleset.perps[gestalt] || ruleset.tokens[gestalt]
     : undefined;
   var typeData: PerpTypeData | undefined = perpDef ? perpDef.type_data : undefined;
   if (!typeData || typeof typeData.charge_time !== 'number') {
@@ -1946,34 +2034,41 @@ export function chargePerp(
     if (ce && ce.path === path) return Promise.resolve({ result: { error: 2 } });
   }
 
-  var gv           = state.game_values || {};
+  var gv = state.game_values || {};
   var instanceData: NodeInstanceData = node.instance_data || {};
   // charge_cost: instance_data wins (powerup-modified), then type_data, then 0.
-  var chargeCost = typeof instanceData.charge_cost === 'number'
-    ? instanceData.charge_cost
-    : (typeof typeData.charge_cost === 'number' ? typeData.charge_cost : 0);
+  var chargeCost =
+    typeof instanceData.charge_cost === 'number'
+      ? instanceData.charge_cost
+      : typeof typeData.charge_cost === 'number'
+        ? typeData.charge_cost
+        : 0;
 
   // Distinct codes (1=AP, 3=cash) let Game.js show the correct feedback animation.
-  if ((gv.ap_snapshot || 0) < 1)           return Promise.resolve({ result: { error: 1 } });
-  if ((gv.cash_value  || 0) < chargeCost)  return Promise.resolve({ result: { error: 3 } });
+  if ((gv.ap_snapshot || 0) < 1) return Promise.resolve({ result: { error: 1 } });
+  if ((gv.cash_value || 0) < chargeCost) return Promise.resolve({ result: { error: 3 } });
 
   // ClientPerps don't carry collect_amount in the ruleset — they ship
   // income_base / income_factor instead. Fall back so charging the car
   // company actually pays out when collected.
-  var baseAmount = typeof instanceData.collect_amount === 'number'
-    ? instanceData.collect_amount
-    : (typeof typeData.collect_amount === 'number' ? typeData.collect_amount
-      : (typeof typeData.income_base === 'number' ? typeData.income_base : 0));
+  var baseAmount =
+    typeof instanceData.collect_amount === 'number'
+      ? instanceData.collect_amount
+      : typeof typeData.collect_amount === 'number'
+        ? typeData.collect_amount
+        : typeof typeData.income_base === 'number'
+          ? typeData.income_base
+          : 0;
   var chargeResult = { amount: _getVariatedAmount(baseAmount, now, path) };
 
-  var durationMs  = typeData.charge_time;
+  var durationMs = typeData.charge_time;
   var chargeEntry = {
-    path:         path,
-    result:       chargeResult,
+    path: path,
+    result: chargeResult,
     charge_start: now,
-    charge_end:   now + durationMs,
-    game_id:      node.game_id   || path,
-    game_type:    node.game_type || '',
+    charge_end: now + durationMs,
+    game_id: node.game_id || path,
+    game_type: node.game_type || '',
   };
 
   var xpInc = typeof typeData.xp_inc === 'number' ? typeData.xp_inc : 0;
@@ -1988,9 +2083,9 @@ export function chargePerp(
   });
 
   var newGv: GameValues = Object.assign({}, gv, {
-    cash_value:  (gv.cash_value  || 0) - chargeCost,
-    cash_spent:  (gv.cash_spent  || 0) + chargeCost,
-    xp_value:    (gv.xp_value   || 0) + xpInc,
+    cash_value: (gv.cash_value || 0) - chargeCost,
+    cash_spent: (gv.cash_spent || 0) + chargeCost,
+    xp_value: (gv.xp_value || 0) + xpInc,
     ap_snapshot: Math.max(0, (gv.ap_snapshot || 0) - 1),
   });
 
@@ -2009,21 +2104,23 @@ export function chargePerp(
   }
 
   var preMissionStateCharge = Object.assign({}, state, {
-    nodes:          newNodes,
+    nodes: newNodes,
     nodes_charging: charging.concat([chargeEntry]),
-    game_values:    newGv,
+    game_values: newGv,
   });
 
   var chargeMissionResult = _advanceChargePerpMissions(preMissionStateCharge, gestalt);
   newGv = _applyRewardsToGv(newGv, chargeMissionResult.rewards);
 
-  _persistDelta(_mkDelta(state.addr, 'chargePerp', [path], {
-    chargeEntry:  chargeEntry,
-    cashDelta:    chargeCost,
-    xpInc:        xpInc,
-    game_values:  newGv,
-    missions:     chargeMissionResult.missions || null,
-  }));
+  _persistDelta(
+    _mkDelta(state.addr, 'chargePerp', [path], {
+      chargeEntry: chargeEntry,
+      cashDelta: chargeCost,
+      xpInc: xpInc,
+      game_values: newGv,
+      missions: chargeMissionResult.missions || null,
+    })
+  );
 
   // Live-tick: schedule one-shot materialize at exactly charge_end so the
   // node_ready event fires without depending on the player reloading.
@@ -2032,23 +2129,27 @@ export function chargePerp(
   // Achievements
   var _cpDisplayName = state.display_name || state.addr;
   if (levelup) {
-    triggerAchievement('levelup',
-      _t('achievement_levelup', _cpDisplayName, String(newLevelNum)));
+    triggerAchievement('levelup', _t('achievement_levelup', _cpDisplayName, String(newLevelNum)));
   }
-  var _cpCompletedMissions = (chargeMissionResult.missions && chargeMissionResult.missions.complete_missions) || [];
+  var _cpCompletedMissions =
+    (chargeMissionResult.missions && chargeMissionResult.missions.complete_missions) || [];
   for (var _cpMi = 0; _cpMi < _cpCompletedMissions.length; _cpMi++) {
     var mGestalt = _cpCompletedMissions[_cpMi];
     if (typeof mGestalt !== 'string') continue;
     var _cpMDef = _findMissionDef(_getRuleset(), mGestalt);
     var _cpMTitle = (_cpMDef && _cpMDef.type_data && _cpMDef.type_data.title) || mGestalt;
-    triggerAchievement('mission_done',
-      _t('achievement_mission_done', _cpDisplayName, _cpMTitle),
-      { mission: mGestalt });
+    triggerAchievement('mission_done', _t('achievement_mission_done', _cpDisplayName, _cpMTitle), {
+      mission: mGestalt,
+    });
   }
 
   return Promise.resolve({
-    result: { game_values: newGv, duration: durationMs, levelup: levelup,
-              missions: chargeMissionResult.missions || {} },
+    result: {
+      game_values: newGv,
+      duration: durationMs,
+      levelup: levelup,
+      missions: chargeMissionResult.missions || {},
+    },
   });
 }
 
@@ -2086,7 +2187,9 @@ function _scheduleChargeReady(chargeEnd: number, path: string): void {
     var s = getState();
     if (!s) return;
     if (path) {
-      var stillCharging = (s.nodes_charging || []).some(function (c: { path: string }) { return c.path === path; });
+      var stillCharging = (s.nodes_charging || []).some(function (c: { path: string }) {
+        return c.path === path;
+      });
       if (!stillCharging) return;
     }
     var mat = materialize(s, clockNow());
@@ -2104,7 +2207,7 @@ function _scheduleChargeReady(chargeEnd: number, path: string): void {
 // PRNG — Mulberry32, seeded for deterministic tests.
 // Call setPrngSeed(n) before any handler invocation that uses RNG.
 // ---------------------------------------------------------------------------
-var _prngSeed = 0xDEADBEEF;
+var _prngSeed = 0xdeadbeef;
 
 /**
  * Seed the deterministic PRNG used for charge-amount jitter.
@@ -2115,7 +2218,7 @@ export function setPrngSeed(seed: number): void {
 }
 
 function _rng(): number {
-  _prngSeed = (_prngSeed + 0x6D2B79F5) | 0;
+  _prngSeed = (_prngSeed + 0x6d2b79f5) | 0;
   var t = Math.imul(_prngSeed ^ (_prngSeed >>> 15), 1 | _prngSeed);
   t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
   return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
@@ -2123,12 +2226,17 @@ function _rng(): number {
 
 function _generateId(): string {
   // Timestamp base + two RNG words → collision-resistant string without deps.
-  return Date.now().toString(36) +
-    Math.floor(_rng() * 0xFFFFFF).toString(36) +
-    Math.floor(_rng() * 0xFFFFFF).toString(36);
+  return (
+    Date.now().toString(36) +
+    Math.floor(_rng() * 0xffffff).toString(36) +
+    Math.floor(_rng() * 0xffffff).toString(36)
+  );
 }
 
-interface KarmaIncident { gestalt: string; karma_delta: number }
+interface KarmaIncident {
+  gestalt: string;
+  karma_delta: number;
+}
 
 // Returns { gestalt, karma_delta } if a karma incident fires, else null.
 // factor = sqrt((-karma)/100) + 0.05  (dd_app views.py:483 WeightedRandomizer)
@@ -2136,7 +2244,7 @@ function _handleKarmaIncident(gv: GameValues, ruleset: Ruleset): KarmaIncident |
   var karma = (gv && gv.karma_value) || 0;
   if (karma >= 0) return null;
 
-  var factor = Math.pow((-karma) / 100, 0.5) + 0.05;
+  var factor = Math.pow(-karma / 100, 0.5) + 0.05;
   if (_rng() >= factor) return null;
 
   var level = (gv && gv.xp_level) || 1;
@@ -2148,7 +2256,7 @@ function _handleKarmaIncident(gv: GameValues, ruleset: Ruleset): KarmaIncident |
   var k = eligible[Math.floor(_rng() * eligible.length)];
   if (!k) return null;
   return {
-    gestalt:     (k.type_data && k.type_data.gestalt) || '',
+    gestalt: (k.type_data && k.type_data.gestalt) || '',
     karma_delta: (k.type_data && k.type_data.karma_points) || -1,
   };
 }
@@ -2180,7 +2288,10 @@ interface DbEntry {
   profile_set: { profiles_value: number; tokens_map: Record<string, { amount: number }> };
   collect_dt?: number;
 }
-interface TokenUpdate { path: string; amount: number }
+interface TokenUpdate {
+  path: string;
+  amount: number;
+}
 
 export function collectPerp(
   gperpPath: string
@@ -2196,7 +2307,10 @@ export function collectPerp(
   var collectEntry: { path: string; result?: { amount?: number } } | null = null;
   for (var i = 0; i < ms.nodes_collect.length; i++) {
     var ne = ms.nodes_collect[i];
-    if (ne && ne.path === gperpPath) { collectEntry = ne; break; }
+    if (ne && ne.path === gperpPath) {
+      collectEntry = ne;
+      break;
+    }
   }
   if (!collectEntry) {
     return Promise.resolve({ result: { error: 1 } });
@@ -2205,7 +2319,10 @@ export function collectPerp(
   var node: GameNode | null = null;
   for (var j = 0; j < ms.nodes.length; j++) {
     var nn = ms.nodes[j];
-    if (nn && nn.full_path === gperpPath) { node = nn; break; }
+    if (nn && nn.full_path === gperpPath) {
+      node = nn;
+      break;
+    }
   }
   if (!node) {
     return Promise.resolve({ result: { error: 2 } });
@@ -2213,15 +2330,17 @@ export function collectPerp(
 
   var gestalt = node.gestalt || _gestaltFrom(node.full_type) || '';
   var perpDef: PerpDef | undefined = gestalt
-    ? (ruleset.perps[gestalt] || ruleset.tokens[gestalt])
+    ? ruleset.perps[gestalt] || ruleset.tokens[gestalt]
     : undefined;
   var typeData: PerpTypeData | undefined = perpDef ? perpDef.type_data : undefined;
 
   var cr = collectEntry.result || {};
-  var xpGain = (typeData && typeof typeData.xp_inc === 'number') ? typeData.xp_inc : 1;
+  var xpGain = typeData && typeof typeData.xp_inc === 'number' ? typeData.xp_inc : 1;
   var gameType = node.game_type;
 
-  var newCollect = ms.nodes_collect.filter(function (e) { return e.path !== gperpPath; });
+  var newCollect = ms.nodes_collect.filter(function (e) {
+    return e.path !== gperpPath;
+  });
   var newGv: GameValues = Object.assign({}, ms.game_values, {
     xp_value: (ms.game_values.xp_value || 0) + xpGain,
   });
@@ -2237,9 +2356,7 @@ export function collectPerp(
     // ContactPerps store yielded token-types under `tokens`; TokenPerps
     // (super-token decomposition) under `contained_tokens` — accept either.
     var tokensMap: Record<string, { amount: number }> = {};
-    var contained: TokenSpec[] = (typeData && (
-      typeData.tokens || typeData.contained_tokens
-    )) || [];
+    var contained: TokenSpec[] = (typeData && (typeData.tokens || typeData.contained_tokens)) || [];
     for (var ct = 0; ct < contained.length; ct++) {
       var ctEntry = contained[ct];
       if (ctEntry && ctEntry.gestalt) {
@@ -2248,21 +2365,19 @@ export function collectPerp(
     }
     var profileSet = { profiles_value: cr.amount || 0, tokens_map: tokensMap };
     dbEntry = {
-      origin:      gperpPath,
-      collect_id:  collectId,
+      origin: gperpPath,
+      collect_id: collectId,
       profile_set: profileSet,
-      collect_dt:  now,
+      collect_dt: now,
     };
     newQueue = newQueue.concat([dbEntry]);
     innerResult = { profile_set: profileSet, origin: gperpPath, collect_id: collectId };
-
   } else if (gameType === 'ClientPerp') {
     var cashGain = cr.amount || 0;
     newGv = Object.assign({}, newGv, {
       cash_value: (ms.game_values.cash_value || 0) + cashGain,
     });
     innerResult = { cash: newGv.cash_value };
-
   } else if (gameType === 'TokenPerp') {
     var tpIdata: NodeInstanceData = node.instance_data || {};
     var prevAmount = typeof tpIdata.amount === 'number' ? tpIdata.amount : 0;
@@ -2275,7 +2390,6 @@ export function collectPerp(
       });
     });
     innerResult = { token_upgraded_amount: newAmount };
-
   } else {
     return Promise.resolve({ result: { error: 3 } });
   }
@@ -2283,14 +2397,13 @@ export function collectPerp(
   var incident = _handleKarmaIncident(newGv, ruleset);
   if (incident) {
     newGv = Object.assign({}, newGv, {
-      karma_value: Math.max(-100, Math.min(100,
-        (newGv.karma_value || 0) + incident.karma_delta))
+      karma_value: Math.max(-100, Math.min(100, (newGv.karma_value || 0) + incident.karma_delta)),
     });
   }
 
   var oldLevel = (ms.game_values && ms.game_values.xp_level) || 1;
   var newLevel = _getLevelByXP(newGv.xp_value || 0);
-  var levelup  = newLevel > oldLevel;
+  var levelup = newLevel > oldLevel;
   if (levelup) {
     var collectLevels = _getRuleset().levels;
     var collectLevelInfo = collectLevels[newLevel - 1] || collectLevels[collectLevels.length - 1];
@@ -2303,29 +2416,36 @@ export function collectPerp(
   }
 
   var preMissionState = Object.assign({}, ms, {
-    nodes:         newNodes,
+    nodes: newNodes,
     nodes_collect: newCollect,
-    db_queue:      newQueue,
-    game_values:   newGv,
-    last_seen_ts:  Math.max(now, ms.last_seen_ts || 0)
+    db_queue: newQueue,
+    game_values: newGv,
+    last_seen_ts: Math.max(now, ms.last_seen_ts || 0),
   });
 
   var collectMissionResult;
   if (gameType === 'ContactPerp') {
-    collectMissionResult = _advanceCollectProfilesMissions(preMissionState, gestalt, cr.amount || 0);
+    collectMissionResult = _advanceCollectProfilesMissions(
+      preMissionState,
+      gestalt,
+      cr.amount || 0
+    );
   } else if (gameType === 'ClientPerp') {
     collectMissionResult = _advanceCollectCashMissions(preMissionState, gestalt, cr.amount || 0);
   } else if (gameType === 'TokenPerp') {
     collectMissionResult = _advanceUpgradeTokenMissions(preMissionState, gestalt);
   } else {
-    collectMissionResult = { missions: null, mission_goals: preMissionState.mission_goals,
-      active_missions: preMissionState.active_missions };
+    collectMissionResult = {
+      missions: null,
+      mission_goals: preMissionState.mission_goals,
+      active_missions: preMissionState.active_missions,
+    };
   }
   newGv = _applyRewardsToGv(newGv, collectMissionResult.rewards);
   var newState = Object.assign({}, preMissionState, {
     game_values: newGv,
     mission_goals: collectMissionResult.mission_goals,
-    active_missions: collectMissionResult.active_missions
+    active_missions: collectMissionResult.active_missions,
   });
 
   var deltaResult: {
@@ -2335,31 +2455,37 @@ export function collectPerp(
     db_entry?: DbEntry;
     token_update?: TokenUpdate;
   } = { game_values: newGv, path: gperpPath, missions: collectMissionResult.missions };
-  if (dbEntry)     deltaResult.db_entry     = dbEntry;
+  if (dbEntry) deltaResult.db_entry = dbEntry;
   if (tokenUpdate) deltaResult.token_update = tokenUpdate;
   _persistDelta(_mkDelta(state.addr, 'collectPerp', [gperpPath], deltaResult));
 
   var response = Object.assign(
-    { result: innerResult, game_values: newGv, levelup: levelup,
-      missions: collectMissionResult.missions || { complete_missions: [], updated_missions: [] } },
+    {
+      result: innerResult,
+      game_values: newGv,
+      levelup: levelup,
+      missions: collectMissionResult.missions || { complete_missions: [], updated_missions: [] },
+    },
     incident ? { karma_incident: incident.gestalt } : {}
   );
 
   // Achievements
   var _clpDisplayName = state.display_name || state.addr;
   if (levelup) {
-    triggerAchievement('levelup',
-      _t('achievement_levelup', _clpDisplayName, String(newLevel)));
+    triggerAchievement('levelup', _t('achievement_levelup', _clpDisplayName, String(newLevel)));
   }
-  var _clpCompletedMissions = (collectMissionResult.missions && collectMissionResult.missions.complete_missions) || [];
+  var _clpCompletedMissions =
+    (collectMissionResult.missions && collectMissionResult.missions.complete_missions) || [];
   for (var _clpMi = 0; _clpMi < _clpCompletedMissions.length; _clpMi++) {
     var clpG = _clpCompletedMissions[_clpMi];
     if (typeof clpG !== 'string') continue;
     var _clpMDef = _findMissionDef(_getRuleset(), clpG);
     var _clpMTitle = (_clpMDef && _clpMDef.type_data && _clpMDef.type_data.title) || clpG;
-    triggerAchievement('mission_done',
+    triggerAchievement(
+      'mission_done',
       _t('achievement_mission_done', _clpDisplayName, _clpMTitle),
-      { mission: clpG });
+      { mission: clpG }
+    );
   }
   var _clpOldKarma = (ms.game_values && ms.game_values.karma_value) || 0;
   var _clpNewKarma = newGv.karma_value || 0;
@@ -2428,28 +2554,31 @@ export function integrateCollected(
   }
 
   var queue = state.db_queue || [];
-  var entry = queue.find(function (q) { return q.collect_id === collectId; });
+  var entry = queue.find(function (q) {
+    return q.collect_id === collectId;
+  });
   if (!entry) {
     return Promise.resolve({ result: { error: 0 } });
   }
-  var newQueue = queue.filter(function (q) { return q.collect_id !== collectId; });
+  var newQueue = queue.filter(function (q) {
+    return q.collect_id !== collectId;
+  });
 
   var ps: ProfileSetView = (entry.profile_set as ProfileSetView) || {};
   var profilesIncrement = ps.profiles_value || 0;
 
   var integratedIds = state.integrated_ids || {};
-  var dup       = integratedIds[collectId] ? profilesIncrement : 0;
+  var dup = integratedIds[collectId] ? profilesIncrement : 0;
   var increment = integratedIds[collectId] ? 0 : profilesIncrement;
   var newIntegratedIds = Object.assign({}, integratedIds, { [collectId]: true });
 
-  var xpGain    = ps.xp_gain    || 0;
+  var xpGain = ps.xp_gain || 0;
   var karmaGain = ps.karma_gain || 0;
   var newGv: GameValues = Object.assign({}, state.game_values, {
-    xp_value:       (state.game_values.xp_value    || 0) + xpGain,
-    karma_value: Math.max(-100, Math.min(100,
-      (state.game_values.karma_value || 0) + karmaGain)),
+    xp_value: (state.game_values.xp_value || 0) + xpGain,
+    karma_value: Math.max(-100, Math.min(100, (state.game_values.karma_value || 0) + karmaGain)),
     profiles_value: (state.game_values.profiles_value || 0) + increment,
-    ap_snapshot:    Math.max(0, (state.game_values.ap_snapshot || 0) - 1),
+    ap_snapshot: Math.max(0, (state.game_values.ap_snapshot || 0) - 1),
   });
 
   var ruleset = _getRuleset();
@@ -2501,30 +2630,32 @@ export function integrateCollected(
   // saveCoordsQueue persists the resolved position. Pre-seeding x/y
   // bypassed that and made every new token stack at a single hashed point.
   // Initial share = ps_share * N / (M + N) (= ps_share when M = 0).
-  if (!skipMerge) Object.keys(tokensMap).forEach(function (gestalt) {
-    if (seenGestalts[gestalt]) return;
-    if (!ruleset.tokens || !ruleset.tokens[gestalt]) return;
-    var tok = tokensMap[gestalt];
-    if (!tok) return;
-    var seedShare = Math.min(100, ((tok.amount || 0) * N) / denom);
-    var newNode: GameNode = {
-      game_id:    gestalt,
-      gestalt:    gestalt,
-      game_type:  'TokenPerp',
-      full_type:  'TokenPerp:' + gestalt,
-      full_path:  'Database.' + gestalt,
-      instance_data: { amount: seedShare },
-    };
-    newNodes.push(newNode);
-    updatedNodes.push(newNode);
-  });
+  if (!skipMerge)
+    Object.keys(tokensMap).forEach(function (gestalt) {
+      if (seenGestalts[gestalt]) return;
+      if (!ruleset.tokens || !ruleset.tokens[gestalt]) return;
+      var tok = tokensMap[gestalt];
+      if (!tok) return;
+      var seedShare = Math.min(100, ((tok.amount || 0) * N) / denom);
+      var newNode: GameNode = {
+        game_id: gestalt,
+        gestalt: gestalt,
+        game_type: 'TokenPerp',
+        full_type: 'TokenPerp:' + gestalt,
+        full_path: 'Database.' + gestalt,
+        instance_data: { amount: seedShare },
+      };
+      newNodes.push(newNode);
+      updatedNodes.push(newNode);
+    });
 
   var oldLevel = (state.game_values && state.game_values.xp_level) || 1;
   var newLevel = _getLevelByXP(newGv.xp_value || 0);
-  var levelup  = newLevel > oldLevel;
+  var levelup = newLevel > oldLevel;
   if (levelup) {
     var integrateLevels = _getRuleset().levels;
-    var integrateLevelInfo = integrateLevels[newLevel - 1] || integrateLevels[integrateLevels.length - 1];
+    var integrateLevelInfo =
+      integrateLevels[newLevel - 1] || integrateLevels[integrateLevels.length - 1];
     if (integrateLevelInfo) {
       newGv = Object.assign({}, newGv, {
         xp_level: newLevel,
@@ -2534,34 +2665,42 @@ export function integrateCollected(
   }
 
   var preMissionState = Object.assign({}, state, {
-    db_queue:       newQueue,
-    nodes:          newNodes,
-    game_values:    newGv,
+    db_queue: newQueue,
+    nodes: newNodes,
+    game_values: newGv,
     integrated_ids: newIntegratedIds,
-    last_seen_ts:   Math.max(now, state.last_seen_ts || 0)
+    last_seen_ts: Math.max(now, state.last_seen_ts || 0),
   });
 
   // Advance integrate_profiles goals against the new TokenPerp amounts.
   var missionResult = _advanceIntegrateProfilesMissions(
-    preMissionState, newGv.profiles_value || 0, newNodes
+    preMissionState,
+    newGv.profiles_value || 0,
+    newNodes
   );
   newGv = _applyRewardsToGv(newGv, missionResult.rewards);
   var newState = Object.assign({}, preMissionState, {
     game_values: newGv,
     mission_goals: missionResult.mission_goals,
-    active_missions: missionResult.active_missions
+    active_missions: missionResult.active_missions,
   });
 
   // Persist delta for webxdc replay; result carries full state for the reducer.
-  _persistDelta(_mkDelta(state.addr, 'integrateCollected', [collectId],
-    { increment: increment, dup: dup, game_values: newGv, nodes: updatedNodes,
-      missions: missionResult.missions }));
+  _persistDelta(
+    _mkDelta(state.addr, 'integrateCollected', [collectId], {
+      increment: increment,
+      dup: dup,
+      game_values: newGv,
+      nodes: updatedNodes,
+      missions: missionResult.missions,
+    })
+  );
 
   var response = {
     result: { nodes: updatedNodes, increment: increment, dup: dup },
     game_values: newGv,
     levelup: levelup,
-    missions: missionResult.missions || { complete_missions: [], updated_missions: [] }
+    missions: missionResult.missions || { complete_missions: [], updated_missions: [] },
   };
 
   if (levelup) {
@@ -2573,18 +2712,18 @@ export function integrateCollected(
   // Achievements
   var _icDisplayName = state.display_name || state.addr;
   if (levelup) {
-    triggerAchievement('levelup',
-      _t('achievement_levelup', _icDisplayName, String(newLevel)));
+    triggerAchievement('levelup', _t('achievement_levelup', _icDisplayName, String(newLevel)));
   }
-  var _icCompletedMissions = (missionResult.missions && missionResult.missions.complete_missions) || [];
+  var _icCompletedMissions =
+    (missionResult.missions && missionResult.missions.complete_missions) || [];
   for (var _icMi = 0; _icMi < _icCompletedMissions.length; _icMi++) {
     var icG = _icCompletedMissions[_icMi];
     if (typeof icG !== 'string') continue;
     var _icMDef = _findMissionDef(_getRuleset(), icG);
     var _icMTitle = (_icMDef && _icMDef.type_data && _icMDef.type_data.title) || icG;
-    triggerAchievement('mission_done',
-      _t('achievement_mission_done', _icDisplayName, _icMTitle),
-      { mission: icG });
+    triggerAchievement('mission_done', _t('achievement_mission_done', _icDisplayName, _icMTitle), {
+      mission: icG,
+    });
   }
   var _icOldProfiles = (state.game_values && state.game_values.profiles_value) || 0;
   var _icNewProfiles = newGv.profiles_value || 0;
@@ -2593,9 +2732,11 @@ export function integrateCollected(
     var ms2 = _icMilestones[_icPi];
     if (ms2 === undefined) continue;
     if (_icOldProfiles < ms2 && _icNewProfiles >= ms2) {
-      triggerAchievement('profiles_milestone',
+      triggerAchievement(
+        'profiles_milestone',
         _t('achievement_profiles_milestone', _icDisplayName, String(ms2)),
-        { threshold: ms2 });
+        { threshold: ms2 }
+      );
     }
   }
   var _icOldKarma = (state.game_values && state.game_values.karma_value) || 0;
@@ -2615,9 +2756,7 @@ export function integrateCollected(
 // the briefing popup for a given mission so we don't re-open it on reload.
 // ---------------------------------------------------------------------------
 
-export function markTokenSeen(
-  gestalt: unknown
-): Promise<{ result: { error: 0 } | { ok: true } }> {
+export function markTokenSeen(gestalt: unknown): Promise<{ result: { error: 0 } | { ok: true } }> {
   if (typeof gestalt !== 'string' || !gestalt) {
     return Promise.resolve({ result: { error: 0 } });
   }
@@ -2630,7 +2769,9 @@ export function markTokenSeen(
   return Promise.resolve({ result: { ok: true } });
 }
 
-export function dismissMissionBriefing(gestalt: unknown): Promise<{ result: { error: 0 } | { ok: true } }> {
+export function dismissMissionBriefing(
+  gestalt: unknown
+): Promise<{ result: { error: 0 } | { ok: true } }> {
   if (typeof gestalt !== 'string' || !gestalt) {
     return Promise.resolve({ result: { error: 0 } });
   }
@@ -2639,8 +2780,7 @@ export function dismissMissionBriefing(gestalt: unknown): Promise<{ result: { er
   if (seen[gestalt]) {
     return Promise.resolve({ result: { ok: true } });
   }
-  _persistDelta(_mkDelta(state.addr, 'dismissMissionBriefing',
-    [gestalt], { gestalt: gestalt }));
+  _persistDelta(_mkDelta(state.addr, 'dismissMissionBriefing', [gestalt], { gestalt: gestalt }));
   return Promise.resolve({ result: { ok: true } });
 }
 
@@ -2658,10 +2798,12 @@ export function recheckMissions(): Promise<{
     return Promise.resolve({ result: { repaired: false } });
   }
   var newGv = _applyRewardsToGv(state.game_values || {}, repair.rewards);
-  _persistDelta(_mkDelta(state.addr, 'recheckMissions', [], {
-    game_values: newGv,
-    missions: repair.missions,
-  }));
+  _persistDelta(
+    _mkDelta(state.addr, 'recheckMissions', [], {
+      game_values: newGv,
+      missions: repair.missions,
+    })
+  );
   return Promise.resolve({
     result: { repaired: true, missions: repair.missions, game_values: newGv, levelup: false },
   });
@@ -2670,9 +2812,7 @@ export function recheckMissions(): Promise<{
 // ---------------------------------------------------------------------------
 // Stub handlers — Wave 4+ issues fill these in.
 // ---------------------------------------------------------------------------
-var _STUBS = [
-  'checkUsername',
-] as const;
+var _STUBS = ['checkUsername'] as const;
 
 type StubName = (typeof _STUBS)[number];
 var _stubHandlers: Record<string, () => Promise<never>> = {};
@@ -2691,32 +2831,35 @@ _STUBS.forEach(function (name: StubName) {
 //
 // HandlerResult shapes are documented in docs/response-shapes.md.
 // ---------------------------------------------------------------------------
-var LocalEngine = Object.assign({
-  getToken:           getToken,
-  ping:               ping,
-  getSessionLocale:   getSessionLocale,
-  setLocale:          setLocale,
-  loadGame:           loadGame,
-  getRanking:         getRanking,
-  setDisplayName:     setDisplayName,
-  setPerpCoordinates: setPerpCoordinates,
-  getProvidedPerps:   getProvidedPerps,
-  getPowerups:        getPowerups,
-  buyKarma:           buyKarma,
-  buyPowerup:         buyPowerup,
-  sellPowerup:        sellPowerup,
-  buySlots:           buySlots,
-  buyPerp:            buyPerp,
-  chargePerp:         chargePerp,
-  collectPerp:        collectPerp,
-  integrateCollected: integrateCollected,
-  dismissMissionBriefing: dismissMissionBriefing,
-  markTokenSeen:      markTokenSeen,
-  recheckMissions:    recheckMissions,
-  setEmitter:           setEmitter,
-  setSendDelta:         setSendDelta,
-  setSendAchievement:   setSendAchievement,
-  setPrngSeed:          setPrngSeed,
-}, _stubHandlers);
+var LocalEngine = Object.assign(
+  {
+    getToken: getToken,
+    ping: ping,
+    getSessionLocale: getSessionLocale,
+    setLocale: setLocale,
+    loadGame: loadGame,
+    getRanking: getRanking,
+    setDisplayName: setDisplayName,
+    setPerpCoordinates: setPerpCoordinates,
+    getProvidedPerps: getProvidedPerps,
+    getPowerups: getPowerups,
+    buyKarma: buyKarma,
+    buyPowerup: buyPowerup,
+    sellPowerup: sellPowerup,
+    buySlots: buySlots,
+    buyPerp: buyPerp,
+    chargePerp: chargePerp,
+    collectPerp: collectPerp,
+    integrateCollected: integrateCollected,
+    dismissMissionBriefing: dismissMissionBriefing,
+    markTokenSeen: markTokenSeen,
+    recheckMissions: recheckMissions,
+    setEmitter: setEmitter,
+    setSendDelta: setSendDelta,
+    setSendAchievement: setSendAchievement,
+    setPrngSeed: setPrngSeed,
+  },
+  _stubHandlers
+);
 
 export default LocalEngine;

--- a/scripts/Render.js
+++ b/scripts/Render.js
@@ -7,387 +7,397 @@ import appModule from './app.js';
 import setup from './setup.js';
 import utilDefault from './util.js';
 
-var Render = function() {
+var Render = function () {
+  var _ = globalThis._;
+  var $ = globalThis.jQuery || globalThis.$;
 
-    var _ = globalThis._;
-    var $ = globalThis.jQuery || globalThis.$;
+  var Scroller = globalThis.Scroller;
+  var core = globalThis.core;
 
-    var Scroller = globalThis.Scroller;
-    var core = globalThis.core;
+  // Tween is the sub-class; Easel and Sound just alias the namespace.
+  var Easel = globalThis.createjs;
+  var Tween = globalThis.createjs.Tween;
+  var Sound = globalThis.createjs;
+  var Ticker = Easel.Ticker;
+  var Ease = Easel.Ease;
 
-    // Tween is the sub-class; Easel and Sound just alias the namespace.
-    var Easel = globalThis.createjs;
-    var Tween = globalThis.createjs.Tween;
-    var Sound = globalThis.createjs;
-    var Ticker = Easel.Ticker;
-    var Ease = Easel.Ease;
-
-    // Shim CreateJS legacy Ticker.{addListener,removeListener,setFPS} onto
-    // the current EventDispatcher API so Render's tick-object callers work.
-    if (typeof Ticker.addListener !== 'function') {
-      var _tickHandlers = new WeakMap();
-      Ticker.addListener = function(obj) {
-        if (_tickHandlers.has(obj)) { return; }
-        var fn = function() { if (typeof obj.tick === 'function') { obj.tick(); } };
-        _tickHandlers.set(obj, fn);
-        Ticker.addEventListener('tick', fn);
-      };
-      Ticker.removeListener = function(obj) {
-        var fn = _tickHandlers.get(obj);
-        if (fn) {
-          Ticker.removeEventListener('tick', fn);
-          _tickHandlers.delete(obj);
+  // Shim CreateJS legacy Ticker.{addListener,removeListener,setFPS} onto
+  // the current EventDispatcher API so Render's tick-object callers work.
+  if (typeof Ticker.addListener !== 'function') {
+    var _tickHandlers = new WeakMap();
+    Ticker.addListener = function (obj) {
+      if (_tickHandlers.has(obj)) {
+        return;
+      }
+      var fn = function () {
+        if (typeof obj.tick === 'function') {
+          obj.tick();
         }
       };
+      _tickHandlers.set(obj, fn);
+      Ticker.addEventListener('tick', fn);
+    };
+    Ticker.removeListener = function (obj) {
+      var fn = _tickHandlers.get(obj);
+      if (fn) {
+        Ticker.removeEventListener('tick', fn);
+        _tickHandlers.delete(obj);
+      }
+    };
+  }
+  // Always override setFPS so we use the modern `framerate=` setter even
+  // when the legacy method still exists (it logs a deprecation warning
+  // on every call in current TweenJS builds).
+  Ticker.setFPS = function (fps) {
+    Ticker.framerate = fps;
+  };
+
+  var app = appModule.getApplication();
+  var extend = utilDefault.extend;
+
+  var renderConf = {
+    cableResolution: 2,
+    tickerFramerate: 60,
+    slowTickerFrameRate: 120,
+    viewMapPerspective: setup.viewMapPerspective,
+    viewMapStopZone: setup.viewMapStopZone,
+  };
+
+  Ticker.setFPS(renderConf.tickerFramerate);
+  Ticker.useRAF = true;
+
+  //////////////////////////////////////////
+  //
+  // The Render API
+  //
+  // Instantiates a tree like structure of
+  // render nodes, feeds events back to
+  // Game controller if available.
+  // Uses mostly jQuery and Vanilla-JS to
+  // manipulate the DOM
+  //
+  // Here be dragons and sea serpents...
+  //
+  //////////////////////////////////////////
+
+  /////////////////////////////////////////////
+  // Some generic tools and getter functions
+  /////////////////////////////////////////////
+
+  var _instances = [];
+  var _ids = {};
+
+  var add = function (node) {
+    _instances[node._id] = node;
+    _ids[node.id] = node;
+  };
+
+  var get = function (_id) {
+    return _instances[_id];
+  };
+
+  var getById = function (id) {
+    return _ids[id];
+  };
+
+  var remove = function (_id) {
+    if (get(_id)) {
+      delete _ids[get(_id).id];
     }
-    // Always override setFPS so we use the modern `framerate=` setter even
-    // when the legacy method still exists (it logs a deprecation warning
-    // on every call in current TweenJS builds).
-    Ticker.setFPS = function(fps) { Ticker.framerate = fps; };
+    _instances[_id] = undefined;
+  };
 
-    var app = appModule.getApplication();
-    var extend = utilDefault.extend;
-
-    var renderConf = {
-      cableResolution : 2,
-      tickerFramerate : 60,
-      slowTickerFrameRate: 120,
-      viewMapPerspective: setup.viewMapPerspective,
-      viewMapStopZone : setup.viewMapStopZone
-    };
-
-    Ticker.setFPS(renderConf.tickerFramerate);
-    Ticker.useRAF = true;
-
-
-    //////////////////////////////////////////
-    //
-    // The Render API
-    //
-    // Instantiates a tree like structure of
-    // render nodes, feeds events back to
-    // Game controller if available.
-    // Uses mostly jQuery and Vanilla-JS to 
-    // manipulate the DOM
-    // 
-    // Here be dragons and sea serpents...
-    //
-    //////////////////////////////////////////
-
-
-    /////////////////////////////////////////////
-    // Some generic tools and getter functions
-    /////////////////////////////////////////////
-
-    var _instances = [];
-    var _ids = {};
-
-    var add = function(node) {
-      _instances[node._id] = node;
-      _ids[node.id] = node;
-    };
-
-    var get = function(_id) {
-      return _instances[_id];
-    };
-
-    var getById = function(id) {
-      return _ids[id];
-    };
-
-    var remove = function(_id){
-      if (get(_id)) {
-        delete _ids[get(_id).id];
+  var clear = function () {
+    // Clear everything that has been rendered so far
+    for (var n = 0; n < _instances.length; n++) {
+      var node = _instances[n];
+      if (node) {
+        node.remove();
       }
-      _instances[_id]=undefined;
+    }
+    _instances.length = 0;
+  };
+
+  /////////////////////////////////////////////
+  // The Draghandler
+  /////////////////////////////////////////////
+
+  var DragHandler = function () {
+    this.jdomelem = $(window);
+    this.domelem = window;
+    this.scale = 1;
+    this.listeners = [];
+    this.init();
+    this.state = 'stopped';
+    this.dragging = false;
+  };
+
+  DragHandler.prototype.addListener = function (node) {
+    //if (!node.draggable) return;
+    node.dragStartPos = {
+      x: node.getPosition().x,
+      y: node.getPosition().y,
+    };
+    node.dragging = true;
+    node.trigger('dragstart');
+    this.listeners.push(node);
+  };
+
+  DragHandler.prototype.removeListener = function (node) {
+    var index = this.listeners.indexOf(node);
+    if (index !== -1) {
+      this.listeners[index].trigger('dragend');
+      this.listeners.splice(index, 1);
+    }
+  };
+
+  DragHandler.prototype.dragVector = {};
+  DragHandler.prototype.dragstart = function (e) {
+    var dm = this;
+    dm.state = 'started';
+    // FIXME: trigger touchhandling broken?!
+    var touch;
+    if (e.originalEvent) {
+      touch = e.originalEvent.touches
+        ? e.originalEvent.touches[0] || e.originalEvent.changedTouches[0]
+        : undefined;
+    }
+    var userPos = touch ? { x: touch.pageX, y: touch.pageY } : { x: e.pageX, y: e.pageY };
+    dm.dragMovePos = dm.dragStartPos = userPos;
+    dm.dragging = true;
+    delete dm.dragVector.x;
+    delete dm.dragVector.y;
+    dm.dragVector.x = (dm.dragMovePos.x - dm.dragStartPos.x) * dm.scale;
+    dm.dragVector.y = (dm.dragMovePos.y - dm.dragStartPos.y) * dm.scale;
+  };
+
+  DragHandler.prototype.dragend = function (e) {
+    var dm = this;
+    dm.state = 'stopped';
+
+    for (var i = 0; i < dm.listeners.length; i++) {
+      var node = dm.listeners[i];
+      node.dragging = false;
+      node.trigger('dragend');
+    }
+    dm.listeners.length = 0;
+    dm.dragging = false;
+  };
+
+  DragHandler.prototype.on = function (event, func) {
+    this.jdomelem.on(event, func);
+  };
+
+  DragHandler.prototype.off = function (event) {
+    this.jdomelem.off(event);
+  };
+
+  DragHandler.prototype.trigger = function (event, params) {
+    this.jdomelem.trigger(event, params);
+  };
+
+  DragHandler.prototype.getCollisionPos = function (node, newPos) {
+    var result = {
+      x: newPos.x,
+      y: newPos.y,
+      coll: false,
+    };
+    var posX = newPos.x - node.offsetX;
+    var posY = newPos.y - node.offsetY;
+    var width = node.getSize().width;
+    var height = node.getSize().height;
+    var rect1 = {
+      tl: { x: posX, y: posY },
+      tr: { x: posX + width, y: posY },
+      bl: { x: posX, y: posY + height },
+      br: { x: posX + width, y: posY + height },
     };
 
-    var clear = function() {
-      // Clear everything that has been rendered so far
-      for (var n=0;n<_instances.length;n++) {
-        var node = _instances[n];
-        if (node) {
-          node.remove();
-        }
-      }
-      _instances.length = 0;
-    };
-
-
-    /////////////////////////////////////////////
-    // The Draghandler
-    /////////////////////////////////////////////
-
-    var DragHandler = function() {
-      this.jdomelem = $(window);
-      this.domelem = window;
-      this.scale=1;
-      this.listeners=[];
-      this.init();
-      this.state='stopped';
-      this.dragging=false;
-    };
-
-    DragHandler.prototype.addListener = function(node){
-      //if (!node.draggable) return;
-      node.dragStartPos = {
-        x: node.getPosition().x,
-        y: node.getPosition().y
-      };
-      node.dragging=true;
-      node.trigger('dragstart');
-      this.listeners.push(node);
-    };
-
-    DragHandler.prototype.removeListener = function(node){
-      var index = this.listeners.indexOf(node);
-      if (index !== -1) {
-        this.listeners[index].trigger('dragend');
-        this.listeners.splice(index, 1);
-      }
-    };
-
-    DragHandler.prototype.dragVector = {};
-    DragHandler.prototype.dragstart = function(e) {
-      var dm = this;
-      dm.state='started';
-      // FIXME: trigger touchhandling broken?!
-      var touch;
-      if (e.originalEvent) {
-        touch = (e.originalEvent.touches) ? e.originalEvent.touches[0] || e.originalEvent.changedTouches[0] : undefined;
-      }
-      var userPos = (touch) ? {x:touch.pageX,y:touch.pageY} : {x:e.pageX,y:e.pageY};
-      dm.dragMovePos = dm.dragStartPos = userPos;
-      dm.dragging = true;
-      delete dm.dragVector.x;
-      delete dm.dragVector.y;
-      dm.dragVector.x = (dm.dragMovePos.x - dm.dragStartPos.x)*dm.scale;
-      dm.dragVector.y = (dm.dragMovePos.y - dm.dragStartPos.y)*dm.scale;
-    };
-
-    DragHandler.prototype.dragend = function(e){
-      var dm = this;
-      dm.state='stopped';
-
-      for (var i=0;i<dm.listeners.length;i++) {
-        var node = dm.listeners[i];
-        node.dragging=false;
-        node.trigger('dragend');
-      }
-      dm.listeners.length=0;
-      dm.dragging = false;
-    };
-
-    DragHandler.prototype.on = function(event,func){
-      this.jdomelem.on(event,func);
-    };
-
-    DragHandler.prototype.off = function(event){
-      this.jdomelem.off(event);
-    };
-
-
-    DragHandler.prototype.trigger = function(event,params){
-      this.jdomelem.trigger(event,params);
-    };
-
-
-
-    DragHandler.prototype.getCollisionPos = function(node,newPos) {
-      var result = {
-        x: newPos.x,
-        y: newPos.y,
-        coll:false
-      };
-      var posX = newPos.x-node.offsetX;
-      var posY = newPos.y-node.offsetY;
-      var width   = node.getSize().width;
-      var height  = node.getSize().height;
-      var rect1 = {
-          tl: { x: posX, y: posY },
-          tr: { x: posX + width, y: posY },
-          bl: { x: posX, y: posY + height },
-          br: { x: posX + width, y: posY + height }
-      };
-
-      this.collisionNodes.each(function(node2,k){
-        if (node2 !== node) {
-          var posX2 = node2.getPosition().x-node2.offsetX;
-          var posY2 = node2.getPosition().y-node2.offsetY;
-          var width2   = node2.getSize().width;
-          var height2  = node2.getSize().height;
-          var rect2 = {
-              tl: { x: posX2, y: posY2 },
-              tr: { x: posX2 + width2, y: posY2 },
-              bl: { x: posX2, y: posY2 + height2 },
-              br: { x: posX2 + width2, y: posY2 + height2 }
-          };
-          if (!(
+    this.collisionNodes.each(function (node2, k) {
+      if (node2 !== node) {
+        var posX2 = node2.getPosition().x - node2.offsetX;
+        var posY2 = node2.getPosition().y - node2.offsetY;
+        var width2 = node2.getSize().width;
+        var height2 = node2.getSize().height;
+        var rect2 = {
+          tl: { x: posX2, y: posY2 },
+          tr: { x: posX2 + width2, y: posY2 },
+          bl: { x: posX2, y: posY2 + height2 },
+          br: { x: posX2 + width2, y: posY2 + height2 },
+        };
+        if (
+          !(
             rect1.br.x < rect2.bl.x ||
             rect1.bl.x > rect2.br.x ||
             rect1.bl.y < rect2.tl.y ||
             rect1.tl.y > rect2.bl.y
-          )) {
-            // Oooh myyy
-            result.coll = true;
-            var width12 = width/2 + width2/2;
-            var height12 = height/2 + height2/2
-            var overlapX = (rect1.tr.x - rect2.tl.x) - width12;
-            var overlapY = (rect1.bl.y - rect2.tl.y) - height12;
-            if (Math.abs(overlapY) > Math.abs(overlapX)) {
-              if (overlapY > 0) {
-                result.y = newPos.y + (height12 - overlapY);
-              } else {
-                result.y = newPos.y - (height12 + overlapY);
-              }
+          )
+        ) {
+          // Oooh myyy
+          result.coll = true;
+          var width12 = width / 2 + width2 / 2;
+          var height12 = height / 2 + height2 / 2;
+          var overlapX = rect1.tr.x - rect2.tl.x - width12;
+          var overlapY = rect1.bl.y - rect2.tl.y - height12;
+          if (Math.abs(overlapY) > Math.abs(overlapX)) {
+            if (overlapY > 0) {
+              result.y = newPos.y + (height12 - overlapY);
             } else {
-              if (overlapX > 0) {
-                result.x = newPos.x + (width12 - overlapX);
-              } else {
-                result.x = newPos.x - (width12 + overlapX);
-              }
+              result.y = newPos.y - (height12 + overlapY);
             }
-            return result;
+          } else {
+            if (overlapX > 0) {
+              result.x = newPos.x + (width12 - overlapX);
+            } else {
+              result.x = newPos.x - (width12 + overlapX);
+            }
           }
+          return result;
         }
-      });
-      return result;
+      }
+    });
+    return result;
+  };
+
+  DragHandler.prototype.testCollisions = function (node, newPos) {
+    var coll = false;
+    var posX = newPos.x - node.offsetX;
+    var posY = newPos.y - node.offsetY;
+    var width = node.getSize().width;
+    var height = node.getSize().height;
+    var rect1 = {
+      tl: { x: posX, y: posY },
+      tr: { x: posX + width, y: posY },
+      bl: { x: posX, y: posY + height },
+      br: { x: posX + width, y: posY + height },
     };
 
-    DragHandler.prototype.testCollisions = function(node,newPos) {
-      var coll = false;
-      var posX = newPos.x-node.offsetX;
-      var posY = newPos.y-node.offsetY;
-      var width   = node.getSize().width;
-      var height  = node.getSize().height;
-      var rect1 = {
-          tl: { x: posX, y: posY },
-          tr: { x: posX + width, y: posY },
-          bl: { x: posX, y: posY + height },
-          br: { x: posX + width, y: posY + height }
-      };
-
-      this.collisionNodes.each(function(node2,k){
-        if (node2 !== node) {
-          var posX2 = node2.getPosition().x-node2.offsetX;
-          var posY2 = node2.getPosition().y-node2.offsetY;
-          var width2   = node2.getSize().width;
-          var height2  = node2.getSize().height;
-          var rect2 = {
-              tl: { x: posX2, y: posY2 },
-              tr: { x: posX2 + width2, y: posY2 },
-              bl: { x: posX2, y: posY2 + height2 },
-              br: { x: posX2 + width2, y: posY2 + height2 }
-          };
-          if (!(
+    this.collisionNodes.each(function (node2, k) {
+      if (node2 !== node) {
+        var posX2 = node2.getPosition().x - node2.offsetX;
+        var posY2 = node2.getPosition().y - node2.offsetY;
+        var width2 = node2.getSize().width;
+        var height2 = node2.getSize().height;
+        var rect2 = {
+          tl: { x: posX2, y: posY2 },
+          tr: { x: posX2 + width2, y: posY2 },
+          bl: { x: posX2, y: posY2 + height2 },
+          br: { x: posX2 + width2, y: posY2 + height2 },
+        };
+        if (
+          !(
             rect1.br.x < rect2.bl.x ||
             rect1.bl.x > rect2.br.x ||
             rect1.bl.y < rect2.tl.y ||
             rect1.tl.y > rect2.bl.y
-          )) {
-            coll = true;
-            return coll;
-          }
+          )
+        ) {
+          coll = true;
+          return coll;
         }
-      });
-      return coll;
-    };
-
-
-    DragHandler.prototype.getCollisions = function(node) {
-      if (this.collisionNodes.set.length === 0) {
-        return false;
       }
-      var data = [];
-      // TODO: Calculate or store Bounding-Box on Perp generation for performance reasons
-      //       and to get better visual collisions (e.g. store in framemaps...)
-      this.collisionNodes.each(function(node){
-        // Add / Subtract 20px for less annyoing detection for now.
-        var posX = node.getPosition().x-node.offsetX;
-        var posY = node.getPosition().y-node.offsetY;
-        var width   = node.getSize().width;
-        var height  = node.getSize().height;
+    });
+    return coll;
+  };
 
-        data.push({
-          tl: { x: posX, y: posY },
-          tr: { x: posX + width, y: posY },
-          bl: { x: posX, y: posY + height },
-          br: { x: posX + width, y: posY + height }
-        });
+  DragHandler.prototype.getCollisions = function (node) {
+    if (this.collisionNodes.set.length === 0) {
+      return false;
+    }
+    var data = [];
+    // TODO: Calculate or store Bounding-Box on Perp generation for performance reasons
+    //       and to get better visual collisions (e.g. store in framemaps...)
+    this.collisionNodes.each(function (node) {
+      // Add / Subtract 20px for less annyoing detection for now.
+      var posX = node.getPosition().x - node.offsetX;
+      var posY = node.getPosition().y - node.offsetY;
+      var width = node.getSize().width;
+      var height = node.getSize().height;
+
+      data.push({
+        tl: { x: posX, y: posY },
+        tr: { x: posX + width, y: posY },
+        bl: { x: posX, y: posY + height },
+        br: { x: posX + width, y: posY + height },
       });
+    });
 
-      var i, l;
+    var i, l;
 
-      i = data.length;
-      while(i--) {
-        l = data.length;
-        while(l-- && l !== i) {
-          if (!(
+    i = data.length;
+    while (i--) {
+      l = data.length;
+      while (l-- && l !== i) {
+        if (
+          !(
             data[l].br.x < data[i].bl.x ||
             data[l].bl.x > data[i].br.x ||
             data[l].bl.y < data[i].tl.y ||
             data[l].tl.y > data[i].bl.y
-          )) {
-            return true;
-          }
+          )
+        ) {
+          return true;
         }
       }
-      return false;
-    };
+    }
+    return false;
+  };
 
-    DragHandler.prototype.init = function(){
-      var dm = this;
-      dm.collisionNodes = new Set();
+  DragHandler.prototype.init = function () {
+    var dm = this;
+    dm.collisionNodes = new Set();
 
-      this.on('mouseup touchend',function(e){
-        e.preventDefault();
-        e.stopPropagation();
-        dm.dragend(e);
-      });
-      this.on('mousemove touchmove',function(e){
-        if (!dm.dragging) {
-          return;
-        }
-        /* Uncomment to delay dragging for timeout and then snap into position
+    this.on('mouseup touchend', function (e) {
+      e.preventDefault();
+      e.stopPropagation();
+      dm.dragend(e);
+    });
+    this.on('mousemove touchmove', function (e) {
+      if (!dm.dragging) {
+        return;
+      }
+      /* Uncomment to delay dragging for timeout and then snap into position
         if (!dm.listeners.length) {
           return;
         }*/
-        dm.state='moved';
-        // FIXME: touchhandling broken?!
-        var touch;
-        if (e.originalEvent) {
-          touch = (e.originalEvent.touches) ? e.originalEvent.touches[0] || e.originalEvent.changedTouches[0] : undefined;
+      dm.state = 'moved';
+      // FIXME: touchhandling broken?!
+      var touch;
+      if (e.originalEvent) {
+        touch = e.originalEvent.touches
+          ? e.originalEvent.touches[0] || e.originalEvent.changedTouches[0]
+          : undefined;
+      }
+      var userPos = touch ? { x: touch.pageX, y: touch.pageY } : { x: e.pageX, y: e.pageY };
+      dm.dragMovePos = userPos;
+      dm.dragVector.x = (dm.dragMovePos.x - dm.dragStartPos.x) * dm.scale;
+      dm.dragVector.y = (dm.dragMovePos.y - dm.dragStartPos.y) * dm.scale;
+      // Drag pixel threshold
+      if (Math.abs(dm.dragVector.x) > 16 || Math.abs(dm.dragVector.y) > 16) {
+        dm.trigger('catchup');
+      }
+      for (var i = 0; i < dm.listeners.length; i++) {
+        var node = dm.listeners[i];
+        node.trigger('dragmove');
+        var oldPos = {
+          x: node.getPosition().x,
+          y: node.getPosition().y,
+        };
+        var newPos = {
+          x: node.dragStartPos.x + dm.dragVector.x,
+          y: node.dragStartPos.y + dm.dragVector.y,
+        };
+        if (e.shiftKey) {
+          newPos.x = Math.round(newPos.x / 20) * 20;
+          newPos.y = Math.round(newPos.y / 20) * 20;
         }
-        var userPos = touch ? {x: touch.pageX, y: touch.pageY} : {x: e.pageX, y: e.pageY};
-        dm.dragMovePos = userPos;
-        dm.dragVector.x = (dm.dragMovePos.x - dm.dragStartPos.x)*dm.scale;
-        dm.dragVector.y = (dm.dragMovePos.y - dm.dragStartPos.y)*dm.scale;
-        // Drag pixel threshold
-        if (Math.abs(dm.dragVector.x) > 16 || Math.abs(dm.dragVector.y) > 16) {
-          dm.trigger('catchup');
-        }
-        for (var i=0;i<dm.listeners.length;i++) {
-          var node = dm.listeners[i];
-          node.trigger('dragmove');
-          var oldPos = {
-            x : node.getPosition().x,
-            y : node.getPosition().y
-          };
-          var newPos = {
-            x: node.dragStartPos.x + dm.dragVector.x,
-            y: node.dragStartPos.y + dm.dragVector.y
-          };
-          if (e.shiftKey) {
-            newPos.x = Math.round(newPos.x/20)*20;
-            newPos.y = Math.round(newPos.y/20)*20;
-          }
 
-          // Start: Perp related special draghandling
-          newPos = node.clipCablePos(newPos);
+        // Start: Perp related special draghandling
+        newPos = node.clipCablePos(newPos);
 
-          // Delete line below to turn on collisions
-          node.moveTo(newPos);
-          /* uncomment for collisions on drag
+        // Delete line below to turn on collisions
+        node.moveTo(newPos);
+        /* uncomment for collisions on drag
           var collPos = dm.getCollisionPos(node,newPos);
           if (collPos.coll === true ) {
             node.FXSimple({x:collPos.x,y:collPos.y},50,'linear');
@@ -395,1376 +405,1460 @@ var Render = function() {
             node.moveTo(collPos);
           }
           */
-        }
+      }
+    });
+  };
+
+  ///////////////////////////////////////////
+  // The Set
+  // An array of Nodes with some shortcuts
+  ///////////////////////////////////////////
+
+  var Set = function (set) {
+    if (!set) {
+      set = [];
+    }
+    //this._id = _instances.length;
+    //addSet(this);
+    this.set = set;
+    this.length = this.set.length;
+    return this;
+  };
+
+  Set.prototype.add = function (node) {
+    this.set.push(node);
+    this.length = this.set.length;
+  };
+
+  Set.prototype.remove = function (node) {
+    var index = this.set.indexOf(node);
+    if (index !== -1) {
+      this.set.splice(index, 1);
+    }
+    this.length = this.set.length;
+  };
+
+  Set.prototype.each = function (func) {
+    if (!func) {
+      return;
+    }
+    for (var n = 0; n < this.set.length; n++) {
+      var node = this.set[n];
+      func(node);
+    }
+    this.length = this.set.length;
+  };
+
+  Set.prototype.hide = function () {
+    this.each(function (node) {
+      node.hide();
+    });
+  };
+
+  Set.prototype.show = function () {
+    this.each(function (node) {
+      node.show();
+    });
+  };
+
+  Set.prototype.fade = function (opa) {
+    this.each(function (node) {
+      node.setOpacity(opa);
+    });
+  };
+
+  Set.prototype.draw = function () {
+    this.each(function (node) {
+      node.draw();
+    });
+  };
+
+  Set.prototype.removeAll = function () {
+    var set = this;
+    while (this.set.length > 0) {
+      var node = this.set[0];
+      this.remove(node);
+      node.remove();
+    }
+  };
+
+  Set.prototype.clear = function () {
+    this.set.length = 0;
+  };
+
+  /////////////////////////////////////////////
+  // The SlowTicker
+  /////////////////////////////////////////////
+
+  // Written as Singleton, like original Ticker
+
+  var SlowTicker = {
+    start: function () {
+      if (!this.timeout) {
+        this.tick();
+      }
+    },
+    tick: function () {
+      this.listeners.each(function (node) {
+        node.tick();
       });
-    };
+      this.timeout = window.setTimeout(function () {
+        SlowTicker.tick();
+      }, renderConf.slowTickerFrameRate);
+    },
+    addListener: function (node) {
+      this.listeners.add(node);
+    },
+    removeListener: function (node) {
+      this.listeners.remove(node);
+    },
+    stop: function () {
+      window.clearTimeout(this.timeout);
+      this.timeout = undefined;
+    },
+  };
+  SlowTicker.listeners = new Set();
+  SlowTicker.start();
 
+  /////////////////////////////
+  // The Node
+  // Basic Render Node with DOM Element
+  /////////////////////////////
 
-    ///////////////////////////////////////////
-    // The Set
-    // An array of Nodes with some shortcuts
-    ///////////////////////////////////////////
+  var Node = function (config) {
+    config = config || {};
+    this.jdomelem = config.jdomelem || $("<div class='Node'></div>");
+    this.domelem = config.domelem || this.jdomelem[0];
+    this.init(config);
+    return this;
+  };
 
-    var Set = function(set){
-      if (!set) {
-        set = [];
+  Node.prototype.init = function (config) {
+    // Add to the Render Getter
+    this._id = _instances.length;
+    this.id = config.id || 'Node' + this._id;
+    add(this);
+    // Set Node defaults if undefined
+    config = config || {};
+
+    this.children = new Set();
+    this.decorators = new Set();
+
+    this.setAttrs(config);
+    if (!this.jdomelem) {
+      this.jdomelem = $(this.domelem);
+    }
+    this.jdomelem.attr('id', this.id);
+    this.updateClass();
+  };
+
+  Node.prototype.x = 0;
+  Node.prototype.y = 0;
+  Node.prototype.z = 0;
+  Node.prototype.position = 'absolute';
+  Node.prototype.width = 0;
+  Node.prototype.height = 0;
+  Node.prototype.opacity = 1;
+  Node.prototype.offsetX = 0;
+  Node.prototype.offsetY = 0;
+  Node.prototype.transX = 0;
+  Node.prototype.transY = 0;
+  Node.prototype.scaleX = 1;
+  Node.prototype.scaleY = 1;
+  Node.prototype.rotate = 0;
+  Node.prototype.hidden = false;
+  Node.prototype.display = 'block';
+  Node.prototype.clickable = false;
+  Node.prototype.draggable = false;
+  Node.prototype.dragging = false;
+  Node.prototype.sticky = false;
+  Node.prototype.extendClass = undefined;
+
+  Node.prototype.setAttrs = function (attrs) {
+    // Set any attribute(s)
+    for (var key in attrs) {
+      if (attrs.hasOwnProperty(key)) {
+        this[key] = attrs[key];
       }
-      //this._id = _instances.length;
-      //addSet(this);
-      this.set = set;
-      this.length = this.set.length;
-      return this;
-    };
+    }
+  };
 
-    Set.prototype.add = function(node){
-      this.set.push(node);
-      this.length = this.set.length;
-    };
+  Node.prototype.onAddInit = function () {
+    // Init stuff when added to a Parent Node
+    if (this.draggable) {
+      this.setDraggable(true);
+    }
+    if (this.clickable) {
+      this.setClickable(true);
+    }
+    this.updateRenderProp();
+    this.draw();
+  };
 
-    Set.prototype.remove = function(node){
-      var index = this.set.indexOf(node);
-      if (index !== -1) {
-        this.set.splice(index, 1);
+  Node.prototype.remove = function () {
+    // Remove Node from all references and remove Domobject
+    Ticker.removeListener(this);
+    SlowTicker.removeListener(this);
+    var node = this;
+    if (this.decoratedNode) {
+      this.decoratedNode.decorators.remove(this);
+    }
+    if (this.parentNode) {
+      this.parentNode.children.remove(this);
+    }
+    if (this.children) {
+      this.children.removeAll();
+    }
+    if (this.cables) {
+      this.cables.removeAll();
+    }
+    if (this.decorators) {
+      this.decorators.removeAll();
+    }
+    if (this.perpTo) {
+      this.perpTo.cables.remove(node);
+    }
+    if (this.perpFrom) {
+      this.perpFrom.cables.remove(node);
+    }
+    this.jdomelem.remove();
+    remove(this._id);
+  };
+
+  Node.prototype.addChild = function (child) {
+    // Add a child to a Node
+    // This actually draws an element on the screen when the topmost Node is inside the html body
+    if (child.hidden) {
+      child.hide();
+    }
+    this.jdomelem.append(child.domelem);
+    child.parentNode = this;
+    this.children.add(child);
+    child.dragHandler = child.dragHandler || this.dragHandler;
+    child.useDragHandler = this.dragHandler;
+    child.onAddInit();
+    return child;
+  };
+
+  Node.prototype.addPopup = function (popup) {
+    // Add a popup to a Node
+    // This draws the popup on the screen inside the popupContainer of the node
+    if (!this.popupContainerDomelem) {
+      return;
+    }
+    this.popupContainerDomelem.empty();
+    this.popupContainerDomelem.append(popup.jdomelem);
+    //this.lock();
+    popup.parentNode = this;
+    this.children.add(popup);
+    popup.dragHandler = popup.dragHandler || this.dragHandler;
+    popup.useDragHandler = this.dragHandler;
+    popup.onAddInit();
+    return popup;
+  };
+
+  Node.prototype.addDecorator = function (deco) {
+    // Add a Decorator to a Node
+    // This actually draws an element on the screen when the topmost Node is inside the html body
+    if (!this.parentNode) {
+      return 'Could not decorate';
+    }
+    //config = config || {};
+    //var deco = new Render[type](config,this);
+    this.decorators.add(deco);
+    if (deco.decoType) {
+      if (this[deco.decoType]) {
+        this[deco.decoType].remove();
       }
-      this.length = this.set.length;
+      this[deco.decoType] = deco;
+    }
+    deco.decoratedNode = this;
+    this.parentNode.addChild(deco);
+    return deco;
+  };
+
+  Node.prototype.removeChild = function (node) {
+    this.children.remove(node);
+  };
+
+  Node.prototype.getPosition = function () {
+    // Quickly return the relative position of an Node in respect to its offset
+    return { x: this.x, y: this.y };
+  };
+
+  Node.prototype.getTopLeftPosition = function () {
+    // Quickly return the relative position of an Node in disrespect to its offset
+    var pos = this.getPosition();
+    var off = this.getOffset();
+    return { x: pos.x - off.x, y: pos.y - off.y };
+  };
+
+  Node.prototype.getTopRightPosition = function () {
+    // Quickly return the relative position of an Node in disrespect to its offset
+    var pos = this.getPosition();
+    var off = this.getOffset();
+    return { x: pos.x + this.width - off.x, y: pos.y - off.y };
+  };
+
+  Node.prototype.setPosition = function (pos) {
+    // Set the relative Position of a Node and invoke dragBound Method if available
+    if (this.dragBound) {
+      this.dragBound(pos);
+    }
+    // CSS translation offset is center by default, calculate offset for our coords
+    var transOffset = {
+      x: this.getSize().width / 2 - this.offsetX,
+      y: this.getSize().height / 2 - this.offsetY,
     };
+    // Round for render performance and better sprite anti aliasing
+    pos.x = Math.round(pos.x);
+    pos.y = Math.round(pos.y);
+    this.domelem.style.webkitTransformOriginZ = 0;
+    // FIXME: Unsure if working correctly, test offset calculation
+    this.domelem.style.webkitTransformOriginX = pos.x - transOffset.x + 'px';
+    this.domelem.style.webkitTransformOriginY = pos.y - transOffset.y + 'px';
+    // Fix for Mozilla offset:
+    this.domelem.style.MozTransformOrigin = pos.x + 'px ' + pos.y + 'px';
 
-    Set.prototype.each = function(func){
-      if (!func) {
-        return;
-      }
-      for (var n=0;n<this.set.length;n++) {
-        var node = this.set[n];
-        func(node);
-      }
-      this.length = this.set.length;
+    this.domelem.style.msTransformOrigin = pos.x + 'px ' + pos.y + 'px';
+
+    this.setTransform({ transX: pos.x - this.offsetX, transY: pos.y - this.offsetY });
+    this.x = pos.x;
+    this.y = pos.y;
+  };
+
+  Node.prototype.setOffset = function (offset) {
+    // Set new Offset and place Object accordingly
+    var offsetDiffX = this.offsetX - offset.x;
+    var offsetDiffY = this.offsetY - offset.y;
+    this.offsetX = offset.x;
+    this.offsetY = offset.y;
+    this.setPosition(this.getPosition());
+  };
+
+  Node.prototype.getOffset = function (offset) {
+    return {
+      x: this.offsetX,
+      y: this.offsetY,
     };
+  };
 
-    Set.prototype.hide = function() {
-      this.each(function(node) {
-        node.hide();
-      });
+  Node.prototype.getCenterPosition = function () {
+    // The actual center regardless of Offset/Pivot and scaling
+    return {
+      x: this.x + this.getSize().width / 2,
+      y: this.y + this.getSize().height / 2,
     };
+  };
 
-    Set.prototype.show = function() {
-      this.each(function(node) {
-        node.show();
-      });
+  Node.prototype.getScaledPosition = function () {
+    // The actual center regardless of Offset/Pivot and scaling
+    return {
+      x: this.x + this.getScaledSize().width / 2,
+      y: this.y + this.getScaledSize().height / 2,
     };
+  };
 
-    Set.prototype.fade = function(opa) {
-      this.each(function(node){
-        node.setOpacity(opa);
-      });
-    };
+  Node.prototype.moveTo = function (pos) {
+    // Wrapper for setPosition, overwritten by e.g. Perp to move along Decorators
+    // and Cables
+    this.setPosition(pos);
+  };
 
-    Set.prototype.draw = function() {
-      this.each(function(node) {
-        node.draw();
-      });
-    };
+  Node.prototype.moveBy = function (vector) {
+    // Move node by vector
+    // and Cables
+    this.moveTo({
+      x: this.getPosition().x + vector.x,
+      y: this.getPosition().y + vector.y,
+    });
+  };
 
-    Set.prototype.removeAll = function() {
-      var set = this;
-      while (this.set.length>0) {
-        var node = this.set[0];
-        this.remove(node);
-        node.remove();
-      }
-    };
-
-    Set.prototype.clear = function() {
-      this.set.length=0;
-    };
-
-
-    /////////////////////////////////////////////
-    // The SlowTicker
-    /////////////////////////////////////////////
-
-    // Written as Singleton, like original Ticker
-
-    var SlowTicker = {
-      start: function(){
-        if (!this.timeout) {
-          this.tick();
+  Node.prototype.clipCablePos = function (newPos) {
+    var node = this;
+    if (node.cables && node.cables.set.length) {
+      var cablecheck = false;
+      //node.cables.each(node.cables.set,function(cable){ return cable.length > cable.cableMaxLength-10 });
+      for (var n = 0; n < node.cables.set.length; n++) {
+        var cable = node.cables.set[n];
+        if (cable.length > cable.cableMaxLength - 10) {
+          cablecheck = true;
+          break;
         }
-      },
-      tick: function(){
-        this.listeners.each(function(node){
-          node.tick();
-        });
-        this.timeout = window.setTimeout(function(){SlowTicker.tick();},renderConf.slowTickerFrameRate);
-      },
-      addListener: function(node) {
-        this.listeners.add(node);
-      },
-      removeListener: function(node) {
-        this.listeners.remove(node);
-      },
-      stop: function(){
-        window.clearTimeout(this.timeout);
-        this.timeout=undefined;
       }
-    };
-    SlowTicker.listeners = new Set();
-    SlowTicker.start();
 
-
-    /////////////////////////////
-    // The Node
-    // Basic Render Node with DOM Element
-    /////////////////////////////
-
-    var Node = function(config){
-      config = config || {};
-      this.jdomelem = config.jdomelem || $("<div class='Node'></div>");
-      this.domelem = config.domelem || this.jdomelem[0];
-      this.init(config);
-      return this;
-    };
-
-    Node.prototype.init = function(config){
-      // Add to the Render Getter
-      this._id = _instances.length;
-      this.id = config.id || "Node"+this._id;
-      add(this);
-      // Set Node defaults if undefined
-      config = config || {};
-
-      this.children = new Set();
-      this.decorators = new Set();
-
-      this.setAttrs(config);
-      if (!this.jdomelem) { this.jdomelem = $(this.domelem); }
-      this.jdomelem.attr('id',this.id);
-      this.updateClass();
-    };
-
-    Node.prototype.x = 0;
-    Node.prototype.y = 0;
-    Node.prototype.z = 0;
-    Node.prototype.position = 'absolute';
-    Node.prototype.width = 0;
-    Node.prototype.height = 0;
-    Node.prototype.opacity = 1;
-    Node.prototype.offsetX = 0;
-    Node.prototype.offsetY = 0;
-    Node.prototype.transX = 0;
-    Node.prototype.transY = 0;
-    Node.prototype.scaleX = 1;
-    Node.prototype.scaleY = 1;
-    Node.prototype.rotate = 0;
-    Node.prototype.hidden = false;
-    Node.prototype.display = 'block';
-    Node.prototype.clickable = false;
-    Node.prototype.draggable = false;
-    Node.prototype.dragging = false;
-    Node.prototype.sticky = false;
-    Node.prototype.extendClass = undefined;
-
-    Node.prototype.setAttrs = function(attrs){
-      // Set any attribute(s)
-      for (var key in attrs) {
-        if (attrs.hasOwnProperty(key)) {
-          this[key] = attrs[key];
-        }
-      }
-    };
-
-    Node.prototype.onAddInit = function(){
-      // Init stuff when added to a Parent Node
-      if (this.draggable) {
-        this.setDraggable(true);
-      }
-      if (this.clickable) {
-        this.setClickable(true);
-      }
-      this.updateRenderProp();
-      this.draw();
-    };
-
-    Node.prototype.remove = function(){
-      // Remove Node from all references and remove Domobject
-      Ticker.removeListener(this);
-      SlowTicker.removeListener(this);
-      var node = this;
-      if (this.decoratedNode) {
-        this.decoratedNode.decorators.remove(this);
-      }
-      if (this.parentNode) {
-        this.parentNode.children.remove(this);
-      }
-      if (this.children) {
-        this.children.removeAll();
-      }
-      if (this.cables) {
-        this.cables.removeAll();
-      }
-      if (this.decorators) {
-        this.decorators.removeAll();
-      }
-      if (this.perpTo) {
-        this.perpTo.cables.remove(node);
-      }
-      if (this.perpFrom) {
-        this.perpFrom.cables.remove(node);
-      }
-      this.jdomelem.remove();
-      remove(this._id);
-    };
-
-    Node.prototype.addChild = function(child){
-      // Add a child to a Node
-      // This actually draws an element on the screen when the topmost Node is inside the html body
-      if (child.hidden) {
-        child.hide();
-      }
-      this.jdomelem.append(child.domelem);
-      child.parentNode = this;
-      this.children.add(child);
-      child.dragHandler = child.dragHandler || this.dragHandler;
-      child.useDragHandler = this.dragHandler;
-      child.onAddInit();
-      return child;
-    };
-
-    Node.prototype.addPopup = function(popup){
-      // Add a popup to a Node
-      // This draws the popup on the screen inside the popupContainer of the node
-      if (!this.popupContainerDomelem) { return; }
-      this.popupContainerDomelem.empty();
-      this.popupContainerDomelem.append(popup.jdomelem);
-      //this.lock();
-      popup.parentNode = this;
-      this.children.add(popup);
-      popup.dragHandler = popup.dragHandler || this.dragHandler;
-      popup.useDragHandler = this.dragHandler;
-      popup.onAddInit();
-      return popup;
-    };
-
-    Node.prototype.addDecorator = function(deco){
-      // Add a Decorator to a Node
-      // This actually draws an element on the screen when the topmost Node is inside the html body
-      if (!this.parentNode) {
-        return 'Could not decorate';
-      }
-      //config = config || {};
-      //var deco = new Render[type](config,this);
-      this.decorators.add(deco);
-      if (deco.decoType) {
-        if (this[deco.decoType]) {
-          this[deco.decoType].remove();
-        }
-        this[deco.decoType] = deco;
-      }
-      deco.decoratedNode=this;
-      this.parentNode.addChild(deco);
-      return deco;
-    };
-
-    Node.prototype.removeChild = function(node){
-      this.children.remove(node);
-    };
-
-    Node.prototype.getPosition = function(){
-      // Quickly return the relative position of an Node in respect to its offset
-      return {x:this.x, y:this.y};
-    };
-
-    Node.prototype.getTopLeftPosition = function(){
-      // Quickly return the relative position of an Node in disrespect to its offset
-      var pos = this.getPosition();
-      var off = this.getOffset();
-      return {x: pos.x - off.x, y: pos.y - off.y};
-    };
-
-    Node.prototype.getTopRightPosition = function(){
-      // Quickly return the relative position of an Node in disrespect to its offset
-      var pos = this.getPosition();
-      var off = this.getOffset();
-      return {x: pos.x + this.width - off.x, y: pos.y - off.y};
-    };
-
-
-    Node.prototype.setPosition = function(pos){
-      // Set the relative Position of a Node and invoke dragBound Method if available
-      if (this.dragBound) {
-        this.dragBound(pos);
-      }
-      // CSS translation offset is center by default, calculate offset for our coords
-      var transOffset = {
-        x:(this.getSize().width/2)-this.offsetX,
-        y:(this.getSize().height/2)-this.offsetY
-      };
-      // Round for render performance and better sprite anti aliasing
-      pos.x = Math.round(pos.x);
-      pos.y = Math.round(pos.y);
-      this.domelem.style.webkitTransformOriginZ = 0;
-      // FIXME: Unsure if working correctly, test offset calculation
-      this.domelem.style.webkitTransformOriginX = pos.x-transOffset.x + "px";
-      this.domelem.style.webkitTransformOriginY = pos.y-transOffset.y + "px";
-      // Fix for Mozilla offset:
-      this.domelem.style.MozTransformOrigin = pos.x + "px " + pos.y + "px";
-
-      this.domelem.style.msTransformOrigin = pos.x + "px " + pos.y + "px";
-
-      this.setTransform({transX:pos.x-this.offsetX,transY:pos.y-this.offsetY});
-      this.x = pos.x;
-      this.y = pos.y;
-    };
-
-    Node.prototype.setOffset = function(offset) {
-      // Set new Offset and place Object accordingly
-      var offsetDiffX = this.offsetX-offset.x;
-      var offsetDiffY = this.offsetY-offset.y;
-      this.offsetX = offset.x;
-      this.offsetY = offset.y;
-      this.setPosition(this.getPosition());
-    };
-
-    Node.prototype.getOffset = function(offset) {
-      return {
-        x:this.offsetX,
-        y:this.offsetY
-      };
-    };
-
-    Node.prototype.getCenterPosition = function(){
-      // The actual center regardless of Offset/Pivot and scaling
-      return {
-        x: this.x + (this.getSize().width / 2),
-        y: this.y + (this.getSize().height / 2)
-      };
-    };
-
-    Node.prototype.getScaledPosition = function(){
-      // The actual center regardless of Offset/Pivot and scaling
-      return {
-        x:this.x+(this.getScaledSize().width/2),
-        y:this.y+(this.getScaledSize().height/2)
-      };
-    };
-
-    Node.prototype.moveTo = function(pos){
-      // Wrapper for setPosition, overwritten by e.g. Perp to move along Decorators
-      // and Cables
-      this.setPosition(pos);
-    };
-
-    Node.prototype.moveBy = function(vector){
-      // Move node by vector
-      // and Cables
-      this.moveTo({
-        x: this.getPosition().x + vector.x,
-        y: this.getPosition().y + vector.y
-      });
-    };
-
-    Node.prototype.clipCablePos = function(newPos) {
-      var node = this;
-      if (node.cables && node.cables.set.length) {
-        var cablecheck = false;
-        //node.cables.each(node.cables.set,function(cable){ return cable.length > cable.cableMaxLength-10 });
-        for (var n=0;n < node.cables.set.length; n++) {
-          var cable = node.cables.set[n];
-          if (cable.length > cable.cableMaxLength-10) {
-            cablecheck = true;
-            break;
-          }
-        }
-
-        var dragBoundFunc = function(pos, otherPos, cableMaxLength) {
-          var circle = {
-            x: otherPos.x,
-            y: otherPos.y,
-            r: cableMaxLength
-          };
-          var scale = circle.r / Math.sqrt(
-            Math.pow(pos.x-circle.x,2) +
-            Math.pow(pos.y-circle.y,2)
-          );
-          if (scale < 1) {
-            return {
-              y: Math.round((pos.y-circle.y)*scale+circle.y),
-              x: Math.round((pos.x-circle.x)*scale+circle.x)
-            };
-          }
-          else {
-            return pos;
-          }
-        };
-        if (cablecheck) {
-          node.cables.each(function(cable){
-            var otherperp = (cable.perpFrom === node) ? cable.perpTo : cable.perpFrom;
-            var otherPos = otherperp.getPosition();
-            newPos = dragBoundFunc(newPos, otherPos, cable.cableMaxLength);
-          });
-        }
-        return newPos;
-      } else {
-        return newPos;
-      }
-    };
-
-    Node.prototype.testParentRadius = function(newPos,radius) {
-      var node = this;
-      radius = radius || 400;
-      var otherperp = node.gameNode.parentNode.renderNode;
-      var dragBoundFunc = function(pos) {
+      var dragBoundFunc = function (pos, otherPos, cableMaxLength) {
         var circle = {
-          x: otherperp.getPosition().x,
-          y: otherperp.getPosition().y,
-          r: radius
+          x: otherPos.x,
+          y: otherPos.y,
+          r: cableMaxLength,
         };
-        var scale = circle.r / Math.sqrt(
-          Math.pow(pos.x-circle.x,2) +
-          Math.pow(pos.y-circle.y,2)
-        );
+        var scale =
+          circle.r / Math.sqrt(Math.pow(pos.x - circle.x, 2) + Math.pow(pos.y - circle.y, 2));
         if (scale < 1) {
           return {
-            y: Math.round((pos.y-circle.y)*scale+circle.y),
-            x: Math.round((pos.x-circle.x)*scale+circle.x)
+            y: Math.round((pos.y - circle.y) * scale + circle.y),
+            x: Math.round((pos.x - circle.x) * scale + circle.x),
           };
-        }
-        else {
+        } else {
           return pos;
         }
       };
-      var clipPos = dragBoundFunc(newPos);
-      newPos.x = clipPos.x;
-      newPos.y = clipPos.y;
-      return newPos;
-    };
-
-
-    Node.prototype.hide = function(){
-      this.css({
-        'display': 'none'
-      });
-      this.hidden = true;
-      if (this.decorators) { this.decorators.hide(); }
-    };
-
-    Node.prototype.show = function(){
-      this.css({
-        'display': this.display
-      });
-      this.hidden = false;
-      if (this.decorators) { this.decorators.show(); }
-    };
-
-    Node.prototype.css = function(css) {
-      // Wrapper for CSS manipulation of domelem, currently jQuery
-      this.jdomelem.css(css);
-    };
-
-    Node.prototype.updateClass = function(){
-      if (this.extendClass) {
-        this.jdomelem.addClass(this.extendClass);
-      }
-    };
-
-    Node.prototype.updateRenderProp = function() {
-      // Update misc render properties, might be obsolete
-      this.css({
-        'z-index': this.z,
-        'position': this.position,
-        'top': 0,
-        'left': 0,
-        'display': this.display
-      });
-    };
-
-    Node.prototype.setZ = function(z) {
-      // Update misc render properties, might be obsolete
-      this.z = z;
-      this.css({
-        'z-index': this.z
-      });
-    };
-
-    Node.prototype.setOpacity = function(opacity) {
-      this.opacity = opacity;
-      this.css({
-        opacity: opacity
-        //display: (opacity === 0) ? "none" : this.display
-      });
-    };
-
-    Node.prototype.setTransform = function(transf) {
-      // Set one or more CSS Transforms with respect to the specific Browser APIs
-      // settings: scaleX, scaleY, transX, transY, rotate
-      // TODO: get rid of jQuery wrapper and implement native JS with fallbacks
-      this.setAttrs(transf);
-      this.css({
-        "-webkit-transform-style": "preserve-3d",
-        "-webkit-backface-visibility": "hidden",
-        "-moz-transform-style": "preserve-3d", // Massive FF Performance Boost on Scrolling ;)
-        "-webkit-transform": "rotateZ("+this.rotate+"deg) scale3d("+this.scaleX+","+this.scaleY+",1) translate3d("+ (this.transX) +"px,"+ (this.transY) +"px,0px)",
-        "-moz-transform": "rotateZ("+this.rotate+"deg) scale3d("+this.scaleX+","+this.scaleY+",1) translate3d("+ (this.transX) +"px,"+ (this.transY) +"px,0px)",
-        //"-moz-transform": "rotate("+this.rotate+"deg) scale("+this.scaleX+","+this.scaleY+") translate("+ (this.transX) +"px,"+ (this.transY) +"px)",
-        "-transform": "rotateZ("+this.rotate+"deg) scale3d("+this.scaleX+","+this.scaleY+",1) translate3d("+ (this.transX) +"px,"+ (this.transY) +"px,0px)"
-      });
-    };
-
-    Node.prototype.getTransform = function() {
-      // Might be obsolete
-      return {
-        scaleX : this.scaleX,
-        scaleY : this.scaleY,
-        transX : this.transX,
-        transY : this.transY,
-        rotate : this.rotate
-      };
-    };
-
-    Node.prototype.setSize = function(size){
-      this.setAttrs(size);
-      this.css({
-        'width':this.width+"px",
-        'height':this.height+"px"
-      });
-    };
-
-    Node.prototype.getSize = function(){
-      return {width: this.width, height: this.height};
-    };
-
-    Node.prototype.getScaledSize = function(){
-      return {width: this.width * this.scaleX, height: this.height * this.scaleY};
-    };
-
-    Node.prototype.getVectorTo = function(node2) {
-      // Get vector to other node
-      return {
-        x: node2.getPosition().x - this.getPosition().x,
-        y: node2.getPosition().y - this.getPosition().y
-      };
-    };
-
-    Node.prototype.getVectorPos = function(vector,scale) {
-      // Get the endpos when adding vector, scale scales length of vector (0-1)
-      scale = scale || 1;
-      return {
-        x: this.getPosition().x + vector.x*scale,
-        y: this.getPosition().y + vector.y*scale
-      };
-    };
-
-
-    Node.prototype.draw = function(){
-      // Update domelem to current settings
-      this.setSize(this.getSize());
-      this.setTransform(this.getTransform());
-      this.setPosition(this.getPosition());
-      this.setOpacity(this.opacity);
-    };
-
-    Node.prototype.tick = function(){
-      // Function to run on EasleJS Ticker Intervals
-      this.draw();
-    };
-
-    Node.prototype.on = function(event,func){
-      // Wrapper for ".on" events
-      this.jdomelem.on(event,func);
-    };
-
-    Node.prototype.trigger = function(event,params){
-      // Wrapper for ".trigger" events
-      if (this.gameNode) {
-        this.gameNode.trigger(event,params);
-      }
-      this.jdomelem.trigger(event,params);
-    };
-
-    Node.prototype.off = function(event){
-      // Wrapper for ".off" events
-      this.jdomelem.off(event);
-    };
-
-
-    ////////////////////////////////
-    // Node Click and Draghandler
-    ////////////////////////////////
-
-    // TODO: wrap dragevents and add to seperate mousedown touchstart handler
-    Node.prototype.setDraggable = function(bit){
-      var node = this;
-      if (bit) {
-        node.draggable = true;
-        if (node.detectCollisions) {
-          node.useDragHandler.collisionNodes.add(node);
-        }
-        node.on('mousedown touchstart',function(e){
-          e.preventDefault();
-          e.stopPropagation();
-
-          // Start dragging by timeout (visual hint)
-          node.dragDelay = window.setTimeout(function(){
-            node.useDragHandler.addListener(node);
-            node.cancelClick = true;
-            node.useDragHandler.off('catchup');
-          },350);
-
-          // Start dragging by mousemove > 10px
-          node.useDragHandler.on('catchup',function(e){
-            node.useDragHandler.addListener(node);
-            node.cancelClick = true;
-            node.useDragHandler.off('catchup');
-            window.clearTimeout(node.dragDelay);
-          });
-
-          // Always start the draghandler
-          node.useDragHandler.dragstart(e);
-
+      if (cablecheck) {
+        node.cables.each(function (cable) {
+          var otherperp = cable.perpFrom === node ? cable.perpTo : cable.perpFrom;
+          var otherPos = otherperp.getPosition();
+          newPos = dragBoundFunc(newPos, otherPos, cable.cableMaxLength);
         });
-        node.on('mouseup touchend',function(e){
+      }
+      return newPos;
+    } else {
+      return newPos;
+    }
+  };
+
+  Node.prototype.testParentRadius = function (newPos, radius) {
+    var node = this;
+    radius = radius || 400;
+    var otherperp = node.gameNode.parentNode.renderNode;
+    var dragBoundFunc = function (pos) {
+      var circle = {
+        x: otherperp.getPosition().x,
+        y: otherperp.getPosition().y,
+        r: radius,
+      };
+      var scale =
+        circle.r / Math.sqrt(Math.pow(pos.x - circle.x, 2) + Math.pow(pos.y - circle.y, 2));
+      if (scale < 1) {
+        return {
+          y: Math.round((pos.y - circle.y) * scale + circle.y),
+          x: Math.round((pos.x - circle.x) * scale + circle.x),
+        };
+      } else {
+        return pos;
+      }
+    };
+    var clipPos = dragBoundFunc(newPos);
+    newPos.x = clipPos.x;
+    newPos.y = clipPos.y;
+    return newPos;
+  };
+
+  Node.prototype.hide = function () {
+    this.css({
+      display: 'none',
+    });
+    this.hidden = true;
+    if (this.decorators) {
+      this.decorators.hide();
+    }
+  };
+
+  Node.prototype.show = function () {
+    this.css({
+      display: this.display,
+    });
+    this.hidden = false;
+    if (this.decorators) {
+      this.decorators.show();
+    }
+  };
+
+  Node.prototype.css = function (css) {
+    // Wrapper for CSS manipulation of domelem, currently jQuery
+    this.jdomelem.css(css);
+  };
+
+  Node.prototype.updateClass = function () {
+    if (this.extendClass) {
+      this.jdomelem.addClass(this.extendClass);
+    }
+  };
+
+  Node.prototype.updateRenderProp = function () {
+    // Update misc render properties, might be obsolete
+    this.css({
+      'z-index': this.z,
+      position: this.position,
+      top: 0,
+      left: 0,
+      display: this.display,
+    });
+  };
+
+  Node.prototype.setZ = function (z) {
+    // Update misc render properties, might be obsolete
+    this.z = z;
+    this.css({
+      'z-index': this.z,
+    });
+  };
+
+  Node.prototype.setOpacity = function (opacity) {
+    this.opacity = opacity;
+    this.css({
+      opacity: opacity,
+      //display: (opacity === 0) ? "none" : this.display
+    });
+  };
+
+  Node.prototype.setTransform = function (transf) {
+    // Set one or more CSS Transforms with respect to the specific Browser APIs
+    // settings: scaleX, scaleY, transX, transY, rotate
+    // TODO: get rid of jQuery wrapper and implement native JS with fallbacks
+    this.setAttrs(transf);
+    this.css({
+      '-webkit-transform-style': 'preserve-3d',
+      '-webkit-backface-visibility': 'hidden',
+      '-moz-transform-style': 'preserve-3d', // Massive FF Performance Boost on Scrolling ;)
+      '-webkit-transform':
+        'rotateZ(' +
+        this.rotate +
+        'deg) scale3d(' +
+        this.scaleX +
+        ',' +
+        this.scaleY +
+        ',1) translate3d(' +
+        this.transX +
+        'px,' +
+        this.transY +
+        'px,0px)',
+      '-moz-transform':
+        'rotateZ(' +
+        this.rotate +
+        'deg) scale3d(' +
+        this.scaleX +
+        ',' +
+        this.scaleY +
+        ',1) translate3d(' +
+        this.transX +
+        'px,' +
+        this.transY +
+        'px,0px)',
+      //"-moz-transform": "rotate("+this.rotate+"deg) scale("+this.scaleX+","+this.scaleY+") translate("+ (this.transX) +"px,"+ (this.transY) +"px)",
+      '-transform':
+        'rotateZ(' +
+        this.rotate +
+        'deg) scale3d(' +
+        this.scaleX +
+        ',' +
+        this.scaleY +
+        ',1) translate3d(' +
+        this.transX +
+        'px,' +
+        this.transY +
+        'px,0px)',
+    });
+  };
+
+  Node.prototype.getTransform = function () {
+    // Might be obsolete
+    return {
+      scaleX: this.scaleX,
+      scaleY: this.scaleY,
+      transX: this.transX,
+      transY: this.transY,
+      rotate: this.rotate,
+    };
+  };
+
+  Node.prototype.setSize = function (size) {
+    this.setAttrs(size);
+    this.css({
+      width: this.width + 'px',
+      height: this.height + 'px',
+    });
+  };
+
+  Node.prototype.getSize = function () {
+    return { width: this.width, height: this.height };
+  };
+
+  Node.prototype.getScaledSize = function () {
+    return { width: this.width * this.scaleX, height: this.height * this.scaleY };
+  };
+
+  Node.prototype.getVectorTo = function (node2) {
+    // Get vector to other node
+    return {
+      x: node2.getPosition().x - this.getPosition().x,
+      y: node2.getPosition().y - this.getPosition().y,
+    };
+  };
+
+  Node.prototype.getVectorPos = function (vector, scale) {
+    // Get the endpos when adding vector, scale scales length of vector (0-1)
+    scale = scale || 1;
+    return {
+      x: this.getPosition().x + vector.x * scale,
+      y: this.getPosition().y + vector.y * scale,
+    };
+  };
+
+  Node.prototype.draw = function () {
+    // Update domelem to current settings
+    this.setSize(this.getSize());
+    this.setTransform(this.getTransform());
+    this.setPosition(this.getPosition());
+    this.setOpacity(this.opacity);
+  };
+
+  Node.prototype.tick = function () {
+    // Function to run on EasleJS Ticker Intervals
+    this.draw();
+  };
+
+  Node.prototype.on = function (event, func) {
+    // Wrapper for ".on" events
+    this.jdomelem.on(event, func);
+  };
+
+  Node.prototype.trigger = function (event, params) {
+    // Wrapper for ".trigger" events
+    if (this.gameNode) {
+      this.gameNode.trigger(event, params);
+    }
+    this.jdomelem.trigger(event, params);
+  };
+
+  Node.prototype.off = function (event) {
+    // Wrapper for ".off" events
+    this.jdomelem.off(event);
+  };
+
+  ////////////////////////////////
+  // Node Click and Draghandler
+  ////////////////////////////////
+
+  // TODO: wrap dragevents and add to seperate mousedown touchstart handler
+  Node.prototype.setDraggable = function (bit) {
+    var node = this;
+    if (bit) {
+      node.draggable = true;
+      if (node.detectCollisions) {
+        node.useDragHandler.collisionNodes.add(node);
+      }
+      node.on('mousedown touchstart', function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        // Start dragging by timeout (visual hint)
+        node.dragDelay = window.setTimeout(function () {
+          node.useDragHandler.addListener(node);
+          node.cancelClick = true;
+          node.useDragHandler.off('catchup');
+        }, 350);
+
+        // Start dragging by mousemove > 10px
+        node.useDragHandler.on('catchup', function (e) {
+          node.useDragHandler.addListener(node);
+          node.cancelClick = true;
           node.useDragHandler.off('catchup');
           window.clearTimeout(node.dragDelay);
         });
-      } else {
-        if (node.draggable) {
-          node.off('mousedown touchstart');
-          node.useDragHandler.off('catchup');
-          node.draggable = false;
-          if (node.detectCollisions) {
-            node.useDragHandler.collisionNodes.remove(node);
-          }
-          if (node.clickable) {
-            node.setClickable(true);
-          }
+
+        // Always start the draghandler
+        node.useDragHandler.dragstart(e);
+      });
+      node.on('mouseup touchend', function (e) {
+        node.useDragHandler.off('catchup');
+        window.clearTimeout(node.dragDelay);
+      });
+    } else {
+      if (node.draggable) {
+        node.off('mousedown touchstart');
+        node.useDragHandler.off('catchup');
+        node.draggable = false;
+        if (node.detectCollisions) {
+          node.useDragHandler.collisionNodes.remove(node);
         }
-      }
-    };
-
-    Node.prototype.setClickable = function(bit){
-      var node = this;
-      node.cancelClick = true;
-      if (bit) {
-        node.clickable= true;
-        node.on('mousedown touchstart',function(e){
-          e.preventDefault();
-          e.stopPropagation();
-          node.cancelClick = false;
-          if (node.cancelClickTimeout) {
-            window.clearTimeout(node.cancelClickTimeout);
-          }
-          node.cancelClickTimeout = window.setTimeout(function(){
-            node.cancelClick = true;
-          },1000);
-        });
-        node.on('mouseup touchend',function(e){
-          if (!node.cancelClick) {
-              e.preventDefault();
-              e.stopPropagation();
-              if (e.shiftKey) {
-                node.trigger('vshiftclick');
-              } else {
-                node.trigger('vclick');
-              }
-          }
-          node.cancelClick = true;
-          // Always propagate mouseup to draghandler to securly cancle dragging
-          if (node.useDragHandler) {
-            node.useDragHandler.trigger('mouseup');
-          }
-        });
-        node.on('dblclick dbltap',function(e){
-          e.preventDefault();
-          e.stopPropagation();
-          //if (node.dragging) return;
-          node.trigger('vdblclick');
-        });
-
-        node.on('mouseenter',function(e){
-          e.stopPropagation();
-          node.trigger('vmouseover');
-        });
-        node.on('mouseleave',function(e){
-          e.stopPropagation();
-          node.trigger('vmouseout');
-        });
-
-        // FIXME: DEBUG those Events, remove
-        node.on('vclick',function(e){
-          e.stopPropagation();
-        });
-        node.on('vdblclick',function(e){
-          e.stopPropagation();
-        });
-
-      } else {
         if (node.clickable) {
-          node.off('mouseup touchend');
-          node.off('dblclick dbltap');
-          node.off('mouseenter');
-          node.off('mouseleave');
-          node.clickable = false;
+          node.setClickable(true);
         }
       }
-    };
+    }
+  };
 
+  Node.prototype.setClickable = function (bit) {
+    var node = this;
+    node.cancelClick = true;
+    if (bit) {
+      node.clickable = true;
+      node.on('mousedown touchstart', function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+        node.cancelClick = false;
+        if (node.cancelClickTimeout) {
+          window.clearTimeout(node.cancelClickTimeout);
+        }
+        node.cancelClickTimeout = window.setTimeout(function () {
+          node.cancelClick = true;
+        }, 1000);
+      });
+      node.on('mouseup touchend', function (e) {
+        if (!node.cancelClick) {
+          e.preventDefault();
+          e.stopPropagation();
+          if (e.shiftKey) {
+            node.trigger('vshiftclick');
+          } else {
+            node.trigger('vclick');
+          }
+        }
+        node.cancelClick = true;
+        // Always propagate mouseup to draghandler to securly cancle dragging
+        if (node.useDragHandler) {
+          node.useDragHandler.trigger('mouseup');
+        }
+      });
+      node.on('dblclick dbltap', function (e) {
+        e.preventDefault();
+        e.stopPropagation();
+        //if (node.dragging) return;
+        node.trigger('vdblclick');
+      });
 
-    ////////////////////
-    // Node FX
-    ////////////////////
+      node.on('mouseenter', function (e) {
+        e.stopPropagation();
+        node.trigger('vmouseover');
+      });
+      node.on('mouseleave', function (e) {
+        e.stopPropagation();
+        node.trigger('vmouseout');
+      });
 
-    Node.prototype.FXSimple = function(config,duration,easing,callback){
-      var node = this;
-      Ticker.addListener(node);
+      // FIXME: DEBUG those Events, remove
+      node.on('vclick', function (e) {
+        e.stopPropagation();
+      });
+      node.on('vdblclick', function (e) {
+        e.stopPropagation();
+      });
+    } else {
+      if (node.clickable) {
+        node.off('mouseup touchend');
+        node.off('dblclick dbltap');
+        node.off('mouseenter');
+        node.off('mouseleave');
+        node.clickable = false;
+      }
+    }
+  };
 
-      this.FXAnimation = Tween.get(node,{
-        override:true
-      })
-      .to(config,duration,Ease[easing])
-      .call(function(){
+  ////////////////////
+  // Node FX
+  ////////////////////
+
+  Node.prototype.FXSimple = function (config, duration, easing, callback) {
+    var node = this;
+    Ticker.addListener(node);
+
+    this.FXAnimation = Tween.get(node, {
+      override: true,
+    })
+      .to(config, duration, Ease[easing])
+      .call(function () {
         Ticker.removeListener(node);
         if (callback) {
           callback();
         }
       });
-      return this.FXAnimation;
-    };
+    return this.FXAnimation;
+  };
 
-    Node.prototype.FXSimpleCue = function(config,duration,easing,callback){
-      var node = this;
-      Ticker.addListener(node);
+  Node.prototype.FXSimpleCue = function (config, duration, easing, callback) {
+    var node = this;
+    Ticker.addListener(node);
 
-      if (!Tween.hasActiveTweens(this)||!this.FXAnimation) {
-        this.FXAnimation = Tween.get(node)
-        .to(config,duration,Ease[easing])
-        .call(function(){
+    if (!Tween.hasActiveTweens(this) || !this.FXAnimation) {
+      this.FXAnimation = Tween.get(node)
+        .to(config, duration, Ease[easing])
+        .call(function () {
           Ticker.removeListener(node);
           if (callback) {
             callback();
           }
         });
-      } else if (Tween.hasActiveTweens(this)) {
+    } else if (Tween.hasActiveTweens(this)) {
+      Ticker.addListener(node);
+      this.FXAnimation.call(function () {
         Ticker.addListener(node);
-        this.FXAnimation
-        .call(function(){Ticker.addListener(node);})
-        .to(config,duration,Ease[easing])
-        .call(function(){
-          Ticker.removeListener(node);
-          if (callback) {
-            callback();
-          }
-        });
-      }
-      return this.FXAnimation;
-    };
-
-    Node.prototype.FXWaitCue = function(time,callback){
-      var node = this;
-      Ticker.addListener(node);
-      if (!Tween.hasActiveTweens(this)||!this.FXAnimation) {
-        this.FXAnimation = Tween.get(node)
-        .wait(time)
-        .call(function(){
-          Ticker.removeListener(node);
-          if (callback) {
-            callback();
-          }
-        });
-      } else if (Tween.hasActiveTweens(this)) {
-        Ticker.addListener(node);
-        this.FXAnimation
-        .call(function(){Ticker.addListener(node);})
-        .wait(time)
-        .call(function(){
-          Ticker.removeListener(node);
-          if (callback) {
-            callback();
-          }
-        });
-      }
-      return this.FXAnimation;
-    };
-
-    Node.prototype.FXStop = function(){
-      this.FXSimple({},0,'linear');
-    };
-
-    Node.prototype.FXClearCue = function(){
-      this.FXAnimation = undefined;
-    };
-
-    Node.prototype.FXSimpleLoop = function(config,duration,easing,callback){
-      var node = this;
-      Ticker.addListener(node);
-      return Tween.get(node,{
-        override:true,
-        loop:true
       })
-      .to(config.one,duration,Ease[easing])
-      .to(config.two,duration,Ease[easing])
-      .call(function(){
+        .to(config, duration, Ease[easing])
+        .call(function () {
+          Ticker.removeListener(node);
           if (callback) {
             callback();
           }
+        });
+    }
+    return this.FXAnimation;
+  };
+
+  Node.prototype.FXWaitCue = function (time, callback) {
+    var node = this;
+    Ticker.addListener(node);
+    if (!Tween.hasActiveTweens(this) || !this.FXAnimation) {
+      this.FXAnimation = Tween.get(node)
+        .wait(time)
+        .call(function () {
+          Ticker.removeListener(node);
+          if (callback) {
+            callback();
+          }
+        });
+    } else if (Tween.hasActiveTweens(this)) {
+      Ticker.addListener(node);
+      this.FXAnimation.call(function () {
+        Ticker.addListener(node);
+      })
+        .wait(time)
+        .call(function () {
+          Ticker.removeListener(node);
+          if (callback) {
+            callback();
+          }
+        });
+    }
+    return this.FXAnimation;
+  };
+
+  Node.prototype.FXStop = function () {
+    this.FXSimple({}, 0, 'linear');
+  };
+
+  Node.prototype.FXClearCue = function () {
+    this.FXAnimation = undefined;
+  };
+
+  Node.prototype.FXSimpleLoop = function (config, duration, easing, callback) {
+    var node = this;
+    Ticker.addListener(node);
+    return Tween.get(node, {
+      override: true,
+      loop: true,
+    })
+      .to(config.one, duration, Ease[easing])
+      .to(config.two, duration, Ease[easing])
+      .call(function () {
+        if (callback) {
+          callback();
+        }
       });
-    };
+  };
 
-    Node.prototype.FXBounce = function(){
-      //'12%':{'transform':'s1.1','easing':'>'},
-      //'24%':{'transform':'s1.05','easing':'<'},
-      //'76%':{'transform':'s1','easing':'bounce'}
-      // 260ms
-      var node = this;
-      Ticker.addListener(node);
-      return Tween.get(node,{
-        override:true
-      })
-      .to({scaleX:1.15,scaleY:1.15},31,Ease.easeOut)
-      .to({scaleX:1.1,scaleY:1.1},31,Ease.easeIn)
-      .to({scaleX:1,scaleY:1},200,Ease.bounceOut)
-      .call(function(){
+  Node.prototype.FXBounce = function () {
+    //'12%':{'transform':'s1.1','easing':'>'},
+    //'24%':{'transform':'s1.05','easing':'<'},
+    //'76%':{'transform':'s1','easing':'bounce'}
+    // 260ms
+    var node = this;
+    Ticker.addListener(node);
+    return Tween.get(node, {
+      override: true,
+    })
+      .to({ scaleX: 1.15, scaleY: 1.15 }, 31, Ease.easeOut)
+      .to({ scaleX: 1.1, scaleY: 1.1 }, 31, Ease.easeIn)
+      .to({ scaleX: 1, scaleY: 1 }, 200, Ease.bounceOut)
+      .call(function () {
         Ticker.removeListener(node);
       });
-    };
+  };
 
-    Node.prototype.FXSpinner = function(config,cb){
-      var config = config || {};
-      var text = config.text || '';
-      var isnew = config.isnew || false;
-      var duration = config.duration+400 || 2000;
-      var node = this;
-      if (!this.spinner) {
-        this.spinner = new Sprite({
-          frame: 'normal',
-          frameSrc: "largespinner.png",
-          frameMap: {
-            normal : { x: 0, y: 0, width: 120, height: 120, pivotx: 60, pivoty: 60 }
-          },
-          z:-1,
-          opacity:0
-        });
-      }
-      var spinner = this.spinner;
-      Ticker.addListener(node);
-      Ticker.addListener(spinner);
-      node.DecoratorAmount.hide();
+  Node.prototype.FXSpinner = function (config, cb) {
+    var config = config || {};
+    var text = config.text || '';
+    var isnew = config.isnew || false;
+    var duration = config.duration + 400 || 2000;
+    var node = this;
+    if (!this.spinner) {
+      this.spinner = new Sprite({
+        frame: 'normal',
+        frameSrc: 'largespinner.png',
+        frameMap: {
+          normal: { x: 0, y: 0, width: 120, height: 120, pivotx: 60, pivoty: 60 },
+        },
+        z: -1,
+        opacity: 0,
+      });
+    }
+    var spinner = this.spinner;
+    Ticker.addListener(node);
+    Ticker.addListener(spinner);
+    node.DecoratorAmount.hide();
 
-      spinner.setFrame('normal');
+    spinner.setFrame('normal');
 
-      node.parentNode.addChild(spinner);
-      var nPos = node.getPosition();
-      spinner.setPosition(nPos);
+    node.parentNode.addChild(spinner);
+    var nPos = node.getPosition();
+    spinner.setPosition(nPos);
 
-      var speed = 1;
-      var sps = (node.width > 99) ? 1.2 : 1 ;
-      return Tween.get(spinner)
-      .to({scaleX:0.8,scaleY:0.8, rotate:125*speed, opacity:0},0,Ease.linear)
-      .to({scaleX:sps,scaleY:sps, rotate:0, opacity:1},250*speed,Ease.linear)
-      .to({scaleX:sps,scaleY:sps, rotate:-1000*speed},duration*speed,Ease.easeIn)
-      .to({scaleX:0.8,scaleY:0.8, rotate:-2000*speed, opacity:0},500*speed,Ease.easeIn)
-      .call(function(){
+    var speed = 1;
+    var sps = node.width > 99 ? 1.2 : 1;
+    return Tween.get(spinner)
+      .to({ scaleX: 0.8, scaleY: 0.8, rotate: 125 * speed, opacity: 0 }, 0, Ease.linear)
+      .to({ scaleX: sps, scaleY: sps, rotate: 0, opacity: 1 }, 250 * speed, Ease.linear)
+      .to({ scaleX: sps, scaleY: sps, rotate: -1000 * speed }, duration * speed, Ease.easeIn)
+      .to({ scaleX: 0.8, scaleY: 0.8, rotate: -2000 * speed, opacity: 0 }, 500 * speed, Ease.easeIn)
+      .call(function () {
         Ticker.removeListener(node);
         Ticker.removeListener(spinner);
         node.FXBounce();
-        node.FXBling({text: text, extendClass: 'ProfileBlingSmall'});
+        node.FXBling({ text: text, extendClass: 'ProfileBlingSmall' });
         node.DecoratorAmount.show();
         node.DecoratorAmount.setAmount();
         spinner.remove();
         delete node.spinner;
         if (cb) cb();
       });
-    };
+  };
 
-    Node.prototype.FXSpark = function(config,cb){
-      var config = config || {};
-      var psid = config.psid || undefined;
-      var oPos = config.oPos || undefined;
-      var isnew = config.isnew || false;
-      var node = this;
-      var spark = new Sprite({
-        x:0,
-        y:0,
-        frame: 'normal',
-        frameSrc: "sprite_spark_big.png",
-        frameMap: {
-          normal : { x: 0, y: 0, width: 36, height: 36, pivotx: 18, pivoty: 18 }
-        },
-        //z:-2,
-        z:5000,
-        opacity:1
-      });
-      Ticker.addListener(node);
-      Ticker.addListener(spark);
-      node.DecoratorAmount.hide();
-      spark.setFrame('normal');
+  Node.prototype.FXSpark = function (config, cb) {
+    var config = config || {};
+    var psid = config.psid || undefined;
+    var oPos = config.oPos || undefined;
+    var isnew = config.isnew || false;
+    var node = this;
+    var spark = new Sprite({
+      x: 0,
+      y: 0,
+      frame: 'normal',
+      frameSrc: 'sprite_spark_big.png',
+      frameMap: {
+        normal: { x: 0, y: 0, width: 36, height: 36, pivotx: 18, pivoty: 18 },
+      },
+      //z:-2,
+      z: 5000,
+      opacity: 1,
+    });
+    Ticker.addListener(node);
+    Ticker.addListener(spark);
+    node.DecoratorAmount.hide();
+    spark.setFrame('normal');
 
-      node.parentNode.addChild(spark);
+    node.parentNode.addChild(spark);
 
-      var nPos = node.getPosition();
-      var oScale = 1;
-      if (psid && !oPos) {
-        oScale = (1/node.parentNode.zoomScale);
-        var PSpos = $('.DatabaseQueue').find('.DatabaseQueueItem[data-psid='+psid+']').position();
-        var PSleft = (PSpos) ? PSpos.left : 0;
-        oPos = {
-          x: (Math.abs(node.parentNode.x)+((node.parentNode.parentNode.width-720)/2+55)+PSleft)*oScale,
-          y: (Math.abs(node.parentNode.y)+node.parentNode.parentNode.height-78)*oScale
-        };
-      } else if (!oPos) {
-        if (cb) { cb(); }
-        return;
-      }
-      var A = nPos.x - oPos.x;
-      var O = oPos.y - nPos.y;
-      var dir = (A > 0) ? 1 : -1;
-
-      var deg = Math.atan(O/Math.abs(A)) * (180/Math.PI);
-
-      var lenratio = Math.sqrt(Math.pow((oPos.x - nPos.x),2) + Math.pow((oPos.y - nPos.y),2))/108;
-
-      spark.setPosition({x:oPos.x,y:oPos.y});
-      spark.rotate = 180+((90-deg)*dir);
-
-      spark.scaleX = oScale*2;
-      spark.scaleY = oScale*2;
-      //var speed = 0.5 + Math.random()*0.5;
-      var speed = 1;
-
-      Tween.get(spark)
-      .to({scaleX:oScale*2,scaleY:oScale*2},0,Ease.linear)
-      .wait(200)
-      .to({scaleX:0.5,scaleY:lenratio},100,Ease.linear)
-      .to({scaleX:1,x:nPos.x,y:nPos.y,opacity:1},300,Ease.easeOut)
-      .to({scaleY:1},100,Ease.linear)
-      .call(function(){
-        spark.hide();
-        if (isnew) { node.show(); }
-        node.FXBounce();
-        spark.remove();
-        if (cb) { cb(); }
-      });
-    };
-
-    Node.prototype.FXWheee = function(config){
-      var node = this;
-      node.FXSpark(config,function(){
-        node.FXSpinner(config);
-      });
-    };
-
-    Node.prototype.FXWheeeOld = function(config){
-      var config = config || {};
-      var text = config.text || '';
-      var psid = config.psid || undefined;
-      var oPos = config.oPos || undefined;
-      var isnew = config.isnew || false;
-      var node = this;
-      var spinner = new Sprite({
-        frame: 'normal',
-        frameSrc: "largespinner.png",
-        frameMap: {
-          normal : { x: 0, y: 0, width: 120, height: 120, pivotx: 60, pivoty: 60 }
-        },
-        z:-1,
-        opacity:0
-      });
-      var spark = new Sprite({
-        x:0,
-        y:0,
-        frame: 'normal',
-        frameSrc: "sprite_spark_big.png",
-        frameMap: {
-          normal : { x: 0, y: 0, width: 36, height: 36, pivotx: 18, pivoty: 18 }
-        },
-        //z:-2,
-        z:5000,
-        opacity:1
-      });
-      Ticker.addListener(node);
-      Ticker.addListener(spinner);
-      Ticker.addListener(spark);
-      node.DecoratorAmount.hide();
-      spinner.setFrame('normal');
-      spark.setFrame('normal');
-
-      node.parentNode.addChild(spark);
-      node.parentNode.addChild(spinner);
-      var nPos = node.getPosition();
-      var oScale = 1;
-      // TODO: make oPos dynamic
-      if (psid && !oPos) {
-        oScale = (1/node.parentNode.zoomScale);
-        var PSleft = $('.DatabaseQueue').find('.DatabaseQueueItem[data-psid='+psid+']').position().left;
-        oPos = {
-          x: (Math.abs(node.parentNode.x)+((node.parentNode.parentNode.width-720)/2+55)+PSleft)*oScale,
-          y: (Math.abs(node.parentNode.y)+node.parentNode.parentNode.height-78)*oScale
-        };
-      } else if (!oPos) {
-        return;
-      }
-      spinner.setPosition(nPos);
-      // 90  = -1
-      // 270 = 1
-      var A = nPos.x - oPos.x;
-      var O = oPos.y - nPos.y;
-      //var lenratio = O * (1/oPos.y);
-      var lenratio = Math.sqrt(Math.pow((oPos.x - nPos.x),2) + Math.pow((oPos.y - nPos.y),2))/108;
-
-      var dir = (A > 0) ? 1 : -1;
-      //A = Math.abs(A);
-      var deg = Math.atan(O/Math.abs(A)) * (180/Math.PI);
-
-      spark.setPosition({x:oPos.x,y:oPos.y});
-      spark.rotate = 180+((90-deg)*dir);
-
-      spark.scaleX = oScale*2;
-      spark.scaleY = oScale*2;
-      //var speed = 0.5 + Math.random()*0.5;
-      var speed = 1;
-
-      Tween.get(spark)
-      .to({scaleX:oScale*2,scaleY:oScale*2},0,Ease.linear)
-      .wait(200)
-      .to({scaleX:0.5,scaleY:lenratio},100,Ease.linear)
-      .to({scaleX:1,x:nPos.x,y:nPos.y,opacity:1},300,Ease.easeOut)
-      .to({scaleY:1},100,Ease.linear)
-      .call(function(){
-        spark.hide();
-        if (isnew) { node.show(); }
-        node.FXBounce();
-      });
-      //.to({scaleX:5,scaleY:5, opacity:0.7},2000,Ease.easeOut);
-      var sps = (node.width > 80) ? 1.3 : 1 ;
-      return Tween.get(spinner)
-      .wait(500)
-      .to({scaleX:0.8,scaleY:0.8, rotate:125*speed, opacity:0},0,Ease.linear)
-      .to({scaleX:sps,scaleY:sps, rotate:0, opacity:1},250*speed,Ease.linear)
-      .to({scaleX:sps,scaleY:sps, rotate:-1000*speed},2000*speed,Ease.easeIn)
-      .to({scaleX:0.8,scaleY:0.8, rotate:-2000*speed, opacity:0},500*speed,Ease.easeIn)
-      .call(function(){
-        Ticker.removeListener(node);
-        Ticker.removeListener(spinner);
-        node.FXBounce();
-        node.FXBling({text: text});
-        node.DecoratorAmount.show();
-        spinner.remove();
-        spark.remove();
-      });
-    };
-
-
-    Node.prototype.FXMeMeMe = function(cb){
-      // Used on DecoratorReady hover
-      var node = this;
-      node.setFrame('hover');
-      this.FXClearCue();
-      this.FXSimpleCue({scaleX:1.1,scaleY:1.1},31,'easeOut');
-      this.FXSimpleCue({scaleX:1.07,scaleY:1.07},31,'easeOut');
-      this.FXSimpleCue({scaleX:1,scaleY:1},200,'bounceOut',function(){
-        if (cb) {
-          cb();
-        }
-      });
-    };
-
-    Node.prototype.FXNotMeMeMe = function(cb){
-      // Used on DecoratorReady hover
-      var node = this;
-      node.setFrame('normal');
+    var nPos = node.getPosition();
+    var oScale = 1;
+    if (psid && !oPos) {
+      oScale = 1 / node.parentNode.zoomScale;
+      var PSpos = $('.DatabaseQueue')
+        .find('.DatabaseQueueItem[data-psid=' + psid + ']')
+        .position();
+      var PSleft = PSpos ? PSpos.left : 0;
+      oPos = {
+        x:
+          (Math.abs(node.parentNode.x) +
+            ((node.parentNode.parentNode.width - 720) / 2 + 55) +
+            PSleft) *
+          oScale,
+        y: (Math.abs(node.parentNode.y) + node.parentNode.parentNode.height - 78) * oScale,
+      };
+    } else if (!oPos) {
       if (cb) {
         cb();
       }
       return;
-    };
+    }
+    var A = nPos.x - oPos.x;
+    var O = oPos.y - nPos.y;
+    var dir = A > 0 ? 1 : -1;
 
-    Node.prototype.FXFeedMe = function(cb){
-      //'25%':{'transform':'s1.1,1'},
-      //'50%':{'transform':'s1,1.1'},
-      //'75%':{'transform':'s1.1'},
-      //'100%':{'transform':'s1'}
-      //},150);
-      this.FXSimpleCue({scaleX:1.1,sacaleY:1},37);
-      this.FXSimpleCue({scaleX:1,scaleY:1.1},37);
-      this.FXSimpleCue({scaleX:1.1,scaleY:1.1},37);
-      this.FXSimpleCue({scaleX:1,scaleY:1},37);
-    };
+    var deg = Math.atan(O / Math.abs(A)) * (180 / Math.PI);
 
-    Node.prototype.FXSproing = function(cb){
-      var node = this;
-      Ticker.addListener(node);
-      node.setTransform({scaleX:0.6,scaleY:0});
-      node.setOpacity(0);
-      return Tween.get(node,{
-        override:true
-      })
-      .to({scaleX:0.8,scaleY:1.2,opacity:0.5},100,Ease.easeOut)
-      .to({scaleX:1.1,scaleY:0.8,opacity:1},100,Ease.easeIn)
-      .to({scaleX:1,scaleY:1},500,Ease.elasticOut)
-      .call(function(){
+    var lenratio = Math.sqrt(Math.pow(oPos.x - nPos.x, 2) + Math.pow(oPos.y - nPos.y, 2)) / 108;
+
+    spark.setPosition({ x: oPos.x, y: oPos.y });
+    spark.rotate = 180 + (90 - deg) * dir;
+
+    spark.scaleX = oScale * 2;
+    spark.scaleY = oScale * 2;
+    //var speed = 0.5 + Math.random()*0.5;
+    var speed = 1;
+
+    Tween.get(spark)
+      .to({ scaleX: oScale * 2, scaleY: oScale * 2 }, 0, Ease.linear)
+      .wait(200)
+      .to({ scaleX: 0.5, scaleY: lenratio }, 100, Ease.linear)
+      .to({ scaleX: 1, x: nPos.x, y: nPos.y, opacity: 1 }, 300, Ease.easeOut)
+      .to({ scaleY: 1 }, 100, Ease.linear)
+      .call(function () {
+        spark.hide();
+        if (isnew) {
+          node.show();
+        }
+        node.FXBounce();
+        spark.remove();
+        if (cb) {
+          cb();
+        }
+      });
+  };
+
+  Node.prototype.FXWheee = function (config) {
+    var node = this;
+    node.FXSpark(config, function () {
+      node.FXSpinner(config);
+    });
+  };
+
+  Node.prototype.FXWheeeOld = function (config) {
+    var config = config || {};
+    var text = config.text || '';
+    var psid = config.psid || undefined;
+    var oPos = config.oPos || undefined;
+    var isnew = config.isnew || false;
+    var node = this;
+    var spinner = new Sprite({
+      frame: 'normal',
+      frameSrc: 'largespinner.png',
+      frameMap: {
+        normal: { x: 0, y: 0, width: 120, height: 120, pivotx: 60, pivoty: 60 },
+      },
+      z: -1,
+      opacity: 0,
+    });
+    var spark = new Sprite({
+      x: 0,
+      y: 0,
+      frame: 'normal',
+      frameSrc: 'sprite_spark_big.png',
+      frameMap: {
+        normal: { x: 0, y: 0, width: 36, height: 36, pivotx: 18, pivoty: 18 },
+      },
+      //z:-2,
+      z: 5000,
+      opacity: 1,
+    });
+    Ticker.addListener(node);
+    Ticker.addListener(spinner);
+    Ticker.addListener(spark);
+    node.DecoratorAmount.hide();
+    spinner.setFrame('normal');
+    spark.setFrame('normal');
+
+    node.parentNode.addChild(spark);
+    node.parentNode.addChild(spinner);
+    var nPos = node.getPosition();
+    var oScale = 1;
+    // TODO: make oPos dynamic
+    if (psid && !oPos) {
+      oScale = 1 / node.parentNode.zoomScale;
+      var PSleft = $('.DatabaseQueue')
+        .find('.DatabaseQueueItem[data-psid=' + psid + ']')
+        .position().left;
+      oPos = {
+        x:
+          (Math.abs(node.parentNode.x) +
+            ((node.parentNode.parentNode.width - 720) / 2 + 55) +
+            PSleft) *
+          oScale,
+        y: (Math.abs(node.parentNode.y) + node.parentNode.parentNode.height - 78) * oScale,
+      };
+    } else if (!oPos) {
+      return;
+    }
+    spinner.setPosition(nPos);
+    // 90  = -1
+    // 270 = 1
+    var A = nPos.x - oPos.x;
+    var O = oPos.y - nPos.y;
+    //var lenratio = O * (1/oPos.y);
+    var lenratio = Math.sqrt(Math.pow(oPos.x - nPos.x, 2) + Math.pow(oPos.y - nPos.y, 2)) / 108;
+
+    var dir = A > 0 ? 1 : -1;
+    //A = Math.abs(A);
+    var deg = Math.atan(O / Math.abs(A)) * (180 / Math.PI);
+
+    spark.setPosition({ x: oPos.x, y: oPos.y });
+    spark.rotate = 180 + (90 - deg) * dir;
+
+    spark.scaleX = oScale * 2;
+    spark.scaleY = oScale * 2;
+    //var speed = 0.5 + Math.random()*0.5;
+    var speed = 1;
+
+    Tween.get(spark)
+      .to({ scaleX: oScale * 2, scaleY: oScale * 2 }, 0, Ease.linear)
+      .wait(200)
+      .to({ scaleX: 0.5, scaleY: lenratio }, 100, Ease.linear)
+      .to({ scaleX: 1, x: nPos.x, y: nPos.y, opacity: 1 }, 300, Ease.easeOut)
+      .to({ scaleY: 1 }, 100, Ease.linear)
+      .call(function () {
+        spark.hide();
+        if (isnew) {
+          node.show();
+        }
+        node.FXBounce();
+      });
+    //.to({scaleX:5,scaleY:5, opacity:0.7},2000,Ease.easeOut);
+    var sps = node.width > 80 ? 1.3 : 1;
+    return Tween.get(spinner)
+      .wait(500)
+      .to({ scaleX: 0.8, scaleY: 0.8, rotate: 125 * speed, opacity: 0 }, 0, Ease.linear)
+      .to({ scaleX: sps, scaleY: sps, rotate: 0, opacity: 1 }, 250 * speed, Ease.linear)
+      .to({ scaleX: sps, scaleY: sps, rotate: -1000 * speed }, 2000 * speed, Ease.easeIn)
+      .to({ scaleX: 0.8, scaleY: 0.8, rotate: -2000 * speed, opacity: 0 }, 500 * speed, Ease.easeIn)
+      .call(function () {
+        Ticker.removeListener(node);
+        Ticker.removeListener(spinner);
+        node.FXBounce();
+        node.FXBling({ text: text });
+        node.DecoratorAmount.show();
+        spinner.remove();
+        spark.remove();
+      });
+  };
+
+  Node.prototype.FXMeMeMe = function (cb) {
+    // Used on DecoratorReady hover
+    var node = this;
+    node.setFrame('hover');
+    this.FXClearCue();
+    this.FXSimpleCue({ scaleX: 1.1, scaleY: 1.1 }, 31, 'easeOut');
+    this.FXSimpleCue({ scaleX: 1.07, scaleY: 1.07 }, 31, 'easeOut');
+    this.FXSimpleCue({ scaleX: 1, scaleY: 1 }, 200, 'bounceOut', function () {
+      if (cb) {
+        cb();
+      }
+    });
+  };
+
+  Node.prototype.FXNotMeMeMe = function (cb) {
+    // Used on DecoratorReady hover
+    var node = this;
+    node.setFrame('normal');
+    if (cb) {
+      cb();
+    }
+    return;
+  };
+
+  Node.prototype.FXFeedMe = function (cb) {
+    //'25%':{'transform':'s1.1,1'},
+    //'50%':{'transform':'s1,1.1'},
+    //'75%':{'transform':'s1.1'},
+    //'100%':{'transform':'s1'}
+    //},150);
+    this.FXSimpleCue({ scaleX: 1.1, sacaleY: 1 }, 37);
+    this.FXSimpleCue({ scaleX: 1, scaleY: 1.1 }, 37);
+    this.FXSimpleCue({ scaleX: 1.1, scaleY: 1.1 }, 37);
+    this.FXSimpleCue({ scaleX: 1, scaleY: 1 }, 37);
+  };
+
+  Node.prototype.FXSproing = function (cb) {
+    var node = this;
+    Ticker.addListener(node);
+    node.setTransform({ scaleX: 0.6, scaleY: 0 });
+    node.setOpacity(0);
+    return Tween.get(node, {
+      override: true,
+    })
+      .to({ scaleX: 0.8, scaleY: 1.2, opacity: 0.5 }, 100, Ease.easeOut)
+      .to({ scaleX: 1.1, scaleY: 0.8, opacity: 1 }, 100, Ease.easeIn)
+      .to({ scaleX: 1, scaleY: 1 }, 500, Ease.elasticOut)
+      .call(function () {
         Ticker.removeListener(node);
         if (cb) {
           cb();
         }
       });
-    };
+  };
 
-    Node.prototype.FXPuff = function(cb){
-      var node = this;
-      //node.FXSimple({offsetX:42,offsetY:68,scaleX:1.5,scaleY:1.5,opacity:0},250,'easeOut',cb);
-      node.FXSimple({scaleX:1.5,scaleY:1.5,opacity:0},250,'easeOut',function(){
-        if (cb) {
-          cb();
-        }
-      });
-      // make shure it really gets removed (callbacks seem to be unstable)
-      window.setTimeout(function(){ node.remove();},350);
-    };
-
-    Node.prototype.FXArise = function(cb){
-      var node = this;
-      var sparkConf = {
-        x:node.getPosition().x,
-        y:node.getPosition().y,
-        frame: 'normal',
-        frameSrc: "MainSprites.png",
-        frameMap: {
-          normal : { x: 679, y: 630, width: 100, height: 100, pivotx: 50, pivoty: 50 }
-        },
-        z:10,
-        scaleX:0,
-        scaleY:0,
-        opacity:1
-      };
-      var spark = new Sprite(sparkConf);
-      var spark2 = new Sprite(sparkConf);
-      Ticker.addListener(spark);
-      Ticker.addListener(spark2);
-
-      spark.setFrame('normal');
-      spark2.setFrame('normal');
-      node.parentNode.addChild(spark);
-      node.parentNode.addChild(spark2);
-
-      Tween.get(spark)
-      .to({rotate:90,scaleX:1,scaleY:1,opacity:1},100,Ease.linear)
-      .to({rotate:200,scaleX:2.2,scaleY:2.2,opacity:1},500,Ease.easeOut)
-      .to({rotate:300,scaleX:0,scaleY:0},500,Ease.easeOut)
-      .call(function(){
-        spark.remove();
-      });
-      Tween.get(spark2)
-      .to({rotate:-100,scaleX:1,scaleY:1,opacity:1},100,Ease.linear)
-      .to({rotate:-220,scaleX:1.8,scaleY:1.8},500,Ease.easeOut)
-      .to({rotate:-320,scaleX:0,scaleY:0},500,Ease.easeOut)
-      .call(function(){
-        spark2.remove();
-      });
-
-      node.scaleX = 0;
-      node.scaleY = 0;
-      node.opacity = 0;
-      node.draw();
-      node.show();
-      node.FXWaitCue(1000);
-      node.FXSimpleCue({scaleX:1,scaleY:1,opacity:1},350,'backOut');
+  Node.prototype.FXPuff = function (cb) {
+    var node = this;
+    //node.FXSimple({offsetX:42,offsetY:68,scaleX:1.5,scaleY:1.5,opacity:0},250,'easeOut',cb);
+    node.FXSimple({ scaleX: 1.5, scaleY: 1.5, opacity: 0 }, 250, 'easeOut', function () {
       if (cb) {
-        window.setTimeout(function(){ node.opacity=1; cb(); },1200);
+        cb();
       }
+    });
+    // make shure it really gets removed (callbacks seem to be unstable)
+    window.setTimeout(function () {
+      node.remove();
+    }, 350);
+  };
+
+  Node.prototype.FXArise = function (cb) {
+    var node = this;
+    var sparkConf = {
+      x: node.getPosition().x,
+      y: node.getPosition().y,
+      frame: 'normal',
+      frameSrc: 'MainSprites.png',
+      frameMap: {
+        normal: { x: 679, y: 630, width: 100, height: 100, pivotx: 50, pivoty: 50 },
+      },
+      z: 10,
+      scaleX: 0,
+      scaleY: 0,
+      opacity: 1,
     };
+    var spark = new Sprite(sparkConf);
+    var spark2 = new Sprite(sparkConf);
+    Ticker.addListener(spark);
+    Ticker.addListener(spark2);
 
+    spark.setFrame('normal');
+    spark2.setFrame('normal');
+    node.parentNode.addChild(spark);
+    node.parentNode.addChild(spark2);
 
-    Node.prototype.FXKatsching = function(cb){
-      var node = this;
-      //node.FXSimple({offsetX:42,offsetY:68,scaleX:1.5,scaleY:1.5,opacity:0},250,'easeOut',cb);
-      // TODO change frame to Cash only and maybe find out absolutepos of cash indicator
-      node.setZ(100);
-      var sparkConf = {
-        x:node.getPosition().x-4,
-        y:node.getPosition().y-40,
-        frame: 'normal',
-        frameSrc: "MainSprites.png",
-        frameMap: {
-          normal : { x: 679, y: 630, width: 100, height: 100, pivotx: 50, pivoty: 50 }
-        },
-        z:10,
-        scaleX:0,
-        scaleY:0,
-        opacity:0.5
-      };
-      var spark = new Sprite(sparkConf);
-      var spark2 = new Sprite(sparkConf);
-      Ticker.addListener(spark);
-      Ticker.addListener(spark2);
-
-      spark.setFrame('normal');
-      spark2.setFrame('normal');
-      node.parentNode.addChild(spark);
-      node.parentNode.addChild(spark2);
-
-      Tween.get(spark)
-      .to({rotate:90,scaleX:1,scaleY:1,opacity:0.5},100,Ease.linear)
-      .to({rotate:200,scaleX:2.2,scaleY:2.2,opacity:0.8},500,Ease.easeOut)
-      .to({rotate:300,scaleX:0,scaleY:0,opacity:1},200,Ease.easeOut)
-      .call(function(){
+    Tween.get(spark)
+      .to({ rotate: 90, scaleX: 1, scaleY: 1, opacity: 1 }, 100, Ease.linear)
+      .to({ rotate: 200, scaleX: 2.2, scaleY: 2.2, opacity: 1 }, 500, Ease.easeOut)
+      .to({ rotate: 300, scaleX: 0, scaleY: 0 }, 500, Ease.easeOut)
+      .call(function () {
         spark.remove();
       });
-      Tween.get(spark2)
-      .to({rotate:-100,scaleX:1,scaleY:1,opacity:0.5},100,Ease.linear)
-      .to({rotate:-220,scaleX:1.8,scaleY:1.8,opacity:0.6},500,Ease.easeOut)
-      .to({rotate:-320,scaleX:0,scaleY:0,opacity:1},200,Ease.easeOut)
-      .call(function(){
+    Tween.get(spark2)
+      .to({ rotate: -100, scaleX: 1, scaleY: 1, opacity: 1 }, 100, Ease.linear)
+      .to({ rotate: -220, scaleX: 1.8, scaleY: 1.8 }, 500, Ease.easeOut)
+      .to({ rotate: -320, scaleX: 0, scaleY: 0 }, 500, Ease.easeOut)
+      .call(function () {
         spark2.remove();
       });
 
-      this.FXAnimation = Tween.get(node,{
-        override:true
-      })
-      .to({scaleX:1,scaleY:1},100,Ease.linear)
+    node.scaleX = 0;
+    node.scaleY = 0;
+    node.opacity = 0;
+    node.draw();
+    node.show();
+    node.FXWaitCue(1000);
+    node.FXSimpleCue({ scaleX: 1, scaleY: 1, opacity: 1 }, 350, 'backOut');
+    if (cb) {
+      window.setTimeout(function () {
+        node.opacity = 1;
+        cb();
+      }, 1200);
+    }
+  };
+
+  Node.prototype.FXKatsching = function (cb) {
+    var node = this;
+    //node.FXSimple({offsetX:42,offsetY:68,scaleX:1.5,scaleY:1.5,opacity:0},250,'easeOut',cb);
+    // TODO change frame to Cash only and maybe find out absolutepos of cash indicator
+    node.setZ(100);
+    var sparkConf = {
+      x: node.getPosition().x - 4,
+      y: node.getPosition().y - 40,
+      frame: 'normal',
+      frameSrc: 'MainSprites.png',
+      frameMap: {
+        normal: { x: 679, y: 630, width: 100, height: 100, pivotx: 50, pivoty: 50 },
+      },
+      z: 10,
+      scaleX: 0,
+      scaleY: 0,
+      opacity: 0.5,
+    };
+    var spark = new Sprite(sparkConf);
+    var spark2 = new Sprite(sparkConf);
+    Ticker.addListener(spark);
+    Ticker.addListener(spark2);
+
+    spark.setFrame('normal');
+    spark2.setFrame('normal');
+    node.parentNode.addChild(spark);
+    node.parentNode.addChild(spark2);
+
+    Tween.get(spark)
+      .to({ rotate: 90, scaleX: 1, scaleY: 1, opacity: 0.5 }, 100, Ease.linear)
+      .to({ rotate: 200, scaleX: 2.2, scaleY: 2.2, opacity: 0.8 }, 500, Ease.easeOut)
+      .to({ rotate: 300, scaleX: 0, scaleY: 0, opacity: 1 }, 200, Ease.easeOut)
+      .call(function () {
+        spark.remove();
+      });
+    Tween.get(spark2)
+      .to({ rotate: -100, scaleX: 1, scaleY: 1, opacity: 0.5 }, 100, Ease.linear)
+      .to({ rotate: -220, scaleX: 1.8, scaleY: 1.8, opacity: 0.6 }, 500, Ease.easeOut)
+      .to({ rotate: -320, scaleX: 0, scaleY: 0, opacity: 1 }, 200, Ease.easeOut)
+      .call(function () {
+        spark2.remove();
+      });
+
+    this.FXAnimation = Tween.get(node, {
+      override: true,
+    })
+      .to({ scaleX: 1, scaleY: 1 }, 100, Ease.linear)
       .wait(500)
-      .to({scaleX:2,scaleY:2,opacity:0},250,Ease.easeOut)
-      .call(function(){
+      .to({ scaleX: 2, scaleY: 2, opacity: 0 }, 250, Ease.easeOut)
+      .call(function () {
         Ticker.removeListener(node);
         if (cb) {
           cb();
           node.remove();
         }
       });
-      // make shure it really gets removed (callbacks seem to be unstable)
-      //window.setTimeout(function(){ node.remove();},350);
-    };
+    // make shure it really gets removed (callbacks seem to be unstable)
+    //window.setTimeout(function(){ node.remove();},350);
+  };
 
-    Node.prototype.FXPulse = function(cb){
-      var node = this;
-      node.FXSimpleLoop({
-        one:{scaleX:0.9,scaleY:0.9},
-        two:{scaleX:1,scaleY:1}
-      },350,'linear',function(){
+  Node.prototype.FXPulse = function (cb) {
+    var node = this;
+    node.FXSimpleLoop(
+      {
+        one: { scaleX: 0.9, scaleY: 0.9 },
+        two: { scaleX: 1, scaleY: 1 },
+      },
+      350,
+      'linear',
+      function () {
         if (cb) {
           cb();
         }
-      });
-    };
+      }
+    );
+  };
 
-    Node.prototype.FXSnooze = function(cb){
-      var node = this;
-      node.FXSimpleLoop({
-        one:{scaleX:0.9,scaleY:0.9},
-        two:{scaleX:1,scaleY:1}
-      },250,'bounceOut',function(){
+  Node.prototype.FXSnooze = function (cb) {
+    var node = this;
+    node.FXSimpleLoop(
+      {
+        one: { scaleX: 0.9, scaleY: 0.9 },
+        two: { scaleX: 1, scaleY: 1 },
+      },
+      250,
+      'bounceOut',
+      function () {
         if (cb) {
           cb();
         }
-      });
-    };
+      }
+    );
+  };
 
-    Node.prototype.FXSuck = function(cb){
-      var node = this;
-      node.FXSimple({scaleX:0.5,scaleY:0.5,opacity:0,offsetY:120},250,'easeOut',function(){
+  Node.prototype.FXSuck = function (cb) {
+    var node = this;
+    node.FXSimple(
+      { scaleX: 0.5, scaleY: 0.5, opacity: 0, offsetY: 120 },
+      250,
+      'easeOut',
+      function () {
         if (cb) {
           cb();
         }
         node.remove();
-      });
-    };
-
-    Node.prototype.FXCharge = function(frame,cb){
-      var node = this;
-      // Find out where to render and at which coordinates
-      var nodePos = node.userClickAbsPos || node.getPosition();
-      var renderParent = (node.userClickAbsPos) ? node : node.parentNode;
-      var bling = new Sprite({
-        x: nodePos.x,
-        y: nodePos.y - 400,
-        // FIXME: bring some meaning to the z values
-        z:100000,
-        hidden:true,
-        frame: frame || 'cash',
-        frameSrc:'MainSprites.png',
-        frameMap: {
-          'cash':{x: 145, y: 616, width: 56, height: 43, pivotx: 25, pivoty: 21},
-          'AP':{x:202,y:616,width:41,height:48,pivotx:20,pivoty:24}
-        }
-      });
-      renderParent.addChild(bling);
-      if (frame!=='AP') {
-        bling.FXSimpleCue({scaleX:5,scaleY:5,rotate: -360,opacity:0},0,'linear');
-      } else {
-        bling.FXSimpleCue({y:nodePos.y,scaleX:1,scaleY:10,rotate: 10,opacity:0},0,'linear');
       }
-      bling.FXWaitCue(200);
-      bling.FXSimpleCue({y:nodePos.y,scaleX:1,scaleY:1,rotate:0,opacity:1},200,'linear');
-      bling.FXWaitCue(0);
-      bling.FXSimpleCue({scaleX:0.1,scaleY:0.1,opacity:0},500,'backIn',function(){
+    );
+  };
+
+  Node.prototype.FXCharge = function (frame, cb) {
+    var node = this;
+    // Find out where to render and at which coordinates
+    var nodePos = node.userClickAbsPos || node.getPosition();
+    var renderParent = node.userClickAbsPos ? node : node.parentNode;
+    var bling = new Sprite({
+      x: nodePos.x,
+      y: nodePos.y - 400,
+      // FIXME: bring some meaning to the z values
+      z: 100000,
+      hidden: true,
+      frame: frame || 'cash',
+      frameSrc: 'MainSprites.png',
+      frameMap: {
+        cash: { x: 145, y: 616, width: 56, height: 43, pivotx: 25, pivoty: 21 },
+        AP: { x: 202, y: 616, width: 41, height: 48, pivotx: 20, pivoty: 24 },
+      },
+    });
+    renderParent.addChild(bling);
+    if (frame !== 'AP') {
+      bling.FXSimpleCue({ scaleX: 5, scaleY: 5, rotate: -360, opacity: 0 }, 0, 'linear');
+    } else {
+      bling.FXSimpleCue(
+        { y: nodePos.y, scaleX: 1, scaleY: 10, rotate: 10, opacity: 0 },
+        0,
+        'linear'
+      );
+    }
+    bling.FXWaitCue(200);
+    bling.FXSimpleCue({ y: nodePos.y, scaleX: 1, scaleY: 1, rotate: 0, opacity: 1 }, 200, 'linear');
+    bling.FXWaitCue(0);
+    bling.FXSimpleCue({ scaleX: 0.1, scaleY: 0.1, opacity: 0 }, 500, 'backIn', function () {
+      bling.remove();
+      if (cb) {
+        cb();
+      }
+    });
+  };
+
+  Node.prototype.FXKarmaBling = function (karma_points, cb) {
+    var node = this;
+    // Find out where to render and at which coordinates
+    //var nodePos = node.userClickAbsPos;
+    var nodePos = node.getCenterPosition();
+    nodePos.x += 130;
+    nodePos.y = 100;
+    var renderParent = node;
+    var bling = new Sprite({
+      x: nodePos.x,
+      y: nodePos.y,
+      // FIXME: bring some meaning to the z values
+      z: 10000,
+      opacity: 0,
+      hidden: true,
+      frame: 'karma_up',
+      frameSrc: 'MainSprites.png',
+      frameMap: {
+        karma_up: { x: 428, y: 860, width: 96, height: 96, pivotx: 48, pivoty: 48 },
+      },
+    });
+    renderParent.addChild(bling);
+    bling.FXWaitCue(0);
+    bling.FXSimpleCue({ scaleX: 0, scaleY: 0, rotate: 720, opacity: 0 }, 0, 'linear', function () {
+      bling.FXBling({
+        text: '+' + _.toKSNum(karma_points),
+        wait: 600,
+        dur: 1300,
+        extendClass: 'KarmaUpBling',
+      });
+    });
+    bling.FXSimpleCue(
+      { y: nodePos.y, scaleX: 1.2, scaleY: 1.2, rotate: 0, opacity: 1 },
+      500,
+      'easeOut'
+    );
+    bling.FXSimpleCue(
+      { y: nodePos.y, scaleX: 1, scaleY: 1, rotate: 0, opacity: 1 },
+      250,
+      'bounceOut'
+    );
+    bling.FXWaitCue(800);
+    bling.FXSimpleCue(
+      { y: nodePos.y - 200, scaleX: 0, scaleY: 4.5, opacity: 0 },
+      200,
+      'linear',
+      function () {
         bling.remove();
         if (cb) {
           cb();
         }
-      });
-    };
+      }
+    );
+  };
 
-    Node.prototype.FXKarmaBling = function(karma_points, cb){
-      var node = this;
-      // Find out where to render and at which coordinates
-      //var nodePos = node.userClickAbsPos;
-      var nodePos = node.getCenterPosition();
-      nodePos.x += 130;
-      nodePos.y = 100;
-      var renderParent = node;
-      var bling = new Sprite({
-        x: nodePos.x,
-        y: nodePos.y,
-        // FIXME: bring some meaning to the z values
-        z:10000,
-        opacity:0,
-        hidden:true,
-        frame: 'karma_up',
-        frameSrc:'MainSprites.png',
-        frameMap: {
-          'karma_up': {x:428,y:860,width:96,height:96,pivotx:48,pivoty:48}
-        }
-      });
-      renderParent.addChild(bling);
-      bling.FXWaitCue(0);
-      bling.FXSimpleCue({scaleX:0,scaleY:0,rotate:720,opacity:0},0,'linear',function(){
-        bling.FXBling({
-          text: "+" + _.toKSNum(karma_points),
-          wait:600,
-          dur:1300,
-          extendClass: "KarmaUpBling"
-        });
-      });
-      bling.FXSimpleCue({y:nodePos.y, scaleX:1.2,scaleY:1.2, rotate:0,opacity:1},500,'easeOut');
-      bling.FXSimpleCue({y:nodePos.y, scaleX:1,scaleY:1, rotate:0,opacity:1},250,'bounceOut');
-      bling.FXWaitCue(800);
-      bling.FXSimpleCue({y:nodePos.y-200, scaleX:0,scaleY:4.5,opacity:0},200,'linear',function(){
-        bling.remove();
-        if (cb) {
-          cb();
-        }
-      });
-    };
-
-    Node.prototype.FXLevelUpBling = function(xp_level, cb){
-      // should be invoked on gameroot
-      var node = this;
-      var nodePos = node.getCenterPosition();
-      var renderParent = node;
-      var bling = new Sprite({
-        x: nodePos.x,
-        y: nodePos.y,
-        // FIXME: bring some meaning to the z values
-        z:100000,
-        opacity:0,
-        hidden:true,
-        frame: 'normal',
-        frameSrc:'MainSprites.png',
-        frameMap: {
-          'normal': { x: 525, y: 842, width: 138, height: 138, pivotx: 69,pivoty: 69 }
-        }
-      });
-      renderParent.addChild(bling);
-      bling.FXWaitCue(0);
-      bling.FXSimpleCue({scaleX:0,scaleY:0,rotate:720,opacity:0},0,'linear',function(){
-        /*
+  Node.prototype.FXLevelUpBling = function (xp_level, cb) {
+    // should be invoked on gameroot
+    var node = this;
+    var nodePos = node.getCenterPosition();
+    var renderParent = node;
+    var bling = new Sprite({
+      x: nodePos.x,
+      y: nodePos.y,
+      // FIXME: bring some meaning to the z values
+      z: 100000,
+      opacity: 0,
+      hidden: true,
+      frame: 'normal',
+      frameSrc: 'MainSprites.png',
+      frameMap: {
+        normal: { x: 525, y: 842, width: 138, height: 138, pivotx: 69, pivoty: 69 },
+      },
+    });
+    renderParent.addChild(bling);
+    bling.FXWaitCue(0);
+    bling.FXSimpleCue({ scaleX: 0, scaleY: 0, rotate: 720, opacity: 0 }, 0, 'linear', function () {
+      /*
         bling.FXBling({
           text: LevelUpText,
           wait:600,
@@ -1772,532 +1866,563 @@ var Render = function() {
           extendClass: "LevelUpBling"
         });
         */
-        bling.FXBling({
-          text: "Level " + xp_level,
-          wait:600,
-          dur:1800,
-          extendClass: "LevelUpBlingBig"
-        });
-
+      bling.FXBling({
+        text: 'Level ' + xp_level,
+        wait: 600,
+        dur: 1800,
+        extendClass: 'LevelUpBlingBig',
       });
-      bling.FXSimpleCue({y:nodePos.y, scaleX:1.2,scaleY:1.2, rotate:0,opacity:1},500,'easeOut');
-      bling.FXSimpleCue({y:nodePos.y, scaleX:2,scaleY:2, rotate:0,opacity:1},250,'bounceOut');
-      bling.FXWaitCue(1000);
-      bling.FXSimpleCue({y:nodePos.y-200, scaleX:0,scaleY:4.5,opacity:0},200,'linear',function(){
+    });
+    bling.FXSimpleCue(
+      { y: nodePos.y, scaleX: 1.2, scaleY: 1.2, rotate: 0, opacity: 1 },
+      500,
+      'easeOut'
+    );
+    bling.FXSimpleCue(
+      { y: nodePos.y, scaleX: 2, scaleY: 2, rotate: 0, opacity: 1 },
+      250,
+      'bounceOut'
+    );
+    bling.FXWaitCue(1000);
+    bling.FXSimpleCue(
+      { y: nodePos.y - 200, scaleX: 0, scaleY: 4.5, opacity: 0 },
+      200,
+      'linear',
+      function () {
         bling.remove();
         if (cb) {
           cb();
         }
-      });
-    };
-
-    Node.prototype.FXMissionComplete = function(text, cb){
-      // should be invoked on gameroot
-      var node = this;
-      var nodePos = node.getCenterPosition();
-      var renderParent = node;
-      var bling = new Sprite({
-        x: nodePos.x,
-        y: nodePos.y,
-        // FIXME: bring some meaning to the z values
-        z:100000,
-        opacity:0,
-        hidden:true,
-        frame: 'normal',
-        frameSrc:'MainSprites.png',
-        frameMap: {
-          'normal': { x: 717, y: 764, width: 122, height: 160, pivotx: 55,pivoty: 90 }
-        }
-      });
-      renderParent.addChild(bling);
-      bling.FXWaitCue(0);
-      bling.FXSimpleCue({scaleX:0,scaleY:0,rotate:0,opacity:0},0,'linear',function(){
-      });
-      bling.FXSimpleCue({y:nodePos.y, scaleX:1.2,scaleY:1.2, rotate:0,opacity:1},250,'easeOut');
-      bling.FXSimpleCue({y:nodePos.y, scaleX:1,scaleY:1, rotate:0,opacity:1},250,'bounceOut');
-      bling.FXWaitCue(1000);
-      bling.FXSimpleCue({y:nodePos.y-200, scaleX:0,scaleY:4.5,opacity:0},200,'linear',function(){
-        bling.remove();
-        if (cb) {
-          cb();
-        }
-      });
-    };
-
-    Node.prototype.FXMissionGoalComplete = function(text, cb){
-      // should be invoked on gameroot
-      var node = this;
-      var nodePos = node.getTopRightPosition();
-      var renderParent = node;
-      var bling = new Sprite({
-        x: nodePos.x -40,
-        y: nodePos.y +50,
-        // FIXME: bring some meaning to the z values
-        z:100000,
-        opacity:0,
-        hidden:true,
-        frame: 'normal',
-        frameSrc:'MainSprites.png',
-        frameMap: {
-          'normal': { x: 717, y: 764, width: 122, height: 160, pivotx: 55,pivoty: 90 }
-        }
-      });
-      renderParent.addChild(bling);
-      bling.FXWaitCue(100);
-      bling.FXSimpleCue({scaleX:0.5,scaleY:0.5, rotate:1,opacity:1},250,'bounceOut');
-      bling.FXWaitCue(1000);
-      bling.FXSimpleCue({scaleX:0,scaleY:4.5,opacity:0},200,'linear',function(){
-        bling.remove();
-        if (cb) {
-          cb();
-        }
-      });
-    };
-
-
-    Node.prototype.FXNoCash = function(frame,cb){
-      var node = this;
-      // Find out where to render and at which coordinates
-      var nodePos = node.userClickAbsPos || node.getPosition();
-      var renderParent = (node.userClickAbsPos) ? node : node.parentNode;
-      var bling = new Sprite({
-        x: nodePos.x,
-        y: nodePos.y-400,
-        // FIXME: bring some meaning to the z values
-        z:100000,
-        opacity:0,
-        hidden:true,
-        frame: frame || 'no_cash',
-        frameSrc:'MainSprites.png',
-        frameMap: {
-          'no_cash':{x:401,y:737,width:65,height:65,pivotx:32,pivoty:32},
-          'no_AP':{x:336,y:737,width:65,height:65,pivotx:32,pivoty:32}
-        }
-      });
-      renderParent.addChild(bling);
-      bling.FXSimpleCue({scaleX:5,scaleY:5,rotate:-360,opacity:0},0,'linear');
-      bling.FXWaitCue(200);
-      bling.FXSimpleCue({y:nodePos.y,scaleX:1,scaleY:1,rotate:0,opacity:1},150,'easeOut');
-      bling.FXWaitCue(1000);
-      bling.FXSimpleCue({scaleX:1.5,scaleY:1.5,opacity:0,rotate:360},200,'linear',function(){
-        bling.remove();
-        if (cb) {
-          cb();
-        }
-      });
-    };
-
-    Node.prototype.FXNoAP = function(frame,cb){
-      var node = this;
-      // Find out where to render and at which coordinates
-      var nodePos = node.userClickAbsPos || node.getPosition();
-      var renderParent = (node.userClickAbsPos) ? node : node.parentNode;
-      var bling = new Sprite({
-        x: nodePos.x,
-        y: nodePos.y,
-        opacity:0,
-        scaleX:0,
-        scaleY:0,
-        // FIXME: bring some meaning to the z values
-        z:100000,
-        hidden:true,
-        frame: frame || 'no_AP',
-        frameSrc:'MainSprites.png',
-        frameMap: {
-          'no_AP':{x:336,y:737,width:65,height:65,pivotx:32,pivoty:32},
-          'bug':{x:362,y:860,width:65,height:65,pivotx:32,pivoty:32}
-        }
-      });
-      renderParent.addChild(bling);
-      bling.FXSimpleCue({ scaleX:0.5, scaleY:0.5, opacity:0 },100,'linear');
-      bling.FXSimpleCue({ y:nodePos.y-32, scaleX:1,scaleY:1, rotate:0, opacity:1 }, 200,'easeOut');
-      bling.FXWaitCue(1000);
-      bling.FXSimpleCue({y:nodePos.y-64,scaleX:1.5,scaleY:1.5,opacity:0},200,'linear',function(){
-        bling.remove();
-        if (cb) {
-          cb();
-        }
-      });
-    };
-
-    Node.prototype.FXError = function(frame,cb){
-      this.FXNoAP('bug');
-    };
-
-    Node.prototype.FXBlingQueue = function(config,cb){
-      // Topleft Blings for DBQueue
-      config = config || {};
-      var node = this.gameNode.GameRoot.renderNode;
-      var nodePos = this.gameNode.GameRoot.renderStatusbar.getTopLeftPosition();
-      config.wait = config.wait || 0;
-      if (!node.renderBlings) {
-        node.renderBlings = {}
       }
-      var bling = new Text({
-        x: nodePos.x,
-        y: nodePos.y + 40 + _.keys(node.renderBlings).length * 32,
-        z:1000,
-        scaleX:0,
-        scaleY:0,
-        hidden:true,
-        text: config.text,
-        textAlign: 'left',
-        extendClass: config.extendClass || "ProfileBling",
-      });
-      node.renderBlings[bling.id] = bling;
-      node.addChild(bling);
+    );
+  };
+
+  Node.prototype.FXMissionComplete = function (text, cb) {
+    // should be invoked on gameroot
+    var node = this;
+    var nodePos = node.getCenterPosition();
+    var renderParent = node;
+    var bling = new Sprite({
+      x: nodePos.x,
+      y: nodePos.y,
+      // FIXME: bring some meaning to the z values
+      z: 100000,
+      opacity: 0,
+      hidden: true,
+      frame: 'normal',
+      frameSrc: 'MainSprites.png',
+      frameMap: {
+        normal: { x: 717, y: 764, width: 122, height: 160, pivotx: 55, pivoty: 90 },
+      },
+    });
+    renderParent.addChild(bling);
+    bling.FXWaitCue(0);
+    bling.FXSimpleCue({ scaleX: 0, scaleY: 0, rotate: 0, opacity: 0 }, 0, 'linear', function () {});
+    bling.FXSimpleCue(
+      { y: nodePos.y, scaleX: 1.2, scaleY: 1.2, rotate: 0, opacity: 1 },
+      250,
+      'easeOut'
+    );
+    bling.FXSimpleCue(
+      { y: nodePos.y, scaleX: 1, scaleY: 1, rotate: 0, opacity: 1 },
+      250,
+      'bounceOut'
+    );
+    bling.FXWaitCue(1000);
+    bling.FXSimpleCue(
+      { y: nodePos.y - 200, scaleX: 0, scaleY: 4.5, opacity: 0 },
+      200,
+      'linear',
+      function () {
+        bling.remove();
+        if (cb) {
+          cb();
+        }
+      }
+    );
+  };
+
+  Node.prototype.FXMissionGoalComplete = function (text, cb) {
+    // should be invoked on gameroot
+    var node = this;
+    var nodePos = node.getTopRightPosition();
+    var renderParent = node;
+    var bling = new Sprite({
+      x: nodePos.x - 40,
+      y: nodePos.y + 50,
+      // FIXME: bring some meaning to the z values
+      z: 100000,
+      opacity: 0,
+      hidden: true,
+      frame: 'normal',
+      frameSrc: 'MainSprites.png',
+      frameMap: {
+        normal: { x: 717, y: 764, width: 122, height: 160, pivotx: 55, pivoty: 90 },
+      },
+    });
+    renderParent.addChild(bling);
+    bling.FXWaitCue(100);
+    bling.FXSimpleCue({ scaleX: 0.5, scaleY: 0.5, rotate: 1, opacity: 1 }, 250, 'bounceOut');
+    bling.FXWaitCue(1000);
+    bling.FXSimpleCue({ scaleX: 0, scaleY: 4.5, opacity: 0 }, 200, 'linear', function () {
+      bling.remove();
+      if (cb) {
+        cb();
+      }
+    });
+  };
+
+  Node.prototype.FXNoCash = function (frame, cb) {
+    var node = this;
+    // Find out where to render and at which coordinates
+    var nodePos = node.userClickAbsPos || node.getPosition();
+    var renderParent = node.userClickAbsPos ? node : node.parentNode;
+    var bling = new Sprite({
+      x: nodePos.x,
+      y: nodePos.y - 400,
+      // FIXME: bring some meaning to the z values
+      z: 100000,
+      opacity: 0,
+      hidden: true,
+      frame: frame || 'no_cash',
+      frameSrc: 'MainSprites.png',
+      frameMap: {
+        no_cash: { x: 401, y: 737, width: 65, height: 65, pivotx: 32, pivoty: 32 },
+        no_AP: { x: 336, y: 737, width: 65, height: 65, pivotx: 32, pivoty: 32 },
+      },
+    });
+    renderParent.addChild(bling);
+    bling.FXSimpleCue({ scaleX: 5, scaleY: 5, rotate: -360, opacity: 0 }, 0, 'linear');
+    bling.FXWaitCue(200);
+    bling.FXSimpleCue(
+      { y: nodePos.y, scaleX: 1, scaleY: 1, rotate: 0, opacity: 1 },
+      150,
+      'easeOut'
+    );
+    bling.FXWaitCue(1000);
+    bling.FXSimpleCue(
+      { scaleX: 1.5, scaleY: 1.5, opacity: 0, rotate: 360 },
+      200,
+      'linear',
+      function () {
+        bling.remove();
+        if (cb) {
+          cb();
+        }
+      }
+    );
+  };
+
+  Node.prototype.FXNoAP = function (frame, cb) {
+    var node = this;
+    // Find out where to render and at which coordinates
+    var nodePos = node.userClickAbsPos || node.getPosition();
+    var renderParent = node.userClickAbsPos ? node : node.parentNode;
+    var bling = new Sprite({
+      x: nodePos.x,
+      y: nodePos.y,
+      opacity: 0,
+      scaleX: 0,
+      scaleY: 0,
+      // FIXME: bring some meaning to the z values
+      z: 100000,
+      hidden: true,
+      frame: frame || 'no_AP',
+      frameSrc: 'MainSprites.png',
+      frameMap: {
+        no_AP: { x: 336, y: 737, width: 65, height: 65, pivotx: 32, pivoty: 32 },
+        bug: { x: 362, y: 860, width: 65, height: 65, pivotx: 32, pivoty: 32 },
+      },
+    });
+    renderParent.addChild(bling);
+    bling.FXSimpleCue({ scaleX: 0.5, scaleY: 0.5, opacity: 0 }, 100, 'linear');
+    bling.FXSimpleCue(
+      { y: nodePos.y - 32, scaleX: 1, scaleY: 1, rotate: 0, opacity: 1 },
+      200,
+      'easeOut'
+    );
+    bling.FXWaitCue(1000);
+    bling.FXSimpleCue(
+      { y: nodePos.y - 64, scaleX: 1.5, scaleY: 1.5, opacity: 0 },
+      200,
+      'linear',
+      function () {
+        bling.remove();
+        if (cb) {
+          cb();
+        }
+      }
+    );
+  };
+
+  Node.prototype.FXError = function (frame, cb) {
+    this.FXNoAP('bug');
+  };
+
+  Node.prototype.FXBlingQueue = function (config, cb) {
+    // Topleft Blings for DBQueue
+    config = config || {};
+    var node = this.gameNode.GameRoot.renderNode;
+    var nodePos = this.gameNode.GameRoot.renderStatusbar.getTopLeftPosition();
+    config.wait = config.wait || 0;
+    if (!node.renderBlings) {
+      node.renderBlings = {};
+    }
+    var bling = new Text({
+      x: nodePos.x,
+      y: nodePos.y + 40 + _.keys(node.renderBlings).length * 32,
+      z: 1000,
+      scaleX: 0,
+      scaleY: 0,
+      hidden: true,
+      text: config.text,
+      textAlign: 'left',
+      extendClass: config.extendClass || 'ProfileBling',
+    });
+    node.renderBlings[bling.id] = bling;
+    node.addChild(bling);
+    bling.show();
+    bling.FXWaitCue(config.wait);
+    bling.FXSimpleCue({ scaleX: 1, scaleY: 1 }, 200, 'backOut', function () {});
+    //bling.FXWaitCue(1000-config.wait);
+    bling.FXWaitCue(2000);
+    bling.FXSimpleCue({ scaleX: 1.2, scaleY: 1.2, opacity: 0 }, 250, 'easeOut', function () {
+      delete node.renderBlings[bling.id];
+      bling.remove();
+      if (cb) {
+        cb();
+      }
+    });
+  };
+
+  Node.prototype.FXBling = function (config, cb) {
+    config = config || {};
+    var node = this;
+    var nodePos = node.getPosition();
+    config.wait = config.wait || 0;
+    config.dur = config.dur || 1000;
+    var bling = new Text({
+      x: config.x === undefined ? nodePos.x : config.x,
+      y: config.y === undefined ? nodePos.y - 50 : config.y,
+      z: 100000,
+      hidden: true,
+      text: config.text,
+      extendClass: config.extendClass || 'ProfileBling',
+    });
+    if (config.renderOn) {
+      config.renderOn.addChild(bling);
+    } else {
+      node.parentNode.addChild(bling);
+    }
+    bling.offsetY = 50;
+    bling.FXWaitCue(config.wait);
+    bling.FXSimpleCue({ scaleX: 0.5, scaleY: 0.5 }, 0, 'linear', function () {
       bling.show();
-      bling.FXWaitCue(config.wait);
-      bling.FXSimpleCue({scaleX:1,scaleY:1},200,'backOut',function(){
-      });
-      //bling.FXWaitCue(1000-config.wait);
-      bling.FXWaitCue(2000);
-      bling.FXSimpleCue({scaleX:1.2,scaleY:1.2,opacity:0},250,'easeOut',function(){
-        delete node.renderBlings[bling.id];
-        bling.remove();
-        if (cb) {
-          cb();
-        }
-      });
-    };
-
-
-    Node.prototype.FXBling = function(config,cb){
-      config = config || {};
-      var node = this;
-      var nodePos = node.getPosition();
-      config.wait = config.wait || 0;
-      config.dur = config.dur || 1000;
-      var bling = new Text({
-        x: (config.x === undefined) ? nodePos.x : config.x,
-        y: (config.y === undefined) ? nodePos.y-50 : config.y,
-        z:100000,
-        hidden:true,
-        text: config.text,
-        extendClass: config.extendClass || "ProfileBling"
-      });
-      if (config.renderOn) {
-        config.renderOn.addChild(bling);
+    });
+    bling.FXSimpleCue({ scaleX: 1, scaleY: 1, opacity: 0 }, config.dur, 'easeOut', function () {
+      bling.remove();
+      if (cb) {
+        cb();
       }
-      else {
-        node.parentNode.addChild(bling);
-      }
-      bling.offsetY=50;
-      bling.FXWaitCue(config.wait);
-      bling.FXSimpleCue({scaleX:0.5,scaleY:0.5},0,'linear',function(){
-        bling.show();
-      });
-      bling.FXSimpleCue({scaleX:1,scaleY:1,opacity:0},config.dur,'easeOut',function(){
-        bling.remove();
-        if (cb) {
-          cb();
-        }
-      });
-    };
+    });
+  };
 
-    Node.prototype.FXElasticTo = function(pos,callb){
-      var node = this;
-      Ticker.addListener(node);
-      return Tween.get(node,{
-        override:true
-      })
-      .to({x:pos.x,y:pos.y},500,Ease.elasticOut)
-      .call(function(){
+  Node.prototype.FXElasticTo = function (pos, callb) {
+    var node = this;
+    Ticker.addListener(node);
+    return Tween.get(node, {
+      override: true,
+    })
+      .to({ x: pos.x, y: pos.y }, 500, Ease.elasticOut)
+      .call(function () {
         if (callb) {
           callb();
         }
         Ticker.removeListener(node);
       });
-    };
+  };
 
+  /////////////////////////////
+  // The Circle
+  /////////////////////////////
 
-    /////////////////////////////
-    // The Circle
-    /////////////////////////////
+  var Circle = function (config) {
+    config = config || {};
+    this._id = _instances.length;
+    this.radius = config.radius || 32;
+    this.fill = config.fill || '#C00';
+    this.stroke = config.stroke || '#F00';
+    this.strokeWidth = config.strokeWidth || 0;
+    this.jdomelem = $("<canvas class='Circle'></canvas>").attr('id', 'Circle' + this._id);
+    this.domelem = this.jdomelem[0];
+    this.init(config);
+  };
 
-    var Circle = function(config){
-      config = config || {};
-      this._id = _instances.length;
-      this.radius = config.radius || 32;
-      this.fill = config.fill || "#C00";
-      this.stroke = config.stroke || "#F00";
-      this.strokeWidth = config.strokeWidth || 0;
-      this.jdomelem = $("<canvas class='Circle'></canvas>").attr('id','Circle'+this._id);
-      this.domelem = this.jdomelem[0];
-      this.init(config);
-    };
+  extend(Circle, Node);
 
-    extend(Circle, Node);
+  Circle.prototype.draw = function () {
+    this.setSize({
+      width: this.radius * 2 + this.strokeWidth * 2,
+      height: this.radius * 2 + this.strokeWidth * 2,
+    });
+    this.setOffset({
+      x: this.width / 2,
+      y: this.height / 2,
+    });
+    this.setTransform(this.getTransform());
+    this.setOpacity(this.opacity);
 
-    Circle.prototype.draw = function(){
-      this.setSize({
-        width:this.radius*2+this.strokeWidth*2,
-        height:this.radius*2+this.strokeWidth*2
-      });
+    var canvas = this.domelem;
+    canvas.width = this.width;
+    canvas.height = this.height;
+    var ctx = canvas.getContext('2d');
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.beginPath();
+    ctx.lineWidth = this.strokeWidth;
+    ctx.arc(this.offsetX, this.offsetY, this.radius, 0, 2 * Math.PI, false);
+    ctx.strokeStyle = this.stroke;
+    ctx.fillStyle = this.fill;
+    if (this.strokeWidth) {
+      ctx.stroke();
+    }
+    ctx.fill();
+  };
+
+  /////////////////////////////
+  // The Text
+  /////////////////////////////
+
+  var Text = function (config) {
+    config = config || {};
+    this._id = _instances.length;
+    this.jdomelem = $("<div class='Text'></div>").attr('id', 'Text' + this._id);
+    this.domelem = this.jdomelem[0];
+    this.init(config);
+  };
+
+  extend(Text, Node);
+
+  Text.prototype.text = '';
+  Text.prototype.textAlign = 'center';
+
+  Text.prototype.updateRenderProp = function () {
+    // Update misc render properties, API for FONT-Settings etc...
+    this.css({
+      top: 0,
+      left: 0,
+      'text-align': this.textAlign,
+      'z-index': this.z,
+      position: this.position,
+    });
+  };
+
+  Text.prototype.draw = function () {
+    // Update domelem to current settings
+    this.setTransform(this.getTransform());
+    this.setPosition(this.getPosition());
+    this.setOpacity(this.opacity);
+  };
+
+  Text.prototype.onAddInit = function () {
+    this.updateText(this.text);
+    this.draw();
+  };
+
+  Text.prototype.updateText = function (text) {
+    if (!text) {
+      text = this.text;
+    }
+
+    this.text = text = _.crlf2html(text);
+    this.updateRenderProp();
+    this.jdomelem.html(text);
+    this.updateSize();
+    var newOffset = { x: 0, y: 0 };
+    var width = this.jdomelem.width() || 200;
+    if (this.textAlign === 'center') {
+      newOffset.x = Math.round(width / 2);
+    } else if (this.textAlign === 'right') {
+      newOffset.x = width;
+    }
+    this.setOffset(newOffset);
+  };
+
+  Text.prototype.updateSize = function () {
+    this.width = this.jdomelem.width() || 200;
+  };
+
+  Text.prototype.ssetSize = function () {
+    this.updateRenderProp();
+    this.updateSize();
+  };
+
+  /////////////////////////////
+  // The Sprite
+  /////////////////////////////
+
+  var Sprite = function (config) {
+    // Basic Sprite, div container with background image using spritemap
+    // Special config settings:
+    // config.frameSrc - Image source for the spritemap
+    // config.frameMap - framemap coordinates and offsets
+    // config.frame    - the currently active frame
+    config = config || {};
+    this._id = _instances.length;
+    this.frameSrc = config.frameSrc;
+    this.frameMap = config.frameMap;
+    this.frame = config.frame || 'normal';
+    this.jdomelem = $("<div class='Sprite'></div>").attr('id', 'Sprite' + this._id);
+    this.domelem = this.jdomelem[0];
+    this.init(config);
+    this.setFrameSrc(this.frameSrc);
+    this.setFrame(this.frame);
+    this.draw();
+  };
+
+  Sprite.prototype.frameSrc = '';
+  Sprite.prototype.frameMap = {
+    normal: { x: 0, y: 0, width: 0, height: 0, pivotx: 0, pivoty: 0 },
+  };
+
+  extend(Sprite, Node);
+
+  Sprite.prototype.setFrameSrc = function (src) {
+    // Set the Framemap source
+    if (!this.frameSrc) {
+      return;
+    }
+    this.spriteSrc = src;
+    this.css({
+      'background-image': 'url(' + setup.imagePathPrefix + this.frameSrc + ')',
+    });
+  };
+
+  Sprite.prototype.setFrame = function (frame) {
+    // Switch to a named frame on the spritemap
+    if (!this.frameMap || !this.frameMap.hasOwnProperty(frame)) {
+      return;
+    }
+    var map = this.frameMap[frame];
+    this.frame = frame;
+    this.width = map.width;
+    this.height = map.height;
+    if (map.pivotx && map.pivoty) {
       this.setOffset({
-        x:this.width/2,
-        y:this.height/2
+        x: map.pivotx,
+        y: map.pivoty,
       });
-      this.setTransform(this.getTransform());
-      this.setOpacity(this.opacity);
+    }
+    this.domelem.style.backgroundPosition = -map.x + 'px ' + -map.y + 'px';
+    this.draw();
+  };
 
-      var canvas = this.domelem;
-      canvas.width = this.width;
-      canvas.height = this.height;
-      var ctx = canvas.getContext('2d');
-      ctx.clearRect(0, 0, canvas.width, canvas.height);
-      ctx.beginPath();
-      ctx.lineWidth=this.strokeWidth;
-      ctx.arc(this.offsetX, this.offsetY, this.radius, 0, 2 * Math.PI, false);
-      ctx.strokeStyle=this.stroke;
-      ctx.fillStyle=this.fill;
-      if (this.strokeWidth) {
-        ctx.stroke();
-      }
-      ctx.fill();
-    };
+  /////////////////////////////
+  // The Perp
+  /////////////////////////////
 
-
-    /////////////////////////////
-    // The Text
-    /////////////////////////////
-
-    var Text = function(config){
-      config = config || {};
-      this._id = _instances.length;
-      this.jdomelem = $("<div class='Text'></div>").attr('id','Text'+this._id);
-      this.domelem = this.jdomelem[0];
-      this.init(config);
-    };
-
-    extend(Text, Node);
-
-    Text.prototype.text = '';
-    Text.prototype.textAlign = 'center';
-
-    Text.prototype.updateRenderProp = function() {
-      // Update misc render properties, API for FONT-Settings etc...
-      this.css({
-        'top':0,
-        'left':0,
-        'text-align':this.textAlign,
-        'z-index':this.z,
-        'position':this.position
-        });
-    };
-
-    Text.prototype.draw = function(){
-      // Update domelem to current settings
-      this.setTransform(this.getTransform());
-      this.setPosition(this.getPosition());
-      this.setOpacity(this.opacity);
-    };
-
-    Text.prototype.onAddInit = function(){
-      this.updateText(this.text);
-      this.draw();
-    };
-
-    Text.prototype.updateText = function(text){
-      if (!text) {
-        text=this.text;
-      }
-
-      this.text = text = _.crlf2html(text);
-      this.updateRenderProp();
-      this.jdomelem.html(text);
-      this.updateSize();
-      var newOffset = {x:0,y:0};
-      var width = this.jdomelem.width() || 200;
-      if (this.textAlign === 'center') {
-        newOffset.x = Math.round(width/2);
-      } else if (this.textAlign === 'right') {
-        newOffset.x = width;
-      }
-      this.setOffset(newOffset);
-     };
-
-    Text.prototype.updateSize = function(){
-      this.width = this.jdomelem.width() || 200;
-    };
-
-    Text.prototype.ssetSize = function(){
-      this.updateRenderProp();
-      this.updateSize();
-    };
-
-
-    /////////////////////////////
-    // The Sprite
-    /////////////////////////////
-
-    var Sprite = function(config){
-      // Basic Sprite, div container with background image using spritemap
-      // Special config settings:
-      // config.frameSrc - Image source for the spritemap
-      // config.frameMap - framemap coordinates and offsets
-      // config.frame    - the currently active frame
-      config = config || {};
-      this._id = _instances.length;
-      this.frameSrc = config.frameSrc;
-      this.frameMap = config.frameMap;
-      this.frame = config.frame || 'normal';
-      this.jdomelem = $("<div class='Sprite'></div>").attr('id','Sprite'+this._id);
-      this.domelem = this.jdomelem[0];
-      this.init(config);
-      this.setFrameSrc(this.frameSrc);
-      this.setFrame(this.frame);
-      this.draw();
-    };
-
-    Sprite.prototype.frameSrc = '';
-    Sprite.prototype.frameMap = {
-      'normal':{x:0,y:0,width:0,height:0,pivotx:0,pivoty:0}
-    };
-
-    extend(Sprite, Node);
-
-    Sprite.prototype.setFrameSrc = function(src) {
-      // Set the Framemap source
-      if (!this.frameSrc) {
-        return;
-      }
-      this.spriteSrc = src;
-      this.css({
-        'background-image': 'url('+setup.imagePathPrefix+this.frameSrc+')'
-      });
-    };
-
-    Sprite.prototype.setFrame = function(frame) {
-      // Switch to a named frame on the spritemap
-      if (!this.frameMap || !this.frameMap.hasOwnProperty(frame)) {
-        return;
-      }
-      var map = this.frameMap[frame];
-      this.frame = frame;
-      this.width = map.width;
-      this.height = map.height;
-      if (map.pivotx && map.pivoty) {
-        this.setOffset({
-          x:map.pivotx,
-          y:map.pivoty
-        });
-      }
-      this.domelem.style.backgroundPosition = -map.x+"px "+-map.y+"px";
-      this.draw();
-    };
-
-
-    /////////////////////////////
-    // The Perp
-    /////////////////////////////
-
-    var Perp = function(config){
-      // Interactive Sprite with decorations, usually lives on a ViewMap.
-      // Special config settings:
-      // config.cables
-      config = config || {};
-      if (config.x === undefined || config.y === undefined) {
-        this.placeRandom = { x: 1024, y: 800 };
-      }
-      this._id = _instances.length;
-      this.frameSrc = config.frameSrc || config.frame_src || 'MainSprites.png';
-      this.frameMap = config.frameMap || config.frame_map || {
-          'normal':{x:0,y:0,width:80,height:80,pivotx:0,pivoty:0}
+  var Perp = function (config) {
+    // Interactive Sprite with decorations, usually lives on a ViewMap.
+    // Special config settings:
+    // config.cables
+    config = config || {};
+    if (config.x === undefined || config.y === undefined) {
+      this.placeRandom = { x: 1024, y: 800 };
+    }
+    this._id = _instances.length;
+    this.frameSrc = config.frameSrc || config.frame_src || 'MainSprites.png';
+    this.frameMap = config.frameMap ||
+      config.frame_map || {
+        normal: { x: 0, y: 0, width: 80, height: 80, pivotx: 0, pivoty: 0 },
       };
-      this.frame = config.frame || 'normal';
-      this.clickable = config.clickable || true;
-      this.detectCollisions = true;
-      this.draggable = config.draggable || true;
-      this.cables = config.cables || new Set();
-      this.perpSprite = config.perpSprite || undefined;
-      this.jdomelem = $("<div class='Perp'></div>");
-      this.domelem = this.jdomelem[0];
-      this.init(config);
-      this.initUI();
+    this.frame = config.frame || 'normal';
+    this.clickable = config.clickable || true;
+    this.detectCollisions = true;
+    this.draggable = config.draggable || true;
+    this.cables = config.cables || new Set();
+    this.perpSprite = config.perpSprite || undefined;
+    this.jdomelem = $("<div class='Perp'></div>");
+    this.domelem = this.jdomelem[0];
+    this.init(config);
+    this.initUI();
 
-      if (!config.frameSrc || !config.frameMap) {
-          console.log('ERROR: could not render perp ' + config.id, config);
+    if (!config.frameSrc || !config.frameMap) {
+      console.log('ERROR: could not render perp ' + config.id, config);
+    }
+
+    if (this.perpSprite) {
+      this.perpSprite = new PerpSprite(this.perpSprite, this._id);
+      this.addChild(this.perpSprite);
+    }
+
+    this.setFrameSrc(this.frameSrc);
+    this.setFrame(this.frame);
+  };
+
+  extend(Perp, Sprite);
+
+  Perp.prototype.getCableTo = function (perpTo) {
+    var perp = this;
+    var cable;
+    perp.cables.each(function (c) {
+      if (c.perpTo === perpTo) {
+        cable = c;
       }
+    });
+    return cable;
+  };
 
-      if (this.perpSprite) {
-        this.perpSprite = new PerpSprite(this.perpSprite,this._id);
-        this.addChild(this.perpSprite);
+  Perp.prototype.initUI = function () {
+    // Initialize Perp UI mouse and touch events
+    // TODO: wrap events in eventhandlers and move this to Node Class
+    var perp = this;
+
+    // FIXME: MANUAL ADD
+
+    perp.on('vclick', function (e) {
+      e.stopPropagation();
+    });
+    perp.on('vdblclick', function (e) {
+      e.stopPropagation();
+    });
+
+    perp.on('dragstart', function (e) {
+      e.stopPropagation();
+      perp.setFrame('drag');
+      perp.setZ(100);
+      if (perp.perpSprite) {
+        perp.perpSprite.offsetX += 2;
+        perp.perpSprite.offsetY += 5;
+        perp.perpSprite.draw();
       }
-
-      this.setFrameSrc(this.frameSrc);
-      this.setFrame(this.frame);
-    };
-
-    extend(Perp, Sprite);
-
-    Perp.prototype.getCableTo = function(perpTo){
-      var perp = this;
-      var cable;
-      perp.cables.each(function(c){
-        if (c.perpTo === perpTo) {
-          cable = c;
-        }
-      });
-      return cable;
-    };
-
-    Perp.prototype.initUI = function(){
-      // Initialize Perp UI mouse and touch events
-      // TODO: wrap events in eventhandlers and move this to Node Class
-      var perp = this;
-
-      // FIXME: MANUAL ADD
-
-      perp.on('vclick',function(e){
-        e.stopPropagation();
-      });
-      perp.on('vdblclick',function(e){
-        e.stopPropagation();
-      });
-
-      perp.on('dragstart',function(e){
-        e.stopPropagation();
-        perp.setFrame('drag');
-        perp.setZ(100);
-        if (perp.perpSprite) {
-          perp.perpSprite.offsetX += 2;
-          perp.perpSprite.offsetY += 5;
-          perp.perpSprite.draw();
-        }
-        perp.decorators.hide();
-        if (!perp.sticky && !perp.dragalong) {
-          perp.cables.each(function(cable){
+      perp.decorators.hide();
+      if (!perp.sticky && !perp.dragalong) {
+        perp.cables.each(function (cable) {
+          if (cable.noWobble) {
+            cable.FXToggleConnect(0);
+          } else {
+            cable.FXWobbleTension(0.5);
+          }
+        });
+      } else if (!perp.sticky && perp.dragalong) {
+        perp.cables.each(function (cable) {
+          cable.FXStraighten(0);
+        });
+      } else if (perp.sticky) {
+        perp.cables.each(function (cable) {
+          var othernode = cable.perpFrom === perp ? cable.perpTo : cable.perpFrom;
+          if (othernode.sticky) {
             if (cable.noWobble) {
               cable.FXToggleConnect(0);
             } else {
               cable.FXWobbleTension(0.5);
             }
-          });
-        }
-        else if (!perp.sticky && perp.dragalong) {
-          perp.cables.each(function(cable){
-            cable.FXStraighten(0);
-          });
-        }
-        else if (perp.sticky) {
-          perp.cables.each(function(cable){
-            var othernode = (cable.perpFrom === perp) ? cable.perpTo : cable.perpFrom;
-            if (othernode.sticky) {
-              if (cable.noWobble) {
-                cable.FXToggleConnect(0);
-              } else {
-                cable.FXWobbleTension(0.5);
-              }
-            }
-            else {
-              othernode.dragalong = true;
-              othernode.useDragHandler.addListener(othernode);
-            }
-          });
-
-        }
-        /*
+          } else {
+            othernode.dragalong = true;
+            othernode.useDragHandler.addListener(othernode);
+          }
+        });
+      }
+      /*
           perp.cables.each(function(cable){
             if (perp.dragalong) {
               cable.FXStraighten(0);
@@ -2305,967 +2430,987 @@ var Render = function() {
             else if (cable.perpTo == perp) cable.FXWobbleTension(0.5);
           });
         */
+    });
 
-      });
+    perp.on('dragend', function (e) {
+      e.stopPropagation();
 
-      perp.on('dragend',function(e){
-        e.stopPropagation();
+      perp.setZ(0);
 
-        perp.setZ(0);
-
-        perp.setFrame('normal');
-        perp.draw();
-        if (perp.perpSprite) {
-          perp.perpSprite.offsetX -= 2;
-          perp.perpSprite.offsetY -= 5;
-          perp.perpSprite.draw();
-        }
-        perp.decorators.show();
-        perp.decorators.draw();
-        perp.cables.each(function(cable){
-          if (perp.dragalong) {
-            cable.FXStraighten(1);
+      perp.setFrame('normal');
+      perp.draw();
+      if (perp.perpSprite) {
+        perp.perpSprite.offsetX -= 2;
+        perp.perpSprite.offsetY -= 5;
+        perp.perpSprite.draw();
+      }
+      perp.decorators.show();
+      perp.decorators.draw();
+      perp.cables.each(function (cable) {
+        if (perp.dragalong) {
+          cable.FXStraighten(1);
+        } else {
+          if (cable.noWobble) {
+            cable.FXToggleConnect(1);
           } else {
-              if (cable.noWobble) {
-                cable.FXToggleConnect(1);
-            } else {
-              cable.FXWobbleTension(1);
-            }
+            cable.FXWobbleTension(1);
           }
-        });
-        perp.dragalong = false;
-      });
-      perp.on('mousedown',function(e){
-        e.stopPropagation();
-      });
-      perp.on('vmouseover',function(e){
-        e.stopPropagation();
-        // FIXME: Write own Event Wrapper for hover events
-        if (e.target!==perp.domelem) {
-          return;
-        }
-        if (!perp.dragging) {
-          perp.setFrame('hover');
-          perp.FXBounce();
-        } else {
-          perp.setFrame('drag');
         }
       });
-      perp.on('vmouseout',function(e){
-        e.stopPropagation();
-        if (perp.dragging) {
-          perp.setFrame('drag');
-        } else {
-          perp.setFrame('normal');
-        }
-      });
-    };
-
-    Perp.prototype.dragBound = function(pos){
-      if (!this.parentNode) {
+      perp.dragalong = false;
+    });
+    perp.on('mousedown', function (e) {
+      e.stopPropagation();
+    });
+    perp.on('vmouseover', function (e) {
+      e.stopPropagation();
+      // FIXME: Write own Event Wrapper for hover events
+      if (e.target !== perp.domelem) {
         return;
       }
-      if (pos.x<35) {
-        pos.x = 35;
-      } else if (pos.x>this.parentNode.width-35) {
-        pos.x = this.parentNode.width-35;
-      }
-      if (pos.y<100) {
-        pos.y = 100;
-      } else if (pos.y>this.parentNode.height - 100) {
-        pos.y = this.parentNode.height - 100;
-      }
-    };
-
-    Perp.prototype.moveTo = function(pos){
-      // Used during animations, to also draw and render other Nodes affected by movement.
-      //if (this.dragging) this.setPosition({x:pos.x-2,y:pos.y-4});
-      //else this.setPosition(pos);
-      this.setPosition(pos);
-      this.cables.draw();
-      this.decorators.draw();
-    };
-
-    // FIXME random placement, remove
-    Perp.prototype.setRandomPosition = function(originPos){
-      var node = this;
-      var tries = 0;
-      var originPos = originPos || { x: 1024, y: 800 };
-      var randomPos = function(pos){
-        return {
-          x: pos.x + 60 * ((Math.random() < 0.5) ? 1 : -1),
-          y: pos.y + 40 * ((Math.random() < 0.5) ? 1 : -1)
-        };
-      };
-      var testPos = this.useDragHandler.getCollisionPos(this,originPos);
-      while (tries < 500 && testPos.coll === true) {
-        testPos = randomPos(testPos);
-        if (node.placeParentRadius) {
-          testPos = node.testParentRadius(testPos,node.placeParentRadius);
-        }
-        testPos.coll = this.useDragHandler.testCollisions(node,testPos);
-        tries +=1;
-      }
-      this.setPosition(testPos);
-    };
-
-
-    Perp.prototype.onAddInit = function(){
-      // Init stuff when added to a Parent Node
-      var node = this;
-      if (this.draggable) {
-        this.setDraggable(true);
-      }
-      if (this.clickable) {
-        this.setClickable(true);
-      }
-      if (this.placeRandom) {
-        node.setRandomPosition(this.placeRandom);
-      }
-      this.updateRenderProp();
-      this.draw();
-    };
-
-    Perp.prototype.cableTo = function(otherperp,config){
-      // Connect this Perp to another one, Perps need to live on the same Node, usually a ViewMap.
-      if (!this.parentNode || !otherperp.parentNode || (this.parentNode !== otherperp.parentNode)) {
-        return 'Could not connect';
-      }
-      config = config || {};
-      var perpcable = new PerpCable(config,this,otherperp);
-      this.parentNode.addChild(perpcable);
-      return perpcable;
-    };
-
-    Perp.prototype.cableAnimatedTo = function(otherperp,config,cb){
-      config = config || {};
-      config.hidden = true;
-      var cable = this.cableTo(otherperp,config);
-      cable.FXConnect(cb);
-      return cable;
-    };
-
-    Perp.prototype.cableAnimatedRemove = function(otherperp,config){
-      var cable = this.getCableTo(otherperp);
-      if (!cable) { return; }
-      cable.FXDisconnect(function(){
-          cable.remove();
-      });
-    };
-
-
-    Perp.prototype.draw = function(){
-      // Update domelem to current settings
-      if (this.dragging) {
-        this.moveTo(this.getPosition());
+      if (!perp.dragging) {
+        perp.setFrame('hover');
+        perp.FXBounce();
       } else {
-        this.setPosition(this.getPosition());
+        perp.setFrame('drag');
       }
-      this.setTransform(this.getTransform());
-      this.setSize(this.getSize());
-      this.setOpacity(this.opacity);
-      if (this.perpSprite) {
-        this.perpSprite.updatePosition();
+    });
+    perp.on('vmouseout', function (e) {
+      e.stopPropagation();
+      if (perp.dragging) {
+        perp.setFrame('drag');
+      } else {
+        perp.setFrame('normal');
       }
-    };
+    });
+  };
 
-    Perp.prototype.getCablesToOrigin = function(){
-      // Doesn't work on a graph, obviously
-      var cables = [];
-      var perp = this;
-      if (!perp.cables.set.length) {
-        return cables;
+  Perp.prototype.dragBound = function (pos) {
+    if (!this.parentNode) {
+      return;
+    }
+    if (pos.x < 35) {
+      pos.x = 35;
+    } else if (pos.x > this.parentNode.width - 35) {
+      pos.x = this.parentNode.width - 35;
+    }
+    if (pos.y < 100) {
+      pos.y = 100;
+    } else if (pos.y > this.parentNode.height - 100) {
+      pos.y = this.parentNode.height - 100;
+    }
+  };
+
+  Perp.prototype.moveTo = function (pos) {
+    // Used during animations, to also draw and render other Nodes affected by movement.
+    //if (this.dragging) this.setPosition({x:pos.x-2,y:pos.y-4});
+    //else this.setPosition(pos);
+    this.setPosition(pos);
+    this.cables.draw();
+    this.decorators.draw();
+  };
+
+  // FIXME random placement, remove
+  Perp.prototype.setRandomPosition = function (originPos) {
+    var node = this;
+    var tries = 0;
+    var originPos = originPos || { x: 1024, y: 800 };
+    var randomPos = function (pos) {
+      return {
+        x: pos.x + 60 * (Math.random() < 0.5 ? 1 : -1),
+        y: pos.y + 40 * (Math.random() < 0.5 ? 1 : -1),
+      };
+    };
+    var testPos = this.useDragHandler.getCollisionPos(this, originPos);
+    while (tries < 500 && testPos.coll === true) {
+      testPos = randomPos(testPos);
+      if (node.placeParentRadius) {
+        testPos = node.testParentRadius(testPos, node.placeParentRadius);
       }
-      var parentPerp=this;
-      perp.cables.each(function(cable){
-         if (cable.perpTo === perp) {
-           parentPerp = cable.perpFrom;
-           cables.push(cable);
-           _.each(parentPerp.getCablesToOrigin(),function(pcable){
-            cables.push(pcable);
-           });
-         }
-      });
+      testPos.coll = this.useDragHandler.testCollisions(node, testPos);
+      tries += 1;
+    }
+    this.setPosition(testPos);
+  };
+
+  Perp.prototype.onAddInit = function () {
+    // Init stuff when added to a Parent Node
+    var node = this;
+    if (this.draggable) {
+      this.setDraggable(true);
+    }
+    if (this.clickable) {
+      this.setClickable(true);
+    }
+    if (this.placeRandom) {
+      node.setRandomPosition(this.placeRandom);
+    }
+    this.updateRenderProp();
+    this.draw();
+  };
+
+  Perp.prototype.cableTo = function (otherperp, config) {
+    // Connect this Perp to another one, Perps need to live on the same Node, usually a ViewMap.
+    if (!this.parentNode || !otherperp.parentNode || this.parentNode !== otherperp.parentNode) {
+      return 'Could not connect';
+    }
+    config = config || {};
+    var perpcable = new PerpCable(config, this, otherperp);
+    this.parentNode.addChild(perpcable);
+    return perpcable;
+  };
+
+  Perp.prototype.cableAnimatedTo = function (otherperp, config, cb) {
+    config = config || {};
+    config.hidden = true;
+    var cable = this.cableTo(otherperp, config);
+    cable.FXConnect(cb);
+    return cable;
+  };
+
+  Perp.prototype.cableAnimatedRemove = function (otherperp, config) {
+    var cable = this.getCableTo(otherperp);
+    if (!cable) {
+      return;
+    }
+    cable.FXDisconnect(function () {
+      cable.remove();
+    });
+  };
+
+  Perp.prototype.draw = function () {
+    // Update domelem to current settings
+    if (this.dragging) {
+      this.moveTo(this.getPosition());
+    } else {
+      this.setPosition(this.getPosition());
+    }
+    this.setTransform(this.getTransform());
+    this.setSize(this.getSize());
+    this.setOpacity(this.opacity);
+    if (this.perpSprite) {
+      this.perpSprite.updatePosition();
+    }
+  };
+
+  Perp.prototype.getCablesToOrigin = function () {
+    // Doesn't work on a graph, obviously
+    var cables = [];
+    var perp = this;
+    if (!perp.cables.set.length) {
       return cables;
-    };
-
-    Perp.prototype.FXDataOut = function(cb){
-      var perp = this;
-      var cables = this.getCablesToOrigin();
-      // Set duration to FXDataIn Duration
-      var duration=500;
-      var delay = 0;
-      _.each(cables,function(cable,k){
-        duration=cable.length*2;
-        if (k === cables.length-1) {
-          var endPerp = cable.perpFrom;
-          window.setTimeout(function() {
-            cable.FXDataIn(function() {
-              endPerp.FXFeedMe();
-              if (cb) {
-                cb();
-              }
-            });
-          }, delay);
-        }
-        else {
-          window.setTimeout(function(){cable.FXDataIn(function(){ if (cb) { cb(); } });},delay);
-        }
-        delay=delay+duration;
-      });
-      return delay;
-    };
-
-    // TODO: Make Loop with FX Start/Stop options
-    Perp.prototype.FXDataIn = function(cb){
-      var cables = this.getCablesToOrigin().reverse();
-      // Set duration to FXDataOut Duration
-      var duration=500;
-      var delay = 0;
-      _.each(cables,function(cable, k){
-        duration=cable.length*2;
-        if (k === cables.length-1) {
-          window.setTimeout(function() {
-            cable.FXDataOut(cb);
-          }, delay);
-        } else {
-          window.setTimeout(function() {
-            cable.FXDataOut();
-          }, delay);
-        }
-        delay = delay + duration;
-      });
-      return delay;
-    };
-
-
-    /////////////////////////////
-    // The PerpSprite
-    /////////////////////////////
-
-    var PerpSprite = function(config){
-      config = config || {};
-      this._id = _instances.length;
-      this.frameSrc = config.frameSrc || config.frame_src;
-      this.frameMap = config.frameMap || config.frame_map;
-      this.frame = config.frame || 'normal';
-      this.jdomelem = $("<div class='PerpSprite'></div>").attr('id','PerpSprite'+this._id);
-      this.domelem = this.jdomelem[0];
-      this.init(config);
-    };
-
-    extend(PerpSprite, Sprite);
-
-    PerpSprite.prototype.onAddInit = function(){
-      var node =this;
-      node.parentNode.perpSprite = this;
-
-      // Set position to parent pivot:
-      _.each(this.frameMap,function(frame,k){
-        if (!frame.pivotx) {
-          frame.pivotx = node.parentNode.frameMap.normal.pivotx;
-        }
-        if (!frame.hasOwnProperty('pivoty')) {
-          frame.pivoty = node.parentNode.frameMap.normal.pivoty;
-        }
-      });
-
-      this.setFrameSrc(this.frameSrc);
-      this.setFrame(this.frame);
-      node.setPosition({x:node.parentNode.offsetX,y:node.parentNode.offsetY});
-
-      this.draw();
-      this.updateRenderProp();
-    };
-
-    PerpSprite.prototype.updatePosition = function() {
-      var node =this;
-      node.setPosition({x:node.parentNode.offsetX,y:node.parentNode.offsetY});
-    };
-
-
-    /////////////////////////////
-    // The Decorator (Dummy Example)
-    // A Decorator is bound to its decorated parent Node by the draw function but lives on the same container
-    /////////////////////////////
-
-    var Decorator = function(config){
-      config = config || {};
-      this._id = _instances.length;
-      this.jdomelem = $("<div class='Decorator'></div>").attr('id','Decorator'+this._id);
-      this.domelem = this.jdomelem[0];
-
-      // Decorators need offsetToParent and be added to the parent's set
-      this.offsetToParent = config.offsetToParent || {x:0,y:0};
-
-      this.init(config);
-      return this;
-    };
-
-    extend(Decorator, Node);
-
-    Decorator.prototype.remove = function(){
-      this.decoratedNode.decorators.remove(this);
-      this.remove();
-    };
-
-    Decorator.prototype.draw = function(){
-      if (this.hidden) {
-        return;
+    }
+    var parentPerp = this;
+    perp.cables.each(function (cable) {
+      if (cable.perpTo === perp) {
+        parentPerp = cable.perpFrom;
+        cables.push(cable);
+        _.each(parentPerp.getCablesToOrigin(), function (pcable) {
+          cables.push(pcable);
+        });
       }
-      if (!this.decoratedNode) {
-        return;
-      }
-      this.setSize(this.getSize());
-      this.setTransform(this.getTransform());
-      this.setPosition({
-        x: this.decoratedNode.getPosition().x + this.offsetToParent.x,
-        y: this.decoratedNode.getPosition().y + this.offsetToParent.y
-      });
-      this.setOpacity(this.opacity);
-    };
+    });
+    return cables;
+  };
 
-
-    /////////////////////////////
-    // The DecoratorReady
-    /////////////////////////////
-
-    var DecoratorReady = function(config){
-      config = config || {};
-      this._id = _instances.length;
-      this.frameSrc = config.frameSrc || 'MainSprites.png';
-      this.frameProfile = {
-        normal: { "x": 50, "y": 668, "width": 46, "height": 58, "pivotx": 25, "pivoty": 56 },
-        hover: { "x": 96, "y": 664, "width": 48, "height": 62, "pivotx": 27, "pivoty": 60 },
-        active: { "x": 420, "y": 660, "width": 57, "height": 70, "pivotx": 31, "pivoty": 64 }
-      };
-      this.frameMoney = {
-        normal: { "x": 203, "y": 668, "width": 52, "height": 59, "pivotx": 29, "pivoty": 57 },
-        hover: { "x": 145, "y": 663, "width": 58, "height": 64, "pivotx": 33, "pivoty": 62 },
-        active: { "x": 144, "y": 616, "width": 58, "height": 44, "pivotx": 33, "pivoty": 63 }
-      };
-      this.frameGear = {
-        normal: { "x": 779, "y": 668, "width": 46, "height": 58, "pivotx": 25, "pivoty": 56 },
-        hover: { "x": 825, "y": 664, "width": 48, "height": 62, "pivotx": 27, "pivoty": 60 },
-        active: { "x": 873, "y": 678, "width": 57, "height": 70, "pivotx": 28, "pivoty": 64 }
-      };
-
-      this.frameMap = this.frameProfile;
-      var textCollect = this.textCollect;
-      if (config.mode && config.mode === "money") {
-        this.frameMap = this.frameMoney;
-        textCollect = this.textCollectCash;
-      } else if (config.mode && config.mode === "gear") {
-        this.frameMap = this.frameGear;
-        textCollect = this.textCollectGear;
-      }
-
-      this.frame = config.frame || 'normal';
-      this.jdomelem = $("<div class='DecoratorReady'></div>").attr('id','Decorator'+this._id).attr('data-testid','dd-collect-ready');
-      this.jdomelem.append(textCollect.clone());
-      this.domelem = this.jdomelem[0];
-      this.clickable=true;
-      this.offsetToParent = config.offsetToParent || {x:0,y:-30};
-
-      this.init(config);
-      this.setFrameSrc(this.frameSrc);
-      this.setFrame(this.frame);
-      return this;
-    };
-
-    extend(DecoratorReady, Sprite);
-
-    DecoratorReady.prototype.textCollect = $('<div class="DecoratorReadyText">' + _._('Collect!') + '</div>' );
-    DecoratorReady.prototype.textCollectGear = $('<div class="DecoratorReadyText">' + _._('Update!') + '</div>' );
-    DecoratorReady.prototype.textCollectCash = $('<div class="DecoratorReadyText Cash">' + _._('Cash up!') + '</div>' );
-
-    DecoratorReady.prototype.decoType = 'DecoratorReady';
-
-    DecoratorReady.prototype.onAddInit = function(){
-      var node =this;
-      if (this.clickable) {
-        this.setClickable(true);
-      }
-
-      this.offsetToParent = {x: 0, y: - this.decoratedNode.height/2 + 15};
-      this.initUI();
-      this.updateRenderProp();
-      this.draw();
-    };
-
-    DecoratorReady.prototype.initUI = function(){
-      var deco = this;
-      deco.on('vclick',function(e){
-        e.stopPropagation();
-        deco.jdomelem.find('.DecoratorReadyText').remove();
-      });
-      deco.on('vdblclick',function(e){
-        e.stopPropagation();
-      });
-      deco.on('vmouseover',function(e){
-        e.stopPropagation();
-        deco.FXMeMeMe();
-      });
-      deco.on('vmouseout',function(e){
-        e.stopPropagation();
-        deco.FXNotMeMeMe();
-      });
-    };
-
-    DecoratorReady.prototype.draw = Decorator.prototype.draw;
-
-
-    /////////////////////////////
-    // The DecoratorLabel
-    /////////////////////////////
-
-    var DecoratorLabel = function(config){
-      config = config || {};
-      this._id = _instances.length;
-      this.text = config.text || "Label";
-      this.jdomelem = $("<div class='DecoratorLabel'></div>").attr('id','DecoratorLabel'+this._id);
-      this.domelem = this.jdomelem[0];
-      this.clickable=false;
-      this.offsetToParent = config.offsetToParent || {x:0,y:0};
-      this.textFontSize = "13px";
-
-      this.init(config);
-      return this;
-    };
-
-    extend(DecoratorLabel, Text);
-
-    DecoratorLabel.prototype.decoType = 'DecoratorLabel';
-
-    DecoratorLabel.prototype.onAddInit = function(){
-      this.offsetToParent = {x: 0 + this.offsetToParent.x, y: this.decoratedNode.height - this.decoratedNode.offsetY-1 + this.offsetToParent.y};
-      this.updateText();
-      this.draw();
-    };
-
-    DecoratorLabel.prototype.draw = Decorator.prototype.draw;
-
-
-    /////////////////////////////
-    // The DecoratorNew
-    /////////////////////////////
-
-    var DecoratorNew = function(config){
-      config = config || {};
-      this._id = _instances.length;
-      this.text = config.text || "New!";
-      this.jdomelem = $("<div class='DecoratorNew'></div>").attr('id','DecoratorNew'+this._id);
-      if (config.extendClass) {
-        this.jdomelem.addClass(config.extendClass);
-      }
-      this.domelem = this.jdomelem[0];
-      this.clickable=true;
-      this.offsetToParent = config.offsetToParent || {x:0,y:0};
-      this.textFontSize = "13px";
-
-      this.init(config);
-      return this;
-    };
-
-    extend(DecoratorNew, Text);
-
-    DecoratorNew.prototype.decoType = 'DecoratorNew';
-
-    DecoratorNew.prototype.onAddInit = function(){
-      //this.offsetToParent = {x: 0 + this.offsetToParent.x, y: this.decoratedNode.height - this.decoratedNode.offsetY-3 + this.offsetToParent.y};
-      if (this.arrow) {
-        this.offsetToParent = {x: 0, y: - this.decoratedNode.height/2-32};
+  Perp.prototype.FXDataOut = function (cb) {
+    var perp = this;
+    var cables = this.getCablesToOrigin();
+    // Set duration to FXDataIn Duration
+    var duration = 500;
+    var delay = 0;
+    _.each(cables, function (cable, k) {
+      duration = cable.length * 2;
+      if (k === cables.length - 1) {
+        var endPerp = cable.perpFrom;
+        window.setTimeout(function () {
+          cable.FXDataIn(function () {
+            endPerp.FXFeedMe();
+            if (cb) {
+              cb();
+            }
+          });
+        }, delay);
       } else {
-        this.offsetToParent = {x: 0, y: - this.decoratedNode.height/2-8};
+        window.setTimeout(function () {
+          cable.FXDataIn(function () {
+            if (cb) {
+              cb();
+            }
+          });
+        }, delay);
       }
-      if (this.clickable) {
-        this.setClickable(true);
-      }
-      this.initUI();
-      this.updateText();
-      if (this.arrow) {
-        this.jdomelem.append('<br /><div class="DecoratorNewArrow"></div>');
-      }
+      delay = delay + duration;
+    });
+    return delay;
+  };
 
-      this.draw();
-    };
-
-    DecoratorNew.prototype.initUI = function(){
-      var deco = this;
-      deco.on('vclick',function(e){
-        e.stopPropagation();
-        if (deco.decoratedNode) {
-          deco.decoratedNode.trigger('vclick');
-        }
-      });
-    };
-
-    DecoratorNew.prototype.draw = Decorator.prototype.draw;
-
-
-
-    /////////////////////////////
-    // The DecoratorGear
-    /////////////////////////////
-
-    var DecoratorGear = function(config){
-      config = config || {};
-      this._id = _instances.length;
-
-      this.frameSrc = config.frameSrc || 'MainSprites.png';
-      this.frameMap = config.frameMap || {
-        normal: { "x": 347, "y": 582, "width": 28, "height": 28, "pivotx": 14, "pivoty": 14 },
-        inactive: { "x": 375, "y": 582, "width": 28, "height": 28, "pivotx": 14, "pivoty": 14 }
-      };
-      this.frame = config.frame || 'normal';
-
-      this.width = this.frameMap.normal.width;
-      this.height = this.frameMap.normal.height;
-
-      this.jdomelem = $("<div class='DecoratorGear'></div>").attr('id','DecoratorGear'+this._id);
-      this.domelem = this.jdomelem[0];
-      this.clickable = true;
-      this.offsetToParent = config.offsetToParent || {x:30,y:-30};
-
-      this.init(config);
-      this.setFrameSrc(this.frameSrc);
-      this.setFrame(this.frame);
-      return this;
-    };
-
-    extend(DecoratorGear, Sprite);
-
-    DecoratorGear.prototype.decoType = 'DecoratorGear';
-
-    DecoratorGear.prototype.draw = Decorator.prototype.draw;
-
-    DecoratorGear.prototype.onAddInit = function(){
-      var node =this;
-      if (this.decoratedNode.gameNode.data.is_supertoken!==true) {
-        this.offsetToParent = {
-          x:(this.decoratedNode.width/2)-11,
-          y:-(this.decoratedNode.height/2-11)
-        };
+  // TODO: Make Loop with FX Start/Stop options
+  Perp.prototype.FXDataIn = function (cb) {
+    var cables = this.getCablesToOrigin().reverse();
+    // Set duration to FXDataOut Duration
+    var duration = 500;
+    var delay = 0;
+    _.each(cables, function (cable, k) {
+      duration = cable.length * 2;
+      if (k === cables.length - 1) {
+        window.setTimeout(function () {
+          cable.FXDataOut(cb);
+        }, delay);
       } else {
-        this.offsetToParent = {
-          x:(this.decoratedNode.width/2)-16,
-          y:-(this.decoratedNode.height/2-16)
-        };
+        window.setTimeout(function () {
+          cable.FXDataOut();
+        }, delay);
       }
-      if (this.clickable) {
-        this.setClickable(true);
+      delay = delay + duration;
+    });
+    return delay;
+  };
+
+  /////////////////////////////
+  // The PerpSprite
+  /////////////////////////////
+
+  var PerpSprite = function (config) {
+    config = config || {};
+    this._id = _instances.length;
+    this.frameSrc = config.frameSrc || config.frame_src;
+    this.frameMap = config.frameMap || config.frame_map;
+    this.frame = config.frame || 'normal';
+    this.jdomelem = $("<div class='PerpSprite'></div>").attr('id', 'PerpSprite' + this._id);
+    this.domelem = this.jdomelem[0];
+    this.init(config);
+  };
+
+  extend(PerpSprite, Sprite);
+
+  PerpSprite.prototype.onAddInit = function () {
+    var node = this;
+    node.parentNode.perpSprite = this;
+
+    // Set position to parent pivot:
+    _.each(this.frameMap, function (frame, k) {
+      if (!frame.pivotx) {
+        frame.pivotx = node.parentNode.frameMap.normal.pivotx;
       }
-      this.initUI();
-      this.updateRenderProp();
-      this.draw();
+      if (!frame.hasOwnProperty('pivoty')) {
+        frame.pivoty = node.parentNode.frameMap.normal.pivoty;
+      }
+    });
+
+    this.setFrameSrc(this.frameSrc);
+    this.setFrame(this.frame);
+    node.setPosition({ x: node.parentNode.offsetX, y: node.parentNode.offsetY });
+
+    this.draw();
+    this.updateRenderProp();
+  };
+
+  PerpSprite.prototype.updatePosition = function () {
+    var node = this;
+    node.setPosition({ x: node.parentNode.offsetX, y: node.parentNode.offsetY });
+  };
+
+  /////////////////////////////
+  // The Decorator (Dummy Example)
+  // A Decorator is bound to its decorated parent Node by the draw function but lives on the same container
+  /////////////////////////////
+
+  var Decorator = function (config) {
+    config = config || {};
+    this._id = _instances.length;
+    this.jdomelem = $("<div class='Decorator'></div>").attr('id', 'Decorator' + this._id);
+    this.domelem = this.jdomelem[0];
+
+    // Decorators need offsetToParent and be added to the parent's set
+    this.offsetToParent = config.offsetToParent || { x: 0, y: 0 };
+
+    this.init(config);
+    return this;
+  };
+
+  extend(Decorator, Node);
+
+  Decorator.prototype.remove = function () {
+    this.decoratedNode.decorators.remove(this);
+    this.remove();
+  };
+
+  Decorator.prototype.draw = function () {
+    if (this.hidden) {
+      return;
+    }
+    if (!this.decoratedNode) {
+      return;
+    }
+    this.setSize(this.getSize());
+    this.setTransform(this.getTransform());
+    this.setPosition({
+      x: this.decoratedNode.getPosition().x + this.offsetToParent.x,
+      y: this.decoratedNode.getPosition().y + this.offsetToParent.y,
+    });
+    this.setOpacity(this.opacity);
+  };
+
+  /////////////////////////////
+  // The DecoratorReady
+  /////////////////////////////
+
+  var DecoratorReady = function (config) {
+    config = config || {};
+    this._id = _instances.length;
+    this.frameSrc = config.frameSrc || 'MainSprites.png';
+    this.frameProfile = {
+      normal: { x: 50, y: 668, width: 46, height: 58, pivotx: 25, pivoty: 56 },
+      hover: { x: 96, y: 664, width: 48, height: 62, pivotx: 27, pivoty: 60 },
+      active: { x: 420, y: 660, width: 57, height: 70, pivotx: 31, pivoty: 64 },
+    };
+    this.frameMoney = {
+      normal: { x: 203, y: 668, width: 52, height: 59, pivotx: 29, pivoty: 57 },
+      hover: { x: 145, y: 663, width: 58, height: 64, pivotx: 33, pivoty: 62 },
+      active: { x: 144, y: 616, width: 58, height: 44, pivotx: 33, pivoty: 63 },
+    };
+    this.frameGear = {
+      normal: { x: 779, y: 668, width: 46, height: 58, pivotx: 25, pivoty: 56 },
+      hover: { x: 825, y: 664, width: 48, height: 62, pivotx: 27, pivoty: 60 },
+      active: { x: 873, y: 678, width: 57, height: 70, pivotx: 28, pivoty: 64 },
     };
 
-    DecoratorGear.prototype.initUI = function(){
-      var deco = this;
-      deco.on('vclick',function(e){
-        e.stopPropagation();
-        if (deco.decoratedNode) {
-          deco.decoratedNode.trigger('vclick');
-          // QuickCharge on Gear?
-          //deco.decoratedNode.gameNode.trigger('Charge');
-        }
-      });
+    this.frameMap = this.frameProfile;
+    var textCollect = this.textCollect;
+    if (config.mode && config.mode === 'money') {
+      this.frameMap = this.frameMoney;
+      textCollect = this.textCollectCash;
+    } else if (config.mode && config.mode === 'gear') {
+      this.frameMap = this.frameGear;
+      textCollect = this.textCollectGear;
+    }
+
+    this.frame = config.frame || 'normal';
+    this.jdomelem = $("<div class='DecoratorReady'></div>")
+      .attr('id', 'Decorator' + this._id)
+      .attr('data-testid', 'dd-collect-ready');
+    this.jdomelem.append(textCollect.clone());
+    this.domelem = this.jdomelem[0];
+    this.clickable = true;
+    this.offsetToParent = config.offsetToParent || { x: 0, y: -30 };
+
+    this.init(config);
+    this.setFrameSrc(this.frameSrc);
+    this.setFrame(this.frame);
+    return this;
+  };
+
+  extend(DecoratorReady, Sprite);
+
+  DecoratorReady.prototype.textCollect = $(
+    '<div class="DecoratorReadyText">' + _._('Collect!') + '</div>'
+  );
+  DecoratorReady.prototype.textCollectGear = $(
+    '<div class="DecoratorReadyText">' + _._('Update!') + '</div>'
+  );
+  DecoratorReady.prototype.textCollectCash = $(
+    '<div class="DecoratorReadyText Cash">' + _._('Cash up!') + '</div>'
+  );
+
+  DecoratorReady.prototype.decoType = 'DecoratorReady';
+
+  DecoratorReady.prototype.onAddInit = function () {
+    var node = this;
+    if (this.clickable) {
+      this.setClickable(true);
+    }
+
+    this.offsetToParent = { x: 0, y: -this.decoratedNode.height / 2 + 15 };
+    this.initUI();
+    this.updateRenderProp();
+    this.draw();
+  };
+
+  DecoratorReady.prototype.initUI = function () {
+    var deco = this;
+    deco.on('vclick', function (e) {
+      e.stopPropagation();
+      deco.jdomelem.find('.DecoratorReadyText').remove();
+    });
+    deco.on('vdblclick', function (e) {
+      e.stopPropagation();
+    });
+    deco.on('vmouseover', function (e) {
+      e.stopPropagation();
+      deco.FXMeMeMe();
+    });
+    deco.on('vmouseout', function (e) {
+      e.stopPropagation();
+      deco.FXNotMeMeMe();
+    });
+  };
+
+  DecoratorReady.prototype.draw = Decorator.prototype.draw;
+
+  /////////////////////////////
+  // The DecoratorLabel
+  /////////////////////////////
+
+  var DecoratorLabel = function (config) {
+    config = config || {};
+    this._id = _instances.length;
+    this.text = config.text || 'Label';
+    this.jdomelem = $("<div class='DecoratorLabel'></div>").attr('id', 'DecoratorLabel' + this._id);
+    this.domelem = this.jdomelem[0];
+    this.clickable = false;
+    this.offsetToParent = config.offsetToParent || { x: 0, y: 0 };
+    this.textFontSize = '13px';
+
+    this.init(config);
+    return this;
+  };
+
+  extend(DecoratorLabel, Text);
+
+  DecoratorLabel.prototype.decoType = 'DecoratorLabel';
+
+  DecoratorLabel.prototype.onAddInit = function () {
+    this.offsetToParent = {
+      x: 0 + this.offsetToParent.x,
+      y: this.decoratedNode.height - this.decoratedNode.offsetY - 1 + this.offsetToParent.y,
     };
+    this.updateText();
+    this.draw();
+  };
 
+  DecoratorLabel.prototype.draw = Decorator.prototype.draw;
 
-    /////////////////////////////
-    // The DecoratorTimer
-    /////////////////////////////
+  /////////////////////////////
+  // The DecoratorNew
+  /////////////////////////////
 
-    var DecoratorTimer = function(config){
-      config = config || {};
-      this._id = _instances.length;
+  var DecoratorNew = function (config) {
+    config = config || {};
+    this._id = _instances.length;
+    this.text = config.text || 'New!';
+    this.jdomelem = $("<div class='DecoratorNew'></div>").attr('id', 'DecoratorNew' + this._id);
+    if (config.extendClass) {
+      this.jdomelem.addClass(config.extendClass);
+    }
+    this.domelem = this.jdomelem[0];
+    this.clickable = true;
+    this.offsetToParent = config.offsetToParent || { x: 0, y: 0 };
+    this.textFontSize = '13px';
 
-      this.frameSrc = config.frameSrc || 'MainSprites.png';
-      this.frameMap = config.frameMap || {
-        //normal: { "x": 12, "y": 1008, "width": 26, "height": 26, "pivotx": 11, "pivoty": 11 }
-        normal: { "x": 0, "y": 580, "width": 35, "height": 35, "pivotx": 18, "pivoty": 18 }
-      };
-      this.frame = config.frame || 'normal';
+    this.init(config);
+    return this;
+  };
 
-      this.serverTime = config.serverTime || 0;
-      this.serverStartTime = config.serverStartTime || 0;
-      this.duration = config.duration || 1000;
-      this.startTime = new Date().getTime()-(this.serverTime-this.serverStartTime);
-      this.endTime = this.startTime+this.duration;
+  extend(DecoratorNew, Text);
 
-      this.width = this.frameMap.normal.width;
-      this.height = this.frameMap.normal.height;
+  DecoratorNew.prototype.decoType = 'DecoratorNew';
 
-      this.jdomelem = $("<div class='DecoratorTimer'></div>").attr('id','DecoratorTimer'+this._id);
-      this.domelem = this.jdomelem[0];
+  DecoratorNew.prototype.onAddInit = function () {
+    //this.offsetToParent = {x: 0 + this.offsetToParent.x, y: this.decoratedNode.height - this.decoratedNode.offsetY-3 + this.offsetToParent.y};
+    if (this.arrow) {
+      this.offsetToParent = { x: 0, y: -this.decoratedNode.height / 2 - 32 };
+    } else {
+      this.offsetToParent = { x: 0, y: -this.decoratedNode.height / 2 - 8 };
+    }
+    if (this.clickable) {
+      this.setClickable(true);
+    }
+    this.initUI();
+    this.updateText();
+    if (this.arrow) {
+      this.jdomelem.append('<br /><div class="DecoratorNewArrow"></div>');
+    }
 
-      this.jdomelem2 = $("<canvas class='DecoratorTimerCanvas'></canvas>").attr('id','DecoratorTimerCanvas'+this._id);
-      this.domelem2 = this.jdomelem2[0];
+    this.draw();
+  };
 
-      this.jdomelem3 = $("<div class='DecoratorTimerText'>6:12:20</div>").attr('id','DecoratorTimerText'+this._id);
-      this.domelem3 = this.jdomelem3[0];
+  DecoratorNew.prototype.initUI = function () {
+    var deco = this;
+    deco.on('vclick', function (e) {
+      e.stopPropagation();
+      if (deco.decoratedNode) {
+        deco.decoratedNode.trigger('vclick');
+      }
+    });
+  };
 
-      this.jdomelem2.attr({'width':config.width,'height':config.height});
-      this.jdomelem.append(this.jdomelem2);
-      this.jdomelem.append(this.jdomelem3);
-      this.clickable=true;
-      this.offsetToParent = config.offsetToParent || {x:30,y:-30};
+  DecoratorNew.prototype.draw = Decorator.prototype.draw;
 
-      this.init(config);
-      this.setFrameSrc(this.frameSrc);
-      this.setFrame(this.frame);
-      return this;
+  /////////////////////////////
+  // The DecoratorGear
+  /////////////////////////////
+
+  var DecoratorGear = function (config) {
+    config = config || {};
+    this._id = _instances.length;
+
+    this.frameSrc = config.frameSrc || 'MainSprites.png';
+    this.frameMap = config.frameMap || {
+      normal: { x: 347, y: 582, width: 28, height: 28, pivotx: 14, pivoty: 14 },
+      inactive: { x: 375, y: 582, width: 28, height: 28, pivotx: 14, pivoty: 14 },
     };
+    this.frame = config.frame || 'normal';
 
-    extend(DecoratorTimer, Sprite);
+    this.width = this.frameMap.normal.width;
+    this.height = this.frameMap.normal.height;
 
-    DecoratorTimer.prototype.decoType = 'DecoratorTimer';
+    this.jdomelem = $("<div class='DecoratorGear'></div>").attr('id', 'DecoratorGear' + this._id);
+    this.domelem = this.jdomelem[0];
+    this.clickable = true;
+    this.offsetToParent = config.offsetToParent || { x: 30, y: -30 };
 
-    DecoratorTimer.prototype.onAddInit = function(){
-      var node =this;
+    this.init(config);
+    this.setFrameSrc(this.frameSrc);
+    this.setFrame(this.frame);
+    return this;
+  };
+
+  extend(DecoratorGear, Sprite);
+
+  DecoratorGear.prototype.decoType = 'DecoratorGear';
+
+  DecoratorGear.prototype.draw = Decorator.prototype.draw;
+
+  DecoratorGear.prototype.onAddInit = function () {
+    var node = this;
+    if (this.decoratedNode.gameNode.data.is_supertoken !== true) {
       this.offsetToParent = {
-        x:(this.decoratedNode.width/2)-12,
-        y:-(this.decoratedNode.height/2-12)
+        x: this.decoratedNode.width / 2 - 11,
+        y: -(this.decoratedNode.height / 2 - 11),
       };
-      if (this.clickable) {
-        this.setClickable(true);
-      }
-
-      // FIXME: Write own slower Timer Ticker
-      SlowTicker.addListener(this);
-
-      this.initUI();
-      this.updateRenderProp();
-      this.draw();
-    };
-
-    DecoratorTimer.prototype.initUI = function(){
-      var deco = this;
-      deco.on('vmouseover',function(){
-        deco.jdomelem3.show();
-        deco.jdomelem3.hidden = false;
-      });
-      deco.on('vmouseout',function(){
-        deco.jdomelem3.hide();
-        deco.jdomelem3.hidden = true;
-      });
-
-    };
-
-    DecoratorTimer.prototype.getPercentage = function(){
-      var now = new Date().getTime();
-      var timespan = this.endTime - this.startTime;
-      this.remainTime = this.endTime-now;
-      return (now-this.startTime)/(timespan/100);
-    };
-
-    DecoratorTimer.prototype.textReadyIn = _._('Ready in') + ' ';
-
-    DecoratorTimer.prototype.draw = function (){
-      if (!this.decoratedNode) {
-        return;
-      }
-      if (this.hidden) {
-        return;
-      }
-      var perc = this.getPercentage();
-      this.setSize(this.getSize());
-      this.setTransform(this.getTransform());
-      this.setPosition({
-        x: this.decoratedNode.getPosition().x + this.offsetToParent.x,
-        y: this.decoratedNode.getPosition().y + this.offsetToParent.y
-      });
-      this.setOpacity(this.opacity);
-
-      if (this.done) {
-        return;
-      }
-      if (perc>100) {
-        SlowTicker.removeListener(this);
-        this.FXSnooze();
-        this.done = true;
-        this.decoratedNode.trigger('TimerEnd');
-      }
-
-      var jtext = this.jdomelem3;
-      // Add some ms to make Countdown shortly show 00:00
-
-      if (!this.jdomelem3.hidden) {
-        jtext.text(this.textReadyIn + _.toTime(this.remainTime+800));
-      }
-
-      var canvas = this.domelem2;
-      canvas.width = this.getSize().width;
-      canvas.height = this.getSize().height;
-      var ctx = canvas.getContext('2d');
-      ctx.clearRect(0, 0, canvas.width, canvas.height);
-      ctx.beginPath();
-      ctx.lineWidth=6;
-      ctx.arc(this.offsetX, this.offsetY, 14, 270*(Math.PI/180), 270*(Math.PI/180) + perc * 3.6 * (Math.PI / 180), false);
-      ctx.strokeStyle='rgba(127, 49, 135, 1)';
-      ctx.stroke();
-    };
-
-
-    /////////////////////////////
-    // The DecoratorAmount
-    /////////////////////////////
-
-    var DecoratorAmount = function(config){
-      config = config || {};
-      this._id = _instances.length;
-      this.text = config.text || "Label";
-      this.jdomelem = $("<div class='DecoratorAmount'></div>");
-      this.jdomelem2 = $("<div class='DecoratorAmountValue'></div>");
-      this.jdomelem3 = $("<div class='DecoratorAmountNum'></div>");
-      this.jdomelem.append(this.jdomelem2);
-      this.jdomelem.append(this.jdomelem3);
-      this.frameSrc = 'MainSprites.png';
-      this.frameMap = {
-        normal: {x: 267, y: 582, width: 80, height: 16, pivotx: 38, pivoty: 4}
+    } else {
+      this.offsetToParent = {
+        x: this.decoratedNode.width / 2 - 16,
+        y: -(this.decoratedNode.height / 2 - 16),
       };
-      this.domelem = this.jdomelem[0];
-      this.offsetToParent = {x:0,y:35};
-      this.amount = config.amount || 0;
-      this.init(config);
-      this.setFrameSrc(this.frameSrc);
-      this.setFrame('normal');
-      this.setAmount();
-      return this;
+    }
+    if (this.clickable) {
+      this.setClickable(true);
+    }
+    this.initUI();
+    this.updateRenderProp();
+    this.draw();
+  };
+
+  DecoratorGear.prototype.initUI = function () {
+    var deco = this;
+    deco.on('vclick', function (e) {
+      e.stopPropagation();
+      if (deco.decoratedNode) {
+        deco.decoratedNode.trigger('vclick');
+        // QuickCharge on Gear?
+        //deco.decoratedNode.gameNode.trigger('Charge');
+      }
+    });
+  };
+
+  /////////////////////////////
+  // The DecoratorTimer
+  /////////////////////////////
+
+  var DecoratorTimer = function (config) {
+    config = config || {};
+    this._id = _instances.length;
+
+    this.frameSrc = config.frameSrc || 'MainSprites.png';
+    this.frameMap = config.frameMap || {
+      //normal: { "x": 12, "y": 1008, "width": 26, "height": 26, "pivotx": 11, "pivoty": 11 }
+      normal: { x: 0, y: 580, width: 35, height: 35, pivotx: 18, pivoty: 18 },
     };
+    this.frame = config.frame || 'normal';
 
-    extend(DecoratorAmount, Sprite);
+    this.serverTime = config.serverTime || 0;
+    this.serverStartTime = config.serverStartTime || 0;
+    this.duration = config.duration || 1000;
+    this.startTime = new Date().getTime() - (this.serverTime - this.serverStartTime);
+    this.endTime = this.startTime + this.duration;
 
+    this.width = this.frameMap.normal.width;
+    this.height = this.frameMap.normal.height;
 
-    DecoratorAmount.prototype.decoType = 'DecoratorAmount';
+    this.jdomelem = $("<div class='DecoratorTimer'></div>").attr('id', 'DecoratorTimer' + this._id);
+    this.domelem = this.jdomelem[0];
 
-    DecoratorAmount.prototype.setAmount = function(amount){
-      amount = amount || this.amount;
-      /*
+    this.jdomelem2 = $("<canvas class='DecoratorTimerCanvas'></canvas>").attr(
+      'id',
+      'DecoratorTimerCanvas' + this._id
+    );
+    this.domelem2 = this.jdomelem2[0];
+
+    this.jdomelem3 = $("<div class='DecoratorTimerText'>6:12:20</div>").attr(
+      'id',
+      'DecoratorTimerText' + this._id
+    );
+    this.domelem3 = this.jdomelem3[0];
+
+    this.jdomelem2.attr({ width: config.width, height: config.height });
+    this.jdomelem.append(this.jdomelem2);
+    this.jdomelem.append(this.jdomelem3);
+    this.clickable = true;
+    this.offsetToParent = config.offsetToParent || { x: 30, y: -30 };
+
+    this.init(config);
+    this.setFrameSrc(this.frameSrc);
+    this.setFrame(this.frame);
+    return this;
+  };
+
+  extend(DecoratorTimer, Sprite);
+
+  DecoratorTimer.prototype.decoType = 'DecoratorTimer';
+
+  DecoratorTimer.prototype.onAddInit = function () {
+    var node = this;
+    this.offsetToParent = {
+      x: this.decoratedNode.width / 2 - 12,
+      y: -(this.decoratedNode.height / 2 - 12),
+    };
+    if (this.clickable) {
+      this.setClickable(true);
+    }
+
+    // FIXME: Write own slower Timer Ticker
+    SlowTicker.addListener(this);
+
+    this.initUI();
+    this.updateRenderProp();
+    this.draw();
+  };
+
+  DecoratorTimer.prototype.initUI = function () {
+    var deco = this;
+    deco.on('vmouseover', function () {
+      deco.jdomelem3.show();
+      deco.jdomelem3.hidden = false;
+    });
+    deco.on('vmouseout', function () {
+      deco.jdomelem3.hide();
+      deco.jdomelem3.hidden = true;
+    });
+  };
+
+  DecoratorTimer.prototype.getPercentage = function () {
+    var now = new Date().getTime();
+    var timespan = this.endTime - this.startTime;
+    this.remainTime = this.endTime - now;
+    return (now - this.startTime) / (timespan / 100);
+  };
+
+  DecoratorTimer.prototype.textReadyIn = _._('Ready in') + ' ';
+
+  DecoratorTimer.prototype.draw = function () {
+    if (!this.decoratedNode) {
+      return;
+    }
+    if (this.hidden) {
+      return;
+    }
+    var perc = this.getPercentage();
+    this.setSize(this.getSize());
+    this.setTransform(this.getTransform());
+    this.setPosition({
+      x: this.decoratedNode.getPosition().x + this.offsetToParent.x,
+      y: this.decoratedNode.getPosition().y + this.offsetToParent.y,
+    });
+    this.setOpacity(this.opacity);
+
+    if (this.done) {
+      return;
+    }
+    if (perc > 100) {
+      SlowTicker.removeListener(this);
+      this.FXSnooze();
+      this.done = true;
+      this.decoratedNode.trigger('TimerEnd');
+    }
+
+    var jtext = this.jdomelem3;
+    // Add some ms to make Countdown shortly show 00:00
+
+    if (!this.jdomelem3.hidden) {
+      jtext.text(this.textReadyIn + _.toTime(this.remainTime + 800));
+    }
+
+    var canvas = this.domelem2;
+    canvas.width = this.getSize().width;
+    canvas.height = this.getSize().height;
+    var ctx = canvas.getContext('2d');
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.beginPath();
+    ctx.lineWidth = 6;
+    ctx.arc(
+      this.offsetX,
+      this.offsetY,
+      14,
+      270 * (Math.PI / 180),
+      270 * (Math.PI / 180) + perc * 3.6 * (Math.PI / 180),
+      false
+    );
+    ctx.strokeStyle = 'rgba(127, 49, 135, 1)';
+    ctx.stroke();
+  };
+
+  /////////////////////////////
+  // The DecoratorAmount
+  /////////////////////////////
+
+  var DecoratorAmount = function (config) {
+    config = config || {};
+    this._id = _instances.length;
+    this.text = config.text || 'Label';
+    this.jdomelem = $("<div class='DecoratorAmount'></div>");
+    this.jdomelem2 = $("<div class='DecoratorAmountValue'></div>");
+    this.jdomelem3 = $("<div class='DecoratorAmountNum'></div>");
+    this.jdomelem.append(this.jdomelem2);
+    this.jdomelem.append(this.jdomelem3);
+    this.frameSrc = 'MainSprites.png';
+    this.frameMap = {
+      normal: { x: 267, y: 582, width: 80, height: 16, pivotx: 38, pivoty: 4 },
+    };
+    this.domelem = this.jdomelem[0];
+    this.offsetToParent = { x: 0, y: 35 };
+    this.amount = config.amount || 0;
+    this.init(config);
+    this.setFrameSrc(this.frameSrc);
+    this.setFrame('normal');
+    this.setAmount();
+    return this;
+  };
+
+  extend(DecoratorAmount, Sprite);
+
+  DecoratorAmount.prototype.decoType = 'DecoratorAmount';
+
+  DecoratorAmount.prototype.setAmount = function (amount) {
+    amount = amount || this.amount;
+    /*
       this.jdomelem2.animate({width:Math.round((amount/100)*60)},600);
       this.jdomelem3.text(_.toKSNum(this.decoratedNode.gameNode.data.absoluteAmount));
       */
 
-      /* FIXME: TURN THIS ON/OFF FOR DEMO BEHAVIOUR */
-      this.jdomelem2.animate({width:Math.round((amount/100)*60)},600);
-      if (amount < 25) {
-        this.jdomelem3.show();
-        this.jdomelem3.text(_.toKSNum(this.decoratedNode.gameNode.data.absoluteAmount));
-        //this.jdomelem2.hide();
-      } else {
-        //this.jdomelem2.show();
-        //this.jdomelem2.animate({width:Math.round((amount/100)*60)},600);
-        this.jdomelem3.hide();
-      }
-      /* END FIXME */
+    /* FIXME: TURN THIS ON/OFF FOR DEMO BEHAVIOUR */
+    this.jdomelem2.animate({ width: Math.round((amount / 100) * 60) }, 600);
+    if (amount < 25) {
+      this.jdomelem3.show();
+      this.jdomelem3.text(_.toKSNum(this.decoratedNode.gameNode.data.absoluteAmount));
+      //this.jdomelem2.hide();
+    } else {
+      //this.jdomelem2.show();
+      //this.jdomelem2.animate({width:Math.round((amount/100)*60)},600);
+      this.jdomelem3.hide();
+    }
+    /* END FIXME */
+  };
+
+  DecoratorAmount.prototype.onAddInit = function () {
+    var node = this;
+    this.offsetToParent = { x: 0, y: this.decoratedNode.height - this.decoratedNode.offsetY - 8 };
+    this.updateRenderProp();
+    this.draw();
+  };
+
+  DecoratorAmount.prototype.draw = Decorator.prototype.draw;
+
+  /////////////////////////////
+  // The Cable
+  /////////////////////////////
+
+  // TODO: Embed Image data or find other solutions to reduce requests
+
+  var SparkImg = new Image();
+  SparkImg.src = 'img/sprite_spark.png';
+  var SparkImg0 = new Image();
+  SparkImg0.src = 'img/sprite_spark_small.png';
+  var PlugImg = new Image();
+  PlugImg.src = 'img/sprite_plug.png';
+
+  var KrapsImg = new Image();
+  KrapsImg.src = 'img/sprite_kraps.png';
+  var KrapsImg0 = new Image();
+  KrapsImg0.src = 'img/sprite_kraps_small.png';
+  var GulpImg = new Image();
+  GulpImg.src = 'img/sprite_gulp.png';
+
+  var Cable = function (config) {
+    // Simple cable with canvas render method, to connect perps use Subclass PerpCable
+    config = config || {};
+    this._id = _instances.length;
+    this.tension = config.tension || 1;
+    this.cableMaxLength = config.cableMaxLength || 400;
+    this.z = -1;
+    this.offsetX = config.offsetX || 16;
+    this.offsetY = config.offsetY || 16;
+    this.pointFrom = config.pointFrom || { x: 350, y: 50 };
+    this.pointTo = config.pointTo || { x: 550, y: 250 };
+    this.jdomelem = $("<canvas class='Cable'>Cable" + this._id + '</canvas>').attr(
+      'id',
+      'Cable' + this._id
+    );
+    this.domelem = this.jdomelem[0];
+    this.init(config);
+    //this.draw();
+  };
+
+  extend(Cable, Node);
+
+  Cable.prototype.straightness = 1;
+  Cable.prototype.progress = 1;
+  Cable.prototype.dataposIn = 0;
+  Cable.prototype.dataposOut = 0;
+  // Modes: in, out, "inout"
+  Cable.prototype.mode = 'in';
+  Cable.prototype.colorIn = '#16A3D7';
+  Cable.prototype.colorOut = '#E85E2B';
+
+  Cable.prototype.getPoints = function () {
+    return {
+      p1: this.pointFrom,
+      p5: this.pointTo,
     };
+  };
 
-    DecoratorAmount.prototype.onAddInit = function(){
-      var node =this;
-      this.offsetToParent = {x: 0, y: this.decoratedNode.height-this.decoratedNode.offsetY-8};
-      this.updateRenderProp();
-      this.draw();
-    };
+  Cable.prototype.getLength = function () {
+    // This is the old Becier fallback, not in use currently
+    var p = this.getPoints();
+    var cx = p.p1.x < p.p5.x ? p.p1.x : p.p5.x;
+    var cy = p.p1.y < p.p5.y ? p.p1.y : p.p5.y;
+    var x = p.p1.x - cx + this.offsetX;
+    var y = p.p1.y - cy + this.offsetY;
+    var x2 = p.p5.x - cx + this.offsetX;
+    var y2 = p.p5.y - cy + this.offsetY;
+    var dx = x2 - x,
+      dy = y2 - y;
+    var len = Math.sqrt(dx * dx + dy * dy);
+    return len;
+  };
 
+  Cable.prototype.draw = function () {
+    if (this.hidden || this.progress <= 0) {
+      this.css({
+        display: 'none',
+      });
+      return;
+    } else {
+      this.css({
+        display: 'block',
+      });
+    }
 
-    DecoratorAmount.prototype.draw = Decorator.prototype.draw;
+    var offset = 0;
+    if (this.mode === 'inout') {
+      offset = 4;
+    }
 
+    var path = this;
+    var p = this.getPoints();
+    path.domelem.width = path.width = Math.abs(p.p1.x - p.p5.x) + path.offsetX * 2;
+    path.domelem.height = path.height = Math.abs(p.p1.y - p.p5.y) + path.offsetY * 2;
+    var cx = p.p1.x < p.p5.x ? p.p1.x : p.p5.x;
+    var cy = p.p1.y < p.p5.y ? p.p1.y : p.p5.y;
 
-    /////////////////////////////
-    // The Cable
-    /////////////////////////////
+    //path.setSize({width:this.width,height:this.height});
+    path.setTransform(path.getTransform());
+    //var modeoff = (this.mode === 'in') ? 0 : 6;
+    path.setPosition({ x: cx, y: cy });
+    var tension = path.tension;
+    var cableMaxLength = path.cableMaxLength;
+    var x = p.p1.x - cx + path.offsetX;
+    var y = p.p1.y - cy + path.offsetY;
+    var x2 = p.p5.x - cx + path.offsetX;
+    var y2 = p.p5.y - cy + path.offsetY;
+    //var xa = p.p2.x-cx;
+    //var ya = p.p2.y-cy;
+    //var xb = p.p3.x-cx;
+    //var yb = p.p3.y-cy;
+    //var xc = p.p4.x-cx;
+    //var yc = p.p4.y-cy;
 
-    // TODO: Embed Image data or find other solutions to reduce requests
+    var dx = x2 - x,
+      dy = y2 - y;
+    var len = Math.sqrt(dx * dx + dy * dy);
+    path.length = len;
+    //tension = (Math.abs(x-p.p3.x)+Math.abs(y-p.p3.y))/len;
+    var sinefreq = 360;
+    var dxa = Math.abs(dx);
+    var dya = Math.abs(dy);
+    var slope = dx * dy > 0 ? -1 : 1;
+    var radalpha = dxa < dya ? Math.asin(dx / len) : Math.asin(dy / len);
+    var radbeta = Math.PI / 2 - Math.abs(radalpha);
+    var sineamp = (len / 4 / Math.tan(radbeta)) * slope;
 
-    var SparkImg = new Image();
-    SparkImg.src = 'img/sprite_spark.png';
-    var SparkImg0 = new Image();
-    SparkImg0.src = 'img/sprite_spark_small.png';
-    var PlugImg = new Image();
-    PlugImg.src = 'img/sprite_plug.png';
+    // adjust for flatter curve
+    //sineamp = sineamp * 0.5;
 
-    var KrapsImg = new Image();
-    KrapsImg.src = 'img/sprite_kraps.png';
-    var KrapsImg0 = new Image();
-    KrapsImg0.src = 'img/sprite_kraps_small.png';
-    var GulpImg = new Image();
-    GulpImg.src = 'img/sprite_gulp.png';
+    // Resolution of path:
+    var seqs = renderConf.cableResolution;
+    //var seqs = renderConf.cableResolution+(1-this.straightness)*10;
+    // Dash Array
+    var da = [seqs, 0];
+    //var da = [seqs,0+(1-this.straightness)*10];
 
-    var Cable = function(config){
-      // Simple cable with canvas render method, to connect perps use Subclass PerpCable
-      config = config || {};
-      this._id = _instances.length;
-      this.tension = config.tension || 1;
-      this.cableMaxLength = config.cableMaxLength || 400;
-      this.z = -1;
-      this.offsetX = config.offsetX || 16;
-      this.offsetY = config.offsetY || 16;
-      this.pointFrom = config.pointFrom || { "x": 350, "y": 50 };
-      this.pointTo = config.pointTo || { "x": 550, "y": 250 };
-      this.jdomelem = $("<canvas class='Cable'>Cable"+this._id+"</canvas>").attr('id','Cable'+this._id);
-      this.domelem = this.jdomelem[0];
-      this.init(config);
-      //this.draw();
-    };
+    var ctx = path.domelem.getContext('2d');
+    var rot = Math.atan2(dy, dx);
+    ctx.lineWidth = 6;
 
-    extend(Cable, Node);
+    ctx.translate(x, y);
+    ctx.rotate(rot);
 
-    Cable.prototype.straightness = 1;
-    Cable.prototype.progress = 1;
-    Cable.prototype.dataposIn = 0;
-    Cable.prototype.dataposOut = 0;
-    // Modes: in, out, "inout"
-    Cable.prototype.mode = "in";
-    Cable.prototype.colorIn = "#16A3D7";
-    Cable.prototype.colorOut = "#E85E2B";
+    var dc = da.length;
+    var di = 0,
+      draw = true;
+    var vari = 0;
+    var snu;
+    var stretch = cableMaxLength - len;
+    var flatness = stretch < 0 ? 0 : (stretch / cableMaxLength) * this.straightness;
+    var progress = len * this.progress;
 
-    Cable.prototype.getPoints = function() {
-      return {
-        p1:this.pointFrom,
-        p5:this.pointTo
-      };
-    };
+    // Orange Cable (Data out of DB)
+    if (this.mode === 'out' || this.mode === 'inout') {
+      ctx.beginPath();
+      ctx.moveTo(len - offset, offset);
+      //ctx.lineTo(dx,0);
+      //ctx.lineTo(dx,dy);
+      //ctx.lineTo(0,dy);
+      //ctx.lineTo(0,0);
+      //ctx.rotate(rot);
+      x = 0;
+      snu = sinefreq / len;
+      while (x < progress) {
+        x += da[di++ % dc];
+        if (x > len) {
+          x = len;
+        }
+        vari = Math.sin((x * snu * Math.PI) / 180) * sineamp * flatness;
+        vari = vari + Math.sin((x * snu * ((1 - tension) * 15) * Math.PI) / 180) * 15 * flatness;
+        draw ? ctx.lineTo(len - x, -vari + offset) : ctx.moveTo(len - x, -vari + offset);
+        //draw ? ctx.rect(x, vari,1,vari): ctx.moveTo(x, vari);
+        //draw ? ctx.arc(x, varisum, 10-Math.abs(vari2), 0 , 2 * Math.PI, false): ctx.moveTo(x, vari);
+        draw = !draw;
 
-    Cable.prototype.getLength = function() {
-      // This is the old Becier fallback, not in use currently
-      var p = this.getPoints();
-      var cx = (p.p1.x < p.p5.x ? p.p1.x : p.p5.x);
-      var cy = (p.p1.y < p.p5.y ? p.p1.y : p.p5.y);
-      var x = p.p1.x-cx+this.offsetX;
-      var y = p.p1.y-cy+this.offsetY;
-      var x2 = p.p5.x-cx+this.offsetX;
-      var y2 = p.p5.y-cy+this.offsetY;
-      var dx = (x2-x), dy = (y2-y);
-      var len = Math.sqrt(dx*dx + dy*dy);
-      return len;
-    };
-
-    Cable.prototype.draw = function() {
-      if (this.hidden || this.progress <= 0) {
-        this.css({
-          'display': 'none'
-        });
-        return;
-      } else {
-        this.css({
-          'display': 'block'
-        });
-      }
-
-      var offset = 0;
-      if (this.mode === "inout") {
-        offset = 4;
-      }
-
-      var path = this;
-      var p = this.getPoints();
-      path.domelem.width = path.width = Math.abs(p.p1.x-p.p5.x)+(path.offsetX*2);
-      path.domelem.height = path.height = Math.abs(p.p1.y-p.p5.y)+(path.offsetY*2);
-      var cx = (p.p1.x < p.p5.x ? p.p1.x : p.p5.x);
-      var cy = (p.p1.y < p.p5.y ? p.p1.y : p.p5.y);
-
-      //path.setSize({width:this.width,height:this.height});
-      path.setTransform(path.getTransform());
-      //var modeoff = (this.mode === 'in') ? 0 : 6;
-      path.setPosition({x:cx,y:cy});
-      var tension = path.tension;
-      var cableMaxLength = path.cableMaxLength;
-      var x = p.p1.x-cx+path.offsetX;
-      var y = p.p1.y-cy+path.offsetY;
-      var x2 = p.p5.x-cx+path.offsetX;
-      var y2 = p.p5.y-cy+path.offsetY;
-      //var xa = p.p2.x-cx;
-      //var ya = p.p2.y-cy;
-      //var xb = p.p3.x-cx;
-      //var yb = p.p3.y-cy;
-      //var xc = p.p4.x-cx;
-      //var yc = p.p4.y-cy;
-
-      var dx = (x2-x), dy = (y2-y);
-      var len = Math.sqrt(dx*dx + dy*dy);
-      path.length = len;
-      //tension = (Math.abs(x-p.p3.x)+Math.abs(y-p.p3.y))/len;
-      var sinefreq = 360;
-      var dxa = Math.abs(dx);
-      var dya = Math.abs(dy);
-      var slope = (dx*dy > 0 ? -1 : 1);
-      var radalpha = ( dxa<dya ? Math.asin(dx/len) : Math.asin(dy/len) );
-      var radbeta = Math.PI/2 - Math.abs(radalpha);
-      var sineamp = (len/4) / Math.tan(radbeta) * slope;
-
-      // adjust for flatter curve
-      //sineamp = sineamp * 0.5;
-
-      // Resolution of path:
-      var seqs = renderConf.cableResolution;
-      //var seqs = renderConf.cableResolution+(1-this.straightness)*10;
-      // Dash Array
-      var da = [seqs,0];
-      //var da = [seqs,0+(1-this.straightness)*10];
-
-      var ctx = path.domelem.getContext('2d');
-      var rot = Math.atan2(dy, dx);
-      ctx.lineWidth = 6;
-
-
-      ctx.translate(x, y);
-      ctx.rotate(rot);
-
-      var dc = da.length;
-      var di = 0, draw = true;
-      var vari = 0;
-      var snu;
-      var stretch = cableMaxLength-len;
-      var flatness = (stretch < 0) ? 0 : (stretch/cableMaxLength)*this.straightness;
-      var progress = len*this.progress;
-
-      // Orange Cable (Data out of DB)
-      if (this.mode === "out" || this.mode === "inout") {
-          ctx.beginPath();
-          ctx.moveTo(len-offset, offset);
-          //ctx.lineTo(dx,0);
-          //ctx.lineTo(dx,dy);
-          //ctx.lineTo(0,dy);
-          //ctx.lineTo(0,0);
-          //ctx.rotate(rot);
-          x = 0;
-          snu = sinefreq/len;
-          while (x < progress) {
-            x += da[di++ % dc];
-            if (x > len) {
-              x = len;
-            }
-            vari = Math.sin(x * snu * Math.PI/180)*sineamp*flatness;
-            vari = vari + (Math.sin(x * snu * ((1-tension) * 15) * Math.PI/180)*15)*flatness;
-            draw ? ctx.lineTo(len-x, -vari+offset): ctx.moveTo(len-x, -vari+offset);
-            //draw ? ctx.rect(x, vari,1,vari): ctx.moveTo(x, vari);
-            //draw ? ctx.arc(x, varisum, 10-Math.abs(vari2), 0 , 2 * Math.PI, false): ctx.moveTo(x, vari);
-            draw = !draw;
-
-            //ctx.lineTo(x, vari);
-          }
-
-          // "#16A3D7" "#E85E2B";
-          //ctx.lineCap = 'round';
-          ctx.lineCap = 'butt';
-          ctx.strokeStyle = this.colorOut;
-          ctx.stroke();
-
-          if (this.progress > 0 && this.progress < 1) {
-            x = offset;
-            progress = len*this.progress;
-            x= len-progress;
-            x=x-16;
-            vari = Math.sin(x * snu * Math.PI/180)*sineamp*flatness;
-            vari = vari + (Math.sin(x * snu * ((1-tension) * 18) * Math.PI/180)*15)*flatness;
-            ctx.drawImage(GulpImg,x,vari-8+offset);
-          }
+        //ctx.lineTo(x, vari);
       }
 
-      // Blue Cable (Data into DB)
-      if (this.mode === "in" || this.mode === "inout") {
-          /* Fallback to Bezier Drawing
+      // "#16A3D7" "#E85E2B";
+      //ctx.lineCap = 'round';
+      ctx.lineCap = 'butt';
+      ctx.strokeStyle = this.colorOut;
+      ctx.stroke();
+
+      if (this.progress > 0 && this.progress < 1) {
+        x = offset;
+        progress = len * this.progress;
+        x = len - progress;
+        x = x - 16;
+        vari = Math.sin((x * snu * Math.PI) / 180) * sineamp * flatness;
+        vari = vari + Math.sin((x * snu * ((1 - tension) * 18) * Math.PI) / 180) * 15 * flatness;
+        ctx.drawImage(GulpImg, x, vari - 8 + offset);
+      }
+    }
+
+    // Blue Cable (Data into DB)
+    if (this.mode === 'in' || this.mode === 'inout') {
+      /* Fallback to Bezier Drawing
           ctx.beginPath();
           ctx.moveTo(x,y);
           ctx.quadraticCurveTo(xa, ya, xb, yb);
@@ -3276,152 +3421,151 @@ var Render = function() {
           return;
           */
 
-          ctx.beginPath();
-          ctx.moveTo(0-offset, 0-offset);
-          //ctx.lineTo(dx,0);
-          //ctx.lineTo(dx,dy);
-          //ctx.lineTo(0,dy);
-          //ctx.lineTo(0,0);
-          dc = da.length;
-          di = 0;
-          draw = true;
-          x = 0;
-          vari = 0;
-          snu = sinefreq/len;
-          stretch = cableMaxLength-len;
-          flatness = (stretch < 0) ? 0 : (stretch/cableMaxLength)*this.straightness;
-          progress = len*this.progress;
-          while (x < progress) {
-            x += da[di++ % dc];
-            if (x > len) {
-              x = len;
-            }
-            vari = Math.sin(x * snu * Math.PI/180)*sineamp*flatness;
-            vari = vari + (Math.sin(x * snu * ((1-tension) * 15) * Math.PI/180)*15)*flatness;
-            draw ? ctx.lineTo(x, vari-offset): ctx.moveTo(x, vari-offset);
-            //draw ? ctx.rect(x, vari,1,vari): ctx.moveTo(x, vari);
-            //draw ? ctx.arc(x, varisum, 10-Math.abs(vari2), 0 , 2 * Math.PI, false): ctx.moveTo(x, vari);
-            draw = !draw;
+      ctx.beginPath();
+      ctx.moveTo(0 - offset, 0 - offset);
+      //ctx.lineTo(dx,0);
+      //ctx.lineTo(dx,dy);
+      //ctx.lineTo(0,dy);
+      //ctx.lineTo(0,0);
+      dc = da.length;
+      di = 0;
+      draw = true;
+      x = 0;
+      vari = 0;
+      snu = sinefreq / len;
+      stretch = cableMaxLength - len;
+      flatness = stretch < 0 ? 0 : (stretch / cableMaxLength) * this.straightness;
+      progress = len * this.progress;
+      while (x < progress) {
+        x += da[di++ % dc];
+        if (x > len) {
+          x = len;
+        }
+        vari = Math.sin((x * snu * Math.PI) / 180) * sineamp * flatness;
+        vari = vari + Math.sin((x * snu * ((1 - tension) * 15) * Math.PI) / 180) * 15 * flatness;
+        draw ? ctx.lineTo(x, vari - offset) : ctx.moveTo(x, vari - offset);
+        //draw ? ctx.rect(x, vari,1,vari): ctx.moveTo(x, vari);
+        //draw ? ctx.arc(x, varisum, 10-Math.abs(vari2), 0 , 2 * Math.PI, false): ctx.moveTo(x, vari);
+        draw = !draw;
 
-            //ctx.lineTo(x, vari);
-          }
-
-          // "#16A3D7" "#E85E2B";
-          //ctx.lineCap = 'round';
-          ctx.lineCap = 'butt';
-          ctx.strokeStyle = this.colorIn;
-          ctx.stroke();
-          if (this.progress > 0 && this.progress < 1) {
-            x = 0-offset;
-            progress = len*this.progress;
-            x= progress;
-            x=x+8;
-            vari = Math.sin(x * snu * Math.PI/180)*sineamp*flatness;
-            vari = vari + (Math.sin(x * snu * ((1-tension) * 18) * Math.PI/180)*15)*flatness;
-            ctx.drawImage(PlugImg,x-8,vari-8-offset);
-          }
-
+        //ctx.lineTo(x, vari);
       }
 
-      // Data Sprites
-
-      var datapos;
-
-      if (this.dataposIn > 0 && this.dataposIn < 1) {
-        x = 0-offset;
-        datapos = len*this.dataposIn;
-        x= datapos;
-        x=x-10;
-        vari = Math.sin(x * snu * Math.PI/180)*sineamp*flatness;
-        vari = vari + (Math.sin(x * snu * ((1-tension) * 18) * Math.PI/180)*15)*flatness;
-        //vari = vari + (Math.sin(x * 90/len * 15 * Math.PI/180)*15)*flatness;
-        ctx.drawImage(SparkImg0,x-12,vari-12-offset);
-        x=x+10;
-        vari = Math.sin(x * snu * Math.PI/180)*sineamp*flatness;
-        vari = vari + (Math.sin(x * snu * ((1-tension) * 18) * Math.PI/180)*15)*flatness;
-        //vari = vari + (Math.sin(x * 90/len * 15 * Math.PI/180)*15)*flatness;
-        //ctx.drawImage(SparkImg,x-16,vari-16);
-        ctx.drawImage(SparkImg,x-16,vari-16-offset);
-        x=x+10;
-        vari = Math.sin(x * snu * Math.PI/180)*sineamp*flatness;
-        vari = vari + (Math.sin(x * snu * ((1-tension) * 15) * Math.PI/180)*15)*flatness;
-        //vari = vari + (Math.sin(x * 90/len * 15 * Math.PI/180)*15)*flatness;
-        ctx.drawImage(SparkImg0,x-12,vari-12-offset);
-      }
-      if (this.dataposOut > 0 && this.dataposOut < 1) {
-        x = offset;
-        datapos = len*this.dataposOut;
-        x= datapos;
-        x=x-10;
-        vari = Math.sin(x * snu * Math.PI/180)*sineamp*flatness;
-        vari = vari + (Math.sin(x * snu * ((1-tension) * 18) * Math.PI/180)*15)*flatness;
-        ctx.drawImage(KrapsImg0,x-12,vari-12+offset);
-        //vari = vari + (Math.sin(x * 90/len * 15 * Math.PI/180)*15)*flatness;
-        x=x+10;
-        vari = Math.sin(x * snu * Math.PI/180)*sineamp*flatness;
-        vari = vari + (Math.sin(x * snu * ((1-tension) * 18) * Math.PI/180)*15)*flatness;
-        //vari = vari + (Math.sin(x * 90/len * 15 * Math.PI/180)*15)*flatness;
-        //ctx.drawImage(SparkImg,x-16,vari-16);
-        ctx.drawImage(KrapsImg,x-16,vari-16+offset);
-        x=x+10;
-        vari = Math.sin(x * snu * Math.PI/180)*sineamp*flatness;
-        vari = vari + (Math.sin(x * snu * ((1-tension) * 15) * Math.PI/180)*15)*flatness;
-        //vari = vari + (Math.sin(x * 90/len * 15 * Math.PI/180)*15)*flatness;
-        ctx.drawImage(KrapsImg0,x-12,vari-12+offset);
-      }
-
-      //ctx.lineTo(x, 0);
+      // "#16A3D7" "#E85E2B";
       //ctx.lineCap = 'round';
-      //ctx.fillStyle="#16A3D7";
-      //ctx.fill();
-    };
+      ctx.lineCap = 'butt';
+      ctx.strokeStyle = this.colorIn;
+      ctx.stroke();
+      if (this.progress > 0 && this.progress < 1) {
+        x = 0 - offset;
+        progress = len * this.progress;
+        x = progress;
+        x = x + 8;
+        vari = Math.sin((x * snu * Math.PI) / 180) * sineamp * flatness;
+        vari = vari + Math.sin((x * snu * ((1 - tension) * 18) * Math.PI) / 180) * 15 * flatness;
+        ctx.drawImage(PlugImg, x - 8, vari - 8 - offset);
+      }
+    }
 
-    Cable.prototype.FXWobbleTension = function(tension){
-      var cable =this;
-      var duration = (tension<1) ? 300 : 500;
-      //this.dataposIn=0;
-      //this.dataposOut=0;
-      // Cue Tweens like this!!! Finally got it to work;
-      return cable.FXSimpleCue({tension:tension},duration,'easeOut');
-    };
+    // Data Sprites
 
-    Cable.prototype.FXToggleConnect = function(progress){
-      var cable =this;
-      var duration = (progress < 1) ? 200 : 800;
-      return cable.FXSimpleCue({progress:progress},duration,'sineInOut');
-    };
+    var datapos;
 
-    Cable.prototype.FXStraighten = function(straightness) {
-      var cable=this;
-      var easing = (straightness === 1) ? 'easeOut' : 'linear';
-      var duration = (straightness === 1) ? 200 : 100;
-      return this.FXSimpleCue({straightness:straightness},duration,easing);
-    };
+    if (this.dataposIn > 0 && this.dataposIn < 1) {
+      x = 0 - offset;
+      datapos = len * this.dataposIn;
+      x = datapos;
+      x = x - 10;
+      vari = Math.sin((x * snu * Math.PI) / 180) * sineamp * flatness;
+      vari = vari + Math.sin((x * snu * ((1 - tension) * 18) * Math.PI) / 180) * 15 * flatness;
+      //vari = vari + (Math.sin(x * 90/len * 15 * Math.PI/180)*15)*flatness;
+      ctx.drawImage(SparkImg0, x - 12, vari - 12 - offset);
+      x = x + 10;
+      vari = Math.sin((x * snu * Math.PI) / 180) * sineamp * flatness;
+      vari = vari + Math.sin((x * snu * ((1 - tension) * 18) * Math.PI) / 180) * 15 * flatness;
+      //vari = vari + (Math.sin(x * 90/len * 15 * Math.PI/180)*15)*flatness;
+      //ctx.drawImage(SparkImg,x-16,vari-16);
+      ctx.drawImage(SparkImg, x - 16, vari - 16 - offset);
+      x = x + 10;
+      vari = Math.sin((x * snu * Math.PI) / 180) * sineamp * flatness;
+      vari = vari + Math.sin((x * snu * ((1 - tension) * 15) * Math.PI) / 180) * 15 * flatness;
+      //vari = vari + (Math.sin(x * 90/len * 15 * Math.PI/180)*15)*flatness;
+      ctx.drawImage(SparkImg0, x - 12, vari - 12 - offset);
+    }
+    if (this.dataposOut > 0 && this.dataposOut < 1) {
+      x = offset;
+      datapos = len * this.dataposOut;
+      x = datapos;
+      x = x - 10;
+      vari = Math.sin((x * snu * Math.PI) / 180) * sineamp * flatness;
+      vari = vari + Math.sin((x * snu * ((1 - tension) * 18) * Math.PI) / 180) * 15 * flatness;
+      ctx.drawImage(KrapsImg0, x - 12, vari - 12 + offset);
+      //vari = vari + (Math.sin(x * 90/len * 15 * Math.PI/180)*15)*flatness;
+      x = x + 10;
+      vari = Math.sin((x * snu * Math.PI) / 180) * sineamp * flatness;
+      vari = vari + Math.sin((x * snu * ((1 - tension) * 18) * Math.PI) / 180) * 15 * flatness;
+      //vari = vari + (Math.sin(x * 90/len * 15 * Math.PI/180)*15)*flatness;
+      //ctx.drawImage(SparkImg,x-16,vari-16);
+      ctx.drawImage(KrapsImg, x - 16, vari - 16 + offset);
+      x = x + 10;
+      vari = Math.sin((x * snu * Math.PI) / 180) * sineamp * flatness;
+      vari = vari + Math.sin((x * snu * ((1 - tension) * 15) * Math.PI) / 180) * 15 * flatness;
+      //vari = vari + (Math.sin(x * 90/len * 15 * Math.PI/180)*15)*flatness;
+      ctx.drawImage(KrapsImg0, x - 12, vari - 12 + offset);
+    }
 
-    Cable.prototype.FXConnect = function(cb) {
-      var cable=this;
-      cable.progress=0;
-      cable.show();
-      //cable.dataposIn=0;
-      //return this.FXSimple({dataposIn:1,progress:1},1000,'sineInOut');
-      return this.FXSimpleCue({progress:1},1000,'sineInOut',cb);
-    };
+    //ctx.lineTo(x, 0);
+    //ctx.lineCap = 'round';
+    //ctx.fillStyle="#16A3D7";
+    //ctx.fill();
+  };
 
-    Cable.prototype.FXDisconnect = function(cb) {
-      var cable=this;
-      cable.progress=1;
-      return this.FXSimpleCue({progress:0},500,'sineInOut',cb);
-    };
+  Cable.prototype.FXWobbleTension = function (tension) {
+    var cable = this;
+    var duration = tension < 1 ? 300 : 500;
+    //this.dataposIn=0;
+    //this.dataposOut=0;
+    // Cue Tweens like this!!! Finally got it to work;
+    return cable.FXSimpleCue({ tension: tension }, duration, 'easeOut');
+  };
 
-    Cable.prototype.FXDataIn = function(cb) {
-      var cable=this;
-      var duration = cable.length*2;
-      cable.FXSimpleCue({dataposIn:1},0);
-      return cable.FXSimpleCue({dataposIn:0},duration,'linear',cb);
-      //cable.dataposIn=1;
-      //cable.tension=1;
-      //return this.FXSimple({datapos:1},1000,'sineInOut',function(){
-      /*
+  Cable.prototype.FXToggleConnect = function (progress) {
+    var cable = this;
+    var duration = progress < 1 ? 200 : 800;
+    return cable.FXSimpleCue({ progress: progress }, duration, 'sineInOut');
+  };
+
+  Cable.prototype.FXStraighten = function (straightness) {
+    var cable = this;
+    var easing = straightness === 1 ? 'easeOut' : 'linear';
+    var duration = straightness === 1 ? 200 : 100;
+    return this.FXSimpleCue({ straightness: straightness }, duration, easing);
+  };
+
+  Cable.prototype.FXConnect = function (cb) {
+    var cable = this;
+    cable.progress = 0;
+    cable.show();
+    //cable.dataposIn=0;
+    //return this.FXSimple({dataposIn:1,progress:1},1000,'sineInOut');
+    return this.FXSimpleCue({ progress: 1 }, 1000, 'sineInOut', cb);
+  };
+
+  Cable.prototype.FXDisconnect = function (cb) {
+    var cable = this;
+    cable.progress = 1;
+    return this.FXSimpleCue({ progress: 0 }, 500, 'sineInOut', cb);
+  };
+
+  Cable.prototype.FXDataIn = function (cb) {
+    var cable = this;
+    var duration = cable.length * 2;
+    cable.FXSimpleCue({ dataposIn: 1 }, 0);
+    return cable.FXSimpleCue({ dataposIn: 0 }, duration, 'linear', cb);
+    //cable.dataposIn=1;
+    //cable.tension=1;
+    //return this.FXSimple({datapos:1},1000,'sineInOut',function(){
+    /*
       var tween = this.FXSimple({dataposIn:0},500,'linear',function(){
         cable.dataposIn=1;
         if (cb) {
@@ -3429,7 +3573,7 @@ var Render = function() {
         }
       });
       */
-      /*
+    /*
       Ticker.addListener(cable);
       // Cue Tweens like this!!! Finally got it to work;
       if (!Tween.hasActiveTweens(this)) {
@@ -3449,164 +3593,165 @@ var Render = function() {
         });
       }
       */
+  };
+
+  Cable.prototype.FXDataOut = function (cb) {
+    var cable = this;
+    var duration = cable.length * 2;
+    cable.FXSimpleCue({ dataposOut: 0 }, 0);
+    return cable.FXSimpleCue({ dataposOut: 1 }, duration, 'linear', cb);
+  };
+
+  /////////////////////////////
+  // The PerpCable
+  /////////////////////////////
+
+  var PerpCable = function (config, perpFrom, perpTo) {
+    // Connection cable with perps as start and endpoint...
+    config = config || {};
+    this._id = _instances.length;
+    this.tension = config.tension || 1;
+    //this.cableMaxLength = config.cableMaxLength || 480;
+    // Clip to 480px, so Cables usually are never longer than 512 (texture size)
+    this.cableMaxLength = config.cableMaxLength || 480;
+    this.z = -1;
+    this.offsetX = config.offsetX || 16;
+    this.offsetY = config.offsetY || 16;
+    this.perpFrom = perpFrom;
+    this.perpTo = perpTo;
+    //if (!perpFrom.sticky) perpFrom.cables.push(this);
+    perpFrom.cables.add(this);
+    perpTo.cables.add(this);
+    this.pointFrom = this.perpFrom.getPosition();
+    this.pointTo = this.perpTo.getPosition();
+    this.jdomelem = $("<canvas class='Cable'></canvas>").attr('id', 'Cable' + this._id);
+    this.domelem = this.jdomelem[0];
+    this.init(config);
+    //this.draw();
+  };
+
+  extend(PerpCable, Cable);
+
+  PerpCable.prototype.getPoints = function () {
+    return {
+      p1: this.perpFrom.getPosition(),
+      p5: this.perpTo.getPosition(),
     };
+  };
 
-    Cable.prototype.FXDataOut = function(cb) {
-      var cable=this;
-      var duration = cable.length*2;
-      cable.FXSimpleCue({dataposOut:0},0);
-      return cable.FXSimpleCue({dataposOut:1},duration,'linear',cb);
-    };
+  /////////////////////////////
+  // The ViewTab
+  /////////////////////////////
 
+  var ViewTab = function (config) {
+    // Generic HTML Template based Container containing template based items
+    config = config || {};
+    this._id = _instances.length;
+    // Set View defaults
+    config.hidden = false;
+    this.draggable = false;
+    this.clickable = false;
+    this.width = config.width || 960;
+    this.height = config.height || 960;
+    this.jdomelem = $("<div class='ViewTab'></div>");
+    this.domelem = this.jdomelem[0];
+    this.jdomelem1 = $("<div class='ViewTabContainer'></div>");
+    this.jdomelem3 = this.popupContainerDomelem = $("<div class='PopupContainer'></div>");
+    //this.jdomelem1.append(this.jdomelem2);
+    this.jdomelem.append(this.jdomelem1);
+    this.jdomelem.append(this.jdomelem3);
+    this.domelem1 = this.jdomelem1[0];
 
-    /////////////////////////////
-    // The PerpCable
-    /////////////////////////////
+    // FIXME: Better collect which events we're listening to
+    this.jdomelem3.on('mousedown mouseup touchstart touchend dblclick dbltap tap', function (e) {
+      e.preventDefault();
+      e.stopPropagation();
+    });
 
-    var PerpCable = function(config,perpFrom,perpTo){
-      // Connection cable with perps as start and endpoint...
-      config = config || {};
-      this._id = _instances.length;
-      this.tension = config.tension || 1;
-      //this.cableMaxLength = config.cableMaxLength || 480;
-      // Clip to 480px, so Cables usually are never longer than 512 (texture size)
-      this.cableMaxLength = config.cableMaxLength || 480;
-      this.z = -1;
-      this.offsetX = config.offsetX || 16;
-      this.offsetY = config.offsetY || 16;
-      this.perpFrom = perpFrom;
-      this.perpTo = perpTo;
-      //if (!perpFrom.sticky) perpFrom.cables.push(this);
-      perpFrom.cables.add(this);
-      perpTo.cables.add(this);
-      this.pointFrom = this.perpFrom.getPosition();
-      this.pointTo = this.perpTo.getPosition();
-      this.jdomelem = $("<canvas class='Cable'></canvas>").attr('id','Cable'+this._id);
-      this.domelem = this.jdomelem[0];
-      this.init(config);
-      //this.draw();
-    };
+    this.init(config);
 
-    extend(PerpCable, Cable);
+    var node = this;
 
-    PerpCable.prototype.getPoints = function() {
-      return {
-        p1:this.perpFrom.getPosition(),
-        p5:this.perpTo.getPosition()
-      };
-    };
+    node.jdomelem.on('click touchend', '.ViewTabMenuButton:not(.disabled, .active)', function (e) {
+      e.stopPropagation();
+      e.preventDefault();
+      var button = $(this);
+      var bgestalt = button.attr('data-button-gestalt');
+      var bdata = button.attr('data-button-data');
+      this.lastButton = button;
+      node.jdomelem.find('.ViewTabMenuButton').removeClass('active');
+      button.addClass('active');
+      node.trigger('button_click.' + button.attr('data-button-id'), [bgestalt, bdata]);
+    });
 
-    /////////////////////////////
-    // The ViewTab
-    /////////////////////////////
+    node.jdomelem.on('click touchend', '.Button:not(.disabled, .active)', function (e) {
+      e.stopPropagation();
+      e.preventDefault();
+      var button = $(this);
+      var bgestalt = button.attr('data-button-gestalt');
+      var bdata = button.attr('data-button-data');
+      node.lastButton = button;
+      button.addClass('active');
+      node.trigger('button_click.' + button.attr('data-button-id'), [bgestalt, bdata]);
+    });
 
-    var ViewTab = function(config){
-      // Generic HTML Template based Container containing template based items
-      config = config || {};
-      this._id = _instances.length;
-      // Set View defaults
-      config.hidden = false;
-      this.draggable = false;
-      this.clickable = false;
-      this.width = config.width || 960;
-      this.height = config.height || 960;
-      this.jdomelem = $("<div class='ViewTab'></div>");
-      this.domelem = this.jdomelem[0];
-      this.jdomelem1 = $("<div class='ViewTabContainer'></div>");
-      this.jdomelem3 = this.popupContainerDomelem = $("<div class='PopupContainer'></div>");
-      //this.jdomelem1.append(this.jdomelem2);
-      this.jdomelem.append(this.jdomelem1);
-      this.jdomelem.append(this.jdomelem3);
-      this.domelem1 = this.jdomelem1[0];
-
-      // FIXME: Better collect which events we're listening to
-      this.jdomelem3.on('mousedown mouseup touchstart touchend dblclick dbltap tap', function(e){
-        e.preventDefault();
-        e.stopPropagation();
-      });
-
-      this.init(config);
-
-      var node = this;
-
-      node.jdomelem.on('click touchend','.ViewTabMenuButton:not(.disabled, .active)',function(e){
-        e.stopPropagation();
-        e.preventDefault();
-        var button = $(this);
-        var bgestalt = button.attr('data-button-gestalt');
-        var bdata = button.attr('data-button-data');
-        this.lastButton = button;
-        node.jdomelem.find('.ViewTabMenuButton').removeClass('active');
-        button.addClass('active');
-        node.trigger('button_click.'+button.attr('data-button-id'),[bgestalt,bdata]);
-      });
-      
-      node.jdomelem.on('click touchend','.Button:not(.disabled, .active)',function(e){
-        e.stopPropagation();
-        e.preventDefault();
-        var button = $(this);
-        var bgestalt = button.attr('data-button-gestalt');
-        var bdata = button.attr('data-button-data');
-        node.lastButton = button;
-        button.addClass('active');
-        node.trigger('button_click.'+button.attr('data-button-id'),[bgestalt,bdata]);
-      });
-
-      // LISTEN TO STATES
-      // FIXME: redundant to viewmap code
-      node.on("states_active",function(e,value){
-        if (value) {
-          node.FXShow();
-          node.parentNode.jdomelem.addClass('Active' + node.jdomelem.attr('id'));
-          node.gameNode.GameRoot.renderMenu.jdomelem.find('.MainMenuButton').removeClass('active');
-          node.gameNode.GameRoot.renderMenu.jdomelem.find('.MainMenuButton[data-button-id='+node.id+']').addClass('active');
-          node.trigger('viewtab_selected');
-        } else {
-          node.parentNode.jdomelem.removeClass('Active' + node.jdomelem.attr('id'));
-          node.FXHide();
-        }
-      });
-    };
-
-    extend(ViewTab, Node);
-
-    ViewTab.prototype.render = function() {
-      if (this.RenderTemplate !== undefined) {
-        var html = app.renderView(this.RenderTemplate,this);
-        this.jdomelem1.html(html);
-      }
-    };
-
-    ViewTab.prototype.addChild = function(child,ui_elem){
-      // Add a child to a Node
-      // This actually draws an element on the screen when the topmost Node is inside the html body
-      // flag ui_elem adds child to wrapper domelem
-      if (child.hidden) {
-        child.hide();
-      }
-      if (ui_elem) {
-        this.jdomelem.append(child.domelem);
+    // LISTEN TO STATES
+    // FIXME: redundant to viewmap code
+    node.on('states_active', function (e, value) {
+      if (value) {
+        node.FXShow();
+        node.parentNode.jdomelem.addClass('Active' + node.jdomelem.attr('id'));
+        node.gameNode.GameRoot.renderMenu.jdomelem.find('.MainMenuButton').removeClass('active');
+        node.gameNode.GameRoot.renderMenu.jdomelem
+          .find('.MainMenuButton[data-button-id=' + node.id + ']')
+          .addClass('active');
+        node.trigger('viewtab_selected');
       } else {
-        this.jdomelem1.append(child.domelem);
+        node.parentNode.jdomelem.removeClass('Active' + node.jdomelem.attr('id'));
+        node.FXHide();
       }
-      child.parentNode = this;
-      this.children.add(child);
-      //child.dragHandler = child.dragHandler || this.dragHandler;
-      //child.useDragHandler = this.dragHandler;
-      child.onAddInit();
-      return child;
-    };
+    });
+  };
 
-    ViewTab.prototype.lock = function(){
-      this.jdomelem3.addClass('lockOn');
-    };
+  extend(ViewTab, Node);
 
-    ViewTab.prototype.unlock = function(){
-      this.jdomelem3.removeClass('lockOn');
-    };
+  ViewTab.prototype.render = function () {
+    if (this.RenderTemplate !== undefined) {
+      var html = app.renderView(this.RenderTemplate, this);
+      this.jdomelem1.html(html);
+    }
+  };
 
-    ViewTab.prototype.onAddInit = function(){
-      /*
+  ViewTab.prototype.addChild = function (child, ui_elem) {
+    // Add a child to a Node
+    // This actually draws an element on the screen when the topmost Node is inside the html body
+    // flag ui_elem adds child to wrapper domelem
+    if (child.hidden) {
+      child.hide();
+    }
+    if (ui_elem) {
+      this.jdomelem.append(child.domelem);
+    } else {
+      this.jdomelem1.append(child.domelem);
+    }
+    child.parentNode = this;
+    this.children.add(child);
+    //child.dragHandler = child.dragHandler || this.dragHandler;
+    //child.useDragHandler = this.dragHandler;
+    child.onAddInit();
+    return child;
+  };
+
+  ViewTab.prototype.lock = function () {
+    this.jdomelem3.addClass('lockOn');
+  };
+
+  ViewTab.prototype.unlock = function () {
+    this.jdomelem3.removeClass('lockOn');
+  };
+
+  ViewTab.prototype.onAddInit = function () {
+    /*
       if (this.draggable) {
         this.initScroller();
       }
@@ -3614,209 +3759,218 @@ var Render = function() {
       this.dragHandler = new DragHandler();
       this.useDragHandler=this.dragHandler;
       */
-      this.render();
-      this.draw();
-      if (this.hidden) {
-        this.hide();
-      }
-    };
+    this.render();
+    this.draw();
+    if (this.hidden) {
+      this.hide();
+    }
+  };
 
-    ViewTab.prototype.css = function(css) {
-      // Wrapper for CSS manipulation of domelem, currently jQuery
-      this.jdomelem1.css(css);
-    };
+  ViewTab.prototype.css = function (css) {
+    // Wrapper for CSS manipulation of domelem, currently jQuery
+    this.jdomelem1.css(css);
+  };
 
-    ViewTab.prototype.FXShow = function(){
-        var node=this;
-        //node.show();
-        node.jdomelem.addClass('active');
-    };
+  ViewTab.prototype.FXShow = function () {
+    var node = this;
+    //node.show();
+    node.jdomelem.addClass('active');
+  };
 
-    ViewTab.prototype.FXHide = function(){
-        var node=this;
-        //node.hide();
-        node.jdomelem.removeClass('active');
-    };
+  ViewTab.prototype.FXHide = function () {
+    var node = this;
+    //node.hide();
+    node.jdomelem.removeClass('active');
+  };
 
-    ViewTab.prototype.updateScroller = function(){
-      // FIXME: do something on resize?
-      var node = this;
-      var stage = this.parentNode;
-      var scaleW = stage.width/node.width;
-      var scaleH = stage.height/node.height;
-    };
+  ViewTab.prototype.updateScroller = function () {
+    // FIXME: do something on resize?
+    var node = this;
+    var stage = this.parentNode;
+    var scaleW = stage.width / node.width;
+    var scaleH = stage.height / node.height;
+  };
 
+  /////////////////////////////
+  // The ViewMap
+  /////////////////////////////
 
+  var ViewMap = function (config) {
+    // Zoom- and scrollable Container containing Nodes, Sprites etc... uses Scroller.js
+    config = config || {};
+    this._id = _instances.length;
+    // Set View defaults
+    config.hidden = false;
+    this.draggable = true;
+    this.clickable = true;
+    this.offsetX = 0; // Scroller needs offset 0
+    this.offsetY = 0; // Scroller needs offset 0
+    this.width = config.width || 2920;
+    this.height = config.height || 2200;
+    this.zoomScale = config.zoomScale || 1;
+    this.jdomelem = $("<div class='ViewMap'></div>");
+    this.domelem = this.jdomelem[0];
+    this.jdomelem1 = $("<div class='ViewMapContainer'></div>");
+    this.domelem1 = this.jdomelem1[0];
+    this.jdomelem2 = $(
+      "<img class='ViewMapContainerImg' src='" + setup.imagePathPrefix + config.background + "'>"
+    );
 
-    /////////////////////////////
-    // The ViewMap
-    /////////////////////////////
+    this.jdomelemZoom = $(
+      '<div class="ZoomControls"><div class="ZoomIn"></div><div class="ZoomOut"></div><div class="Fullscreen"></div></div>'
+    );
+    this._jZoomIn = this.jdomelemZoom.find('.ZoomIn');
+    this._jZoomOut = this.jdomelemZoom.find('.ZoomOut');
+    this._jFullscreen = this.jdomelemZoom.find('.Fullscreen');
 
-    var ViewMap = function(config){
-      // Zoom- and scrollable Container containing Nodes, Sprites etc... uses Scroller.js
-      config = config || {};
-      this._id = _instances.length;
-      // Set View defaults
-      config.hidden = false;
-      this.draggable = true;
-      this.clickable = true;
-      this.offsetX = 0; // Scroller needs offset 0
-      this.offsetY = 0; // Scroller needs offset 0
-      this.width = config.width || 2920;
-      this.height = config.height || 2200;
-      this.zoomScale = config.zoomScale || 1;
-      this.jdomelem = $("<div class='ViewMap'></div>");
-      this.domelem = this.jdomelem[0];
-      this.jdomelem1 = $("<div class='ViewMapContainer'></div>");
-      this.domelem1 = this.jdomelem1[0];
-      this.jdomelem2 = $("<img class='ViewMapContainerImg' src='"+setup.imagePathPrefix+config.background+"'>");
+    this.domelem2 = this.jdomelem2[0];
+    this.jdomelem3 = this.popupContainerDomelem = $("<div class='PopupContainer'></div>");
+    //this.jdomelem4 = this.popupContainer = $("<div class='PopupContainer'></div>");
+    this.jdomelem1.append(this.jdomelem2);
+    this.jdomelem.append(this.jdomelem1);
+    this.jdomelem.append(this.jdomelem3);
+    this.jdomelem.append(this.jdomelemZoom);
+    //this.jdomelem.append(this.jdomelem4);
 
-      this.jdomelemZoom = $('<div class="ZoomControls"><div class="ZoomIn"></div><div class="ZoomOut"></div><div class="Fullscreen"></div></div>');
-      this._jZoomIn  = this.jdomelemZoom.find('.ZoomIn');
-      this._jZoomOut = this.jdomelemZoom.find('.ZoomOut');
-      this._jFullscreen = this.jdomelemZoom.find('.Fullscreen');
+    // FIXME: Better collect which events we're listening to
+    this.jdomelem3.on('mousedown mouseup touchstart touchend dblclick dbltap tap', function (e) {
+      e.preventDefault();
+      e.stopPropagation();
+    });
 
-      this.domelem2 = this.jdomelem2[0];
-      this.jdomelem3 = this.popupContainerDomelem = $("<div class='PopupContainer'></div>");
-      //this.jdomelem4 = this.popupContainer = $("<div class='PopupContainer'></div>");
-      this.jdomelem1.append(this.jdomelem2);
-      this.jdomelem.append(this.jdomelem1);
-      this.jdomelem.append(this.jdomelem3);
-      this.jdomelem.append(this.jdomelemZoom);
-      //this.jdomelem.append(this.jdomelem4);
+    this.init(config);
 
-      // FIXME: Better collect which events we're listening to
-      this.jdomelem3.on('mousedown mouseup touchstart touchend dblclick dbltap tap', function(e){
-        e.preventDefault();
-        e.stopPropagation();
-      });
-
-      this.init(config);
-
-      var node = this;
-      // LISTEN TO STATES
-      node.on("states_active",function(e,value){
-        e.stopPropagation();
-        if (value) {
-          node.FXShow();
-          node.parentNode.jdomelem.addClass('Active' + node.jdomelem.attr('id'));
-          node.gameNode.GameRoot.renderMenu.jdomelem.find('.MainMenuButton').removeClass('active');
-          node.gameNode.GameRoot.renderMenu.jdomelem.find('.MainMenuButton[data-button-id='+node.id+']').addClass('active');
-        } else {
-          node.parentNode.jdomelem.removeClass('Active' + node.jdomelem.attr('id'));
-          node.FXHide();
-        }
-
-      });
-    };
-
-    extend(ViewMap, Node);
-
-    ViewMap.prototype.addChild = function(child,ui_elem){
-      // Add a child to a Node
-      // This actually draws an element on the screen when the topmost Node is inside the html body
-      // flag ui_elem adds child to wrapper domelem
-      if (child.hidden) {
-        child.hide();
-      }
-      if (ui_elem) {
-        this.jdomelem.append(child.domelem);
+    var node = this;
+    // LISTEN TO STATES
+    node.on('states_active', function (e, value) {
+      e.stopPropagation();
+      if (value) {
+        node.FXShow();
+        node.parentNode.jdomelem.addClass('Active' + node.jdomelem.attr('id'));
+        node.gameNode.GameRoot.renderMenu.jdomelem.find('.MainMenuButton').removeClass('active');
+        node.gameNode.GameRoot.renderMenu.jdomelem
+          .find('.MainMenuButton[data-button-id=' + node.id + ']')
+          .addClass('active');
       } else {
-        this.jdomelem1.append(child.domelem);
+        node.parentNode.jdomelem.removeClass('Active' + node.jdomelem.attr('id'));
+        node.FXHide();
       }
-      child.parentNode = this;
-      this.children.add(child);
-      child.dragHandler = child.dragHandler || this.dragHandler;
-      child.useDragHandler = this.dragHandler;
-      child.onAddInit();
-      return child;
-    };
+    });
+  };
 
-    ViewMap.prototype.lock = function(){
-      this.jdomelem3.addClass('lockOn');
-    };
+  extend(ViewMap, Node);
 
-    ViewMap.prototype.unlock = function(){
-      this.jdomelem3.removeClass('lockOn');
-    };
+  ViewMap.prototype.addChild = function (child, ui_elem) {
+    // Add a child to a Node
+    // This actually draws an element on the screen when the topmost Node is inside the html body
+    // flag ui_elem adds child to wrapper domelem
+    if (child.hidden) {
+      child.hide();
+    }
+    if (ui_elem) {
+      this.jdomelem.append(child.domelem);
+    } else {
+      this.jdomelem1.append(child.domelem);
+    }
+    child.parentNode = this;
+    this.children.add(child);
+    child.dragHandler = child.dragHandler || this.dragHandler;
+    child.useDragHandler = this.dragHandler;
+    child.onAddInit();
+    return child;
+  };
 
-    ViewMap.prototype.onAddInit = function(){
-      this.setZoomScale(this.zoomScale);
-      if (this.draggable) {
-        this.initScroller();
+  ViewMap.prototype.lock = function () {
+    this.jdomelem3.addClass('lockOn');
+  };
+
+  ViewMap.prototype.unlock = function () {
+    this.jdomelem3.removeClass('lockOn');
+  };
+
+  ViewMap.prototype.onAddInit = function () {
+    this.setZoomScale(this.zoomScale);
+    if (this.draggable) {
+      this.initScroller();
+    }
+    this.updateRenderProp();
+    this.dragHandler = new DragHandler();
+    this.useDragHandler = this.dragHandler;
+    this.draw();
+    if (this.hidden) {
+      this.hide();
+    }
+  };
+
+  ViewMap.prototype.css = function (css) {
+    // Wrapper for CSS manipulation of domelem, currently jQuery
+    this.jdomelem1.css(css);
+  };
+
+  ViewMap.prototype.setPosition = function (pos) {
+    // Override setPosition for Scroller Performance and Usage
+    // Round for render performance and better sprite anti aliasing
+    if (renderConf.viewMapStopZone) {
+      var stopZone = renderConf.viewMapStopZone;
+      var clipx = this.parentNode.width - this.getScaledSize().width - stopZone;
+      var clipy = this.parentNode.height - this.getScaledSize().height - stopZone;
+      var clipdiff;
+      if (pos.x > stopZone) {
+        pos.x = stopZone + (pos.x - stopZone) * (stopZone / pos.x);
+      } else if (pos.x < clipx) {
+        clipdiff = pos.x - clipx;
+        pos.x = clipx + clipdiff * (stopZone / (stopZone - clipdiff));
       }
-      this.updateRenderProp();
-      this.dragHandler = new DragHandler();
-      this.useDragHandler=this.dragHandler;
-      this.draw();
-      if (this.hidden) {
-        this.hide();
+      if (pos.y > stopZone) {
+        pos.y = stopZone + (pos.y - stopZone) * (stopZone / pos.y);
+      } else if (pos.y < clipy) {
+        clipdiff = pos.y - clipy;
+        pos.y = clipy + clipdiff * (stopZone / (stopZone - clipdiff));
       }
-    };
+    }
+    pos.x = Math.round(pos.x);
+    pos.y = Math.round(pos.y);
+    this.x = pos.x;
+    this.y = pos.y;
+    this.domelem1.style.webkitTransformOriginZ = 0;
+    this.domelem1.style.webkitTransformOriginX = pos.x + 'px';
+    this.domelem1.style.webkitTransformOriginY = pos.y + 'px';
+    this.domelem1.style.MozTransformOrigin = pos.x + 'px ' + pos.y + 'px';
+    this.domelem1.style.msTransformOrigin = pos.x + 'px ' + pos.y + 'px';
+    // TODO Styles for other browsers and fallback
+    this.setTransform({ transX: pos.x + this.offsetX, transY: pos.y + this.offsetY });
+  };
 
-    ViewMap.prototype.css = function(css) {
-      // Wrapper for CSS manipulation of domelem, currently jQuery
-      this.jdomelem1.css(css);
-    };
+  ViewMap.prototype.updateScroller = function () {
+    var node = this;
+    var stage = this.parentNode;
+    var scaleW = stage.width / node.width;
+    var scaleH = stage.height / node.height;
+    var minZoom = scaleW > scaleH ? scaleW : scaleH;
+    if (minZoom > 1) {
+      minZoom = 1;
+    }
+    node.scroller.options.minZoom = minZoom < 0.5 ? 0.5 : minZoom;
+    node.scroller.zoomTo(this.zoomScale);
+    node.scroller.setDimensions(
+      stage.width,
+      stage.height,
+      node.getSize().width,
+      node.getSize().height
+    );
+    node._updateZoomButtonsState();
+  };
 
-    ViewMap.prototype.setPosition = function(pos){
-      // Override setPosition for Scroller Performance and Usage
-      // Round for render performance and better sprite anti aliasing
-      if (renderConf.viewMapStopZone) {
-        var stopZone = renderConf.viewMapStopZone;
-        var clipx = this.parentNode.width - this.getScaledSize().width - stopZone;
-        var clipy = this.parentNode.height - this.getScaledSize().height - stopZone;
-        var clipdiff;
-        if (pos.x > stopZone) {
-          pos.x = stopZone + (pos.x-stopZone)*(stopZone/pos.x);
-        } else if (pos.x < clipx) {
-          clipdiff = pos.x-clipx;
-          pos.x = clipx + clipdiff*(stopZone/(stopZone-clipdiff));
-        }
-        if (pos.y > stopZone) {
-          pos.y = stopZone + (pos.y-stopZone)*(stopZone/pos.y);
-        } else if (pos.y < clipy) {
-          clipdiff = pos.y-clipy;
-          pos.y = clipy + clipdiff*(stopZone/(stopZone-clipdiff));
-        }
-      }
-      pos.x = Math.round(pos.x);
-      pos.y = Math.round(pos.y);
-      this.x = pos.x;
-      this.y = pos.y;
-      this.domelem1.style.webkitTransformOriginZ = 0;
-      this.domelem1.style.webkitTransformOriginX = pos.x + "px";
-      this.domelem1.style.webkitTransformOriginY = pos.y + "px";
-      this.domelem1.style.MozTransformOrigin = pos.x + "px " + pos.y + "px";
-      this.domelem1.style.msTransformOrigin = pos.x + "px " + pos.y + "px";
-      // TODO Styles for other browsers and fallback
-      this.setTransform({transX:pos.x+this.offsetX,transY:pos.y+this.offsetY});
-    };
-
-    ViewMap.prototype.updateScroller = function(){
-      var node = this;
-      var stage = this.parentNode;
-      var scaleW = stage.width/node.width;
-      var scaleH = stage.height/node.height;
-      var minZoom = (scaleW > scaleH) ? scaleW : scaleH;
-      if (minZoom>1) {
-        minZoom = 1;
-      }
-      node.scroller.options.minZoom = (minZoom < 0.5) ? 0.5 : minZoom;
-      node.scroller.zoomTo(this.zoomScale);
-      node.scroller.setDimensions(stage.width, stage.height, node.getSize().width, node.getSize().height);
-      node._updateZoomButtonsState();
-    };
-
-    ViewMap.prototype.initScroller = function(){
-      //this.cursor = new Circle({radius:12,fill:"rgba(22,163,215,0.5)",strokeWidth:3,stroke:"rgba(22,163,215,1)"});
-      //this.cursor.setOpacity(0);
-      //this.addChild(this.cursor);
-      // TODO: Maybe make a true Scroller Module like dragHandler
-      var node = this;
-      var initx = this.x;
-      var inity = this.y;
-      node.scroller = new Scroller(function(left,top,zoom){
+  ViewMap.prototype.initScroller = function () {
+    //this.cursor = new Circle({radius:12,fill:"rgba(22,163,215,0.5)",strokeWidth:3,stroke:"rgba(22,163,215,1)"});
+    //this.cursor.setOpacity(0);
+    //this.addChild(this.cursor);
+    // TODO: Maybe make a true Scroller Module like dragHandler
+    var node = this;
+    var initx = this.x;
+    var inity = this.y;
+    node.scroller = new Scroller(
+      function (left, top, zoom) {
         // Scroller Render Method
         /* FIXME: set actual transform offset to screen center
         node.offsetX=left;
@@ -3824,106 +3978,132 @@ var Render = function() {
         var newpos = node.parentNode.getCenterPosition()
         node.setPosition({x:newpos.x,y:newpos.y});
         */
-        if (!node.scroller.__isDecelerating && !node.scroller.__isDragging && !node.scroller.__isAnimating) {
-          node.trigger('scrollend',[node]);
+        if (
+          !node.scroller.__isDecelerating &&
+          !node.scroller.__isDragging &&
+          !node.scroller.__isAnimating
+        ) {
+          node.trigger('scrollend', [node]);
         }
         node.setZoomScale(zoom);
-        node.setPosition({x:-left,y:-top});
-        node.setTransform({scaleX:zoom,scaleY:zoom});
-      }, {
+        node.setPosition({ x: -left, y: -top });
+        node.setTransform({ scaleX: zoom, scaleY: zoom });
+      },
+      {
         zooming: true,
-        locking:false,
-        bouncing:false,
+        locking: false,
+        bouncing: false,
         // animating:true means zoomTo and scrollTo with animate=true tween
         // smoothly via core.effect.Animate; the previous stub left this
         // false because it had no animation loop anyway.
-        animating:true,
-        animationDuration:300,
-        minZoom:0.5,
-        maxZoom:1
-      });
-      //node.scroller.setDimensions(node.parentNode.getSize().width, node.parentNode.getSize().height, node.getSize().width, node.getSize().height);
-      node.scroller.setPosition(0,0);
-      node.updateScroller();
-      node.scroller.scrollTo(-initx,-inity);
+        animating: true,
+        animationDuration: 300,
+        minZoom: 0.5,
+        maxZoom: 1,
+      }
+    );
+    //node.scroller.setDimensions(node.parentNode.getSize().width, node.parentNode.getSize().height, node.getSize().width, node.getSize().height);
+    node.scroller.setPosition(0, 0);
+    node.updateScroller();
+    node.scroller.scrollTo(-initx, -inity);
 
-      node.jdomelem.on('dblclick','.ZoomControls', function(e){
-        e.stopPropagation();
-      });
-      node.jdomelem.on('click touchend','.ZoomControls .ZoomOut', function(e){
-        e.stopPropagation();
-        node._cancelWheelZoom();
-        node.zoomOut();
-      });
-      node.jdomelem.on('click touchend','.ZoomControls .ZoomIn', function(e){
-        e.stopPropagation();
-        node._cancelWheelZoom();
-        node.zoomIn();
-      });
+    node.jdomelem.on('dblclick', '.ZoomControls', function (e) {
+      e.stopPropagation();
+    });
+    node.jdomelem.on('click touchend', '.ZoomControls .ZoomOut', function (e) {
+      e.stopPropagation();
+      node._cancelWheelZoom();
+      node.zoomOut();
+    });
+    node.jdomelem.on('click touchend', '.ZoomControls .ZoomIn', function (e) {
+      e.stopPropagation();
+      node._cancelWheelZoom();
+      node.zoomIn();
+    });
 
-      node.jdomelem.on('click touchend','.ZoomControls .Fullscreen', function(e){
-        e.stopPropagation();
-        node._cancelWheelZoom();
-        app.game.resetZoom();
-      });
+    node.jdomelem.on('click touchend', '.ZoomControls .Fullscreen', function (e) {
+      e.stopPropagation();
+      node._cancelWheelZoom();
+      app.game.resetZoom();
+    });
 
+    node.on('dblclick', function (e) {
+      e.stopPropagation();
+      node._cancelWheelZoom();
+      // Same animating-toggle anti-pattern as zoomIn/zoomOut: don't flip
+      // it back to false synchronously, the scroller animation reads the
+      // flag every frame.
+      if (node.zoomScale !== 1) {
+        node.scroller.zoomTo(1, true, node.userAbsPos.x, node.userAbsPos.y);
+      } else {
+        node.scroller.zoomTo(
+          node.scroller.options.minZoom,
+          true,
+          node.userAbsPos.x,
+          node.userAbsPos.y
+        );
+      }
+    });
 
-      node.on('dblclick',function(e){
-        e.stopPropagation();
-        node._cancelWheelZoom();
-        // Same animating-toggle anti-pattern as zoomIn/zoomOut: don't flip
-        // it back to false synchronously, the scroller animation reads the
-        // flag every frame.
-        if (node.zoomScale !== 1) {
-          node.scroller.zoomTo(1, true, node.userAbsPos.x,node.userAbsPos.y);
-        } else {
-          node.scroller.zoomTo(node.scroller.options.minZoom, true, node.userAbsPos.x,node.userAbsPos.y);
-        }
-      });
+    node.on('mousedown', function (e) {
+      //e.stopPropagation();
+      e.preventDefault();
+      // Set misc positioning variables
+      var userPos = {};
+      var userScaledPos = {};
+      var userAbsPos = {};
+      var stageCenter = node.parentNode.getCenterPosition();
+      userPos.x = e.pageX - node.jdomelem.offset().left;
+      userPos.y = e.pageY - node.jdomelem.offset().top;
+      userScaledPos.x = (e.pageX - node.jdomelem.offset().left) * node.dragHandler.scale;
+      userScaledPos.y = (e.pageY - node.jdomelem.offset().top) * node.dragHandler.scale;
+      userAbsPos.x = e.pageX - node.parentNode.jdomelem.offset().left;
+      userAbsPos.y = e.pageY - node.parentNode.jdomelem.offset().top;
+      node.userPos = userPos;
+      node.userAbsPos = userAbsPos;
+      node.userScaledPos = userScaledPos;
 
-      node.on('mousedown',function(e){
-        //e.stopPropagation();
-        e.preventDefault();
-        // Set misc positioning variables
-        var userPos= {};
-        var userScaledPos= {};
-        var userAbsPos= {};
-        var stageCenter = node.parentNode.getCenterPosition();
-        userPos.x = (e.pageX-node.jdomelem.offset().left);
-        userPos.y = (e.pageY-node.jdomelem.offset().top);
-        userScaledPos.x = (e.pageX-node.jdomelem.offset().left)*node.dragHandler.scale;
-        userScaledPos.y = (e.pageY-node.jdomelem.offset().top)*node.dragHandler.scale;
-        userAbsPos.x = e.pageX-node.parentNode.jdomelem.offset().left;
-        userAbsPos.y = e.pageY-node.parentNode.jdomelem.offset().top;
-        node.userPos=userPos;
-        node.userAbsPos=userAbsPos;
-        node.userScaledPos=userScaledPos;
-
-        // Start scroller
-        node.dragging=true;
-        node.scroller.doTouchStart([{
-          pageX: e.pageX,
-          pageY: e.pageY
-        }], e.timeStamp);
-      });
-
-      node.useDragHandler.on('mousemove',function(e){
-        if (node.dragging) {
-          node.scroller.doTouchMove([{
+      // Start scroller
+      node.dragging = true;
+      node.scroller.doTouchStart(
+        [
+          {
             pageX: e.pageX,
-            pageY: e.pageY
-          }], e.timeStamp);
-        }
-      });
+            pageY: e.pageY,
+          },
+        ],
+        e.timeStamp
+      );
+    });
 
-      node.useDragHandler.on('mouseup',function(e){
-        node.dragging=false;
-        node.scroller.doTouchEnd(e.timeStamp);
-      });
+    node.useDragHandler.on('mousemove', function (e) {
+      if (node.dragging) {
+        node.scroller.doTouchMove(
+          [
+            {
+              pageX: e.pageX,
+              pageY: e.pageY,
+            },
+          ],
+          e.timeStamp
+        );
+      }
+    });
 
-      node.domelem.addEventListener("touchstart", function(e) {
+    node.useDragHandler.on('mouseup', function (e) {
+      node.dragging = false;
+      node.scroller.doTouchEnd(e.timeStamp);
+    });
+
+    node.domelem.addEventListener(
+      'touchstart',
+      function (e) {
         // Don't react if initial down happens on a form element
-        if (e.touches[0] && e.touches[0].target && e.touches[0].target.tagName.match(/input|textarea|select/i)) {
+        if (
+          e.touches[0] &&
+          e.touches[0].target &&
+          e.touches[0].target.tagName.match(/input|textarea|select/i)
+        ) {
           return;
         }
         var touch = e.touches[0];
@@ -3932,7 +4112,7 @@ var Render = function() {
         // on pure-touch devices where mousedown never fires.
         node.userAbsPos = {
           x: touch.pageX - parentOffset.left,
-          y: touch.pageY - parentOffset.top
+          y: touch.pageY - parentOffset.top,
         };
         // Record initial finger distance so non-iOS browsers (which don't
         // emit GestureEvent.scale) can derive a pinch ratio in touchmove.
@@ -3945,9 +4125,13 @@ var Render = function() {
         }
         node.scroller.doTouchStart(e.touches, e.timeStamp);
         e.preventDefault();
-      }, {passive: false});
+      },
+      { passive: false }
+    );
 
-      node.useDragHandler.domelem.addEventListener("touchmove", function(e) {
+    node.useDragHandler.domelem.addEventListener(
+      'touchmove',
+      function (e) {
         // The Scroller expects an absolute pinch scale relative to touchstart
         // (iOS Safari supplies this as e.scale). Other engines don't, so
         // derive it from the two-finger distance ratio when needed.
@@ -3962,49 +4146,61 @@ var Render = function() {
         }
         node.scroller.doTouchMove(e.touches, e.timeStamp, scale);
         e.preventDefault();
-      }, {passive: false});
+      },
+      { passive: false }
+    );
 
-      node.useDragHandler.domelem.addEventListener("touchend", function(e) {
+    node.useDragHandler.domelem.addEventListener(
+      'touchend',
+      function (e) {
         node.scroller.doTouchEnd(e.timeStamp);
-      }, false);
+      },
+      false
+    );
 
-      node.useDragHandler.domelem.addEventListener("touchcancel", function(e) {
+    node.useDragHandler.domelem.addEventListener(
+      'touchcancel',
+      function (e) {
         node.scroller.doTouchEnd(e.timeStamp);
-      }, false);
+      },
+      false
+    );
 
-      // Mouse-wheel zoom: continuous and smoothly tweened. We accumulate
-      // wheel deltas into a target zoom level and let a single rAF loop
-      // ease the scroller toward it, which avoids the choppy "step per
-      // notch" feel of calling zoomBy synchronously on every event.
+    // Mouse-wheel zoom: continuous and smoothly tweened. We accumulate
+    // wheel deltas into a target zoom level and let a single rAF loop
+    // ease the scroller toward it, which avoids the choppy "step per
+    // notch" feel of calling zoomBy synchronously on every event.
+    node._wheelZoomTarget = null;
+    node._wheelZoomOrigin = null;
+    node._cancelWheelZoom = function () {
+      // Called by the +/-/Fullscreen/dblclick handlers so an in-flight
+      // wheel-zoom rAF doesn't fight their zoomTo (it would otherwise
+      // ease back to the wheel target on the next frame).
       node._wheelZoomTarget = null;
-      node._wheelZoomOrigin = null;
-      node._cancelWheelZoom = function() {
-        // Called by the +/-/Fullscreen/dblclick handlers so an in-flight
-        // wheel-zoom rAF doesn't fight their zoomTo (it would otherwise
-        // ease back to the wheel target on the next frame).
-        node._wheelZoomTarget = null;
-        if (node._wheelZoomRaf) {
-          cancelAnimationFrame(node._wheelZoomRaf);
-          node._wheelZoomRaf = 0;
-        }
-      };
-      var stepTowardTarget = function() {
+      if (node._wheelZoomRaf) {
+        cancelAnimationFrame(node._wheelZoomRaf);
         node._wheelZoomRaf = 0;
-        var target = node._wheelZoomTarget;
-        var origin = node._wheelZoomOrigin;
-        if (target == null) return;
-        var current = node.scroller.__zoomLevel || node.zoomScale || 1;
-        var next = current + (target - current) * 0.25;
-        if (Math.abs(target - next) < 0.001) {
-          next = target;
-          node._wheelZoomTarget = null;
-        }
-        node.scroller.zoomTo(next, false, origin.x, origin.y);
-        if (node._wheelZoomTarget != null) {
-          node._wheelZoomRaf = requestAnimationFrame(stepTowardTarget);
-        }
-      };
-      node.domelem.addEventListener("wheel", function(e) {
+      }
+    };
+    var stepTowardTarget = function () {
+      node._wheelZoomRaf = 0;
+      var target = node._wheelZoomTarget;
+      var origin = node._wheelZoomOrigin;
+      if (target == null) return;
+      var current = node.scroller.__zoomLevel || node.zoomScale || 1;
+      var next = current + (target - current) * 0.25;
+      if (Math.abs(target - next) < 0.001) {
+        next = target;
+        node._wheelZoomTarget = null;
+      }
+      node.scroller.zoomTo(next, false, origin.x, origin.y);
+      if (node._wheelZoomTarget != null) {
+        node._wheelZoomRaf = requestAnimationFrame(stepTowardTarget);
+      }
+    };
+    node.domelem.addEventListener(
+      'wheel',
+      function (e) {
         e.preventDefault();
         var offset = node.jdomelem.offset();
         // Normalize across deltaMode (pixel/line/page) and clamp so a
@@ -4012,561 +4208,575 @@ var Render = function() {
         // Per-pixel base is intentionally tiny — a typical wheel notch
         // (~100px) ends up around ~10% zoom, so the change feels
         // continuous rather than stepped like the +/- buttons.
-        var unit = (e.deltaMode === 1) ? 16 : (e.deltaMode === 2) ? 400 : 1;
+        var unit = e.deltaMode === 1 ? 16 : e.deltaMode === 2 ? 400 : 1;
         var delta = Math.max(-400, Math.min(400, e.deltaY * unit));
         var factor = Math.pow(0.999, delta);
         var opts = node.scroller.options;
-        var base = (node._wheelZoomTarget != null)
-          ? node._wheelZoomTarget
-          : (node.scroller.__zoomLevel || node.zoomScale || 1);
+        var base =
+          node._wheelZoomTarget != null
+            ? node._wheelZoomTarget
+            : node.scroller.__zoomLevel || node.zoomScale || 1;
         var target = Math.max(opts.minZoom, Math.min(opts.maxZoom, base * factor));
         node._wheelZoomTarget = target;
         node._wheelZoomOrigin = {
           x: e.pageX - offset.left,
-          y: e.pageY - offset.top
+          y: e.pageY - offset.top,
         };
         if (!node._wheelZoomRaf) {
           node._wheelZoomRaf = requestAnimationFrame(stepTowardTarget);
         }
-      }, {passive: false});
-    };
+      },
+      { passive: false }
+    );
+  };
 
-    ViewMap.prototype.scrollTo = function(pos,dur){
-      var vpCenter = this.parentNode.getCenterPosition();
-      dur = (dur !== undefined) ? dur : 300;
-      this.scroller.options.animating = (dur > 0) ? true : false;
-      this.scroller.options.animationDuration = dur;
-      this.scroller.scrollTo(pos.x-vpCenter.x,pos.y-vpCenter.y,true);
-      this.scroller.options.animating=false;
-      this.scroller.options.animationDuration = 300;
-    };
+  ViewMap.prototype.scrollTo = function (pos, dur) {
+    var vpCenter = this.parentNode.getCenterPosition();
+    dur = dur !== undefined ? dur : 300;
+    this.scroller.options.animating = dur > 0 ? true : false;
+    this.scroller.options.animationDuration = dur;
+    this.scroller.scrollTo(pos.x - vpCenter.x, pos.y - vpCenter.y, true);
+    this.scroller.options.animating = false;
+    this.scroller.options.animationDuration = 300;
+  };
 
-    ViewMap.prototype.setZoomScale = function(scale){
-      this.zoomScale = scale;
-      this.dragHandler.scale = 1/scale;
-      if (scale < 0.75) {
-        this.jdomelem.addClass('zoomHide2');
-      } else {
-        this.jdomelem.removeClass('zoomHide2');
+  ViewMap.prototype.setZoomScale = function (scale) {
+    this.zoomScale = scale;
+    this.dragHandler.scale = 1 / scale;
+    if (scale < 0.75) {
+      this.jdomelem.addClass('zoomHide2');
+    } else {
+      this.jdomelem.removeClass('zoomHide2');
+    }
+    if (scale < 1) {
+      this.jdomelem.addClass('zoomHide1');
+    } else {
+      this.jdomelem.removeClass('zoomHide1');
+    }
+    this._updateZoomButtonsState();
+  };
+
+  ViewMap.prototype._updateZoomButtonsState = function () {
+    if (!this._jZoomIn) return;
+    var maxZoom = (this.scroller && this.scroller.options && this.scroller.options.maxZoom) || 1;
+    var minZoom = (this.scroller && this.scroller.options && this.scroller.options.minZoom) || 0.5;
+    var atMax = this.zoomScale >= maxZoom - 0.001;
+    var atMin = this.zoomScale <= minZoom + 0.001;
+    this._jZoomIn.toggleClass('disabled', atMax);
+    this._jZoomOut.toggleClass('disabled', atMin);
+    this._jFullscreen.toggleClass('disabled', atMin && atMax);
+  };
+
+  ViewMap.prototype.zoomIn = function () {
+    var node = this;
+    var zoomTo = node.zoomScale + 0.25 > 1 ? 1 : node.zoomScale + 0.25;
+    if (zoomTo === node.zoomScale) return;
+    node.scroller.zoomTo(zoomTo, true);
+  };
+
+  ViewMap.prototype.zoomOut = function () {
+    var node = this;
+    var zoomTo = node.zoomScale - 0.25 < 0.5 ? 0.5 : node.zoomScale - 0.25;
+    if (zoomTo === node.zoomScale) return;
+    node.scroller.zoomTo(zoomTo, true);
+  };
+
+  ViewMap.prototype.FXShow = function () {
+    var node = this;
+    //node.show();
+    node.jdomelem.addClass('active');
+  };
+
+  ViewMap.prototype.FXHide = function () {
+    var node = this;
+    //node.hide();
+    node.jdomelem.removeClass('active');
+  };
+
+  /////////////////////////////
+  //       The Stage
+  /////////////////////////////
+
+  var Stage = function (config) {
+    // The Stage, contains all Render Items, this is also the Viewport
+    this._id = _instances.length;
+    config = config || {};
+    config.x = 0;
+    config.y = 0;
+    this.x = 0;
+    this.y = 0;
+    this.offsetX = config.offsetX || 0;
+    this.offsetY = config.offsetY || 0;
+    this.width = config.width || 960;
+    this.height = config.height || 600;
+    this.jdomelem = $("<div class='Stage'></div>").attr('id', 'Stage' + this._id);
+    this.jdomelem2 = this.popupContainerDomelem = $(
+      "<div class='PopupContainer Top NoClose'></div>"
+    );
+    this.jdomelem.append(this.jdomelem2);
+    this.domelem = this.jdomelem[0];
+    this.position = 'relative';
+    this.dragHandler = new DragHandler();
+    this.useDragHandler = this.dragHandler;
+    this.init(config);
+    this.initUI();
+    this.onAddInit();
+    return this;
+  };
+
+  extend(Stage, Node);
+
+  Stage.prototype.initUI = function () {
+    var stage = this;
+    stage.on('mousemove', function (e) {
+      var userPos = {};
+      userPos.x = e.pageX - stage.jdomelem.offset().left;
+      userPos.y = e.pageY - stage.jdomelem.offset().top;
+      stage.userAbsPos = userPos;
+    });
+    stage.on('mousedown touchstart', function (e) {
+      // FIX for FF accidential selection getting stuck
+      document.getSelection().removeAllRanges();
+      var userPos = {};
+      userPos.x = e.pageX - stage.jdomelem.offset().left;
+      userPos.y = e.pageY - stage.jdomelem.offset().top;
+      stage.userClickAbsPos = userPos;
+    });
+  };
+
+  Stage.prototype.lock = function () {
+    this.jdomelem2.addClass('lockOn');
+  };
+
+  Stage.prototype.unlock = function () {
+    this.jdomelem2.removeClass('lockOn');
+  };
+
+  Stage.prototype.setSize = function (size) {
+    this.setAttrs(size);
+    this.css({
+      width: this.width + 'px',
+      height: this.height + 'px',
+    });
+    var stage = this;
+    stage.children.each(function (node) {
+      if (node.scroller) {
+        node.updateScroller();
       }
-      if (scale < 1) {
-        this.jdomelem.addClass('zoomHide1');
-      } else {
-        this.jdomelem.removeClass('zoomHide1');
-      }
-      this._updateZoomButtonsState();
-    };
+    });
+  };
 
-    ViewMap.prototype._updateZoomButtonsState = function(){
-      if (!this._jZoomIn) return;
-      var maxZoom = (this.scroller && this.scroller.options && this.scroller.options.maxZoom) || 1;
-      var minZoom = (this.scroller && this.scroller.options && this.scroller.options.minZoom) || 0.5;
-      var atMax = this.zoomScale >= maxZoom - 0.001;
-      var atMin = this.zoomScale <= minZoom + 0.001;
-      this._jZoomIn.toggleClass('disabled', atMax);
-      this._jZoomOut.toggleClass('disabled', atMin);
-      this._jFullscreen.toggleClass('disabled', atMin && atMax);
-    };
+  /////////////////////////////
+  // The Main Menu
+  /////////////////////////////
 
-    ViewMap.prototype.zoomIn = function(){
-      var node = this;
-      var zoomTo = (node.zoomScale+0.25 > 1) ? 1 : node.zoomScale+0.25;
-      if (zoomTo === node.zoomScale) return;
-      node.scroller.zoomTo(zoomTo, true);
-    };
+  var MainMenu = function (config) {
+    config = config || {};
+    this._id = _instances.length;
+    this.jdomelem = $("<div class='MainMenu'></div>");
+    this.domelem = this.jdomelem[0];
+    this.position = 'relative';
+    this.width = config.width || 960;
+    this.height = config.height || 48;
+    this.z = 1000;
+    this.data = config.data || { buttons: [] };
+    this.data.logo = RenderSprite(this.data.logo);
 
-    ViewMap.prototype.zoomOut = function(){
-      var node = this;
-      var zoomTo = (node.zoomScale-0.25 < 0.5) ? 0.5 : node.zoomScale-0.25;
-      if (zoomTo === node.zoomScale) return;
-      node.scroller.zoomTo(zoomTo, true);
-    };
+    this.init(config);
+    this.setSize(this.getSize());
+    this.updateRenderProp();
+    this.render();
 
-    ViewMap.prototype.FXShow = function(){
-        var node=this;
-        //node.show();
-        node.jdomelem.addClass('active');
-    };
+    // Setup Button Events
+    var GameRoot = this.gameNode.GameRoot;
+    var menu = this;
+    this.jdomelem.on('click touchend', '#LocaleToggle:not(.disabled)', function (e) {
+      e.stopPropagation();
+      e.preventDefault();
+      GameRoot.trigger('toggle_locale');
+    });
+    this.jdomelem.on('click touchend', '#UserData:not(.disabled)', function (e) {
+      e.stopPropagation();
+      e.preventDefault();
+      GameRoot.trigger('user_data');
+    });
+    this.jdomelem.on('click touchend', '.MainMenuButton:not(.disabled)', function (e) {
+      e.stopPropagation();
+      e.preventDefault();
+      GameRoot.trigger('switch_view', [$(this).attr('data-button-id')]);
+    });
 
-    ViewMap.prototype.FXHide = function(){
-        var node=this;
-        //node.hide();
-        node.jdomelem.removeClass('active');
-    };
+    return this;
+  };
 
+  extend(MainMenu, Stage);
 
-    /////////////////////////////
-    //       The Stage
-    /////////////////////////////
+  MainMenu.prototype.template = 'mainmenu.html';
 
-    var Stage = function(config){
-      // The Stage, contains all Render Items, this is also the Viewport
-      this._id = _instances.length;
-      config = config || {};
-      config.x = 0;
-      config.y = 0;
-      this.x = 0;
-      this.y = 0;
-      this.offsetX = config.offsetX || 0;
-      this.offsetY = config.offsetY || 0;
-      this.width = config.width || 960;
-      this.height = config.height || 600;
-      this.jdomelem = $("<div class='Stage'></div>").attr('id','Stage'+this._id);
-      this.jdomelem2 = this.popupContainerDomelem = $("<div class='PopupContainer Top NoClose'></div>");
-      this.jdomelem.append(this.jdomelem2);
-      this.domelem = this.jdomelem[0];
-      this.position = 'relative';
-      this.dragHandler = new DragHandler();
-      this.useDragHandler = this.dragHandler;
-      this.init(config);
-      this.initUI();
-      this.onAddInit();
-      return this;
-    };
+  MainMenu.prototype.render = function () {
+    var html = app.renderView(this.template, this.data);
+    this.jdomelem.html(html);
+  };
 
-    extend(Stage, Node);
+  MainMenu.prototype.lock = function () {
+    var node = this;
+    node.jdomelem.addClass('locked');
+    node.jdomelem.find('.UserButton, .MainMenuButton').addClass('disabled');
+  };
 
-    Stage.prototype.initUI = function(){
-      var stage= this;
-      stage.on('mousemove',function(e){
-        var userPos= {};
-        userPos.x = e.pageX-stage.jdomelem.offset().left;
-        userPos.y = e.pageY-stage.jdomelem.offset().top;
-        stage.userAbsPos=userPos;
-      });
-      stage.on('mousedown touchstart',function(e){
-        // FIX for FF accidential selection getting stuck
-        document.getSelection().removeAllRanges();
-        var userPos= {};
-        userPos.x = e.pageX-stage.jdomelem.offset().left;
-        userPos.y = e.pageY-stage.jdomelem.offset().top;
-        stage.userClickAbsPos=userPos;
-      });
+  MainMenu.prototype.unlock = function () {
+    var node = this;
+    node.jdomelem.removeClass('locked');
+    node.jdomelem.find('.UserButton, .MainMenuButton').removeClass('disabled');
+  };
 
-    };
+  MainMenu.prototype.addButton = function (text, id, states) {
+    this.data.buttons.push({
+      label: text,
+      id: id,
+      states: states,
+    });
+    this.render();
+  };
 
-    Stage.prototype.lock = function(){
-      this.jdomelem2.addClass('lockOn');
-    };
+  /////////////////////////////
+  //       The ButtonInline
+  /////////////////////////////
 
-    Stage.prototype.unlock = function(){
-      this.jdomelem2.removeClass('lockOn');
-    };
+  // FIXME: Find a better way to implement Buttons, Menus
+  // and all that stuff that doesn't actually need generic RenderNode stuff
+  var ButtonInline = function (config) {
+    config = config || {};
+    this._id = _instances.length;
+    this.display = 'inline-block';
+    this.position = 'relative';
+    this.textAlign = config.textAlign || 'center';
+    this.textFontSize = config.textFontSize || '20px';
+    this.jdomelem = $("<div class='Button'></div>");
+    this.domelem = this.jdomelem[0];
+    this.init(config);
+  };
 
-    Stage.prototype.setSize = function(size){
-      this.setAttrs(size);
-      this.css({
-        'width':this.width+"px",
-        'height':this.height+"px"
-      });
-      var stage = this;
-      stage.children.each(function(node){
-        if (node.scroller) {
-          node.updateScroller();
-        }
-      });
-    };
+  extend(ButtonInline, Text);
 
+  // Dispable Positioning for Buttons
+  ButtonInline.prototype.setPosition = function () {
+    return false;
+  };
+  ButtonInline.prototype.setTransform = function () {
+    return false;
+  };
 
-    /////////////////////////////
-    // The Main Menu
-    /////////////////////////////
+  /////////////////////////////
+  //       The Statusbar
+  /////////////////////////////
 
-    var MainMenu = function(config){
-      config = config || {};
-      this._id = _instances.length;
-      this.jdomelem = $("<div class='MainMenu'></div>");
-      this.domelem = this.jdomelem[0];
-      this.position='relative';
-      this.width = config.width || 960;
-      this.height = config.height || 48;
-      this.z = 1000;
-      this.data = config.data || { buttons:[] };
-      this.data.logo = RenderSprite(this.data.logo);
+  var Statusbar = function (config) {
+    config = config || {};
+    var node = this;
+    this._id = _instances.length;
+    this.jdomelem = $("<div class='Statusbar'></div>");
+    this.domelem = this.jdomelem[0];
 
-      this.init(config);
-      this.setSize(this.getSize());
-      this.updateRenderProp();
+    this.init(config);
+
+    this.profiles_val = this.profiles.val;
+    this.profiles_max = this.profiles.max;
+    this.profiles_barsize = this.profiles.barsize;
+    this.profiles_crosssum = this.profiles.crosssum;
+    this.profiles_tokenslength = this.profiles.tokenslength;
+    this.profiles_tokenslengthmax = this.profiles.tokenslengthmax;
+    this.cash_val = this.cash.val;
+    this.AP_val = this.AP.val;
+    this.AP_max = this.AP.max;
+    this.AP_barsize = this.AP.barsize;
+    this.karma_val = this.karma.val;
+    this.karma_max = this.karma.max;
+    this.karma_intensity = this.karma_intensity;
+    this.karma_barsize = this.karma.barsize;
+    this.XP_val = this.XP.val;
+    this.XP_max = this.XP.max;
+    this.XP_level = this.XP.level;
+    this.XP_barsize = this.XP.barsize;
+
+    this.initUI();
+
+    // FIXME: data should be referenced to serverdata
+  };
+  extend(Statusbar, Node);
+
+  Statusbar.prototype.onAddInit = function () {
+    this.updateRenderProp();
+    this.render();
+  };
+
+  Statusbar.prototype.draw = function () {
+    // Update domelem to current settings
+    this.setSize(this.getSize());
+    this.setTransform(this.getTransform());
+    this.setPosition(this.getPosition());
+    this.setOpacity(this.opacity);
+  };
+
+  Statusbar.prototype.template = 'statusbar.html';
+  Statusbar.prototype.width = 720;
+  Statusbar.prototype.height = 25;
+  Statusbar.prototype.y = 12;
+  Statusbar.prototype.z = 10000;
+  Statusbar.prototype.offsetX = Statusbar.prototype.width / 2;
+  Statusbar.prototype.offsetY = 0;
+
+  Statusbar.prototype.render = function () {
+    this.x = this.parentNode.getSize().width / 2;
+    this.jdomelem.empty();
+    var html = app.renderView(this.template, this);
+    this.jdomelem.append(html);
+    this.draw();
+  };
+
+  Statusbar.prototype.tick = function () {
+    this.render();
+  };
+
+  // Silent paths bypass the Tween machinery: we just assign the flat
+  // template props and re-render once. FXSimpleCue with dur=0 still
+  // queues a Ticker listener and chains onto any active tween, so
+  // letting silent updateGameValues run through it would grow the
+  // tween queue under bursty silent traffic.
+  Statusbar.prototype.FXUpdateAP = function (silent) {
+    this.AP_val = this.AP.val;
+    if (silent) {
+      this.AP_active = 0;
+      this.AP_max = this.AP.max;
+      this.AP_barsize = this.AP.barsize;
       this.render();
-
-      // Setup Button Events
-      var GameRoot = this.gameNode.GameRoot;
-      var menu = this;
-      this.jdomelem.on('click touchend','#LocaleToggle:not(.disabled)',function(e){
-        e.stopPropagation();
-        e.preventDefault();
-        GameRoot.trigger('toggle_locale');
-      });
-      this.jdomelem.on('click touchend','#UserData:not(.disabled)',function(e){
-        e.stopPropagation();
-        e.preventDefault();
-        GameRoot.trigger('user_data');
-      });
-      this.jdomelem.on('click touchend','.MainMenuButton:not(.disabled)',function(e){
-        e.stopPropagation();
-        e.preventDefault();
-        GameRoot.trigger('switch_view',[$(this).attr('data-button-id')]);
-      });
-
-      return this;
-    };
-
-    extend(MainMenu,Stage);
-
-    MainMenu.prototype.template = 'mainmenu.html';
-
-    MainMenu.prototype.render = function() {
-      var html = app.renderView(this.template, this.data);
-      this.jdomelem.html(html);
-    };
-
-    MainMenu.prototype.lock = function() {
-      var node = this;
-      node.jdomelem.addClass('locked');
-      node.jdomelem.find('.UserButton, .MainMenuButton').addClass('disabled');
-    };
-
-    MainMenu.prototype.unlock = function() {
-      var node = this;
-      node.jdomelem.removeClass('locked');
-      node.jdomelem.find('.UserButton, .MainMenuButton').removeClass('disabled');
-    };
-
-    MainMenu.prototype.addButton = function(text,id,states) {
-      this.data.buttons.push({
-        label:text,
-        id:id,
-        states:states
-      });
+      return;
+    }
+    this.AP_active = 1;
+    this.FXSimpleCue(
+      { AP_active: 0, AP_max: this.AP.max, AP_barsize: this.AP.barsize },
+      250,
+      'linear'
+    );
+  };
+  Statusbar.prototype.FXUpdateXP = function (silent) {
+    this.XP_level = this.XP.level;
+    this.XP_val = this.XP.val;
+    if (silent) {
+      this.XP_active = 0;
+      this.XP_barsize = this.XP.barsize;
       this.render();
-    };
-
-    /////////////////////////////
-    //       The ButtonInline
-    /////////////////////////////
-
-    // FIXME: Find a better way to implement Buttons, Menus
-    // and all that stuff that doesn't actually need generic RenderNode stuff
-    var ButtonInline = function(config){
-      config = config || {};
-      this._id = _instances.length;
-      this.display='inline-block';
-      this.position='relative';
-      this.textAlign = config.textAlign || "center";
-      this.textFontSize = config.textFontSize || "20px";
-      this.jdomelem = $("<div class='Button'></div>");
-      this.domelem = this.jdomelem[0];
-      this.init(config);
-    };
-
-    extend(ButtonInline, Text);
-
-    // Dispable Positioning for Buttons
-    ButtonInline.prototype.setPosition = function(){
-      return false;
-    };
-    ButtonInline.prototype.setTransform = function(){
-      return false;
-    };
-
-
-    /////////////////////////////
-    //       The Statusbar
-    /////////////////////////////
-
-    var Statusbar = function(config){
-      config = config || {};
-      var node = this;
-      this._id = _instances.length;
-      this.jdomelem = $("<div class='Statusbar'></div>");
-      this.domelem = this.jdomelem[0];
-
-
-      this.init(config);
-
+      return;
+    }
+    this.XP_active = 1;
+    this.FXSimpleCue({ XP_active: 0, XP_barsize: this.XP.barsize }, 250, 'linear');
+  };
+  Statusbar.prototype.FXUpdateCash = function (silent) {
+    if (silent) {
+      this.cash_active = 0;
+      this.cash_val = this.cash.val;
+      this.render();
+      return;
+    }
+    this.cash_active = 1;
+    this.FXSimpleCue({ cash_active: 0, cash_val: this.cash.val }, 250, 'linear');
+  };
+  Statusbar.prototype.FXUpdateKarma = function (silent) {
+    if (silent) {
+      this.karma_active = 0;
+      this.karma_val = this.karma.val;
+      this.karma_barsize = this.karma.barsize;
+      this.render();
+      return;
+    }
+    this.karma_active = 1;
+    this.FXSimpleCue(
+      { karma_active: 0, karma_val: this.karma.val, karma_barsize: this.karma.barsize },
+      250,
+      'linear'
+    );
+  };
+  Statusbar.prototype.FXUpdateProfiles = function (silent) {
+    if (silent) {
+      this.profiles_active = 0;
       this.profiles_val = this.profiles.val;
-      this.profiles_max = this.profiles.max;
       this.profiles_barsize = this.profiles.barsize;
       this.profiles_crosssum = this.profiles.crosssum;
       this.profiles_tokenslength = this.profiles.tokenslength;
-      this.profiles_tokenslengthmax = this.profiles.tokenslengthmax;
-      this.cash_val = this.cash.val;
-      this.AP_val = this.AP.val;
-      this.AP_max = this.AP.max;
-      this.AP_barsize = this.AP.barsize;
-      this.karma_val = this.karma.val;
-      this.karma_max = this.karma.max;
-      this.karma_intensity = this.karma_intensity;
-      this.karma_barsize = this.karma.barsize;
-      this.XP_val = this.XP.val;
-      this.XP_max = this.XP.max;
-      this.XP_level = this.XP.level;
-      this.XP_barsize = this.XP.barsize;
-
-      this.initUI();
-
-      // FIXME: data should be referenced to serverdata
-    };
-    extend(Statusbar, Node);
-
-    Statusbar.prototype.onAddInit = function(){
-      this.updateRenderProp();
       this.render();
-    };
-
-    Statusbar.prototype.draw = function(){
-      // Update domelem to current settings
-      this.setSize(this.getSize());
-      this.setTransform(this.getTransform());
-      this.setPosition(this.getPosition());
-      this.setOpacity(this.opacity);
-    };
-
-    Statusbar.prototype.template = 'statusbar.html';
-    Statusbar.prototype.width = 720;
-    Statusbar.prototype.height = 25;
-    Statusbar.prototype.y = 12;
-    Statusbar.prototype.z = 10000;
-    Statusbar.prototype.offsetX = Statusbar.prototype.width/2;
-    Statusbar.prototype.offsetY = 0;
-
-    Statusbar.prototype.render = function(){
-      this.x = this.parentNode.getSize().width/2;
-      this.jdomelem.empty();
-      var html = app.renderView(this.template, this);
-      this.jdomelem.append(html);
-      this.draw();
-    };
-
-    Statusbar.prototype.tick = function(){
-      this.render();
+      return;
     }
+    this.profiles_active = 1;
+    this.FXSimpleCue(
+      {
+        profiles_active: 0,
+        profiles_val: this.profiles.val,
+        profiles_barsize: this.profiles.barsize,
+        profiles_crosssum: this.profiles.crosssum,
+        profiles_tokenslength: this.profiles.tokenslength,
+      },
+      500,
+      'linear'
+    );
+  };
 
-    // Silent paths bypass the Tween machinery: we just assign the flat
-    // template props and re-render once. FXSimpleCue with dur=0 still
-    // queues a Ticker listener and chains onto any active tween, so
-    // letting silent updateGameValues run through it would grow the
-    // tween queue under bursty silent traffic.
-    Statusbar.prototype.FXUpdateAP = function(silent){
-      this.AP_val = this.AP.val;
-      if (silent) {
-        this.AP_active = 0;
-        this.AP_max = this.AP.max;
-        this.AP_barsize = this.AP.barsize;
-        this.render();
+  Statusbar.prototype.startLoop = function (func, time) {
+    var node = this;
+    // only one loop per node
+    time = time || 1000;
+    if (this.loop) {
+      window.clearTimeout(this.loop);
+    }
+    if (func) {
+      func();
+    }
+    this.loop = window.setTimeout(function () {
+      node.startLoop(func, time);
+    }, time);
+  };
+
+  Statusbar.prototype.stopLoop = function () {
+    if (this.loop) {
+      window.clearTimeout(this.loop);
+    }
+  };
+
+  Statusbar.prototype.textMoreIn = _._('More Energy in') + ' ';
+  Statusbar.prototype.initUI = function () {
+    var node = this;
+    node.jdomelem.on('click touchend', '.StatusItem', function (e) {
+      e.stopPropagation();
+      var statusid = $(this).attr('data-status-id');
+      node.trigger('click_status.' + statusid);
+    });
+
+    node.jdomelem.on('mouseenter', '.StatusItem.AP', function (e) {
+      e.stopPropagation();
+      var groot = node.gameNode.GameRoot;
+      if (groot.ap_value >= groot.xp_level.ap_max) {
         return;
       }
-      this.AP_active = 1;
-      this.FXSimpleCue({AP_active:0,AP_max:this.AP.max,AP_barsize:this.AP.barsize},250,'linear');
+      var jtext = $(this).find('.StatusRemain');
+      jtext.show();
+      var APT = groot.APTicker;
+      node.startLoop(function () {
+        jtext.html(node.textMoreIn + _.span(_.toTime(APT.getRemainingTime())));
+      }, 1000);
+    });
+    node.jdomelem.on('mouseleave', '.StatusItem.AP', function (e) {
+      e.stopPropagation();
+      node.stopLoop();
+      var jtext = $(this).find('.StatusRemain');
+      jtext.hide();
+    });
+  };
+
+  /////////////////////////////
+  //       The Status
+  /////////////////////////////
+
+  var StatusItem = function (config) {
+    config = config || {};
+    var node = this;
+    this._id = _instances.length;
+    this.jdomelem = $("<div class='StatusItem'></div>");
+    this.frameSrc = config.frameSrc || 'MainSprites.png';
+    this.frameMap = config.frameMap || {
+      normal: { x: 36, y: 580, width: 128, height: 25, pivotx: 0, pivoty: 0 },
     };
-    Statusbar.prototype.FXUpdateXP = function(silent){
-      this.XP_level = this.XP.level;
-      this.XP_val = this.XP.val;
-      if (silent) {
-        this.XP_active = 0;
-        this.XP_barsize = this.XP.barsize;
-        this.render();
-        return;
-      }
-      this.XP_active = 1;
-      this.FXSimpleCue({XP_active:0,XP_barsize:this.XP.barsize},250,'linear');
-    };
-    Statusbar.prototype.FXUpdateCash = function(silent){
-      if (silent) {
-        this.cash_active = 0;
-        this.cash_val = this.cash.val;
-        this.render();
-        return;
-      }
-      this.cash_active = 1;
-      this.FXSimpleCue({cash_active:0,cash_val:this.cash.val},250,'linear');
-    };
-    Statusbar.prototype.FXUpdateKarma = function(silent){
-      if (silent) {
-        this.karma_active = 0;
-        this.karma_val = this.karma.val;
-        this.karma_barsize = this.karma.barsize;
-        this.render();
-        return;
-      }
-      this.karma_active = 1;
-      this.FXSimpleCue({karma_active:0,karma_val:this.karma.val,karma_barsize:this.karma.barsize},250,'linear');
-    };
-    Statusbar.prototype.FXUpdateProfiles = function(silent){
-      if (silent) {
-        this.profiles_active = 0;
-        this.profiles_val = this.profiles.val;
-        this.profiles_barsize = this.profiles.barsize;
-        this.profiles_crosssum = this.profiles.crosssum;
-        this.profiles_tokenslength = this.profiles.tokenslength;
-        this.render();
-        return;
-      }
-      this.profiles_active = 1;
-      this.FXSimpleCue({
-        profiles_active:0,
-        profiles_val:this.profiles.val,
-        profiles_barsize:this.profiles.barsize,
-        profiles_crosssum : this.profiles.crosssum,
-        profiles_tokenslength : this.profiles.tokenslength
-      },500,'linear');
-    };
+    this.frame = 'normal';
+    this.domelem = this.jdomelem[0];
+    this.init(config);
+    this.setFrameSrc(this.frameSrc);
+    this.setFrame(this.frame);
+    this.draw();
+  };
+  extend(StatusItem, Sprite);
 
-    Statusbar.prototype.startLoop = function(func, time){
-      var node = this;
-      // only one loop per node
-      time = time || 1000;
-      if (this.loop) {
-        window.clearTimeout(this.loop);
-      }
-      if (func) {
-        func();
-      }
-      this.loop = window.setTimeout(function(){
-        node.startLoop(func, time);
-      }, time);
-    };
+  /////////////////////////////
+  //       The DatabaseQueue
+  /////////////////////////////
 
-    Statusbar.prototype.stopLoop = function(){
-      if (this.loop) {
-        window.clearTimeout(this.loop);
-      }
-    };
+  var DBQueue = function (config) {
+    config = config || {};
+    var node = this;
+    this._id = _instances.length;
+    this.jdomelem = $("<div class='DatabaseQueue'></div>");
+    this.domelem = this.jdomelem[0];
 
-    Statusbar.prototype.textMoreIn = _._('More Energy in') + " ";
-    Statusbar.prototype.initUI = function(){
-      var node = this;
-      node.jdomelem.on('click touchend','.StatusItem',function(e){
-        e.stopPropagation();
-        var statusid = $(this).attr('data-status-id');
-        node.trigger('click_status.'+statusid);
-      });
+    this.init(config);
+    this.off();
 
-      node.jdomelem.on('mouseenter','.StatusItem.AP', function(e){
-        e.stopPropagation();
-        var groot = node.gameNode.GameRoot;
-        if (groot.ap_value >= groot.xp_level.ap_max) {
-          return;
-        }
-        var jtext = $(this).find(".StatusRemain");
-        jtext.show();
-        var APT = groot.APTicker;
-        node.startLoop(function(){
-          jtext.html(node.textMoreIn + _.span(_.toTime(APT.getRemainingTime())));
-        }, 1000);
-      });
-      node.jdomelem.on('mouseleave','.StatusItem.AP', function(e){
-        e.stopPropagation();
-        node.stopLoop();
-        var jtext = $(this).find(".StatusRemain");
-        jtext.hide();
-      });
-    };
-
-
-    /////////////////////////////
-    //       The Status
-    /////////////////////////////
-
-    var StatusItem = function(config){
-      config = config || {};
-      var node = this;
-      this._id = _instances.length;
-      this.jdomelem = $("<div class='StatusItem'></div>");
-      this.frameSrc = config.frameSrc || 'MainSprites.png';
-      this.frameMap = config.frameMap || {
-        normal: {x: 36, y: 580, width: 128, height: 25, pivotx: 0, pivoty: 0}
-      };
-      this.frame = 'normal';
-      this.domelem = this.jdomelem[0];
-      this.init(config);
-      this.setFrameSrc(this.frameSrc);
-      this.setFrame(this.frame);
-      this.draw();
-    };
-    extend(StatusItem, Sprite);
-
-
-    /////////////////////////////
-    //       The DatabaseQueue
-    /////////////////////////////
-
-    var DBQueue = function(config){
-      config = config || {};
-      var node = this;
-      this._id = _instances.length;
-      this.jdomelem = $("<div class='DatabaseQueue'></div>");
-      this.domelem = this.jdomelem[0];
-
-      this.init(config);
-      this.off();
-
-      this.jdomelem.on('click touchend','.Button:not(.disabled)[data-button-id="DatabaseUpgrades"]',function(e){
+    this.jdomelem.on(
+      'click touchend',
+      '.Button:not(.disabled)[data-button-id="DatabaseUpgrades"]',
+      function (e) {
         e.stopPropagation();
         e.preventDefault();
         node.trigger('select_upgrades');
-      });
-      this.jdomelem.on('click touchend','.DatabaseQueueItem:not(.disabled)',function(e){
-        e.stopPropagation();
-        e.preventDefault();
-        // TODO get real ID, currently needs integer...
-        var psid = $(this).attr('data-psid');
-        node.jdomelem.find('.DatabaseQueueItem').removeClass('selected');
-        $(this).addClass('selected');
+      }
+    );
+    this.jdomelem.on('click touchend', '.DatabaseQueueItem:not(.disabled)', function (e) {
+      e.stopPropagation();
+      e.preventDefault();
+      // TODO get real ID, currently needs integer...
+      var psid = $(this).attr('data-psid');
+      node.jdomelem.find('.DatabaseQueueItem').removeClass('selected');
+      $(this).addClass('selected');
 
-        if (e.shiftKey) {
-          node.trigger('profileset_shift_click',[psid]);
-        }
-        else {
-          node.trigger('profileset_click',[psid]);
-        }
-      });
+      if (e.shiftKey) {
+        node.trigger('profileset_shift_click', [psid]);
+      } else {
+        node.trigger('profileset_click', [psid]);
+      }
+    });
 
-      node.on('mousedown touchstart',function(e){
-        var userPos= {};
-        userPos.x = e.pageX-node.jdomelem.offset().left;
-        userPos.y = e.pageY-node.jdomelem.offset().top;
-        node.userClickAbsPos=userPos;
-      });
+    node.on('mousedown touchstart', function (e) {
+      var userPos = {};
+      userPos.x = e.pageX - node.jdomelem.offset().left;
+      userPos.y = e.pageY - node.jdomelem.offset().top;
+      node.userClickAbsPos = userPos;
+    });
+  };
+  extend(DBQueue, Node);
 
-    };
-    extend(DBQueue, Node);
+  DBQueue.prototype.onAddInit = function () {
+    this.updateRenderProp();
+    this.render();
+  };
 
-    DBQueue.prototype.onAddInit = function(){
-      this.updateRenderProp();
-      this.render();
-    };
+  DBQueue.prototype.textProfilesNew = _._('%s New');
+  DBQueue.prototype.textUpdated = _._('%s Updated');
+  DBQueue.prototype.FXMerge = function (psid, inc, dup, wait) {
+    var ps = this.jdomelem.find('.DatabaseQueueItem[data-psid=' + psid + ']');
+    var after = ps.nextAll('.DatabaseQueueItem');
+    ps.addClass('disabled');
+    this.FXBlingQueue({
+      text: _.sprintf(this.textProfilesNew, _.toKSNum(inc)),
+      wait: 200,
+      extendClass: 'ProfileBlingNew',
+    });
+    this.FXBlingQueue({
+      text: _.sprintf(this.textUpdated, _.toKSNum(dup)),
+      wait: 500,
+      extendClass: 'ProfileBlingUpdated',
+    });
+    window.setTimeout(function () {
+      ps.addClass('merging');
+    }, 200);
+    // FIXME: BROKEN ANI
 
-    DBQueue.prototype.textProfilesNew = _._('%s New');
-    DBQueue.prototype.textUpdated = _._('%s Updated');
-    DBQueue.prototype.FXMerge = function(psid,inc,dup,wait){
-      var ps = this.jdomelem.find('.DatabaseQueueItem[data-psid='+psid+']');
-      var after = ps.nextAll('.DatabaseQueueItem');
-      ps.addClass('disabled');
-      this.FXBlingQueue({
-        text: _.sprintf(this.textProfilesNew, _.toKSNum(inc)),
-        wait: 200,
-        extendClass: "ProfileBlingNew"
-      });
-      this.FXBlingQueue({
-        text: _.sprintf(this.textUpdated,_.toKSNum(dup)),
-        wait: 500,
-        extendClass: "ProfileBlingUpdated"
-      });
-      window.setTimeout(function(){ ps.addClass('merging'); }, 200);
-      // FIXME: BROKEN ANI
-
-      window.setTimeout(function(){
-        ps.animate({top: '102'}, 250, function(){
-          var del = 0;
-          after.each(function(){
-            $(this).animate({left:"-=100"},250+del);
-            del += 50;
-          });
-          ps.remove();
+    window.setTimeout(function () {
+      ps.animate({ top: '102' }, 250, function () {
+        var del = 0;
+        after.each(function () {
+          $(this).animate({ left: '-=100' }, 250 + del);
+          del += 50;
         });
-      }, 2000+wait);
-      /*
+        ps.remove();
+      });
+    }, 2000 + wait);
+    /*
       ps.delay(500 + wait).animate({top: '102'}, 250, function(){
         after.each(function(){
           $(this).animate({left:"-=100"},500);
@@ -4574,203 +4784,198 @@ var Render = function() {
         ps.remove();
       });
       */
-      /*
+    /*
       ps.delay(2500+wait).animate({top: '100'}, 250, function() {
         ps.remove()
       });
       */
 
+    //window.setTimeout(function(){ps.remove();},1000)
+  };
 
-      //window.setTimeout(function(){ps.remove();},1000)
-    };
+  DBQueue.prototype.draw = function () {
+    // Update domelem to current settings
+    this.setSize(this.getSize());
+    this.setTransform(this.getTransform());
+    this.setPosition(this.getPosition());
+    this.setOpacity(this.opacity);
+  };
 
-    DBQueue.prototype.draw = function(){
-      // Update domelem to current settings
-      this.setSize(this.getSize());
-      this.setTransform(this.getTransform());
-      this.setPosition(this.getPosition());
-      this.setOpacity(this.opacity);
-    };
+  DBQueue.prototype.template = 'db_queue.html';
+  DBQueue.prototype.width = 720;
+  DBQueue.prototype.height = 100;
+  DBQueue.prototype.z = 10;
+  DBQueue.prototype.offsetX = DBQueue.prototype.width / 2;
+  DBQueue.prototype.offsetY = -58;
 
-    DBQueue.prototype.template = 'db_queue.html';
-    DBQueue.prototype.width = 720;
-    DBQueue.prototype.height = 100;
-    DBQueue.prototype.z = 10;
-    DBQueue.prototype.offsetX = DBQueue.prototype.width/2;
-    DBQueue.prototype.offsetY = -58;
+  DBQueue.prototype.render = function () {
+    this.x = this.parentNode.parentNode.getSize().width / 2;
+    this.y = this.parentNode.parentNode.getSize().height - this.height;
+    this.jdomelem.empty();
+    var html = app.renderView(this.template, this);
+    this.jdomelem.append(html);
+    this.draw();
+  };
 
-    DBQueue.prototype.render = function(){
-      this.x = this.parentNode.parentNode.getSize().width/2;
-      this.y = this.parentNode.parentNode.getSize().height - this.height;
-      this.jdomelem.empty();
-      var html = app.renderView(this.template, this);
-      this.jdomelem.append(html);
-      this.draw();
-    };
+  DBQueue.prototype.tick = function () {
+    this.render();
+  };
 
-    DBQueue.prototype.tick = function(){
-      this.render();
+  /////////////////////////////
+  //       The Popup
+  /////////////////////////////
+
+  var Popup = function Popup(config) {
+    config = config || {};
+
+    this.open = true;
+    var node = this;
+    this._id = _instances.length;
+    this.jdomelem = $("<div class='Popup'></div>");
+    this.domelem = this.jdomelem[0];
+    this.init(config);
+    this.initBaseUI();
+  };
+  extend(Popup, Node);
+
+  Popup.prototype.template = 'popup.html';
+  Popup.prototype.width = 600;
+  //Popup.prototype.height = 520;
+  Popup.prototype.offsetX = Popup.prototype.width / 2;
+  Popup.prototype.offsetY = Popup.prototype.height / 2 - 10;
+
+  Popup.prototype.initBaseUI = function () {
+    var node = this;
+    var tdata = this.templateData;
+    // Render sprites only if not instantiated yet
+    if (tdata.data && tdata.data.popup_sprite && !tdata.data.popup_sprite.html) {
+      tdata.data.popup_sprite.html = RenderSprite(tdata.data.popup_sprite);
+    }
+    tdata.button = tdata.button;
+
+    if (this.popupContainer && this.extendClass) {
+      this.popupContainer.renderNode.popupContainerDomelem.addClass(this.extendClass);
     }
 
+    node.render();
 
+    node.jdomelem.on('click touchend', function (e) {
+      e.stopPropagation();
+      e.preventDefault();
+    });
 
-    /////////////////////////////
-    //       The Popup
-    /////////////////////////////
+    if (this.popupContainer) {
+      this.popupContainer.lock();
+      this.popupContainer.renderNode.popupContainerDomelem.on('click touchend', function (e) {
+        if (!$(this).hasClass('NoClose')) {
+          node.trigger('popup_close');
+          node.trigger('popup_cancel');
+        }
+      });
+    }
 
-    var Popup = function Popup(config){
-      config = config || {};
-
-      this.open = true;
-      var node = this;
-      this._id = _instances.length;
-      this.jdomelem = $("<div class='Popup'></div>");
-      this.domelem = this.jdomelem[0];
-      this.init(config);
-      this.initBaseUI();
-    };
-    extend(Popup, Node);
-
-    Popup.prototype.template = 'popup.html';
-    Popup.prototype.width = 600;
-    //Popup.prototype.height = 520;
-    Popup.prototype.offsetX = Popup.prototype.width/2;
-    Popup.prototype.offsetY = Popup.prototype.height/2-10;
-
-    Popup.prototype.initBaseUI = function() {
-      var node = this;
-      var tdata = this.templateData;
-      // Render sprites only if not instantiated yet
-      if (tdata.data && tdata.data.popup_sprite && !tdata.data.popup_sprite.html) {
-        tdata.data.popup_sprite.html = RenderSprite(tdata.data.popup_sprite);
+    node.on('no_cash', function (e) {
+      if (node.lastButton) {
+        node.jdomelem.find('.Button').removeClass('disabled no_cash');
+        node.lastButton.addClass('disabled no_cash');
+      } else {
+        node.jdomelem.find('.Button.MainButton').addClass('disabled no_cash').removeClass('active');
       }
-      tdata.button = tdata.button;
+      node.FXNoCash();
+    });
 
-
-      if (this.popupContainer && this.extendClass) {
-        this.popupContainer.renderNode.popupContainerDomelem.addClass(this.extendClass);
+    node.on('no_AP', function (e) {
+      if (node.lastButton) {
+        node.jdomelem.find('.Button').removeClass('disabled no_AP');
+        node.lastButton.addClass('disabled no_AP');
+      } else {
+        node.jdomelem.find('.Button.MainButton').addClass('disabled no_AP').removeClass('active');
       }
+      node.FXNoAP();
+    });
 
-      node.render();
-
-      node.jdomelem.on('click touchend',function(e){
-        e.stopPropagation();
-        e.preventDefault();
-      });
-
-      if (this.popupContainer) {
-        this.popupContainer.lock();
-        this.popupContainer.renderNode.popupContainerDomelem.on('click touchend',function(e){
-          if (!$(this).hasClass('NoClose')) {
-            node.trigger('popup_close');
-            node.trigger('popup_cancel');
-          }
-        });
+    node.on('error', function (e) {
+      if (node.lastButton) {
+        node.jdomelem.find('.Button').removeClass('active disabled ERROR');
+        node.lastButton.addClass('disabled ERROR');
+      } else {
+        node.jdomelem.find('.Button.MainButton').addClass('disabled ERROR').removeClass('active');
       }
+      node.FXError();
+    });
 
-      node.on('no_cash',function(e){
-        if (node.lastButton) {
-          node.jdomelem.find('.Button').removeClass('disabled no_cash');;
-          node.lastButton.addClass('disabled no_cash');
+    node.jdomelem.on('click touchend', '.PopupLogo', function (e) {
+      // FIXME: put debug flag here!
+      if (setup.debug) {
+        node.jdomelem.find('.Debug').toggle();
+        console.log(node.gameNode);
+      }
+    });
+
+    node.jdomelem.on('click touchend', '.Button:not(.disabled, .active)', function (e) {
+      e.stopPropagation();
+      e.preventDefault();
+      var button = $(this);
+      var bgestalt = button.attr('data-button-gestalt');
+      //var bslot = button.attr('data-slot-id');
+      var bdata = button.attr('data-button-data');
+      node.lastButton = button;
+      button.addClass('active');
+      node.trigger('button_click.' + button.attr('data-button-id'), [bgestalt, bdata]);
+    });
+
+    node.jdomelem.on('click touchend', '.Button.no_cash', function (e) {
+      e.stopPropagation();
+      e.preventDefault();
+      node.FXNoCash();
+    });
+
+    node.jdomelem.on('click touchend', '.Button.no_AP', function (e) {
+      e.stopPropagation();
+      e.preventDefault();
+      node.FXNoAP();
+    });
+
+    node.jdomelem.on('click touchend', '.PopupClose', function (e) {
+      e.stopPropagation();
+      e.preventDefault();
+      node.trigger('popup_close');
+      node.trigger('popup_cancel');
+    });
+
+    // Tutorial dialogs advance on tap anywhere (body or backdrop).
+    // tutorialTouchFired guards against the synthesized click that some
+    // browsers emit after touchend even when preventDefault() is called.
+    if (node.extendClass === 'Tutorial') {
+      var tutorialTouchFired = false;
+      var advanceTutorial = function (e) {
+        if (e.type === 'touchend') {
+          tutorialTouchFired = true;
+        } else if (tutorialTouchFired) {
+          tutorialTouchFired = false;
+          return;
         }
-        else {
-          node.jdomelem.find('.Button.MainButton').addClass('disabled no_cash').removeClass('active');
-        }
-        node.FXNoCash();
-      });
-
-      node.on('no_AP',function(e){
-        if (node.lastButton) {
-          node.jdomelem.find('.Button').removeClass('disabled no_AP');;
-          node.lastButton.addClass('disabled no_AP');
-        }
-        else {
-          node.jdomelem.find('.Button.MainButton').addClass('disabled no_AP').removeClass('active');
-        }
-        node.FXNoAP();
-      });
-
-      node.on('error',function(e){
-        if (node.lastButton) {
-          node.jdomelem.find('.Button').removeClass('active disabled ERROR');;
-          node.lastButton.addClass('disabled ERROR');
-        }
-        else {
-          node.jdomelem.find('.Button.MainButton').addClass('disabled ERROR').removeClass('active');
-        }
-        node.FXError();
-      });
-
-      node.jdomelem.on('click touchend','.PopupLogo',function(e){
-        // FIXME: put debug flag here!
-        if (setup.debug) {
-          node.jdomelem.find('.Debug').toggle();
-          console.log(node.gameNode);
-        }
-      });
-
-      node.jdomelem.on('click touchend','.Button:not(.disabled, .active)',function(e){
-        e.stopPropagation();
-        e.preventDefault();
-        var button = $(this);
-        var bgestalt = button.attr('data-button-gestalt');
-        //var bslot = button.attr('data-slot-id');
-        var bdata = button.attr('data-button-data');
-        node.lastButton = button;
-        button.addClass('active');
-        node.trigger('button_click.'+button.attr('data-button-id'),[bgestalt,bdata]);
-      });
-
-      node.jdomelem.on('click touchend','.Button.no_cash',function(e){
-        e.stopPropagation();
-        e.preventDefault();
-        node.FXNoCash();
-      });
-
-      node.jdomelem.on('click touchend','.Button.no_AP',function(e){
-        e.stopPropagation();
-        e.preventDefault();
-        node.FXNoAP();
-      });
-
-
-      node.jdomelem.on('click touchend','.PopupClose',function(e){
         e.stopPropagation();
         e.preventDefault();
         node.trigger('popup_close');
-        node.trigger('popup_cancel');
-      });
-
-      // Tutorial dialogs advance on tap anywhere (body or backdrop).
-      // tutorialTouchFired guards against the synthesized click that some
-      // browsers emit after touchend even when preventDefault() is called.
-      if (node.extendClass === 'Tutorial') {
-        var tutorialTouchFired = false;
-        var advanceTutorial = function(e) {
-          if (e.type === 'touchend') {
-            tutorialTouchFired = true;
-          } else if (tutorialTouchFired) {
-            tutorialTouchFired = false;
-            return;
-          }
-          e.stopPropagation();
-          e.preventDefault();
-          node.trigger('popup_close');
-        };
-        node.jdomelem.on('touchend click', '.TutorialBody', advanceTutorial);
-        if (this.popupContainer) {
-          var $tutorialContainer = this.popupContainer.renderNode.popupContainerDomelem;
-          $tutorialContainer.on('touchend click', advanceTutorial);
-          // Each tutorial step creates a new Popup and calls initEvents, so
-          // without cleanup advanceTutorial accumulates on the persistent
-          // container element (Popup.close never calls .off on it).
-          node.on('popup_close', function() {
-            $tutorialContainer.off('touchend click', advanceTutorial);
-          });
-        }
+      };
+      node.jdomelem.on('touchend click', '.TutorialBody', advanceTutorial);
+      if (this.popupContainer) {
+        var $tutorialContainer = this.popupContainer.renderNode.popupContainerDomelem;
+        $tutorialContainer.on('touchend click', advanceTutorial);
+        // Each tutorial step creates a new Popup and calls initEvents, so
+        // without cleanup advanceTutorial accumulates on the persistent
+        // container element (Popup.close never calls .off on it).
+        node.on('popup_close', function () {
+          $tutorialContainer.off('touchend click', advanceTutorial);
+        });
       }
+    }
 
-      node.jdomelem.on('click touchend','.Subpop[data-subpop-id="buyslots"] .BuySlotsInc',function(e){
+    node.jdomelem.on(
+      'click touchend',
+      '.Subpop[data-subpop-id="buyslots"] .BuySlotsInc',
+      function (e) {
         e.stopPropagation();
         e.preventDefault();
         var spop = $(this).parents('.Subpop[data-subpop-id="buyslots"]');
@@ -4780,15 +4985,19 @@ var Render = function() {
         var jprice = spop.find('.SlotCost');
         var price = parseInt(jprice.attr('data-slot-cost'));
         var max_slots = left;
-        num = (num+1 > max_slots) ? num : num + 1;
-        price = price*num;
+        num = num + 1 > max_slots ? num : num + 1;
+        price = price * num;
         jprice.text(_.toKSNum(price));
         spop.find('.BuySlotsNum').text(num);
         spop.find('.BuySlotsNum').text(num);
-        button.attr('data-button-data',num);
-      });
+        button.attr('data-button-data', num);
+      }
+    );
 
-      node.jdomelem.on('click touchend','.Subpop[data-subpop-id="buyslots"] .BuySlotsDec',function(e){
+    node.jdomelem.on(
+      'click touchend',
+      '.Subpop[data-subpop-id="buyslots"] .BuySlotsDec',
+      function (e) {
         e.stopPropagation();
         e.preventDefault();
         var spop = $(this).parents('.Subpop[data-subpop-id="buyslots"]');
@@ -4796,102 +5005,115 @@ var Render = function() {
         var num = parseInt(button.attr('data-button-data'));
         var jprice = spop.find('.SlotCost');
         var price = parseInt(jprice.attr('data-slot-cost'));
-        num = (num-1 < 1) ? 1 : num - 1;
-        price = price*num;
+        num = num - 1 < 1 ? 1 : num - 1;
+        price = price * num;
         jprice.text(_.toKSNum(price));
         spop.find('.BuySlotsNum').text(num);
-        button.attr('data-button-data',num);
-      });
+        button.attr('data-button-data', num);
+      }
+    );
 
-      node.jdomelem.on('click touchend','.PopupMenu .PopupMenuButton',function(e){
-        e.stopPropagation();
-        e.preventDefault();
-        var mbutton = $(this);
-        node.jdomelem.find('.PopupMenuButton').removeClass('active');
-        mbutton.addClass('active');
-        if (mbutton.hasClass('TabArrowNew')) {
-          mbutton.removeClass('TabArrowNew');
-        }
-        node.jdomelem.find('.PopupTab').hide();
-        node.jdomelem.find('.PopupTab[data-tab="' + mbutton.attr('data-tab') + '"]').show();
-        node.jdomelem.find('.PopupText.TabText').hide();
-        node.jdomelem.find('.PopupText.TabText[data-tab="' + mbutton.attr('data-tab') + '"]').show();
-        node.templateData.lastTab = mbutton.attr('data-tab');
-      });
+    node.jdomelem.on('click touchend', '.PopupMenu .PopupMenuButton', function (e) {
+      e.stopPropagation();
+      e.preventDefault();
+      var mbutton = $(this);
+      node.jdomelem.find('.PopupMenuButton').removeClass('active');
+      mbutton.addClass('active');
+      if (mbutton.hasClass('TabArrowNew')) {
+        mbutton.removeClass('TabArrowNew');
+      }
+      node.jdomelem.find('.PopupTab').hide();
+      node.jdomelem.find('.PopupTab[data-tab="' + mbutton.attr('data-tab') + '"]').show();
+      node.jdomelem.find('.PopupText.TabText').hide();
+      node.jdomelem.find('.PopupText.TabText[data-tab="' + mbutton.attr('data-tab') + '"]').show();
+      node.templateData.lastTab = mbutton.attr('data-tab');
+    });
 
-      node.jdomelem.on('click touchend','.Powerup:not(.updating, .locked)',function(e){
-        e.stopPropagation();
-        e.preventDefault();
-        var powerup = $(this);
-        var subpopid = powerup.attr('data-subpop-id');
-        var slotid = powerup.attr('data-button-data');
-        var container = powerup.parents('.PopupTab').find('.SubpopContainer');
-        powerup.parents('.PopupTab').addClass('hasPopup');;
-        container.addClass('open');
-        container.find('.Selector.open').addClass('hasPopup');
-        container.find('.Subpop[data-subpop-id='+subpopid+']').addClass('open');
-        container.find('.Subpop[data-subpop-id='+subpopid+']').find('.Powerup, .Button').attr('data-button-data',slotid);
-      });
+    node.jdomelem.on('click touchend', '.Powerup:not(.updating, .locked)', function (e) {
+      e.stopPropagation();
+      e.preventDefault();
+      var powerup = $(this);
+      var subpopid = powerup.attr('data-subpop-id');
+      var slotid = powerup.attr('data-button-data');
+      var container = powerup.parents('.PopupTab').find('.SubpopContainer');
+      powerup.parents('.PopupTab').addClass('hasPopup');
+      container.addClass('open');
+      container.find('.Selector.open').addClass('hasPopup');
+      container.find('.Subpop[data-subpop-id=' + subpopid + ']').addClass('open');
+      container
+        .find('.Subpop[data-subpop-id=' + subpopid + ']')
+        .find('.Powerup, .Button')
+        .attr('data-button-data', slotid);
+    });
 
-      node.jdomelem.on('click touchend','.PopupPerp:not(.locked)',function(e){
-        e.stopPropagation();
-        e.preventDefault();
-        var perp = $(this);
-        var subpopid = perp.attr('data-subpop-id');
-        var container = perp.parents('.PopupTab').find('.SubpopContainer');
-        perp.parents('.PopupTab').addClass('hasPopup');;
-        container.addClass('open');
-        container.find('.Selector.open').addClass('hasPopup');
-        container.find('.Subpop[data-subpop-id='+subpopid+']').addClass('open');
-      });
+    node.jdomelem.on('click touchend', '.PopupPerp:not(.locked)', function (e) {
+      e.stopPropagation();
+      e.preventDefault();
+      var perp = $(this);
+      var subpopid = perp.attr('data-subpop-id');
+      var container = perp.parents('.PopupTab').find('.SubpopContainer');
+      perp.parents('.PopupTab').addClass('hasPopup');
+      container.addClass('open');
+      container.find('.Selector.open').addClass('hasPopup');
+      container.find('.Subpop[data-subpop-id=' + subpopid + ']').addClass('open');
+    });
 
-      node.jdomelem.on('click touchend','.PopupToken:not(.locked)',function(e){
-        e.stopPropagation();
-        e.preventDefault();
-        var token = $(this);
-        var subpopid = token.attr('data-subpop-id');
-        var container = token.parents('.PopupTab').find('.SubpopContainer');
-        token.parents('.PopupTab').addClass('hasPopup');
-        container.addClass('open');
-        container.find('.Subpop[data-subpop-id='+subpopid+']').addClass('open');
-        // subpop-id is "token<gestalt>"; surface the gestalt so the game side
-        // can persist the seen-flag and clear the NEW badge across reloads.
-        var gestalt = (subpopid && subpopid.indexOf('token') === 0) ? subpopid.slice(5) : '';
-        if (gestalt) {
-          token.find('.new').remove();
-          node.trigger('popup_token_seen', [gestalt]);
-        }
-      });
+    node.jdomelem.on('click touchend', '.PopupToken:not(.locked)', function (e) {
+      e.stopPropagation();
+      e.preventDefault();
+      var token = $(this);
+      var subpopid = token.attr('data-subpop-id');
+      var container = token.parents('.PopupTab').find('.SubpopContainer');
+      token.parents('.PopupTab').addClass('hasPopup');
+      container.addClass('open');
+      container.find('.Subpop[data-subpop-id=' + subpopid + ']').addClass('open');
+      // subpop-id is "token<gestalt>"; surface the gestalt so the game side
+      // can persist the seen-flag and clear the NEW badge across reloads.
+      var gestalt = subpopid && subpopid.indexOf('token') === 0 ? subpopid.slice(5) : '';
+      if (gestalt) {
+        token.find('.new').remove();
+        node.trigger('popup_token_seen', [gestalt]);
+      }
+    });
 
-      node.jdomelem.on('click touchend','.SubpopClose, .Button[data-button-id=OKButton]',function(e){
+    node.jdomelem.on(
+      'click touchend',
+      '.SubpopClose, .Button[data-button-id=OKButton]',
+      function (e) {
         e.stopPropagation();
         e.preventDefault();
         var jelem = $(this);
         jelem.removeClass('active');
         var container = jelem.parents('.PopupTab').find('.SubpopContainer');
         container.find('.Selector.open').removeClass('hasPopup');
-        jelem.parents('.PopupTab').removeClass('hasPopup');;
+        jelem.parents('.PopupTab').removeClass('hasPopup');
         var subpop = jelem.parents('.Subpop');
         subpop.removeClass('open');
         if (!container.find('.Subpop.open').length) {
           container.removeClass('open');
         }
-      });
+      }
+    );
 
-      node.on('close_powerup',function(e,cb){
-        // unused?
-        var jelem = node.lastButton;
-        jelem.removeClass('active');
-        var container = jelem.parents('.PopupTab').find('.SubpopContainer, .Selector');
-        jelem.parents('.PopupTab').removeClass('hasPopup');;
-        container.removeClass('hasPopup');;
-        var subpop = jelem.parents('.Subpop');
-        subpop.removeClass('open');
-        container.removeClass('open');
-        if (cb) { window.setTimeout(cb,400); }
-      });
+    node.on('close_powerup', function (e, cb) {
+      // unused?
+      var jelem = node.lastButton;
+      jelem.removeClass('active');
+      var container = jelem.parents('.PopupTab').find('.SubpopContainer, .Selector');
+      jelem.parents('.PopupTab').removeClass('hasPopup');
+      container.removeClass('hasPopup');
+      var subpop = jelem.parents('.Subpop');
+      subpop.removeClass('open');
+      container.removeClass('open');
+      if (cb) {
+        window.setTimeout(cb, 400);
+      }
+    });
 
-      node.jdomelem.on('click touchend','.Pagination .PopupPageArrowR, .Pagination .PopupPageArrowL',function(e){
+    node.jdomelem.on(
+      'click touchend',
+      '.Pagination .PopupPageArrowR, .Pagination .PopupPageArrowL',
+      function (e) {
         var dir_next = $(this).hasClass('PopupPageArrowR');
         var Pagination = $(this).parent();
         var Pages = Pagination.find('.PopupPage');
@@ -4907,226 +5129,228 @@ var Render = function() {
         } else {
           index = index - 1;
         }
-        PageWrap.animate({left: -(index*540)},0);
-        active = Pages.filter('[data-page-id=' + index +']');
+        PageWrap.animate({ left: -(index * 540) }, 0);
+        active = Pages.filter('[data-page-id=' + index + ']');
         active.removeClass('hidden');
         if (index === len) {
           next.addClass('hidden');
           prev.removeClass('hidden');
-        }
-        else if (index <= 0) {
+        } else if (index <= 0) {
           prev.addClass('hidden');
           next.removeClass('hidden');
-        }
-        else {
+        } else {
           prev.removeClass('hidden');
           next.removeClass('hidden');
         }
-      });
-
-      node.on('mousemove',function(e){
-        var userPos= {};
-        userPos.x = e.pageX-node.jdomelem.offset().left;
-        userPos.y = e.pageY-node.jdomelem.offset().top;
-        node.userAbsPos=userPos;
-      });
-
-      node.on('mousedown touchstart',function(e){
-        var userPos= {};
-        userPos.x = e.pageX-node.jdomelem.offset().left;
-        userPos.y = e.pageY-node.jdomelem.offset().top;
-        node.userClickAbsPos=userPos;
-      });
-
-      // FIXME DEBUG example implementation on how to change active popup on state change events
-      // on('states') -> all state changes
-      // on('states_idle') -> specific [idle] state change.
-      node.on('states',function(e,state,value){
-        //console.log(state,value);
-      });
-      node.on('states_idle',function(e,value){
-        //console.log('states.idle',value);
-      });
-
-    };
-
-    Popup.prototype.render = function(){
-      var node = this;
-      this.jdomelem.empty();
-      var html = app.renderView(this.template, this.templateData);
-      this.jdomelem.append(html);
-      var mbutton = this.jdomelem.find('.PopupMenuButton[data-tab="'+node.templateData.lastTab+'"]');
-      if (node.templateData.lastTab) {
-        node.jdomelem.find('.PopupMenuButton').removeClass('active');
-        mbutton.addClass('active');
-        node.jdomelem.find('.PopupTab').hide();
-        node.jdomelem.find('.PopupTab[data-tab="'+mbutton.attr('data-tab')+'"]').show();
-        node.jdomelem.find('.PopupText.TabText').hide();
-        node.jdomelem.find('.PopupText.TabText[data-tab="' + mbutton.attr('data-tab') + '"]').show();
       }
+    );
 
-      if (node.templateData.highlightTabs) {
-        _.each(node.templateData.highlightTabs, function(tabid){
-          node.jdomelem.find('.PopupMenuButton[data-tab="'+ tabid +'"]').addClass('TabArrowNew');
-        });
-      }
-    };
+    node.on('mousemove', function (e) {
+      var userPos = {};
+      userPos.x = e.pageX - node.jdomelem.offset().left;
+      userPos.y = e.pageY - node.jdomelem.offset().top;
+      node.userAbsPos = userPos;
+    });
 
-    Popup.prototype.renderDataTab = function(){
-      var node = this;
-      var htmlPS = app.renderView('profileset.html', this.templateData);
-      var htmlButt = app.renderView('buttons_project.html', this.templateData);
-      this.jdomelem.find('.PopupTab.data').empty().append(htmlPS).append(htmlButt);
-    };
+    node.on('mousedown touchstart', function (e) {
+      var userPos = {};
+      userPos.x = e.pageX - node.jdomelem.offset().left;
+      userPos.y = e.pageY - node.jdomelem.offset().top;
+      node.userClickAbsPos = userPos;
+    });
 
-    Popup.prototype.renderPowerupSelectors = function(pkey){
-      if (!pkey) { return; }
-      var node = this;
-      var pcat = this.templateData.data.powerups_compiled[pkey];
-      var html = app.renderView('selector_powerups.html', {
-        D: node.templateData.data,
-        game_values: node.templateData.game_values,
-        pcat : pcat,
-        data: node.templateData.data,
-        typelower : pcat.typelower,
-        pkey : pkey
+    // FIXME DEBUG example implementation on how to change active popup on state change events
+    // on('states') -> all state changes
+    // on('states_idle') -> specific [idle] state change.
+    node.on('states', function (e, state, value) {
+      //console.log(state,value);
+    });
+    node.on('states_idle', function (e, value) {
+      //console.log('states.idle',value);
+    });
+  };
+
+  Popup.prototype.render = function () {
+    var node = this;
+    this.jdomelem.empty();
+    var html = app.renderView(this.template, this.templateData);
+    this.jdomelem.append(html);
+    var mbutton = this.jdomelem.find(
+      '.PopupMenuButton[data-tab="' + node.templateData.lastTab + '"]'
+    );
+    if (node.templateData.lastTab) {
+      node.jdomelem.find('.PopupMenuButton').removeClass('active');
+      mbutton.addClass('active');
+      node.jdomelem.find('.PopupTab').hide();
+      node.jdomelem.find('.PopupTab[data-tab="' + mbutton.attr('data-tab') + '"]').show();
+      node.jdomelem.find('.PopupText.TabText').hide();
+      node.jdomelem.find('.PopupText.TabText[data-tab="' + mbutton.attr('data-tab') + '"]').show();
+    }
+
+    if (node.templateData.highlightTabs) {
+      _.each(node.templateData.highlightTabs, function (tabid) {
+        node.jdomelem.find('.PopupMenuButton[data-tab="' + tabid + '"]').addClass('TabArrowNew');
       });
-      var jtab = node.jdomelem.find('.PopupTab.Powerups[data-tab="'+pkey+'"]');
-      jtab.find('.Subpop.InSelector').remove();
-      jtab.find('.Subpop.Selector').remove();
-      jtab.find('.SubpopContainer').append(html);
-    };
+    }
+  };
 
+  Popup.prototype.renderDataTab = function () {
+    var node = this;
+    var htmlPS = app.renderView('profileset.html', this.templateData);
+    var htmlButt = app.renderView('buttons_project.html', this.templateData);
+    this.jdomelem.find('.PopupTab.data').empty().append(htmlPS).append(htmlButt);
+  };
 
-    Popup.prototype.onAddInit = function(){
-      this.height = this.jdomelem.height();
-      var pbody = this.jdomelem.find('.PopupBody');
-      pbody.css({height:pbody.height()});
-      this.offsetY = this.height/2-10;
-      this.updateRenderProp();
-      if (this.placeBottom) {
-        this.y = app.game.renderNode.getSize().height - this.height/2-32;
-      } else {
-        this.y = app.game.renderNode.getSize().height/2;
-      }
-      this.x = app.game.renderNode.getSize().width/2;
-      this.draw();
-    };
+  Popup.prototype.renderPowerupSelectors = function (pkey) {
+    if (!pkey) {
+      return;
+    }
+    var node = this;
+    var pcat = this.templateData.data.powerups_compiled[pkey];
+    var html = app.renderView('selector_powerups.html', {
+      D: node.templateData.data,
+      game_values: node.templateData.game_values,
+      pcat: pcat,
+      data: node.templateData.data,
+      typelower: pcat.typelower,
+      pkey: pkey,
+    });
+    var jtab = node.jdomelem.find('.PopupTab.Powerups[data-tab="' + pkey + '"]');
+    jtab.find('.Subpop.InSelector').remove();
+    jtab.find('.Subpop.Selector').remove();
+    jtab.find('.SubpopContainer').append(html);
+  };
 
-    Popup.prototype.draw = function(){
-      // Update domelem to current settings
-      this.setSize(this.getSize());
-      this.setTransform(this.getTransform());
-      this.setPosition(this.getPosition());
-      this.setOpacity(this.opacity);
-    };
+  Popup.prototype.onAddInit = function () {
+    this.height = this.jdomelem.height();
+    var pbody = this.jdomelem.find('.PopupBody');
+    pbody.css({ height: pbody.height() });
+    this.offsetY = this.height / 2 - 10;
+    this.updateRenderProp();
+    if (this.placeBottom) {
+      this.y = app.game.renderNode.getSize().height - this.height / 2 - 32;
+    } else {
+      this.y = app.game.renderNode.getSize().height / 2;
+    }
+    this.x = app.game.renderNode.getSize().width / 2;
+    this.draw();
+  };
 
-    Popup.prototype.close = function(cb){
-      var popup = this;
-      popup.open = false;
-      // uncomment below to reset lastTab
-      //popup.templateData.lastTab = undefined;
-      // Transitionend test
-      popup.jdomelem.on('otransitionend MSTransitionEnd transitionend webkitTransitionEnd',function(e){
+  Popup.prototype.draw = function () {
+    // Update domelem to current settings
+    this.setSize(this.getSize());
+    this.setTransform(this.getTransform());
+    this.setPosition(this.getPosition());
+    this.setOpacity(this.opacity);
+  };
+
+  Popup.prototype.close = function (cb) {
+    var popup = this;
+    popup.open = false;
+    // uncomment below to reset lastTab
+    //popup.templateData.lastTab = undefined;
+    // Transitionend test
+    popup.jdomelem.on(
+      'otransitionend MSTransitionEnd transitionend webkitTransitionEnd',
+      function (e) {
         popup.remove();
-      });
-      window.setTimeout(function(){
-        // fallback for non transition
-        popup.remove();
-      },500);
-      window.setTimeout(function(){
-        // Trigger Callback
-        if (cb) { cb() };
-      },250);
-
-
-      if (this.popupContainer) {
-        this.popupContainer.renderNode.popupContainerDomelem.removeClass(this.extendClass);
-        //if (node.extendClass) { container.removeClass(node.extendClass); }
-        //this.popupContainer.renderNode.unlock();
-        this.popupContainer.unlock();
       }
-      this.off('states');
-      popup.jdomelem.addClass('close');
-      // Timeout corresponds to CSS transitions
-    };
-
-
-    /////////////////////////////
-    // The RenderSprite
-    /////////////////////////////
-
-    var RenderSprite = function(config,frame){
-      // config.frameSrc - Image source for the spritemap
-      // config.frameMap - framemap coordinates and offsets
-      // config.frame    - the currently active frame
-      if (!config || !config.frameSrc || !config.frameMap) {
-        return '';
+    );
+    window.setTimeout(function () {
+      // fallback for non transition
+      popup.remove();
+    }, 500);
+    window.setTimeout(function () {
+      // Trigger Callback
+      if (cb) {
+        cb();
       }
-      var s = {};
-      s.frameSrc = config.frameSrc || config.frame_src;
-      s.frameMap = config.frameMap || config.frame_map;
-      s.frame = frame || config.frame || 'normal';
-      s.jdomelem = $("<div class='RenderSprite'></div>");
-      if (config.className) {
-        s.jdomelem.addClass(config.className);
-      }
-      if (config.dataButtonId) {
-        s.jdomelem.attr('data-button-id',config.dataButtonId);
-      }
-      s.domelem = s.jdomelem[0];
+    }, 250);
+
+    if (this.popupContainer) {
+      this.popupContainer.renderNode.popupContainerDomelem.removeClass(this.extendClass);
+      //if (node.extendClass) { container.removeClass(node.extendClass); }
+      //this.popupContainer.renderNode.unlock();
+      this.popupContainer.unlock();
+    }
+    this.off('states');
+    popup.jdomelem.addClass('close');
+    // Timeout corresponds to CSS transitions
+  };
+
+  /////////////////////////////
+  // The RenderSprite
+  /////////////////////////////
+
+  var RenderSprite = function (config, frame) {
+    // config.frameSrc - Image source for the spritemap
+    // config.frameMap - framemap coordinates and offsets
+    // config.frame    - the currently active frame
+    if (!config || !config.frameSrc || !config.frameMap) {
+      return '';
+    }
+    var s = {};
+    s.frameSrc = config.frameSrc || config.frame_src;
+    s.frameMap = config.frameMap || config.frame_map;
+    s.frame = frame || config.frame || 'normal';
+    s.jdomelem = $("<div class='RenderSprite'></div>");
+    if (config.className) {
+      s.jdomelem.addClass(config.className);
+    }
+    if (config.dataButtonId) {
+      s.jdomelem.attr('data-button-id', config.dataButtonId);
+    }
+    s.domelem = s.jdomelem[0];
+    s.jdomelem.css({
+      'background-image': 'url(' + setup.imagePathPrefix + s.frameSrc + ')',
+    });
+    // Switch to a named frame on the spritemap
+    var map = s.frameMap[s.frame];
+    s.jdomelem.width(map.width);
+    s.jdomelem.height(map.height);
+    if (map.pivotx && map.pivoty) {
       s.jdomelem.css({
-        'background-image': 'url('+setup.imagePathPrefix+s.frameSrc+')'
+        left: -map.pivotx,
+        top: -map.pivoty,
       });
-      // Switch to a named frame on the spritemap
-      var map = s.frameMap[s.frame];
-      s.jdomelem.width(map.width);
-      s.jdomelem.height(map.height);
-      if (map.pivotx && map.pivoty) {
-        s.jdomelem.css({
-          left:-map.pivotx,
-          top:-map.pivoty
-        });
-      }
-      s.domelem.style.backgroundPosition = -map.x+"px "+-map.y+"px";
+    }
+    s.domelem.style.backgroundPosition = -map.x + 'px ' + -map.y + 'px';
 
-      //s.html = String($('<div>').append(s.jdomelem.clone()).html());
-      //s.html = $('<div>').append(s.jdomelem).html();
-      // FIXME: TESTING faster RenderSprite, does this work in any browser?
-      s.html = s.jdomelem[0].outerHTML;
-      return s.html;
+    //s.html = String($('<div>').append(s.jdomelem.clone()).html());
+    //s.html = $('<div>').append(s.jdomelem).html();
+    // FIXME: TESTING faster RenderSprite, does this work in any browser?
+    s.html = s.jdomelem[0].outerHTML;
+    return s.html;
+  };
+
+  /////////////////////////////
+  // The RenderAmount
+  /////////////////////////////
+
+  var RenderAmount = function (amount, frame, upgradeAmount, upgradeAbsAmount) {
+    config = {};
+
+    var s = {};
+    s.frameSrc = 'MainSprites.png';
+    s.frameMap = {
+      normal: { x: 267, y: 582, width: 80, height: 16, pivotx: 0, pivoty: -69 },
+      consumed: { x: 187, y: 582, width: 80, height: 16, pivotx: 0, pivoty: -69 },
     };
+    s.frame = frame || 'normal';
+    s.jdomelem = $("<div class='DecoratorAmount'></div>");
+    s.jdomelem2 = $("<div class='DecoratorAmountValue'></div>");
+    //s.jdomelem3 = $("<div class='DecoratorAmountNum'></div>");
+    s.jdomelem.append(s.jdomelem2);
+    if (frame) {
+      s.jdomelem.addClass(frame);
+    }
+    s.domelem = s.jdomelem[0];
+    s.jdomelem.css({
+      'background-image': 'url(' + setup.imagePathPrefix + s.frameSrc + ')',
+    });
+    var map = s.frameMap[s.frame];
 
-
-    /////////////////////////////
-    // The RenderAmount
-    /////////////////////////////
-
-    var RenderAmount = function(amount,frame,upgradeAmount,upgradeAbsAmount) {
-      config = {};
-
-      var s = {};
-      s.frameSrc = 'MainSprites.png';
-      s.frameMap = {
-        normal: {x: 267, y: 582, width: 80, height: 16, pivotx: 0, pivoty: -69},
-        consumed: {x: 187, y: 582, width: 80, height: 16, pivotx: 0, pivoty: -69}
-      };
-      s.frame = frame || 'normal';
-      s.jdomelem = $("<div class='DecoratorAmount'></div>");
-      s.jdomelem2 = $("<div class='DecoratorAmountValue'></div>");
-      //s.jdomelem3 = $("<div class='DecoratorAmountNum'></div>");
-      s.jdomelem.append(s.jdomelem2);
-      if (frame) {
-        s.jdomelem.addClass(frame);
-      }
-      s.domelem = s.jdomelem[0];
-      s.jdomelem.css({
-        'background-image': 'url('+setup.imagePathPrefix+s.frameSrc+')'
-      });
-      var map = s.frameMap[s.frame];
-
-
-      /*
+    /*
       if (amount < 50) {
         s.jdomelem3.show();
         s.jdomelem3.text(_.toKSNum(amount));
@@ -5136,276 +5360,279 @@ var Render = function() {
       }
       */
 
-      s.jdomelem.width(map.width);
-      s.jdomelem.height(map.height);
-      s.jdomelem.css({
-        left:-map.pivotx,
-        top:-map.pivoty
-      });
-      s.domelem.style.backgroundPosition = -map.x+"px "+-map.y+"px";
-      amount = amount || 0;
-      s.jdomelem2.width(Math.round((amount/100)*60));
-      if (upgradeAmount !== undefined) {
-        if (amount > 0) {
-          s.jdomelem.addClass('hasUpgrade');
-        }
-
-        s.jdomelem4 = $("<div class='DecoratorAmountUpgrade'></div>");
-        s.jdomelem4.width(Math.round((upgradeAmount/100)*60));
-        s.jdomelem4.css({ left: 9 + Math.round((amount/100)*60) +"px" });
-        s.jdomelem.append(s.jdomelem4);
-
-        if (upgradeAmount < 25) {
-          s.jdomelem3 = $("<div class='DecoratorAmountNum'></div>");
-          s.jdomelem3.text(_.toKSNum(upgradeAbsAmount));
-          s.jdomelem.append(s.jdomelem3);
-        }
-
-      }
-
-      s.html = String($('<div>').append(s.jdomelem.clone()).html());
-      return s.html;
-    };
-
-
-    /////////////////////////////////////////
-    //  The Mission Perp
-    ////////////////////////////////////////
-
-    var MissionPerp = function(config){
-      config = config || {};
-      this._id = _instances.length;
-      this.position = "relative";
-      this.display = "block";
-      this.clickable = true;
-      this.frameSrc = config.frameSrc;
-      this.frameMap = config.frameMap;
-      this.frame = config.frame || 'normal';
-      this.jdomelem = $("<div class='MissionPerp'></div>");
-      this.domelem = this.jdomelem[0];
-      this.init(config);
-      this.draw();
-    };
-    extend(MissionPerp, Node);
-
-    MissionPerp.prototype.onAddInit = function(){
-      // Init stuff when added to a Parent Node
-      var node = this;
-      if (this.clickable) {
-        this.setClickable(true);
-      }
-      this.updateRenderProp();
-      this.render();
-      this.initUI();
-    };
-
-    MissionPerp.prototype.setPosition = function(){
-      // FIXME: maybe adapt to allow transforms
-      return;
-    };
-
-    MissionPerp.prototype.setTransform = function() {
-      // FIXME: maybe adapt to allow transforms
-      return;
-    };
-
-    MissionPerp.prototype.template = 'mission.html';
-
-    MissionPerp.prototype.render = function(){
-      //this.x = this.parentNode.getSize().width/2;
-      this.jdomelem.removeClass("active");
-      this.jdomelem.removeClass("complete");
-      if (this.gameNode.states.active) {
-        this.jdomelem.addClass("active");
-      }
-      if (this.gameNode.states.complete) {
-        this.jdomelem.addClass("complete");
-      }
-      if (!this.gameNode.states.complete && !this.gameNode.states.active) {
-        this.hide();
-      } else {
-        this.show();
-      }
-      this.jdomelem.empty();
-      var html = app.renderView(this.template, this);
-      this.jdomelem.append(html);
-      this.draw();
-    };
-
-    MissionPerp.prototype.draw = function(){
-      // Update domelem to current settings
-      this.setSize(this.getSize());
-      this.setTransform(this.getTransform());
-      this.setPosition(this.getPosition());
-      this.setOpacity(this.opacity);
-    };
-
-    MissionPerp.prototype.tick = function(){
-      this.render();
-    }
-
-    MissionPerp.prototype.initUI = function(){
-      var node = this;
-      node.on('vclick',function(e){
-        e.stopPropagation();
-      });
-      node.on('states',function(e,state,value){
-        e.stopPropagation();
-        node.render();
-      });
-      node.on('states_active',function(e,state,value){
-        e.stopPropagation();
-      });
-
-    };
-
-    /////////////////////////////////////////
-    //  The Topscore Perp
-    ////////////////////////////////////////
-
-    var TopscorePerp = function(config){
-      config = config || {};
-      this._id = _instances.length;
-      this.position = "relative";
-      this.hidden = true;
-      this.clickable = true;
-      this.frameSrc = config.frameSrc;
-      this.frameMap = config.frameMap;
-      this.frame = config.frame || 'normal';
-      this.jdomelem = $("<div class='TopscorePerp'></div>");
-      this.domelem = this.jdomelem[0];
-      this.init(config);
-      this.draw();
-    };
-    extend(TopscorePerp, Node);
-
-    TopscorePerp.prototype.onAddInit = function(){
-      // Init stuff when added to a Parent Node
-      var node = this;
-      if (this.clickable) {
-        this.setClickable(true);
-      }
-      this.updateRenderProp();
-      this.render();
-      this.initUI();
-    };
-
-    TopscorePerp.prototype.setPosition = function(){
-      // FIXME: maybe adapt to allow transforms
-      return;
-    };
-
-    TopscorePerp.prototype.setTransform = function() {
-      // FIXME: maybe adapt to allow transforms
-      return;
-    };
-
-    TopscorePerp.prototype.template = 'topscore.html';
-
-    TopscorePerp.prototype.render = function(){
-      //this.x = this.parentNode.getSize().width/2;
-      this.jdomelem.empty();
-      var html = app.renderView(this.template, this);
-      this.jdomelem.append(html);
-      this.draw();
-    };
-
-    TopscorePerp.prototype.draw = function(){
-      // Update domelem to current settings
-      if (this.hidden) {
-        this.hide();
-      }
-      this.setSize(this.getSize());
-      this.setTransform(this.getTransform());
-      this.setPosition(this.getPosition());
-      this.setOpacity(this.opacity);
-    };
-
-    TopscorePerp.prototype.tick = function(){
-      this.render();
-    }
-
-    TopscorePerp.prototype.initUI = function(){
-      var node = this;
-      node.on('vclick',function(e){
-        e.stopPropagation();
-        node.parentNode.jdomelem.find('.TopscorePerp').removeClass('active');
-        //node.jdomelem.addClass('active');
-      });
-      node.on('states',function(e,state,value){
-        e.stopPropagation();
-        node.render();
-      });
-      node.on('states_active',function(e,state,value){
-        e.stopPropagation();
-      });
-    };
-    
-    TopscorePerp.prototype.renderRank = function(){
-      var rank = this.jdomelem.find('.TopscoreRank');
-      rank.empty();
-      var html = app.renderView('topscore_rank.html', { data:this.gameNode.data, parentdata:this.gameNode.parentNode.data, type:this.gameNode.scoretype });
-      rank.append(html);
-    };
-
-    TopscorePerp.prototype.renderList = function(){
-      var list = this.jdomelem.find('.TopscoreList');
-      list.empty();
-      var html = app.renderView('topscore_list.html', { data:this.gameNode.data, parentdata:this.gameNode.parentNode.data, type:this.gameNode.scoretype });
-      list.append(html);
-    };
-
-
-    ////////////////////////////
-    // Underscore Mix-ins
-    ////////////////////////////
-
-    _.mixin({
-      RenderAmount: RenderAmount,
-      RenderSprite: RenderSprite
+    s.jdomelem.width(map.width);
+    s.jdomelem.height(map.height);
+    s.jdomelem.css({
+      left: -map.pivotx,
+      top: -map.pivoty,
     });
+    s.domelem.style.backgroundPosition = -map.x + 'px ' + -map.y + 'px';
+    amount = amount || 0;
+    s.jdomelem2.width(Math.round((amount / 100) * 60));
+    if (upgradeAmount !== undefined) {
+      if (amount > 0) {
+        s.jdomelem.addClass('hasUpgrade');
+      }
 
+      s.jdomelem4 = $("<div class='DecoratorAmountUpgrade'></div>");
+      s.jdomelem4.width(Math.round((upgradeAmount / 100) * 60));
+      s.jdomelem4.css({ left: 9 + Math.round((amount / 100) * 60) + 'px' });
+      s.jdomelem.append(s.jdomelem4);
 
-    ////////////////////////////
-    // The API Publisher
-    ////////////////////////////
+      if (upgradeAmount < 25) {
+        s.jdomelem3 = $("<div class='DecoratorAmountNum'></div>");
+        s.jdomelem3.text(_.toKSNum(upgradeAbsAmount));
+        s.jdomelem.append(s.jdomelem3);
+      }
+    }
 
-    return {
-      _instances: _instances,
-      _ids: _ids,
-      //_sets: _sets,
-      get: get,
-      getById: getById,
-      clear: clear,
-      DragHandler: DragHandler,
-      Set: Set,
-      Node: Node,
-      Circle: Circle,
-      Text: Text,
-      Sprite: Sprite,
-      Perp: Perp,
-      PerpSprite: PerpSprite,
-      PerpCable: PerpCable,
-      Decorator: Decorator,
-      DecoratorReady: DecoratorReady,
-      DecoratorAmount: DecoratorAmount,
-      DecoratorLabel: DecoratorLabel,
-      DecoratorTimer: DecoratorTimer,
-      DecoratorGear: DecoratorGear,
-      DecoratorNew: DecoratorNew,
-      Cable: Cable,
-      MissionPerp: MissionPerp,
-      TopscorePerp: TopscorePerp,
-      ViewTab: ViewTab,
-      ViewMap: ViewMap,
-      MainMenu: MainMenu,
-      ButtonInline: ButtonInline,
-      Stage: Stage,
-      Popup: Popup,
-      SlowTicker: SlowTicker,
-      Statusbar: Statusbar,
-      DBQueue: DBQueue
-    };
+    s.html = String($('<div>').append(s.jdomelem.clone()).html());
+    return s.html;
+  };
+
+  /////////////////////////////////////////
+  //  The Mission Perp
+  ////////////////////////////////////////
+
+  var MissionPerp = function (config) {
+    config = config || {};
+    this._id = _instances.length;
+    this.position = 'relative';
+    this.display = 'block';
+    this.clickable = true;
+    this.frameSrc = config.frameSrc;
+    this.frameMap = config.frameMap;
+    this.frame = config.frame || 'normal';
+    this.jdomelem = $("<div class='MissionPerp'></div>");
+    this.domelem = this.jdomelem[0];
+    this.init(config);
+    this.draw();
+  };
+  extend(MissionPerp, Node);
+
+  MissionPerp.prototype.onAddInit = function () {
+    // Init stuff when added to a Parent Node
+    var node = this;
+    if (this.clickable) {
+      this.setClickable(true);
+    }
+    this.updateRenderProp();
+    this.render();
+    this.initUI();
+  };
+
+  MissionPerp.prototype.setPosition = function () {
+    // FIXME: maybe adapt to allow transforms
+    return;
+  };
+
+  MissionPerp.prototype.setTransform = function () {
+    // FIXME: maybe adapt to allow transforms
+    return;
+  };
+
+  MissionPerp.prototype.template = 'mission.html';
+
+  MissionPerp.prototype.render = function () {
+    //this.x = this.parentNode.getSize().width/2;
+    this.jdomelem.removeClass('active');
+    this.jdomelem.removeClass('complete');
+    if (this.gameNode.states.active) {
+      this.jdomelem.addClass('active');
+    }
+    if (this.gameNode.states.complete) {
+      this.jdomelem.addClass('complete');
+    }
+    if (!this.gameNode.states.complete && !this.gameNode.states.active) {
+      this.hide();
+    } else {
+      this.show();
+    }
+    this.jdomelem.empty();
+    var html = app.renderView(this.template, this);
+    this.jdomelem.append(html);
+    this.draw();
+  };
+
+  MissionPerp.prototype.draw = function () {
+    // Update domelem to current settings
+    this.setSize(this.getSize());
+    this.setTransform(this.getTransform());
+    this.setPosition(this.getPosition());
+    this.setOpacity(this.opacity);
+  };
+
+  MissionPerp.prototype.tick = function () {
+    this.render();
+  };
+
+  MissionPerp.prototype.initUI = function () {
+    var node = this;
+    node.on('vclick', function (e) {
+      e.stopPropagation();
+    });
+    node.on('states', function (e, state, value) {
+      e.stopPropagation();
+      node.render();
+    });
+    node.on('states_active', function (e, state, value) {
+      e.stopPropagation();
+    });
+  };
+
+  /////////////////////////////////////////
+  //  The Topscore Perp
+  ////////////////////////////////////////
+
+  var TopscorePerp = function (config) {
+    config = config || {};
+    this._id = _instances.length;
+    this.position = 'relative';
+    this.hidden = true;
+    this.clickable = true;
+    this.frameSrc = config.frameSrc;
+    this.frameMap = config.frameMap;
+    this.frame = config.frame || 'normal';
+    this.jdomelem = $("<div class='TopscorePerp'></div>");
+    this.domelem = this.jdomelem[0];
+    this.init(config);
+    this.draw();
+  };
+  extend(TopscorePerp, Node);
+
+  TopscorePerp.prototype.onAddInit = function () {
+    // Init stuff when added to a Parent Node
+    var node = this;
+    if (this.clickable) {
+      this.setClickable(true);
+    }
+    this.updateRenderProp();
+    this.render();
+    this.initUI();
+  };
+
+  TopscorePerp.prototype.setPosition = function () {
+    // FIXME: maybe adapt to allow transforms
+    return;
+  };
+
+  TopscorePerp.prototype.setTransform = function () {
+    // FIXME: maybe adapt to allow transforms
+    return;
+  };
+
+  TopscorePerp.prototype.template = 'topscore.html';
+
+  TopscorePerp.prototype.render = function () {
+    //this.x = this.parentNode.getSize().width/2;
+    this.jdomelem.empty();
+    var html = app.renderView(this.template, this);
+    this.jdomelem.append(html);
+    this.draw();
+  };
+
+  TopscorePerp.prototype.draw = function () {
+    // Update domelem to current settings
+    if (this.hidden) {
+      this.hide();
+    }
+    this.setSize(this.getSize());
+    this.setTransform(this.getTransform());
+    this.setPosition(this.getPosition());
+    this.setOpacity(this.opacity);
+  };
+
+  TopscorePerp.prototype.tick = function () {
+    this.render();
+  };
+
+  TopscorePerp.prototype.initUI = function () {
+    var node = this;
+    node.on('vclick', function (e) {
+      e.stopPropagation();
+      node.parentNode.jdomelem.find('.TopscorePerp').removeClass('active');
+      //node.jdomelem.addClass('active');
+    });
+    node.on('states', function (e, state, value) {
+      e.stopPropagation();
+      node.render();
+    });
+    node.on('states_active', function (e, state, value) {
+      e.stopPropagation();
+    });
+  };
+
+  TopscorePerp.prototype.renderRank = function () {
+    var rank = this.jdomelem.find('.TopscoreRank');
+    rank.empty();
+    var html = app.renderView('topscore_rank.html', {
+      data: this.gameNode.data,
+      parentdata: this.gameNode.parentNode.data,
+      type: this.gameNode.scoretype,
+    });
+    rank.append(html);
+  };
+
+  TopscorePerp.prototype.renderList = function () {
+    var list = this.jdomelem.find('.TopscoreList');
+    list.empty();
+    var html = app.renderView('topscore_list.html', {
+      data: this.gameNode.data,
+      parentdata: this.gameNode.parentNode.data,
+      type: this.gameNode.scoretype,
+    });
+    list.append(html);
+  };
+
+  ////////////////////////////
+  // Underscore Mix-ins
+  ////////////////////////////
+
+  _.mixin({
+    RenderAmount: RenderAmount,
+    RenderSprite: RenderSprite,
+  });
+
+  ////////////////////////////
+  // The API Publisher
+  ////////////////////////////
+
+  return {
+    _instances: _instances,
+    _ids: _ids,
+    //_sets: _sets,
+    get: get,
+    getById: getById,
+    clear: clear,
+    DragHandler: DragHandler,
+    Set: Set,
+    Node: Node,
+    Circle: Circle,
+    Text: Text,
+    Sprite: Sprite,
+    Perp: Perp,
+    PerpSprite: PerpSprite,
+    PerpCable: PerpCable,
+    Decorator: Decorator,
+    DecoratorReady: DecoratorReady,
+    DecoratorAmount: DecoratorAmount,
+    DecoratorLabel: DecoratorLabel,
+    DecoratorTimer: DecoratorTimer,
+    DecoratorGear: DecoratorGear,
+    DecoratorNew: DecoratorNew,
+    Cable: Cable,
+    MissionPerp: MissionPerp,
+    TopscorePerp: TopscorePerp,
+    ViewTab: ViewTab,
+    ViewMap: ViewMap,
+    MainMenu: MainMenu,
+    ButtonInline: ButtonInline,
+    Stage: Stage,
+    Popup: Popup,
+    SlowTicker: SlowTicker,
+    Statusbar: Statusbar,
+    DBQueue: DBQueue,
+  };
 };
 
 var render; // We store our singleton instance here.

--- a/scripts/Render.js
+++ b/scripts/Render.js
@@ -153,8 +153,7 @@ var Render = function () {
 
   DragHandler.prototype.dragVector = {};
   DragHandler.prototype.dragstart = function (e) {
-    var dm = this;
-    dm.state = 'started';
+    this.state = 'started';
     // FIXME: trigger touchhandling broken?!
     var touch;
     if (e.originalEvent) {
@@ -163,25 +162,24 @@ var Render = function () {
         : undefined;
     }
     var userPos = touch ? { x: touch.pageX, y: touch.pageY } : { x: e.pageX, y: e.pageY };
-    dm.dragMovePos = dm.dragStartPos = userPos;
-    dm.dragging = true;
-    delete dm.dragVector.x;
-    delete dm.dragVector.y;
-    dm.dragVector.x = (dm.dragMovePos.x - dm.dragStartPos.x) * dm.scale;
-    dm.dragVector.y = (dm.dragMovePos.y - dm.dragStartPos.y) * dm.scale;
+    this.dragMovePos = this.dragStartPos = userPos;
+    this.dragging = true;
+    delete this.dragVector.x;
+    delete this.dragVector.y;
+    this.dragVector.x = (this.dragMovePos.x - this.dragStartPos.x) * this.scale;
+    this.dragVector.y = (this.dragMovePos.y - this.dragStartPos.y) * this.scale;
   };
 
   DragHandler.prototype.dragend = function (e) {
-    var dm = this;
-    dm.state = 'stopped';
+    this.state = 'stopped';
 
-    for (var i = 0; i < dm.listeners.length; i++) {
-      var node = dm.listeners[i];
+    for (var i = 0; i < this.listeners.length; i++) {
+      var node = this.listeners[i];
       node.dragging = false;
       node.trigger('dragend');
     }
-    dm.listeners.length = 0;
-    dm.dragging = false;
+    this.listeners.length = 0;
+    this.dragging = false;
   };
 
   DragHandler.prototype.on = function (event, func) {
@@ -414,6 +412,7 @@ var Render = function () {
   // An array of Nodes with some shortcuts
   ///////////////////////////////////////////
 
+  // biome-ignore lint/suspicious/noShadowRestrictedNames: legacy collection class predates ES6 Set
   var Set = function (set) {
     if (!set) {
       set = [];
@@ -474,7 +473,6 @@ var Render = function () {
   };
 
   Set.prototype.removeAll = function () {
-    var set = this;
     while (this.set.length > 0) {
       var node = this.set[0];
       this.remove(node);
@@ -599,7 +597,6 @@ var Render = function () {
     // Remove Node from all references and remove Domobject
     Ticker.removeListener(this);
     SlowTicker.removeListener(this);
-    var node = this;
     if (this.decoratedNode) {
       this.decoratedNode.decorators.remove(this);
     }
@@ -616,10 +613,10 @@ var Render = function () {
       this.decorators.removeAll();
     }
     if (this.perpTo) {
-      this.perpTo.cables.remove(node);
+      this.perpTo.cables.remove(this);
     }
     if (this.perpFrom) {
-      this.perpFrom.cables.remove(node);
+      this.perpFrom.cables.remove(this);
     }
     this.jdomelem.remove();
     remove(this._id);
@@ -793,8 +790,7 @@ var Render = function () {
           y: otherPos.y,
           r: cableMaxLength,
         };
-        var scale =
-          circle.r / Math.sqrt(Math.pow(pos.x - circle.x, 2) + Math.pow(pos.y - circle.y, 2));
+        var scale = circle.r / Math.sqrt((pos.x - circle.x) ** 2 + (pos.y - circle.y) ** 2);
         if (scale < 1) {
           return {
             y: Math.round((pos.y - circle.y) * scale + circle.y),
@@ -818,17 +814,15 @@ var Render = function () {
   };
 
   Node.prototype.testParentRadius = function (newPos, radius) {
-    var node = this;
     radius = radius || 400;
-    var otherperp = node.gameNode.parentNode.renderNode;
+    var otherperp = this.gameNode.parentNode.renderNode;
     var dragBoundFunc = function (pos) {
       var circle = {
         x: otherperp.getPosition().x,
         y: otherperp.getPosition().y,
         r: radius,
       };
-      var scale =
-        circle.r / Math.sqrt(Math.pow(pos.x - circle.x, 2) + Math.pow(pos.y - circle.y, 2));
+      var scale = circle.r / Math.sqrt((pos.x - circle.x) ** 2 + (pos.y - circle.y) ** 2);
       if (scale < 1) {
         return {
           y: Math.round((pos.y - circle.y) * scale + circle.y),
@@ -1232,9 +1226,8 @@ var Render = function () {
   };
 
   Node.prototype.FXSimpleLoop = function (config, duration, easing, callback) {
-    var node = this;
-    Ticker.addListener(node);
-    return Tween.get(node, {
+    Ticker.addListener(this);
+    return Tween.get(this, {
       override: true,
       loop: true,
     })
@@ -1366,7 +1359,7 @@ var Render = function () {
 
     var deg = Math.atan(O / Math.abs(A)) * (180 / Math.PI);
 
-    var lenratio = Math.sqrt(Math.pow(oPos.x - nPos.x, 2) + Math.pow(oPos.y - nPos.y, 2)) / 108;
+    var lenratio = Math.sqrt((oPos.x - nPos.x) ** 2 + (oPos.y - nPos.y) ** 2) / 108;
 
     spark.setPosition({ x: oPos.x, y: oPos.y });
     spark.rotate = 180 + (90 - deg) * dir;
@@ -1464,7 +1457,7 @@ var Render = function () {
     var A = nPos.x - oPos.x;
     var O = oPos.y - nPos.y;
     //var lenratio = O * (1/oPos.y);
-    var lenratio = Math.sqrt(Math.pow(oPos.x - nPos.x, 2) + Math.pow(oPos.y - nPos.y, 2)) / 108;
+    var lenratio = Math.sqrt((oPos.x - nPos.x) ** 2 + (oPos.y - nPos.y) ** 2) / 108;
 
     var dir = A > 0 ? 1 : -1;
     //A = Math.abs(A);
@@ -1511,9 +1504,7 @@ var Render = function () {
   };
 
   Node.prototype.FXMeMeMe = function (cb) {
-    // Used on DecoratorReady hover
-    var node = this;
-    node.setFrame('hover');
+    this.setFrame('hover');
     this.FXClearCue();
     this.FXSimpleCue({ scaleX: 1.1, scaleY: 1.1 }, 31, 'easeOut');
     this.FXSimpleCue({ scaleX: 1.07, scaleY: 1.07 }, 31, 'easeOut');
@@ -1525,9 +1516,7 @@ var Render = function () {
   };
 
   Node.prototype.FXNotMeMeMe = function (cb) {
-    // Used on DecoratorReady hover
-    var node = this;
-    node.setFrame('normal');
+    this.setFrame('normal');
     if (cb) {
       cb();
     }
@@ -1695,8 +1684,7 @@ var Render = function () {
   };
 
   Node.prototype.FXPulse = function (cb) {
-    var node = this;
-    node.FXSimpleLoop(
+    this.FXSimpleLoop(
       {
         one: { scaleX: 0.9, scaleY: 0.9 },
         two: { scaleX: 1, scaleY: 1 },
@@ -1712,8 +1700,7 @@ var Render = function () {
   };
 
   Node.prototype.FXSnooze = function (cb) {
-    var node = this;
-    node.FXSimpleLoop(
+    this.FXSimpleLoop(
       {
         one: { scaleX: 0.9, scaleY: 0.9 },
         two: { scaleX: 1, scaleY: 1 },
@@ -1744,10 +1731,9 @@ var Render = function () {
   };
 
   Node.prototype.FXCharge = function (frame, cb) {
-    var node = this;
     // Find out where to render and at which coordinates
-    var nodePos = node.userClickAbsPos || node.getPosition();
-    var renderParent = node.userClickAbsPos ? node : node.parentNode;
+    var nodePos = this.userClickAbsPos || this.getPosition();
+    var renderParent = this.userClickAbsPos ? this : this.parentNode;
     var bling = new Sprite({
       x: nodePos.x,
       y: nodePos.y - 400,
@@ -1783,13 +1769,11 @@ var Render = function () {
   };
 
   Node.prototype.FXKarmaBling = function (karma_points, cb) {
-    var node = this;
     // Find out where to render and at which coordinates
     //var nodePos = node.userClickAbsPos;
-    var nodePos = node.getCenterPosition();
+    var nodePos = this.getCenterPosition();
     nodePos.x += 130;
     nodePos.y = 100;
-    var renderParent = node;
     var bling = new Sprite({
       x: nodePos.x,
       y: nodePos.y,
@@ -1803,7 +1787,7 @@ var Render = function () {
         karma_up: { x: 428, y: 860, width: 96, height: 96, pivotx: 48, pivoty: 48 },
       },
     });
-    renderParent.addChild(bling);
+    this.addChild(bling);
     bling.FXWaitCue(0);
     bling.FXSimpleCue({ scaleX: 0, scaleY: 0, rotate: 720, opacity: 0 }, 0, 'linear', function () {
       bling.FXBling({
@@ -1838,10 +1822,7 @@ var Render = function () {
   };
 
   Node.prototype.FXLevelUpBling = function (xp_level, cb) {
-    // should be invoked on gameroot
-    var node = this;
-    var nodePos = node.getCenterPosition();
-    var renderParent = node;
+    var nodePos = this.getCenterPosition();
     var bling = new Sprite({
       x: nodePos.x,
       y: nodePos.y,
@@ -1855,7 +1836,7 @@ var Render = function () {
         normal: { x: 525, y: 842, width: 138, height: 138, pivotx: 69, pivoty: 69 },
       },
     });
-    renderParent.addChild(bling);
+    this.addChild(bling);
     bling.FXWaitCue(0);
     bling.FXSimpleCue({ scaleX: 0, scaleY: 0, rotate: 720, opacity: 0 }, 0, 'linear', function () {
       /*
@@ -1898,10 +1879,7 @@ var Render = function () {
   };
 
   Node.prototype.FXMissionComplete = function (text, cb) {
-    // should be invoked on gameroot
-    var node = this;
-    var nodePos = node.getCenterPosition();
-    var renderParent = node;
+    var nodePos = this.getCenterPosition();
     var bling = new Sprite({
       x: nodePos.x,
       y: nodePos.y,
@@ -1915,7 +1893,7 @@ var Render = function () {
         normal: { x: 717, y: 764, width: 122, height: 160, pivotx: 55, pivoty: 90 },
       },
     });
-    renderParent.addChild(bling);
+    this.addChild(bling);
     bling.FXWaitCue(0);
     bling.FXSimpleCue({ scaleX: 0, scaleY: 0, rotate: 0, opacity: 0 }, 0, 'linear', function () {});
     bling.FXSimpleCue(
@@ -1943,10 +1921,7 @@ var Render = function () {
   };
 
   Node.prototype.FXMissionGoalComplete = function (text, cb) {
-    // should be invoked on gameroot
-    var node = this;
-    var nodePos = node.getTopRightPosition();
-    var renderParent = node;
+    var nodePos = this.getTopRightPosition();
     var bling = new Sprite({
       x: nodePos.x - 40,
       y: nodePos.y + 50,
@@ -1960,7 +1935,7 @@ var Render = function () {
         normal: { x: 717, y: 764, width: 122, height: 160, pivotx: 55, pivoty: 90 },
       },
     });
-    renderParent.addChild(bling);
+    this.addChild(bling);
     bling.FXWaitCue(100);
     bling.FXSimpleCue({ scaleX: 0.5, scaleY: 0.5, rotate: 1, opacity: 1 }, 250, 'bounceOut');
     bling.FXWaitCue(1000);
@@ -1973,10 +1948,9 @@ var Render = function () {
   };
 
   Node.prototype.FXNoCash = function (frame, cb) {
-    var node = this;
     // Find out where to render and at which coordinates
-    var nodePos = node.userClickAbsPos || node.getPosition();
-    var renderParent = node.userClickAbsPos ? node : node.parentNode;
+    var nodePos = this.userClickAbsPos || this.getPosition();
+    var renderParent = this.userClickAbsPos ? this : this.parentNode;
     var bling = new Sprite({
       x: nodePos.x,
       y: nodePos.y - 400,
@@ -2014,10 +1988,9 @@ var Render = function () {
   };
 
   Node.prototype.FXNoAP = function (frame, cb) {
-    var node = this;
     // Find out where to render and at which coordinates
-    var nodePos = node.userClickAbsPos || node.getPosition();
-    var renderParent = node.userClickAbsPos ? node : node.parentNode;
+    var nodePos = this.userClickAbsPos || this.getPosition();
+    var renderParent = this.userClickAbsPos ? this : this.parentNode;
     var bling = new Sprite({
       x: nodePos.x,
       y: nodePos.y,
@@ -2097,8 +2070,7 @@ var Render = function () {
 
   Node.prototype.FXBling = function (config, cb) {
     config = config || {};
-    var node = this;
-    var nodePos = node.getPosition();
+    var nodePos = this.getPosition();
     config.wait = config.wait || 0;
     config.dur = config.dur || 1000;
     var bling = new Text({
@@ -2112,7 +2084,7 @@ var Render = function () {
     if (config.renderOn) {
       config.renderOn.addChild(bling);
     } else {
-      node.parentNode.addChild(bling);
+      this.parentNode.addChild(bling);
     }
     bling.offsetY = 50;
     bling.FXWaitCue(config.wait);
@@ -2361,9 +2333,8 @@ var Render = function () {
   extend(Perp, Sprite);
 
   Perp.prototype.getCableTo = function (perpTo) {
-    var perp = this;
     var cable;
-    perp.cables.each(function (c) {
+    this.cables.each(function (c) {
       if (c.perpTo === perpTo) {
         cable = c;
       }
@@ -2512,7 +2483,6 @@ var Render = function () {
 
   // FIXME random placement, remove
   Perp.prototype.setRandomPosition = function (originPos) {
-    var node = this;
     var tries = 0;
     var originPos = originPos || { x: 1024, y: 800 };
     var randomPos = function (pos) {
@@ -2524,18 +2494,16 @@ var Render = function () {
     var testPos = this.useDragHandler.getCollisionPos(this, originPos);
     while (tries < 500 && testPos.coll === true) {
       testPos = randomPos(testPos);
-      if (node.placeParentRadius) {
-        testPos = node.testParentRadius(testPos, node.placeParentRadius);
+      if (this.placeParentRadius) {
+        testPos = this.testParentRadius(testPos, this.placeParentRadius);
       }
-      testPos.coll = this.useDragHandler.testCollisions(node, testPos);
+      testPos.coll = this.useDragHandler.testCollisions(this, testPos);
       tries += 1;
     }
     this.setPosition(testPos);
   };
 
   Perp.prototype.onAddInit = function () {
-    // Init stuff when added to a Parent Node
-    var node = this;
     if (this.draggable) {
       this.setDraggable(true);
     }
@@ -2543,7 +2511,7 @@ var Render = function () {
       this.setClickable(true);
     }
     if (this.placeRandom) {
-      node.setRandomPosition(this.placeRandom);
+      this.setRandomPosition(this.placeRandom);
     }
     this.updateRenderProp();
     this.draw();
@@ -2614,7 +2582,6 @@ var Render = function () {
   };
 
   Perp.prototype.FXDataOut = function (cb) {
-    var perp = this;
     var cables = this.getCablesToOrigin();
     // Set duration to FXDataIn Duration
     var duration = 500;
@@ -2707,8 +2674,7 @@ var Render = function () {
   };
 
   PerpSprite.prototype.updatePosition = function () {
-    var node = this;
-    node.setPosition({ x: node.parentNode.offsetX, y: node.parentNode.offsetY });
+    this.setPosition({ x: this.parentNode.offsetX, y: this.parentNode.offsetY });
   };
 
   /////////////////////////////
@@ -2816,7 +2782,6 @@ var Render = function () {
   DecoratorReady.prototype.decoType = 'DecoratorReady';
 
   DecoratorReady.prototype.onAddInit = function () {
-    var node = this;
     if (this.clickable) {
       this.setClickable(true);
     }
@@ -2973,7 +2938,6 @@ var Render = function () {
   DecoratorGear.prototype.draw = Decorator.prototype.draw;
 
   DecoratorGear.prototype.onAddInit = function () {
-    var node = this;
     if (this.decoratedNode.gameNode.data.is_supertoken !== true) {
       this.offsetToParent = {
         x: this.decoratedNode.width / 2 - 11,
@@ -3061,7 +3025,6 @@ var Render = function () {
   DecoratorTimer.prototype.decoType = 'DecoratorTimer';
 
   DecoratorTimer.prototype.onAddInit = function () {
-    var node = this;
     this.offsetToParent = {
       x: this.decoratedNode.width / 2 - 12,
       y: -(this.decoratedNode.height / 2 - 12),
@@ -3204,7 +3167,6 @@ var Render = function () {
   };
 
   DecoratorAmount.prototype.onAddInit = function () {
-    var node = this;
     this.offsetToParent = { x: 0, y: this.decoratedNode.height - this.decoratedNode.offsetY - 8 };
     this.updateRenderProp();
     this.draw();
@@ -3301,24 +3263,22 @@ var Render = function () {
     if (this.mode === 'inout') {
       offset = 4;
     }
-
-    var path = this;
     var p = this.getPoints();
-    path.domelem.width = path.width = Math.abs(p.p1.x - p.p5.x) + path.offsetX * 2;
-    path.domelem.height = path.height = Math.abs(p.p1.y - p.p5.y) + path.offsetY * 2;
+    this.domelem.width = this.width = Math.abs(p.p1.x - p.p5.x) + this.offsetX * 2;
+    this.domelem.height = this.height = Math.abs(p.p1.y - p.p5.y) + this.offsetY * 2;
     var cx = p.p1.x < p.p5.x ? p.p1.x : p.p5.x;
     var cy = p.p1.y < p.p5.y ? p.p1.y : p.p5.y;
 
     //path.setSize({width:this.width,height:this.height});
-    path.setTransform(path.getTransform());
+    this.setTransform(this.getTransform());
     //var modeoff = (this.mode === 'in') ? 0 : 6;
-    path.setPosition({ x: cx, y: cy });
-    var tension = path.tension;
-    var cableMaxLength = path.cableMaxLength;
-    var x = p.p1.x - cx + path.offsetX;
-    var y = p.p1.y - cy + path.offsetY;
-    var x2 = p.p5.x - cx + path.offsetX;
-    var y2 = p.p5.y - cy + path.offsetY;
+    this.setPosition({ x: cx, y: cy });
+    var tension = this.tension;
+    var cableMaxLength = this.cableMaxLength;
+    var x = p.p1.x - cx + this.offsetX;
+    var y = p.p1.y - cy + this.offsetY;
+    var x2 = p.p5.x - cx + this.offsetX;
+    var y2 = p.p5.y - cy + this.offsetY;
     //var xa = p.p2.x-cx;
     //var ya = p.p2.y-cy;
     //var xb = p.p3.x-cx;
@@ -3329,7 +3289,7 @@ var Render = function () {
     var dx = x2 - x,
       dy = y2 - y;
     var len = Math.sqrt(dx * dx + dy * dy);
-    path.length = len;
+    this.length = len;
     //tension = (Math.abs(x-p.p3.x)+Math.abs(y-p.p3.y))/len;
     var sinefreq = 360;
     var dxa = Math.abs(dx);
@@ -3349,7 +3309,7 @@ var Render = function () {
     var da = [seqs, 0];
     //var da = [seqs,0+(1-this.straightness)*10];
 
-    var ctx = path.domelem.getContext('2d');
+    var ctx = this.domelem.getContext('2d');
     var rot = Math.atan2(dy, dx);
     ctx.lineWidth = 6;
 
@@ -3521,47 +3481,41 @@ var Render = function () {
   };
 
   Cable.prototype.FXWobbleTension = function (tension) {
-    var cable = this;
     var duration = tension < 1 ? 300 : 500;
     //this.dataposIn=0;
     //this.dataposOut=0;
     // Cue Tweens like this!!! Finally got it to work;
-    return cable.FXSimpleCue({ tension: tension }, duration, 'easeOut');
+    return this.FXSimpleCue({ tension: tension }, duration, 'easeOut');
   };
 
   Cable.prototype.FXToggleConnect = function (progress) {
-    var cable = this;
     var duration = progress < 1 ? 200 : 800;
-    return cable.FXSimpleCue({ progress: progress }, duration, 'sineInOut');
+    return this.FXSimpleCue({ progress: progress }, duration, 'sineInOut');
   };
 
   Cable.prototype.FXStraighten = function (straightness) {
-    var cable = this;
     var easing = straightness === 1 ? 'easeOut' : 'linear';
     var duration = straightness === 1 ? 200 : 100;
     return this.FXSimpleCue({ straightness: straightness }, duration, easing);
   };
 
   Cable.prototype.FXConnect = function (cb) {
-    var cable = this;
-    cable.progress = 0;
-    cable.show();
+    this.progress = 0;
+    this.show();
     //cable.dataposIn=0;
     //return this.FXSimple({dataposIn:1,progress:1},1000,'sineInOut');
     return this.FXSimpleCue({ progress: 1 }, 1000, 'sineInOut', cb);
   };
 
   Cable.prototype.FXDisconnect = function (cb) {
-    var cable = this;
-    cable.progress = 1;
+    this.progress = 1;
     return this.FXSimpleCue({ progress: 0 }, 500, 'sineInOut', cb);
   };
 
   Cable.prototype.FXDataIn = function (cb) {
-    var cable = this;
-    var duration = cable.length * 2;
-    cable.FXSimpleCue({ dataposIn: 1 }, 0);
-    return cable.FXSimpleCue({ dataposIn: 0 }, duration, 'linear', cb);
+    var duration = this.length * 2;
+    this.FXSimpleCue({ dataposIn: 1 }, 0);
+    return this.FXSimpleCue({ dataposIn: 0 }, duration, 'linear', cb);
     //cable.dataposIn=1;
     //cable.tension=1;
     //return this.FXSimple({datapos:1},1000,'sineInOut',function(){
@@ -3596,10 +3550,9 @@ var Render = function () {
   };
 
   Cable.prototype.FXDataOut = function (cb) {
-    var cable = this;
-    var duration = cable.length * 2;
-    cable.FXSimpleCue({ dataposOut: 0 }, 0);
-    return cable.FXSimpleCue({ dataposOut: 1 }, duration, 'linear', cb);
+    var duration = this.length * 2;
+    this.FXSimpleCue({ dataposOut: 0 }, 0);
+    return this.FXSimpleCue({ dataposOut: 1 }, duration, 'linear', cb);
   };
 
   /////////////////////////////
@@ -3772,23 +3725,19 @@ var Render = function () {
   };
 
   ViewTab.prototype.FXShow = function () {
-    var node = this;
     //node.show();
-    node.jdomelem.addClass('active');
+    this.jdomelem.addClass('active');
   };
 
   ViewTab.prototype.FXHide = function () {
-    var node = this;
     //node.hide();
-    node.jdomelem.removeClass('active');
+    this.jdomelem.removeClass('active');
   };
 
   ViewTab.prototype.updateScroller = function () {
-    // FIXME: do something on resize?
-    var node = this;
     var stage = this.parentNode;
-    var scaleW = stage.width / node.width;
-    var scaleH = stage.height / node.height;
+    var scaleW = stage.width / this.width;
+    var scaleH = stage.height / this.height;
   };
 
   /////////////////////////////
@@ -3942,23 +3891,22 @@ var Render = function () {
   };
 
   ViewMap.prototype.updateScroller = function () {
-    var node = this;
     var stage = this.parentNode;
-    var scaleW = stage.width / node.width;
-    var scaleH = stage.height / node.height;
+    var scaleW = stage.width / this.width;
+    var scaleH = stage.height / this.height;
     var minZoom = scaleW > scaleH ? scaleW : scaleH;
     if (minZoom > 1) {
       minZoom = 1;
     }
-    node.scroller.options.minZoom = minZoom < 0.5 ? 0.5 : minZoom;
-    node.scroller.zoomTo(this.zoomScale);
-    node.scroller.setDimensions(
+    this.scroller.options.minZoom = minZoom < 0.5 ? 0.5 : minZoom;
+    this.scroller.zoomTo(this.zoomScale);
+    this.scroller.setDimensions(
       stage.width,
       stage.height,
-      node.getSize().width,
-      node.getSize().height
+      this.getSize().width,
+      this.getSize().height
     );
-    node._updateZoomButtonsState();
+    this._updateZoomButtonsState();
   };
 
   ViewMap.prototype.initScroller = function () {
@@ -4210,7 +4158,7 @@ var Render = function () {
         // continuous rather than stepped like the +/- buttons.
         var unit = e.deltaMode === 1 ? 16 : e.deltaMode === 2 ? 400 : 1;
         var delta = Math.max(-400, Math.min(400, e.deltaY * unit));
-        var factor = Math.pow(0.999, delta);
+        var factor = 0.999 ** delta;
         var opts = node.scroller.options;
         var base =
           node._wheelZoomTarget != null
@@ -4233,7 +4181,7 @@ var Render = function () {
   ViewMap.prototype.scrollTo = function (pos, dur) {
     var vpCenter = this.parentNode.getCenterPosition();
     dur = dur !== undefined ? dur : 300;
-    this.scroller.options.animating = dur > 0 ? true : false;
+    this.scroller.options.animating = dur > 0;
     this.scroller.options.animationDuration = dur;
     this.scroller.scrollTo(pos.x - vpCenter.x, pos.y - vpCenter.y, true);
     this.scroller.options.animating = false;
@@ -4268,29 +4216,25 @@ var Render = function () {
   };
 
   ViewMap.prototype.zoomIn = function () {
-    var node = this;
-    var zoomTo = node.zoomScale + 0.25 > 1 ? 1 : node.zoomScale + 0.25;
-    if (zoomTo === node.zoomScale) return;
-    node.scroller.zoomTo(zoomTo, true);
+    var zoomTo = this.zoomScale + 0.25 > 1 ? 1 : this.zoomScale + 0.25;
+    if (zoomTo === this.zoomScale) return;
+    this.scroller.zoomTo(zoomTo, true);
   };
 
   ViewMap.prototype.zoomOut = function () {
-    var node = this;
-    var zoomTo = node.zoomScale - 0.25 < 0.5 ? 0.5 : node.zoomScale - 0.25;
-    if (zoomTo === node.zoomScale) return;
-    node.scroller.zoomTo(zoomTo, true);
+    var zoomTo = this.zoomScale - 0.25 < 0.5 ? 0.5 : this.zoomScale - 0.25;
+    if (zoomTo === this.zoomScale) return;
+    this.scroller.zoomTo(zoomTo, true);
   };
 
   ViewMap.prototype.FXShow = function () {
-    var node = this;
     //node.show();
-    node.jdomelem.addClass('active');
+    this.jdomelem.addClass('active');
   };
 
   ViewMap.prototype.FXHide = function () {
-    var node = this;
     //node.hide();
-    node.jdomelem.removeClass('active');
+    this.jdomelem.removeClass('active');
   };
 
   /////////////////////////////
@@ -4358,8 +4302,7 @@ var Render = function () {
       width: this.width + 'px',
       height: this.height + 'px',
     });
-    var stage = this;
-    stage.children.each(function (node) {
+    this.children.each(function (node) {
       if (node.scroller) {
         node.updateScroller();
       }
@@ -4389,7 +4332,6 @@ var Render = function () {
 
     // Setup Button Events
     var GameRoot = this.gameNode.GameRoot;
-    var menu = this;
     this.jdomelem.on('click touchend', '#LocaleToggle:not(.disabled)', function (e) {
       e.stopPropagation();
       e.preventDefault();
@@ -4419,15 +4361,13 @@ var Render = function () {
   };
 
   MainMenu.prototype.lock = function () {
-    var node = this;
-    node.jdomelem.addClass('locked');
-    node.jdomelem.find('.UserButton, .MainMenuButton').addClass('disabled');
+    this.jdomelem.addClass('locked');
+    this.jdomelem.find('.UserButton, .MainMenuButton').addClass('disabled');
   };
 
   MainMenu.prototype.unlock = function () {
-    var node = this;
-    node.jdomelem.removeClass('locked');
-    node.jdomelem.find('.UserButton, .MainMenuButton').removeClass('disabled');
+    this.jdomelem.removeClass('locked');
+    this.jdomelem.find('.UserButton, .MainMenuButton').removeClass('disabled');
   };
 
   MainMenu.prototype.addButton = function (text, id, states) {
@@ -4473,7 +4413,6 @@ var Render = function () {
 
   var Statusbar = function (config) {
     config = config || {};
-    var node = this;
     this._id = _instances.length;
     this.jdomelem = $("<div class='Statusbar'></div>");
     this.domelem = this.jdomelem[0];
@@ -4677,7 +4616,6 @@ var Render = function () {
 
   var StatusItem = function (config) {
     config = config || {};
-    var node = this;
     this._id = _instances.length;
     this.jdomelem = $("<div class='StatusItem'></div>");
     this.frameSrc = config.frameSrc || 'MainSprites.png';
@@ -4829,7 +4767,6 @@ var Render = function () {
     config = config || {};
 
     this.open = true;
-    var node = this;
     this._id = _instances.length;
     this.jdomelem = $("<div class='Popup'></div>");
     this.domelem = this.jdomelem[0];
@@ -4851,6 +4788,7 @@ var Render = function () {
     if (tdata.data && tdata.data.popup_sprite && !tdata.data.popup_sprite.html) {
       tdata.data.popup_sprite.html = RenderSprite(tdata.data.popup_sprite);
     }
+    // biome-ignore lint/correctness/noSelfAssign: legacy no-op, kept to avoid accidental removal of the property
     tdata.button = tdata.button;
 
     if (this.popupContainer && this.extendClass) {
@@ -4980,10 +4918,10 @@ var Render = function () {
         e.preventDefault();
         var spop = $(this).parents('.Subpop[data-subpop-id="buyslots"]');
         var button = spop.find('.Button[data-button-id="PowerupBuySlotsButton"]');
-        var num = parseInt(button.attr('data-button-data'));
-        var left = parseInt(spop.find('.BuySlotsNumLeft').text());
+        var num = Number.parseInt(button.attr('data-button-data'));
+        var left = Number.parseInt(spop.find('.BuySlotsNumLeft').text());
         var jprice = spop.find('.SlotCost');
-        var price = parseInt(jprice.attr('data-slot-cost'));
+        var price = Number.parseInt(jprice.attr('data-slot-cost'));
         var max_slots = left;
         num = num + 1 > max_slots ? num : num + 1;
         price = price * num;
@@ -5002,9 +4940,9 @@ var Render = function () {
         e.preventDefault();
         var spop = $(this).parents('.Subpop[data-subpop-id="buyslots"]');
         var button = spop.find('.Button[data-button-id="PowerupBuySlotsButton"]');
-        var num = parseInt(button.attr('data-button-data'));
+        var num = Number.parseInt(button.attr('data-button-data'));
         var jprice = spop.find('.SlotCost');
-        var price = parseInt(jprice.attr('data-slot-cost'));
+        var price = Number.parseInt(jprice.attr('data-slot-cost'));
         num = num - 1 < 1 ? 1 : num - 1;
         price = price * num;
         jprice.text(_.toKSNum(price));
@@ -5122,7 +5060,7 @@ var Render = function () {
         var next = Pagination.find('.PopupPageArrowR');
         var prev = Pagination.find('.PopupPageArrowL');
         var active = Pages.filter(':not(.hidden)');
-        var index = parseInt(active.attr('data-page-id'));
+        var index = Number.parseInt(active.attr('data-page-id'));
         Pages.addClass('hidden');
         if (dir_next) {
           index = index + 1;
@@ -5195,7 +5133,6 @@ var Render = function () {
   };
 
   Popup.prototype.renderDataTab = function () {
-    var node = this;
     var htmlPS = app.renderView('profileset.html', this.templateData);
     var htmlButt = app.renderView('buttons_project.html', this.templateData);
     this.jdomelem.find('.PopupTab.data').empty().append(htmlPS).append(htmlButt);
@@ -5205,17 +5142,16 @@ var Render = function () {
     if (!pkey) {
       return;
     }
-    var node = this;
     var pcat = this.templateData.data.powerups_compiled[pkey];
     var html = app.renderView('selector_powerups.html', {
-      D: node.templateData.data,
-      game_values: node.templateData.game_values,
+      D: this.templateData.data,
+      game_values: this.templateData.game_values,
       pcat: pcat,
-      data: node.templateData.data,
+      data: this.templateData.data,
       typelower: pcat.typelower,
       pkey: pkey,
     });
-    var jtab = node.jdomelem.find('.PopupTab.Powerups[data-tab="' + pkey + '"]');
+    var jtab = this.jdomelem.find('.PopupTab.Powerups[data-tab="' + pkey + '"]');
     jtab.find('.Subpop.InSelector').remove();
     jtab.find('.Subpop.Selector').remove();
     jtab.find('.SubpopContainer').append(html);
@@ -5411,8 +5347,6 @@ var Render = function () {
   extend(MissionPerp, Node);
 
   MissionPerp.prototype.onAddInit = function () {
-    // Init stuff when added to a Parent Node
-    var node = this;
     if (this.clickable) {
       this.setClickable(true);
     }
@@ -5501,8 +5435,6 @@ var Render = function () {
   extend(TopscorePerp, Node);
 
   TopscorePerp.prototype.onAddInit = function () {
-    // Init stuff when added to a Parent Node
-    var node = this;
     if (this.clickable) {
       this.setClickable(true);
     }

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -5,11 +5,11 @@
 // loaded as plain `<script>` tags in index.html before this bundle
 // runs.
 
-import setup from './setup.js';
-import i18n from './i18n.js';
-import LocalEngine from './LocalEngine.js';
 import { getGame } from './Game.js';
+import LocalEngine from './LocalEngine.js';
 import { getRender } from './Render.js';
+import i18n from './i18n.js';
+import setup from './setup.js';
 
 // All view sources are inlined at bundle time; templates are compiled
 // the first (and only) time the Application factory runs, when
@@ -152,11 +152,11 @@ const Application = function () {
     renderView: app.renderView,
     pad0: function (number, length) {
       // Fastest implementation according to http://jsperf.com/ways-to-0-pad-a-number
-      const N = Math.pow(10, length);
+      const N = 10 ** length;
       return number < N ? ('' + (N + number)).slice(1) : '' + number;
     },
     crlf2html: function (str) {
-      return String(str || '').replace(new RegExp('\r?\n|\r', 'g'), '<br>');
+      return String(str || '').replace(/\r?\n|\r/g, '<br>');
     },
     toKSNum: function (number) {
       // To activate german language set:

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -33,8 +33,7 @@ function compileTemplates() {
   return out;
 }
 
-const Application = function() {
-
+const Application = function () {
   const _ = globalThis._;
   const $ = globalThis.jQuery || globalThis.$;
   const numeral = globalThis.numeral;
@@ -48,12 +47,12 @@ const Application = function() {
   // Templates are pre-compiled at bundle time; loadViews is retained as
   // an immediately-resolved Deferred so callers (bootstrap.continueStart,
   // any Game-internal reset path) keep their `.then(...)` chains.
-  app.loadViews = function() {
+  app.loadViews = function () {
     return $.when();
   };
 
   // A nice wrapper for rendering underscore templates.
-  app.renderView = function(viewName, data) {
+  app.renderView = function (viewName, data) {
     const view = templates[viewName];
     if (!view) {
       console.warn('Could not render view “%s”: not bundled', viewName);
@@ -72,17 +71,17 @@ const Application = function() {
   // Promise.
   const INTERNAL_API = { setEmitter: 1, setSendDelta: 1, setPrngSeed: 1 };
   app.remote = {};
-  Object.keys(LocalEngine).forEach(function(name) {
+  Object.keys(LocalEngine).forEach(function (name) {
     if (INTERNAL_API[name]) return;
     const fn = LocalEngine[name];
     if (typeof fn !== 'function') return;
-    app.remote[name] = function() {
+    app.remote[name] = function () {
       return $.when(fn.apply(LocalEngine, arguments));
     };
   });
 
-  app.start = function() {
-    LocalEngine.setEmitter(function(ev, pl) {
+  app.start = function () {
+    LocalEngine.setEmitter(function (ev, pl) {
       $(document).trigger(ev, [pl]);
     });
 
@@ -93,25 +92,25 @@ const Application = function() {
     // but no per-perp gnode listener (which lives on gnode.jq = $(this),
     // not on document) ever fires — the timer decorator stays put and
     // the collect icon never appears.
-    $(document).on('node_ready', function(e, pl) {
+    $(document).on('node_ready', function (e, pl) {
       if (!app.game || !pl || !pl.id) return;
       const gnode = app.game.getById(pl.id);
       if (gnode) gnode.trigger('node_ready', [pl.result]);
     });
-    $(document).on('new_items', function(e, pl) {
+    $(document).on('new_items', function (e, pl) {
       if (!app.game) return;
       app.game.trigger('new_items', [pl]);
     });
 
     $('#loadertext').text('Loading saved game');
-    return app.remote.getSessionLocale().then(function(data) {
+    return app.remote.getSessionLocale().then(function (data) {
       const locale = data.result === 'de' ? 'de_AT' : 'en_US';
       i18n.setLocale(locale);
       // type_settings runs gettext at module load — must wait for the
       // locale JSON before requiring Game.
       $('#loadertext').text('Loading translations');
-      return i18n.ready().then(function() {
-        return app.remote.loadGame().then(function(data) {
+      return i18n.ready().then(function () {
+        return app.remote.loadGame().then(function (data) {
           const html = app.renderView('game.html');
           $('#dd-control').html(html);
           const Game = getGame();
@@ -137,40 +136,48 @@ const Application = function() {
 
   // Extending Underscore with some helpers for easier templating.
   _.mixin({
-    mixindone: function() { return true; },
-    game: function() {
+    mixindone: function () {
+      return true;
+    },
+    game: function () {
       // FIXME: only expose certain functions to _
-      if (app.game) { return app.game; }
-      else { return {}; }
+      if (app.game) {
+        return app.game;
+      } else {
+        return {};
+      }
     },
     numeral: numeral,
     sprintf: window.sprintf,
     renderView: app.renderView,
-    pad0: function(number, length) {
+    pad0: function (number, length) {
       // Fastest implementation according to http://jsperf.com/ways-to-0-pad-a-number
       const N = Math.pow(10, length);
       return number < N ? ('' + (N + number)).slice(1) : '' + number;
     },
-    crlf2html: function(str) {
+    crlf2html: function (str) {
       return String(str || '').replace(new RegExp('\r?\n|\r', 'g'), '<br>');
     },
-    toKSNum: function(number) {
+    toKSNum: function (number) {
       // To activate german language set:
       //_.numeral.language('de-de');  // load vendor/numeral-de.js first
       return _.numeral(number).format('0,0');
     },
-    toTime: function(ms) {
+    toTime: function (ms) {
       const date = new Date(ms || 0);
       if (ms >= 3600000) {
-        return _.pad0(date.getUTCHours(), 2) + ':' +
-               _.pad0(date.getUTCMinutes(), 2) + ':' +
-               _.pad0(date.getUTCSeconds(), 2);
+        return (
+          _.pad0(date.getUTCHours(), 2) +
+          ':' +
+          _.pad0(date.getUTCMinutes(), 2) +
+          ':' +
+          _.pad0(date.getUTCSeconds(), 2)
+        );
       } else {
-        return _.pad0(date.getUTCMinutes(), 2) + ':' +
-               _.pad0(date.getUTCSeconds(), 2);
+        return _.pad0(date.getUTCMinutes(), 2) + ':' + _.pad0(date.getUTCSeconds(), 2);
       }
     },
-    span: function(text, CSSClass) {
+    span: function (text, CSSClass) {
       CSSClass = CSSClass || 'highlight';
       return '<span class="' + CSSClass + '">' + text + '</span>';
     },
@@ -178,12 +185,14 @@ const Application = function() {
     __: i18n.ngettext,
   });
 
-
-  $(function() {
+  $(function () {
     // Inject a new style element to define our main sprite image.
     // FIXME: This needs to be modified for retrieving the image path from the back-end.
-    $('head').append($('<style type="text/css">')
-        .html('.RenderSprite {background-image: url(img/MainSprites.png);}'));
+    $('head').append(
+      $('<style type="text/css">').html(
+        '.RenderSprite {background-image: url(img/MainSprites.png);}'
+      )
+    );
   });
 
   return app;

--- a/scripts/boot.js
+++ b/scripts/boot.js
@@ -26,7 +26,7 @@
 // The underlying state logic (freshState / applyDelta) is fully unit-tested in
 // tests/state/state.test.js.
 
-import { freshState, applyDelta } from './state.js';
+import { applyDelta, freshState } from './state.js';
 
 var _currentState = null;
 var _bootPromise = null;

--- a/scripts/boot.js
+++ b/scripts/boot.js
@@ -29,7 +29,7 @@
 import { freshState, applyDelta } from './state.js';
 
 var _currentState = null;
-var _bootPromise  = null;
+var _bootPromise = null;
 
 // Subscribers notified whenever applyDelta produces a new state.peers
 // reference.  Used by the Topscores view to refresh the leaderboard
@@ -60,9 +60,12 @@ export function boot(options) {
   if (_bootPromise) return _bootPromise;
   options = options || {};
 
-  var selfAddr = options.selfAddr != null
-    ? options.selfAddr
-    : (typeof webxdc !== 'undefined' ? webxdc.selfAddr : '');  // eslint-disable-line no-undef
+  var selfAddr =
+    options.selfAddr != null
+      ? options.selfAddr
+      : typeof webxdc !== 'undefined'
+        ? webxdc.selfAddr
+        : ''; // eslint-disable-line no-undef
 
   // selfAddr MUST be set before the listener is registered.  applyDelta's
   // addr guard rejects any delta whose addr differs from state.addr, including
@@ -80,13 +83,16 @@ export function boot(options) {
       if (_currentState && _currentState.peers !== prevPeers) {
         _notifyPeersChanged();
       }
-      var s = (typeof update.serial     === 'number') ? update.serial     : 0;
-      var m = (typeof update.max_serial === 'number') ? update.max_serial : s;
-      if (s > _replayProgress.serial)     _replayProgress.serial     = s;
+      var s = typeof update.serial === 'number' ? update.serial : 0;
+      var m = typeof update.max_serial === 'number' ? update.max_serial : s;
+      if (s > _replayProgress.serial) _replayProgress.serial = s;
       if (m > _replayProgress.max_serial) _replayProgress.max_serial = m;
       if (typeof options.onReplayProgress === 'function') {
-        try { options.onReplayProgress(_replayProgress.serial, _replayProgress.max_serial); }
-        catch (_) { /* never let the UI hook break replay */ }
+        try {
+          options.onReplayProgress(_replayProgress.serial, _replayProgress.max_serial);
+        } catch (_) {
+          /* never let the UI hook break replay */
+        }
       }
     }, 0);
   }
@@ -120,9 +126,9 @@ export function getBootPromise() {
  */
 export function getReplayProgress() {
   return {
-    serial:     _replayProgress.serial,
+    serial: _replayProgress.serial,
     max_serial: _replayProgress.max_serial,
-    done:       _replayProgress.done
+    done: _replayProgress.done,
   };
 }
 
@@ -171,7 +177,10 @@ export function subscribePeersChanged(fn) {
 
 function _notifyPeersChanged() {
   for (var i = 0; i < _peersChangedSubs.length; i++) {
-    try { _peersChangedSubs[i](_currentState); }
-    catch (_) { /* never let one subscriber break the listener */ }
+    try {
+      _peersChangedSubs[i](_currentState);
+    } catch (_) {
+      /* never let one subscriber break the listener */
+    }
   }
 }

--- a/scripts/bootstrap.js
+++ b/scripts/bootstrap.js
@@ -41,22 +41,28 @@ if (typeof window !== 'undefined' && typeof document !== 'undefined') {
     const detail = (err && err.message) || String(err || '');
     $('#loadertext').html(
       'Sorry, the Game failed to start.<br>' +
-      '<small style="opacity:.7">' + message + (detail ? ': ' + detail : '') + '</small>'
+        '<small style="opacity:.7">' +
+        message +
+        (detail ? ': ' + detail : '') +
+        '</small>'
     );
   };
 
   const continueStart = () => {
     clearInterval(progressTimer);
-    app.loadViews().then(() => {
-      console.info('Starting Game');
-      try {
-        app.start().fail(function () {
-          showFatal('app.start rejected', arguments.length ? arguments[0] : null);
-        });
-      } catch (err) {
-        showFatal('app.start threw', err);
-      }
-    }, (err) => showFatal('app.loadViews rejected', err));
+    app.loadViews().then(
+      () => {
+        console.info('Starting Game');
+        try {
+          app.start().fail(function () {
+            showFatal('app.start rejected', arguments.length ? arguments[0] : null);
+          });
+        } catch (err) {
+          showFatal('app.start threw', err);
+        }
+      },
+      (err) => showFatal('app.loadViews rejected', err)
+    );
   };
 
   const bootPromise = getBootPromise();

--- a/scripts/devtools.js
+++ b/scripts/devtools.js
@@ -12,7 +12,7 @@
 //   window.__dd.getZoom();                          // current zoom of active ViewMap
 //   window.__dd.setZoom(0.6);                       // jump zoom (no animation)
 
-import { setOverride, clearOverride, advance } from './clock.js';
+import { advance, clearOverride, setOverride } from './clock.js';
 
 if (
   typeof window !== 'undefined' &&

--- a/scripts/devtools.js
+++ b/scripts/devtools.js
@@ -28,8 +28,8 @@ if (
     return (view && view.renderNode) || null;
   };
   window.__dd = {
-    setNow:          setOverride,
-    advanceNow:      advance,
+    setNow: setOverride,
+    advanceNow: advance,
     clearNowOverride: clearOverride,
     // Test hooks for the zoom-controls e2e spec — read from / write to the
     // active ViewMap's scroller without exposing the whole app surface.

--- a/scripts/esm-entry.js
+++ b/scripts/esm-entry.js
@@ -25,7 +25,8 @@ if (typeof window !== 'undefined') {
       const resolved = deps.map(lookup);
       if (cb) cb(...resolved);
     } catch (e) {
-      if (errCb) errCb(e); else throw e;
+      if (errCb) errCb(e);
+      else throw e;
     }
   };
 }

--- a/scripts/esm-entry.js
+++ b/scripts/esm-entry.js
@@ -4,9 +4,9 @@
 // `<script>` tags.  All the wiring (boot kick-off, UI hand-off,
 // devtools hooks) lives in the modules imported here as side effects.
 
-import * as bootMod from './boot.js';
 import LocalEngine from './LocalEngine.js';
 import appModule from './app.js';
+import * as bootMod from './boot.js';
 import './devtools.js';
 
 // Test-only shim: the playwright specs reach into engine internals

--- a/scripts/i18n.js
+++ b/scripts/i18n.js
@@ -9,9 +9,9 @@
 // helpers (registered as mixins by app.js), so those calls read `_` from
 // globalThis at call time — long after vendor/underscore.js has loaded.
 
-import setup from './setup.js';
 import deAT from '../i18n/de_AT.json' with { type: 'json' };
 import enUS from '../i18n/en_US.json' with { type: 'json' };
+import setup from './setup.js';
 
 let locale = 'en_US';
 

--- a/scripts/materializer.ts
+++ b/scripts/materializer.ts
@@ -109,7 +109,9 @@ export function materialize(state: LocalState, now: number): MaterializeResult {
 
   // Emit events in temporal order (earliest charge_end first) so Game.js
   // handlers light up the UI as if the player had been watching live.
-  newlyReady.sort(function(a, b) { return a.charge_end - b.charge_end; });
+  newlyReady.sort(function (a, b) {
+    return a.charge_end - b.charge_end;
+  });
 
   for (var k = 0; k < newlyReady.length; k++) {
     var entry = newlyReady[k];
@@ -122,11 +124,11 @@ export function materialize(state: LocalState, now: number): MaterializeResult {
     events.push({
       ev: 'node_ready',
       pl: {
-        id:     entry.game_id,
-        type:   entry.game_type,
-        path:   entry.path,
-        result: entry.result
-      }
+        id: entry.game_id,
+        type: entry.game_type,
+        path: entry.path,
+        result: entry.result,
+      },
     });
   }
 
@@ -137,20 +139,20 @@ export function materialize(state: LocalState, now: number): MaterializeResult {
   var gv: GameValues = state.game_values || {};
   var newGv: GameValues = Object.assign({}, gv);
   if (
-    typeof gv.ap_snapshot     === 'number' &&
-    typeof gv.ap_inc_value    === 'number' &&
+    typeof gv.ap_snapshot === 'number' &&
+    typeof gv.ap_inc_value === 'number' &&
     typeof gv.ap_inc_interval === 'number' &&
-    gv.ap_inc_interval > 0                 &&
-    typeof gv.ap_max          === 'number'
+    gv.ap_inc_interval > 0 &&
+    typeof gv.ap_max === 'number'
   ) {
     // Lazy-init: when ap_update is null/undefined (e.g. fresh game), start
     // the regen clock at `now` so the next materialize-after-elapsed-time
     // can tick. Without this, ap_update stays null forever and regen never
     // runs, so APs added in-memory by Game.js APTicker reset to ap_snapshot
     // on every reload.
-    var apUpdate = (typeof gv.ap_update === 'number') ? gv.ap_update : now;
-    var elapsed  = Math.max(0, now - apUpdate);
-    var ticks    = Math.floor(elapsed / gv.ap_inc_interval);
+    var apUpdate = typeof gv.ap_update === 'number' ? gv.ap_update : now;
+    var elapsed = Math.max(0, now - apUpdate);
+    var ticks = Math.floor(elapsed / gv.ap_inc_interval);
     newGv = Object.assign({}, gv, {
       ap_snapshot: Math.min(gv.ap_max, gv.ap_snapshot + ticks * gv.ap_inc_value),
       // Advance ap_update only to the last full-tick boundary so the
@@ -171,9 +173,9 @@ export function materialize(state: LocalState, now: number): MaterializeResult {
   return {
     state: Object.assign({}, state, {
       nodes_charging: stillCharging,
-      nodes_collect:  collect,
-      game_values:    newGv
+      nodes_collect: collect,
+      game_values: newGv,
     }),
-    events: events
+    events: events,
   };
 }

--- a/scripts/materializer.ts
+++ b/scripts/materializer.ts
@@ -5,7 +5,7 @@
 //
 // Source authority for each rule: docs/async-map.md.
 
-import type { LocalState, ChargingEntry, CollectEntry, GameValues } from './state.js';
+import type { ChargingEntry, CollectEntry, GameValues, LocalState } from './state.js';
 
 // ---------------------------------------------------------------------------
 // Types

--- a/scripts/state.ts
+++ b/scripts/state.ts
@@ -716,7 +716,8 @@ function _applyPeerDelta(state: LocalState, delta: Delta): LocalState {
   var existing: PeerEntry = peers[addr] || {};
 
   // Stale-delta guard: skip if this delta is older than the last we recorded.
-  var prevTs = typeof existing.last_seen_ts === 'number' ? existing.last_seen_ts : -Infinity;
+  var prevTs =
+    typeof existing.last_seen_ts === 'number' ? existing.last_seen_ts : Number.NEGATIVE_INFINITY;
   if (typeof delta.ts === 'number' && delta.ts < prevTs) return state;
 
   var peer: PeerEntry = Object.assign({}, existing);

--- a/scripts/state.ts
+++ b/scripts/state.ts
@@ -238,7 +238,7 @@ var OP_NAMES = [
  *   integrated_ids  — set of collect_ids already processed by integrateCollected
  */
 export function freshState(selfAddr?: string, seed?: GameSeed): LocalState {
-  var src: GameSeed = (seed || _defaultSeed) || {};
+  var src: GameSeed = seed || _defaultSeed || {};
   var gv: GameValues = Object.assign(
     {
       xp_value: 0,
@@ -293,7 +293,6 @@ export function freshState(selfAddr?: string, seed?: GameSeed): LocalState {
 export function seedNewGame(state: LocalState): LocalState {
   return state;
 }
-
 
 function _seedNodesFromTree(src: GameSeed): GameNode[] {
   var out: GameNode[] = [];
@@ -351,16 +350,24 @@ var reducers: Record<string, Reducer> = {};
 // progression handler shipped them under .missions.mission_data. Returns
 // pass-through values when the delta has no mission update so reducers can
 // always spread the result without a conditional.
-function _missionDataFromResult(state: LocalState, r: any): { mission_goals: MissionGoal[]; active_missions: string[] } {
+function _missionDataFromResult(
+  state: LocalState,
+  r: any
+): { mission_goals: MissionGoal[]; active_missions: string[] } {
   var md = r && r.missions && r.missions.mission_data;
   return {
     mission_goals: (md && md.mission_goals) || state.mission_goals,
-    active_missions: (md && md.active_missions) || state.active_missions
+    active_missions: (md && md.active_missions) || state.active_missions,
   };
 }
 
-function _filterByPath(arr: Array<{ path: string }> | undefined, path: string): Array<{ path: string }> {
-  return (arr || []).filter(function (e) { return e.path !== path; });
+function _filterByPath(
+  arr: Array<{ path: string }> | undefined,
+  path: string
+): Array<{ path: string }> {
+  return (arr || []).filter(function (e) {
+    return e.path !== path;
+  });
 }
 
 reducers.setDisplayName = function setDisplayNameReducer(state, delta) {
@@ -388,7 +395,7 @@ reducers.setPerpCoordinates = function setPerpCoordinatesReducer(state, delta) {
     var entry = updates[i];
     if (!Array.isArray(entry) || entry.length < 2) continue;
     var path = entry[0];
-    var pos  = entry[1];
+    var pos = entry[1];
     if (typeof path !== 'string' || !pos || typeof pos !== 'object') continue;
     coordMap[path] = pos;
   }
@@ -397,7 +404,7 @@ reducers.setPerpCoordinates = function setPerpCoordinatesReducer(state, delta) {
     var pos = coordMap[node.full_path];
     if (!pos) return node;
     return Object.assign({}, node, {
-      instance_data: Object.assign({}, node.instance_data, { x: pos.x, y: pos.y })
+      instance_data: Object.assign({}, node.instance_data, { x: pos.x, y: pos.y }),
     });
   });
 
@@ -408,7 +415,7 @@ reducers.buyKarma = function buyKarmaReducer(state, delta) {
   var gv = delta.result && delta.result.game_values;
   if (!gv) return state;
   return Object.assign({}, state, {
-    game_values: Object.assign({}, state.game_values, gv)
+    game_values: Object.assign({}, state.game_values, gv),
   });
 };
 
@@ -427,16 +434,16 @@ function _nodeGvReducer(state: LocalState, delta: Delta): LocalState {
 
   var mp = _missionDataFromResult(state, res);
   return Object.assign({}, state, {
-    nodes:           newNodes,
-    game_values:     Object.assign({}, state.game_values, res.game_values || {}),
-    mission_goals:   mp.mission_goals,
+    nodes: newNodes,
+    game_values: Object.assign({}, state.game_values, res.game_values || {}),
+    mission_goals: mp.mission_goals,
     active_missions: mp.active_missions,
   });
 }
 
-reducers.buyPowerup  = _nodeGvReducer;
+reducers.buyPowerup = _nodeGvReducer;
 reducers.sellPowerup = _nodeGvReducer;
-reducers.buySlots    = _nodeGvReducer;
+reducers.buySlots = _nodeGvReducer;
 
 // 'buyPerp' replays the state mutations committed by the LocalEngine handler.
 // The delta result carries the full post-mutation values so replay is exact.
@@ -450,7 +457,9 @@ reducers.buyPerp = function buyPerpReducer(state, delta) {
 
   // Guard against double-apply on replay.
   var nodes = (state.nodes || []).slice();
-  var alreadyPresent = nodes.some(function (n) { return n.full_path === newNode.full_path; });
+  var alreadyPresent = nodes.some(function (n) {
+    return n.full_path === newNode.full_path;
+  });
   if (!alreadyPresent) {
     nodes = nodes.concat([newNode]);
   }
@@ -458,13 +467,17 @@ reducers.buyPerp = function buyPerpReducer(state, delta) {
   var dbQueue = (state.db_queue || []).slice();
   if (r.profile_set) {
     var ps = r.profile_set;
-    var inQueue = dbQueue.some(function (q) { return q.collect_id === ps.collect_id; });
+    var inQueue = dbQueue.some(function (q) {
+      return q.collect_id === ps.collect_id;
+    });
     if (!inQueue) {
-      dbQueue = dbQueue.concat([{
-        origin: ps.origin,
-        collect_id: ps.collect_id,
-        profile_set: ps.profile_set
-      }]);
+      dbQueue = dbQueue.concat([
+        {
+          origin: ps.origin,
+          collect_id: ps.collect_id,
+          profile_set: ps.profile_set,
+        },
+      ]);
     }
   }
 
@@ -473,9 +486,7 @@ reducers.buyPerp = function buyPerpReducer(state, delta) {
   // Snapshot pattern: the handler emits the post-mutation node_counter in
   // r.node_counter so listener echo is idempotent. Fallback to incremental
   // for legacy pre-fix deltas (one buyPerp creates exactly one node).
-  var counter = (typeof r.node_counter === 'number')
-    ? r.node_counter
-    : (state.node_counter || 0) + 1;
+  var counter = typeof r.node_counter === 'number' ? r.node_counter : (state.node_counter || 0) + 1;
 
   return Object.assign({}, state, {
     nodes: nodes,
@@ -483,26 +494,26 @@ reducers.buyPerp = function buyPerpReducer(state, delta) {
     game_values: r.game_values || state.game_values,
     mission_goals: mp.mission_goals,
     active_missions: mp.active_missions,
-    node_counter: counter
+    node_counter: counter,
   });
 };
 
 reducers.chargePerp = function chargePerpReducer(state, delta) {
-  var r           = delta.result || {};
+  var r = delta.result || {};
   var chargeEntry = r.chargeEntry;
   if (!chargeEntry || !chargeEntry.path) return state;
 
   // Key by path, not positional index: cold-start replay can reorder
   // state.nodes between the handler and the reducer, so a stale index
   // would charge the wrong perp.
-  var path     = chargeEntry.path;
-  var nodes    = state.nodes || [];
-  var newNodes = nodes.map(function(n) {
+  var path = chargeEntry.path;
+  var nodes = state.nodes || [];
+  var newNodes = nodes.map(function (n) {
     if (n.full_path !== path) return n;
     return Object.assign({}, n, {
       instance_data: Object.assign({}, n.instance_data, {
-        charge_start: chargeEntry.charge_start
-      })
+        charge_start: chargeEntry.charge_start,
+      }),
     });
   });
 
@@ -512,27 +523,27 @@ reducers.chargePerp = function chargePerpReducer(state, delta) {
   // game_values in r.game_values; applying it via Object.assign is idempotent
   // under self-echo. The incremental form below remains as a fallback for
   // already-persisted pre-fix deltas so they still replay correctly.
-  var gv    = state.game_values || {};
+  var gv = state.game_values || {};
   var newGv: GameValues;
   if (r.game_values) {
     newGv = Object.assign({}, gv, r.game_values);
   } else {
     var cashDelta = typeof r.cashDelta === 'number' ? r.cashDelta : 0;
-    var xpInc     = typeof r.xpInc    === 'number' ? r.xpInc    : 0;
+    var xpInc = typeof r.xpInc === 'number' ? r.xpInc : 0;
     newGv = Object.assign({}, gv, {
-      cash_value:  (gv.cash_value  || 0) - cashDelta,
-      cash_spent:  (gv.cash_spent  || 0) + cashDelta,
-      xp_value:    (gv.xp_value   || 0) + xpInc,
+      cash_value: (gv.cash_value || 0) - cashDelta,
+      cash_spent: (gv.cash_spent || 0) + cashDelta,
+      xp_value: (gv.xp_value || 0) + xpInc,
       ap_snapshot: Math.max(0, (gv.ap_snapshot || 0) - 1),
     });
   }
 
   var mp = _missionDataFromResult(state, r);
   return Object.assign({}, state, {
-    nodes:           newNodes,
-    nodes_charging:  stillCharging.concat([chargeEntry]),
-    game_values:     newGv,
-    mission_goals:   mp.mission_goals,
+    nodes: newNodes,
+    nodes_charging: stillCharging.concat([chargeEntry]),
+    game_values: newGv,
+    mission_goals: mp.mission_goals,
     active_missions: mp.active_missions,
   });
 };
@@ -556,7 +567,9 @@ reducers.collectPerp = function collectPerpReducer(state, delta) {
 
   var newQueue: DbQueueEntry[] = state.db_queue || [];
   if (r.db_entry) {
-    var inQueue = newQueue.some(function (q) { return q.collect_id === r.db_entry.collect_id; });
+    var inQueue = newQueue.some(function (q) {
+      return q.collect_id === r.db_entry.collect_id;
+    });
     if (!inQueue) newQueue = newQueue.concat([r.db_entry]);
   }
 
@@ -565,20 +578,20 @@ reducers.collectPerp = function collectPerpReducer(state, delta) {
     newNodes = state.nodes.map(function (n) {
       if (n.full_path !== r.token_update.path) return n;
       return Object.assign({}, n, {
-        instance_data: Object.assign({}, n.instance_data, { amount: r.token_update.amount })
+        instance_data: Object.assign({}, n.instance_data, { amount: r.token_update.amount }),
       });
     });
   }
 
   var mp = _missionDataFromResult(state, r);
   return Object.assign({}, state, {
-    nodes_collect:  newCollect,
+    nodes_collect: newCollect,
     nodes_charging: newCharging,
-    game_values:    newGv,
-    db_queue:       newQueue,
-    nodes:          newNodes,
-    mission_goals:  mp.mission_goals,
-    active_missions: mp.active_missions
+    game_values: newGv,
+    db_queue: newQueue,
+    nodes: newNodes,
+    mission_goals: mp.mission_goals,
+    active_missions: mp.active_missions,
   });
 };
 
@@ -602,7 +615,9 @@ reducers.integrateCollected = function integrateCollectedReducer(state, delta) {
   if (r.nodes && r.nodes.length) {
     var existingPaths: Record<string, boolean> = {};
     var updMap: Record<string, any> = {};
-    r.nodes.forEach(function (u: any) { updMap[u.full_path] = u; });
+    r.nodes.forEach(function (u: any) {
+      updMap[u.full_path] = u;
+    });
     newNodes = state.nodes.map(function (n) {
       existingPaths[n.full_path] = true;
       var u = updMap[n.full_path];
@@ -611,25 +626,27 @@ reducers.integrateCollected = function integrateCollectedReducer(state, delta) {
     // Append fresh TokenPerp nodes (first-time integration of a token type).
     r.nodes.forEach(function (u: any) {
       if (existingPaths[u.full_path]) return;
-      newNodes = newNodes.concat([{
-        game_id:       u.game_id,
-        gestalt:       u.gestalt,
-        game_type:     u.game_type,
-        full_type:     u.full_type,
-        full_path:     u.full_path,
-        instance_data: u.instance_data || {}
-      }]);
+      newNodes = newNodes.concat([
+        {
+          game_id: u.game_id,
+          gestalt: u.gestalt,
+          game_type: u.game_type,
+          full_type: u.full_type,
+          full_path: u.full_path,
+          instance_data: u.instance_data || {},
+        },
+      ]);
     });
   }
 
   var mp = _missionDataFromResult(state, r);
   return Object.assign({}, state, {
-    db_queue:       newQueue,
+    db_queue: newQueue,
     integrated_ids: newIntegratedIds,
-    game_values:    newGv,
-    nodes:          newNodes,
+    game_values: newGv,
+    nodes: newNodes,
     mission_goals: mp.mission_goals,
-    active_missions: mp.active_missions
+    active_missions: mp.active_missions,
   });
 };
 
@@ -706,11 +723,11 @@ function _applyPeerDelta(state: LocalState, delta: Delta): LocalState {
 
   var gv = delta.result && delta.result.game_values;
   if (gv) {
-    if (typeof gv.cash_value     === 'number') peer.cash     = gv.cash_value;
+    if (typeof gv.cash_value === 'number') peer.cash = gv.cash_value;
     if (typeof gv.profiles_value === 'number') peer.profiles = gv.profiles_value;
-    if (typeof gv.xp_value       === 'number') peer.xp       = gv.xp_value;
-    if (typeof gv.xp_level       === 'number') peer.level    = gv.xp_level;
-    if (typeof gv.cash_spent     === 'number') peer.spent    = gv.cash_spent;
+    if (typeof gv.xp_value === 'number') peer.xp = gv.xp_value;
+    if (typeof gv.xp_level === 'number') peer.level = gv.xp_level;
+    if (typeof gv.cash_spent === 'number') peer.spent = gv.cash_spent;
   }
 
   if (delta.op === 'setDisplayName') {

--- a/scripts/type_settings.js
+++ b/scripts/type_settings.js
@@ -4,987 +4,984 @@
 // call time; getTypeSettings() is invoked after app.start() has run
 // _.mixin({_: i18n.gettext}), so `_._('msgid')` resolves correctly.
 
-var typeSettings = function() {
-    var _ = globalThis._;
-    var type_settings = {
-      "GameRoot": {
-        "type_data": {
-          "id": "Game",
-          "x":0,
-          "y":0,
-          "width":960,
-          "height":600,
-          "status_icons": {
-            profiles: {
-              icon: {
-                frameSrc: 'MainSprites.png',
-                frameMap: {
-                  normal: {x: 331, y: 616, width: 38, height: 38, pivotx: 18, pivoty: 7}
-                },
-                frame: 'normal'
-              }
-            },
-            cash: {
-              icon: {
-                frameSrc: 'MainSprites.png',
-                frameMap: {
-                  normal: {x: 369, y: 616, width: 45, height: 34, pivotx: 14, pivoty: 5},
-                  button_deco: {x: 145, y: 616, width: 56, height: 43, pivotx: 26, pivoty: 10}
-                },
-                frame: 'normal'
-              }
-            },
-            time: {
-              icon: {
-                frameSrc: 'MainSprites.png',
-                frameMap: {
-                  normal: {x: 0, y: 616, width: 48, height: 48, pivotx: 22, pivoty: 22},
-                  button_deco: {x: 0, y: 616, width: 48, height: 48, pivotx: -76, pivoty: 13}
-                },
-                frame: 'normal'
-              }
-            },
-            AP: {
-              icon: {
-                frameSrc: 'MainSprites.png',
-                frameMap: {
-                  normal: {x: 292, y: 655, width: 33, height: 38, pivotx: 12, pivoty: 7}
-                },
-                frame: 'normal'
-              }
-            },
-            karma: {
-              icon: {
-                frameSrc: 'MainSprites.png',
-                frameMap: {
-                  up: {x: 374, y: 689, width: 34, height: 34, pivotx: 16, pivoty: 4},
-                  normal: {x: 374, y: 655, width: 34, height: 34, pivotx: 16, pivoty: 4}
-                },
-                frame: 'normal'
-              }
-            },
-            karmaUp: {
-              icon: {
-                frameSrc: 'MainSprites.png',
-                frameMap: {
-                  normal: {x: 374, y: 655, width: 34, height: 34, pivotx: 16, pivoty: 4}
-                },
-                frame: 'normal'
-              }
-            },
-            karmaDown: {
-              icon: {
-                frameSrc: 'MainSprites.png',
-                frameMap: {
-                  normal: {x: 374, y: 689, width: 34, height: 34, pivotx: 16, pivoty: 4},
-                },
-                frame: 'normal'
-              }
-            },
-            XP: {
-              icon: {
-                frameSrc: 'MainSprites.png',
-                frameMap: {
-                  normal: {x: 325, y: 655, width: 47, height: 46, pivotx: -116, pivoty: 10}
-                },
-                frame: 'normal'
-              }
-            },
-
-          },
-          "slot_background": {
-            "frameMap": {
-              "free": {
-                "height": 100,
-                "pivotx": 0,
-                "pivoty": 0,
-                "width": 100,
-                "x": 516,
-                "y": 0
-              },
-              "locked": {
-                "height": 100,
-                "pivotx": 0,
-                "pivoty": 0,
-                "width": 100,
-                "x": 716,
-                "y": 0
-              },
-              "hover": {
-                "height": 100,
-                "pivotx": 0,
-                "pivoty": 0,
-                "width": 100,
-                "x": 616,
-                "y": 0
-              },
-              "normal": {
-                "height": 100,
-                "pivotx": 0,
-                "pivoty": 0,
-                "width": 100,
-                "x": 416,
-                "y": 0
-              }
-            },
-            "frameSrc": "MainSprites.png"
-          },
-          "status_bar": {
-            profiles: {
-              icon: {
-                frameSrc: 'MainSprites.png',
-                frameMap: {
-                  normal: {x: 331, y: 616, width: 38, height: 38, pivotx: 18, pivoty: 7}
-                },
-                frame: 'normal',
-                className: 'StatusIcon'
-              }
-            },
-            cash: {
-              icon: {
-                frameSrc: 'MainSprites.png',
-                frameMap: {
-                  normal: {x: 369, y: 616, width: 45, height: 34, pivotx: 14, pivoty: 5}
-                },
-                frame: 'normal',
-                className: 'StatusIcon'
-              }
-            },
-            AP: {
-              icon: {
-                frameSrc: 'MainSprites.png',
-                frameMap: {
-                  normal: {x: 292, y: 655, width: 32, height: 38, pivotx: 12, pivoty: 7}
-                },
-                frame: 'normal',
-                className: 'StatusIcon'
-              }
-            },
-            karma: {
-              icon: {
-                frameSrc: 'MainSprites.png',
-                frameMap: {
-                  up: {x: 374, y: 689, width: 34, height: 34, pivotx: 16, pivoty: 4},
-                  normal: {x: 374, y: 655, width: 34, height: 34, pivotx: 16, pivoty: 4}
-                },
-                frame: 'normal',
-                className: 'StatusIcon'
-              }
-            },
-            karmaUp: {
-              icon: {
-                frameSrc: 'MainSprites.png',
-                frameMap: {
-                  normal: {x: 374, y: 689, width: 34, height: 34, pivotx: -102, pivoty: 4},
-                },
-                frame: 'normal',
-                className: 'StatusIcon'
-              }
-            },
-            karmaDown: {
-              icon: {
-                frameSrc: 'MainSprites.png',
-                frameMap: {
-                  normal: {x: 374, y: 655, width: 34, height: 34, pivotx: 10, pivoty: 4}
-                },
-                frame: 'normal',
-                className: 'StatusIcon'
-              }
-            },
-            karmaUpInactive: {
-              icon: {
-                frameSrc: 'MainSprites.png',
-                frameMap: {
-                  normal: {x: 0, y: 702, width: 34, height: 34, pivotx: -102, pivoty: 4},
-                },
-                frame: 'normal',
-                className: 'StatusIcon inactive'
-              }
-            },
-            karmaDownInactive: {
-              icon: {
-                frameSrc: 'MainSprites.png',
-                frameMap: {
-                  normal: {x: 0, y: 668, width: 34, height: 34, pivotx: 10, pivoty: 4}
-                },
-                frame: 'normal',
-                className: 'StatusIcon inactive'
-              }
-            },
-
-            XP: {
-              icon: {
-                frameSrc: 'MainSprites.png',
-                frameMap: {
-                  normal: {x: 325, y: 655, width: 47, height: 46, pivotx: -92, pivoty: 10}
-                },
-                frame: 'normal',
-                className: 'StatusIcon'
-              }
-            },
-            background : {
+var typeSettings = function () {
+  var _ = globalThis._;
+  var type_settings = {
+    GameRoot: {
+      type_data: {
+        id: 'Game',
+        x: 0,
+        y: 0,
+        width: 960,
+        height: 600,
+        status_icons: {
+          profiles: {
+            icon: {
               frameSrc: 'MainSprites.png',
               frameMap: {
-                normal: {x: 36, y: 580, width: 131, height: 28, pivotx: 0, pivoty: 0}
+                normal: { x: 331, y: 616, width: 38, height: 38, pivotx: 18, pivoty: 7 },
               },
               frame: 'normal',
-              className: 'StatusBackground'
             },
-            background2 : {
+          },
+          cash: {
+            icon: {
               frameSrc: 'MainSprites.png',
               frameMap: {
-                normal: {x: 2, y: 942, width: 130, height: 34, pivotx: 0, pivoty: 0}
+                normal: { x: 369, y: 616, width: 45, height: 34, pivotx: 14, pivoty: 5 },
+                button_deco: { x: 145, y: 616, width: 56, height: 43, pivotx: 26, pivoty: 10 },
               },
               frame: 'normal',
-              className: 'StatusBackground'
             },
-            background3 : {
+          },
+          time: {
+            icon: {
               frameSrc: 'MainSprites.png',
               frameMap: {
-                normal: {x: 132, y: 942, width: 107, height: 34, pivotx: 0, pivoty: 0}
+                normal: { x: 0, y: 616, width: 48, height: 48, pivotx: 22, pivoty: 22 },
+                button_deco: { x: 0, y: 616, width: 48, height: 48, pivotx: -76, pivoty: 13 },
               },
               frame: 'normal',
-              className: 'StatusBackground'
-            }
-          }
-        }
-      },
-      "Missions": {
-        "type_data": {
-          "background": "database-background.jpg",
-          "width": 960,
-          "height": 600,
-          "x": 0,
-          "y": 0
-        }
-      },
-      "Mission": {
-        "type_data": {
-          "goals_texts": {
-            "buy_perp": _._("goal Buy Perp %s"),
-            "buy_powerup": _._("goal Buy %s in Project %s"),
-            "charge_perp": _._("goal Charge Perp %s"),
-            "collect_cash": _._("goal Collect $%s from %s"),
-            "collect_profiles": _._("goal Collect %s Profiles from %s"),
-            "integrate_profiles": _._("goal Integrate %s x %s"),
-            "upgrade_token": _._("goal Upgrade %s")
+            },
           },
-          "popup_sprite": {
-              "frameSrc": 'MainSprites.png',
-              "frameMap": {
-                "normal": { x: 698, y: 764, width: 140, height: 160, pivotx: 155,pivoty: 90 }
+          AP: {
+            icon: {
+              frameSrc: 'MainSprites.png',
+              frameMap: {
+                normal: { x: 292, y: 655, width: 33, height: 38, pivotx: 12, pivoty: 7 },
               },
-              "frame": 'normal'
-          }
-        }
-      },
-      "Topscore": {
-        "type_data": {
-          "type_headlines": {
-            "cash": _._('topscore cash headline'),
-            "profiles": _._('topscore profiles headline'),
-            "xp": _._('topscore xp headline'),
-            "spent": _._('topscore spent headline')
-          }
-        }
-      },
-      "Topscores": {
-        "type_data": {
-          "RenderTemplate" : "topscores.html",
-          "type_titles": {
-            "cash": _._('topscore Cash'),
-            "profiles": _._('topscore Profiles'),
-            "xp": _._('topscore XP'),
-            "spent": _._('topscore Investor')
-          }
-        }
-      },
-
-      "Karmalauter": {
-        "type_data": {
-          "buy_button_text": _._('karma_buy Do it!')
-        }
-      },
-      "DatabasePerp": {
-        "type_data": {
-          "label": _._('Database'),
-          "perp_background": {
-            "frameMap": {
-              "active": {
-                "height": 184,
-                "pivotx": 70,
-                "pivoty": 87,
-                "width": 145,
-                "x": 516,
-                "y": 314
-              },
-              "drag": {
-                "height": 193,
-                "pivotx": 72,
-                "pivoty": 94,
-                "width": 146,
-                "x": 561,
-                "y": 250
-              },
-              "hover": {
-                "height": 195,
-                "pivotx": 76,
-                "pivoty": 94,
-                "width": 156,
-                "x": 707,
-                "y": 250
-              },
-              "normal": {
-                "height": 184,
-                "pivotx": 70,
-                "pivoty": 87,
-                "width": 145,
-                "x": 416,
-                "y": 250
-              }
+              frame: 'normal',
             },
-            "frameSrc": "MainSprites.png"
-          }
-        }
-      },
-      "Database": {
-        "type_data": {
-          "background": "database-background.jpg",
-          "width": 2048,
-          "height": 1600,
-          "x": -544,
-          "y": -500,
-          "zoom_scale": 1
-        }
-      },
-      "UpgradePowerup": {
-        "type_data": {
-          "mgoal_text": _._("goal_upgrade %s in project %s"),
-          "ntitle": _._("New Upgrade!"),
-          "ntext": _._('ntext_upgrade Upgrade is now available in projects: %s'),
-          "slot_background": {
-            "frameMap": {
-              "free": {
-                "height": 100,
-                "pivotx": 0,
-                "pivoty": 0,
-                "width": 100,
-                "x": 516,
-                "y": 0
-              },
-              "locked": {
-                "height": 100,
-                "pivotx": 0,
-                "pivoty": 0,
-                "width": 100,
-                "x": 716,
-                "y": 0
-              },
-              "hover": {
-                "height": 100,
-                "pivotx": 0,
-                "pivoty": 0,
-                "width": 100,
-                "x": 616,
-                "y": 0
-              },
-              "normal": {
-                "height": 100,
-                "pivotx": 0,
-                "pivoty": 0,
-                "width": 100,
-                "x": 416,
-                "y": 0
-              }
-            },
-            "frameSrc": "MainSprites.png"
-          }
-        }
-      },
-      "AdPowerup": {
-        "type_data": {
-          "mgoal_text": _._("goal_ad %s in project %s"),
-          "ntitle": _._("New Ad!"),
-          "ntext": _._('ntext_ad Ad is now available in projects: %s'),
-          "ntext_server": _._('ntext_server Ad is now available in projects: %s'),
-          "slot_background": {
-            "frameMap": {
-              "free": {
-                "height": 100,
-                "pivotx": 0,
-                "pivoty": 0,
-                "width": 100,
-                "x": 516,
-                "y": 0
-              },
-              "locked": {
-                "height": 100,
-                "pivotx": 0,
-                "pivoty": 0,
-                "width": 100,
-                "x": 616,
-                "y": 0
-              },
-              "normal": {
-                "height": 100,
-                "pivotx": 0,
-                "pivoty": 0,
-                "width": 100,
-                "x": 416,
-                "y": 0
-              }
-            },
-            "frameSrc": "MainSprites.png"
-          }
-        }
-      },
-      "TeamMemberPowerup": {
-        "type_data": {
-          "mgoal_text": _._("goal_teammember %s in project %s"),
-          "ntitle": _._("New Teammember!"),
-          "ntext": _._('ntext_teammember teammember is now available in projects: %s'),
-          "slot_background": {
-            "frameMap": {
-              "free": {
-                "height": 100,
-                "pivotx": 0,
-                "pivoty": 0,
-                "width": 100,
-                "x": 516,
-                "y": 0
-              },
-              "locked": {
-                "height": 100,
-                "pivotx": 0,
-                "pivoty": 0,
-                "width": 100,
-                "x": 616,
-                "y": 0
-              },
-              "normal": {
-                "height": 100,
-                "pivotx": 0,
-                "pivoty": 0,
-                "width": 100,
-                "x": 416,
-                "y": 0
-              }
-            },
-            "frameSrc": "MainSprites.png"
-          }
-        }
-      },
-
-      "Imperium": {
-        "type_data": {
-          "background": "imperium-background.jpg",
-          "width": 2048,
-          "height": 1600,
-          "x": -544,
-          "y": -500,
-          "zoom_scale": 1
-        }
-      },
-      "AgentPerp": {
-        "type_data": {
-          "mgoal_text": _._("goal_agent %s"),
-          "ntitle": _._("New Agent!"),
-          "ntext": _._('ntext_agent click on %s'),
-          "buy_button_text": _._('agent buy_button'),
-          "provided_perps_text": _._('contact_buy Knows %s contacts'),
-          "provided_perps_button_text": _._('pusher buy_contact_button'),
-          "perp_background": {
-            "frameMap": {
-              "active": {
-                "height": 104,
-                "pivotx": 50,
-                "pivoty": 50,
-                "width": 104,
-                "x": 208,
-                "y": 0
-              },
-              "drag": {
-                "height": 104,
-                "pivotx": 47,
-                "pivoty": 50,
-                "width": 104,
-                "x": 312,
-                "y": 0
-              },
-              "hover": {
-                "height": 104,
-                "pivotx": 50,
-                "pivoty": 50,
-                "width": 104,
-                "x": 104,
-                "y": 0
-              },
-              "normal": {
-                "height": 100,
-                "pivotx": 47,
-                "pivoty": 47,
-                "width": 100,
-                "x": 2,
-                "y": 2
-              }
-            },
-            "frameSrc": "MainSprites.png"
-          }
-        }
-      },
-      "ContactPerp": {
-        "type_data": {
-          "mgoal_text": _._("goal_contact %s"),
-          "mgoal_text_charge_perp": _._("goal_contact Charge %s"),
-          "ntitle": _._("New Contact!"),
-          "ntext": _._('ntext_contact click on %s'),
-          "button_text": _._("contact Make a Deal"),
-          "buy_button_text": _._('contact buy_button'),
-          "perp_background": {
-            "frameMap": {
-              "active": {
-                "height": 82,
-                "pivotx": 40,
-                "pivoty": 40,
-                "width": 82,
-                "x": 164,
-                "y": 416
-              },
-              "drag": {
-                "height": 82,
-                "pivotx": 38,
-                "pivoty": 41,
-                "width": 82,
-                "x": 246,
-                "y": 416
-              },
-              "hover": {
-                "height": 82,
-                "pivotx": 40,
-                "pivoty": 40,
-                "width": 82,
-                "x": 82,
-                "y": 416
-              },
-              "normal": {
-                "height": 80,
-                "pivotx": 38,
-                "pivoty": 38,
-                "width": 80,
-                "x": 1,
-                "y": 417
-              }
-            },
-            "frameSrc": "MainSprites.png"
-          }
-        }
-      },
-      "PusherPerp": {
-        "type_data": {
-          "mgoal_text": _._("goal_pusher %s"),
-          "ntitle": _._("New Pusher!"),
-          "ntext": _._('ntext_pusher click on %s'),
-          "provided_perps_text": _._('pusher_buy Knows %s clients'),
-          "buy_button_text": _._('pusher buy_button'),
-          "perp_background": {
-            "frameMap": {
-              "active": {
-                "height": 82,
-                "pivotx": 40,
-                "pivoty": 40,
-                "width": 82,
-                "x": 164,
-                "y": 860
-              },
-              "drag": {
-                "height": 82,
-                "pivotx": 40,
-                "pivoty": 41,
-                "width": 82,
-                "x": 246,
-                "y": 860
-              },
-              "hover": {
-                "height": 82,
-                "pivotx": 40,
-                "pivoty": 40,
-                "width": 82,
-                "x": 82,
-                "y": 860
-              },
-              "normal": {
-                "height": 80,
-                "pivotx": 37,
-                "pivoty": 37,
-                "width": 80,
-                "x": 1,
-                "y": 861
-              }
-            },
-            "frameSrc": "MainSprites.png"
-          }
-        }
-      },
-      "ClientPerp": {
-        "type_data": {
-          "mgoal_text": _._("goal_client %s"),
-          "mgoal_text_charge_perp": _._("goal_client Charge %s"),
-          "ntitle": _._("New Client!"),
-          "ntext": _._('ntext_client click on %s'),
-          "button_text": _._("client Make a Deal"),
-          "buy_button_text": _._('client buy_button'),
-          "perp_background": {
-            "frameMap": {
-              "active": {
-                "height": 104,
-                "pivotx": 50,
-                "pivoty": 50,
-                "width": 104,
-                "x": 208,
-                "y": 208
-              },
-              "drag": {
-                "height": 104,
-                "pivotx": 47,
-                "pivoty": 50,
-                "width": 104,
-                "x": 312,
-                "y": 208
-              },
-              "hover": {
-                "height": 104,
-                "pivotx": 50,
-                "pivoty": 50,
-                "width": 104,
-                "x": 104,
-                "y": 208
-              },
-              "normal": {
-                "height": 100,
-                "pivotx": 47,
-                "pivoty": 47,
-                "width": 100,
-                "x": 2,
-                "y": 210
-              }
-            },
-            "frameSrc": "MainSprites.png"
-          }
-        }
-      },
-      "ProxyPerp": {
-        "type_data": {
-          "mgoal_text": _._("goal_proxy"),
-          "ntitle": _._("New Proxy!"),
-          "ntext": _._('ntext_proxy click on %s'),
-          "buy_button_text": _._('proxy buy_button'),
-          "perp_background": {
-            "frameMap": {
-              "active": {
-                "height": 82,
-                "pivotx": 40,
-                "pivoty": 40,
-                "width": 82,
-                "x": 164,
-                "y": 736
-              },
-              "drag": {
-                "height": 82,
-                "pivotx": 40,
-                "pivoty": 41,
-                "width": 82,
-                "x": 246,
-                "y": 736
-              },
-              "hover": {
-                "height": 83,
-                "pivotx": 40,
-                "pivoty": 40,
-                "width": 82,
-                "x": 82,
-                "y": 736
-              },
-              "normal": {
-                "height": 80,
-                "pivotx": 38,
-                "pivoty": 37,
-                "width": 80,
-                "x": 1,
-                "y": 739
-              }
-            },
-            "frameSrc": "MainSprites.png"
-          }
-        }
-      },
-      "CityPerp": {
-        "type_data": {
-          "mgoal_text": _._("goal_city %s"),
-          "ntitle": _._("New City!"),
-          "ntext": _._('ntext_city click on'),
-          "buy_button_text": _._('city buy_button'),
-          "perp_background": {
-            "frameMap": {
-              "active": {
-                "height": 150,
-                "pivotx": 60,
-                "pivoty": 120,
-                "width": 120,
-                "x": 416,
-                "y": 100
-              },
-              "drag": {
-                "height": 150,
-                "pivotx": 60,
-                "pivoty": 120,
-                "width": 120,
-                "x": 656,
-                "y": 100
-              },
-              "hover": {
-                "height": 150,
-                "pivotx": 60,
-                "pivoty": 120,
-                "width": 120,
-                "x": 536,
-                "y": 100
-              },
-              "normal": {
-                "height": 150,
-                "pivotx": 60,
-                "pivoty": 120,
-                "width": 120,
-                "x": 416,
-                "y": 100
-              }
-            },
-            "frameSrc": "MainSprites.png"
-          }
-        }
-      },
-      "TokenPerp": {
-        "type_data": {
-          "mgoal_text": _._("goal_token %s"),
-          "mgoal_text_charge_perp": _._("goal_token Charge %s"),
-          "mgoal_text_collect_perp": _._("goal_token Integrate %s"),
-          "ntitle": _._("New Token!"),
-          "ntext": _._('ntext_token click on upgrade in the database to get %s'),
-          "buy_button_text": _._('token buy_button'),
-          "perp_background": {
-            "frameMap": {
-              "active": {
-                "height": 82,
-                "pivotx": 40,
-                "pivoty": 40,
-                "width": 82,
-                "x": 164,
-                "y": 498
-              },
-              "drag": {
-                "height": 82,
-                "pivotx": 38,
-                "pivoty": 41,
-                "width": 82,
-                "x": 164,
-                "y": 498
-              },
-              "hover": {
-                "height": 82,
-                "pivotx": 40,
-                "pivoty": 40,
-                "width": 82,
-                "x": 82,
-                "y": 498
-              },
-              "normal": {
-                "height": 80,
-                "pivotx": 38,
-                "pivoty": 38,
-                "width": 80,
-                "x": 1,
-                "y": 499
-              },
-              "consumed": {
-                "height": 80,
-                "pivotx": 38,
-                "pivoty": 38,
-                "width": 80,
-                "x": 247,
-                "y": 499
-              }
-
-            },
-            "frameSrc": "MainSprites.png"
           },
-          "perp_background2": {
-            "frameMap": {
-              "normal": {
-                "height": 100,
-                "width": 100,
-                "pivotx": 49,
-                "pivoty": 49,
-                "x": 2,
-                "y": 314
+          karma: {
+            icon: {
+              frameSrc: 'MainSprites.png',
+              frameMap: {
+                up: { x: 374, y: 689, width: 34, height: 34, pivotx: 16, pivoty: 4 },
+                normal: { x: 374, y: 655, width: 34, height: 34, pivotx: 16, pivoty: 4 },
               },
-              "hover": {
-                "height": 104,
-                "width": 104,
-                "pivotx": 52,
-                "pivoty": 52,
-                "x": 104,
-                "y": 312
-              },
-              "drag": {
-                "height": 104,
-                "width": 104,
-                "pivotx": 50,
-                "pivoty": 52,
-                "x": 208,
-                "y": 312
-              },
-              "consumed": {
-                "height": 104,
-                "width": 104,
-                "pivotx": 52,
-                "pivoty": 52,
-                "x": 312,
-                "y": 312
-              }
+              frame: 'normal',
             },
-            "frameSrc": "MainSprites.png"
-          }
+          },
+          karmaUp: {
+            icon: {
+              frameSrc: 'MainSprites.png',
+              frameMap: {
+                normal: { x: 374, y: 655, width: 34, height: 34, pivotx: 16, pivoty: 4 },
+              },
+              frame: 'normal',
+            },
+          },
+          karmaDown: {
+            icon: {
+              frameSrc: 'MainSprites.png',
+              frameMap: {
+                normal: { x: 374, y: 689, width: 34, height: 34, pivotx: 16, pivoty: 4 },
+              },
+              frame: 'normal',
+            },
+          },
+          XP: {
+            icon: {
+              frameSrc: 'MainSprites.png',
+              frameMap: {
+                normal: { x: 325, y: 655, width: 47, height: 46, pivotx: -116, pivoty: 10 },
+              },
+              frame: 'normal',
+            },
+          },
+        },
+        slot_background: {
+          frameMap: {
+            free: {
+              height: 100,
+              pivotx: 0,
+              pivoty: 0,
+              width: 100,
+              x: 516,
+              y: 0,
+            },
+            locked: {
+              height: 100,
+              pivotx: 0,
+              pivoty: 0,
+              width: 100,
+              x: 716,
+              y: 0,
+            },
+            hover: {
+              height: 100,
+              pivotx: 0,
+              pivoty: 0,
+              width: 100,
+              x: 616,
+              y: 0,
+            },
+            normal: {
+              height: 100,
+              pivotx: 0,
+              pivoty: 0,
+              width: 100,
+              x: 416,
+              y: 0,
+            },
+          },
+          frameSrc: 'MainSprites.png',
+        },
+        status_bar: {
+          profiles: {
+            icon: {
+              frameSrc: 'MainSprites.png',
+              frameMap: {
+                normal: { x: 331, y: 616, width: 38, height: 38, pivotx: 18, pivoty: 7 },
+              },
+              frame: 'normal',
+              className: 'StatusIcon',
+            },
+          },
+          cash: {
+            icon: {
+              frameSrc: 'MainSprites.png',
+              frameMap: {
+                normal: { x: 369, y: 616, width: 45, height: 34, pivotx: 14, pivoty: 5 },
+              },
+              frame: 'normal',
+              className: 'StatusIcon',
+            },
+          },
+          AP: {
+            icon: {
+              frameSrc: 'MainSprites.png',
+              frameMap: {
+                normal: { x: 292, y: 655, width: 32, height: 38, pivotx: 12, pivoty: 7 },
+              },
+              frame: 'normal',
+              className: 'StatusIcon',
+            },
+          },
+          karma: {
+            icon: {
+              frameSrc: 'MainSprites.png',
+              frameMap: {
+                up: { x: 374, y: 689, width: 34, height: 34, pivotx: 16, pivoty: 4 },
+                normal: { x: 374, y: 655, width: 34, height: 34, pivotx: 16, pivoty: 4 },
+              },
+              frame: 'normal',
+              className: 'StatusIcon',
+            },
+          },
+          karmaUp: {
+            icon: {
+              frameSrc: 'MainSprites.png',
+              frameMap: {
+                normal: { x: 374, y: 689, width: 34, height: 34, pivotx: -102, pivoty: 4 },
+              },
+              frame: 'normal',
+              className: 'StatusIcon',
+            },
+          },
+          karmaDown: {
+            icon: {
+              frameSrc: 'MainSprites.png',
+              frameMap: {
+                normal: { x: 374, y: 655, width: 34, height: 34, pivotx: 10, pivoty: 4 },
+              },
+              frame: 'normal',
+              className: 'StatusIcon',
+            },
+          },
+          karmaUpInactive: {
+            icon: {
+              frameSrc: 'MainSprites.png',
+              frameMap: {
+                normal: { x: 0, y: 702, width: 34, height: 34, pivotx: -102, pivoty: 4 },
+              },
+              frame: 'normal',
+              className: 'StatusIcon inactive',
+            },
+          },
+          karmaDownInactive: {
+            icon: {
+              frameSrc: 'MainSprites.png',
+              frameMap: {
+                normal: { x: 0, y: 668, width: 34, height: 34, pivotx: 10, pivoty: 4 },
+              },
+              frame: 'normal',
+              className: 'StatusIcon inactive',
+            },
+          },
 
-        }
+          XP: {
+            icon: {
+              frameSrc: 'MainSprites.png',
+              frameMap: {
+                normal: { x: 325, y: 655, width: 47, height: 46, pivotx: -92, pivoty: 10 },
+              },
+              frame: 'normal',
+              className: 'StatusIcon',
+            },
+          },
+          background: {
+            frameSrc: 'MainSprites.png',
+            frameMap: {
+              normal: { x: 36, y: 580, width: 131, height: 28, pivotx: 0, pivoty: 0 },
+            },
+            frame: 'normal',
+            className: 'StatusBackground',
+          },
+          background2: {
+            frameSrc: 'MainSprites.png',
+            frameMap: {
+              normal: { x: 2, y: 942, width: 130, height: 34, pivotx: 0, pivoty: 0 },
+            },
+            frame: 'normal',
+            className: 'StatusBackground',
+          },
+          background3: {
+            frameSrc: 'MainSprites.png',
+            frameMap: {
+              normal: { x: 132, y: 942, width: 107, height: 34, pivotx: 0, pivoty: 0 },
+            },
+            frame: 'normal',
+            className: 'StatusBackground',
+          },
+        },
       },
-      "ProjectPerp": {
-        "type_data": {
-          "mgoal_text": _._("goal_project %s"),
-          "mgoal_text_charge_perp": _._("goal_project Charge %s"),
-          "ntitle": _._("New Project!"),
-          "ntext": _._('ntext_project click on %s'),
-          "button_text": _._("project Invest"),
-          "buy_button_text": _._('project buy_button'),
-          "upgrade_tab_text":_._('upgrade_tab text'),
-          "ad_tab_text":_._('ad_tab text'),
-          "server_tab_text":_._('server_tab text'),
-          "teammember_tab_text":_._('teammember_tab text'),
-          "powerup_slot_texts": {
-            "upgrade": {
-              "button_text": _._('upgrade buy_button'),
-              "empty_slot_label": _._('upgrade empty_slot'),
-              "add_slots_label": _._('upgrade add_slots label'),
-              "title": _._('upgrade_slotbuy title'),
-              "subtitle":  _._('upgrade_slotbuy subtitle'),
-              "description": _._('upgrade_slotbuy description'),
-              "slot_button_text":_._('upgrade_slotbuy buttontext')
-            },
-            "ad": {
-              "button_text": _._('ad buy_button'),
-              "empty_slot_label": _._('ad empty_slot'),
-              "add_slots_label": _._('ad add_slots label'),
-              "title": _._('ad_slotbuy title'),
-              "subtitle":  _._('ad_slotbuy subtitle'),
-              "description": _._('ad_slotbuy description'),
-              "slot_button_text":_._('ad_slotbuy buttontext')
-            },
-            "server": {
-              "button_text": _._('server buy_button'),
-              "empty_slot_label": _._('server empty_slot'),
-              "add_slots_label": _._('server add_slots label'),
-              "title": _._('server_slotbuy title'),
-              "subtitle":  _._('server_slotbuy subtitle'),
-              "description": _._('server_slotbuy description'),
-              "slot_button_text":_._('server_slotbuy buttontext')
-            },
-            "teammember": {
-              "button_text": _._('teammember buy_button'),
-              "empty_slot_label": _._('teammember empty_slot'),
-              "add_slots_label": _._('teammember add_slots label'),
-              "title": _._('teammember_slotbuy title'),
-              "subtitle":  _._('teammember_slotbuy subtitle'),
-              "description": _._('teammember_slotbuy description'),
-              "slot_button_text":_._('teammember_slotbuy buttontext')
-            }
+    },
+    Missions: {
+      type_data: {
+        background: 'database-background.jpg',
+        width: 960,
+        height: 600,
+        x: 0,
+        y: 0,
+      },
+    },
+    Mission: {
+      type_data: {
+        goals_texts: {
+          buy_perp: _._('goal Buy Perp %s'),
+          buy_powerup: _._('goal Buy %s in Project %s'),
+          charge_perp: _._('goal Charge Perp %s'),
+          collect_cash: _._('goal Collect $%s from %s'),
+          collect_profiles: _._('goal Collect %s Profiles from %s'),
+          integrate_profiles: _._('goal Integrate %s x %s'),
+          upgrade_token: _._('goal Upgrade %s'),
+        },
+        popup_sprite: {
+          frameSrc: 'MainSprites.png',
+          frameMap: {
+            normal: { x: 698, y: 764, width: 140, height: 160, pivotx: 155, pivoty: 90 },
           },
-          "perp_background": {
-            "frameMap": {
-              "active": {
-                "height": 104,
-                "pivotx": 50,
-                "pivoty": 50,
-                "width": 104,
-                "x": 208,
-                "y": 104
-              },
-              "drag": {
-                "height": 104,
-                "pivotx": 47,
-                "pivoty": 50,
-                "width": 104,
-                "x": 312,
-                "y": 104
-              },
-              "hover": {
-                "height": 104,
-                "pivotx": 50,
-                "pivoty": 50,
-                "width": 104,
-                "x": 104,
-                "y": 104
-              },
-              "normal": {
-                "height": 100,
-                "pivotx": 47,
-                "pivoty": 47,
-                "width": 100,
-                "x": 2,
-                "y": 106
-              }
-            },
-            "frameSrc": "MainSprites.png"
-          },
-          "slot_background": {
-            "frameMap": {
-              "free": {
-                "height": 100,
-                "pivotx": 0,
-                "pivoty": 0,
-                "width": 100,
-                "x": 516,
-                "y": 0
-              },
-              "locked": {
-                "height": 100,
-                "pivotx": 0,
-                "pivoty": 0,
-                "width": 100,
-                "x": 716,
-                "y": 0
-              },
-              "hover": {
-                "height": 100,
-                "pivotx": 0,
-                "pivoty": 0,
-                "width": 100,
-                "x": 616,
-                "y": 0
-              },
-              "normal": {
-                "height": 100,
-                "pivotx": 0,
-                "pivoty": 0,
-                "width": 100,
-                "x": 416,
-                "y": 0
-              }
-            },
-            "frameSrc": "MainSprites.png"
-          }
-        }
-      }
-    };
+          frame: 'normal',
+        },
+      },
+    },
+    Topscore: {
+      type_data: {
+        type_headlines: {
+          cash: _._('topscore cash headline'),
+          profiles: _._('topscore profiles headline'),
+          xp: _._('topscore xp headline'),
+          spent: _._('topscore spent headline'),
+        },
+      },
+    },
+    Topscores: {
+      type_data: {
+        RenderTemplate: 'topscores.html',
+        type_titles: {
+          cash: _._('topscore Cash'),
+          profiles: _._('topscore Profiles'),
+          xp: _._('topscore XP'),
+          spent: _._('topscore Investor'),
+        },
+      },
+    },
 
-    return type_settings;
+    Karmalauter: {
+      type_data: {
+        buy_button_text: _._('karma_buy Do it!'),
+      },
+    },
+    DatabasePerp: {
+      type_data: {
+        label: _._('Database'),
+        perp_background: {
+          frameMap: {
+            active: {
+              height: 184,
+              pivotx: 70,
+              pivoty: 87,
+              width: 145,
+              x: 516,
+              y: 314,
+            },
+            drag: {
+              height: 193,
+              pivotx: 72,
+              pivoty: 94,
+              width: 146,
+              x: 561,
+              y: 250,
+            },
+            hover: {
+              height: 195,
+              pivotx: 76,
+              pivoty: 94,
+              width: 156,
+              x: 707,
+              y: 250,
+            },
+            normal: {
+              height: 184,
+              pivotx: 70,
+              pivoty: 87,
+              width: 145,
+              x: 416,
+              y: 250,
+            },
+          },
+          frameSrc: 'MainSprites.png',
+        },
+      },
+    },
+    Database: {
+      type_data: {
+        background: 'database-background.jpg',
+        width: 2048,
+        height: 1600,
+        x: -544,
+        y: -500,
+        zoom_scale: 1,
+      },
+    },
+    UpgradePowerup: {
+      type_data: {
+        mgoal_text: _._('goal_upgrade %s in project %s'),
+        ntitle: _._('New Upgrade!'),
+        ntext: _._('ntext_upgrade Upgrade is now available in projects: %s'),
+        slot_background: {
+          frameMap: {
+            free: {
+              height: 100,
+              pivotx: 0,
+              pivoty: 0,
+              width: 100,
+              x: 516,
+              y: 0,
+            },
+            locked: {
+              height: 100,
+              pivotx: 0,
+              pivoty: 0,
+              width: 100,
+              x: 716,
+              y: 0,
+            },
+            hover: {
+              height: 100,
+              pivotx: 0,
+              pivoty: 0,
+              width: 100,
+              x: 616,
+              y: 0,
+            },
+            normal: {
+              height: 100,
+              pivotx: 0,
+              pivoty: 0,
+              width: 100,
+              x: 416,
+              y: 0,
+            },
+          },
+          frameSrc: 'MainSprites.png',
+        },
+      },
+    },
+    AdPowerup: {
+      type_data: {
+        mgoal_text: _._('goal_ad %s in project %s'),
+        ntitle: _._('New Ad!'),
+        ntext: _._('ntext_ad Ad is now available in projects: %s'),
+        ntext_server: _._('ntext_server Ad is now available in projects: %s'),
+        slot_background: {
+          frameMap: {
+            free: {
+              height: 100,
+              pivotx: 0,
+              pivoty: 0,
+              width: 100,
+              x: 516,
+              y: 0,
+            },
+            locked: {
+              height: 100,
+              pivotx: 0,
+              pivoty: 0,
+              width: 100,
+              x: 616,
+              y: 0,
+            },
+            normal: {
+              height: 100,
+              pivotx: 0,
+              pivoty: 0,
+              width: 100,
+              x: 416,
+              y: 0,
+            },
+          },
+          frameSrc: 'MainSprites.png',
+        },
+      },
+    },
+    TeamMemberPowerup: {
+      type_data: {
+        mgoal_text: _._('goal_teammember %s in project %s'),
+        ntitle: _._('New Teammember!'),
+        ntext: _._('ntext_teammember teammember is now available in projects: %s'),
+        slot_background: {
+          frameMap: {
+            free: {
+              height: 100,
+              pivotx: 0,
+              pivoty: 0,
+              width: 100,
+              x: 516,
+              y: 0,
+            },
+            locked: {
+              height: 100,
+              pivotx: 0,
+              pivoty: 0,
+              width: 100,
+              x: 616,
+              y: 0,
+            },
+            normal: {
+              height: 100,
+              pivotx: 0,
+              pivoty: 0,
+              width: 100,
+              x: 416,
+              y: 0,
+            },
+          },
+          frameSrc: 'MainSprites.png',
+        },
+      },
+    },
+
+    Imperium: {
+      type_data: {
+        background: 'imperium-background.jpg',
+        width: 2048,
+        height: 1600,
+        x: -544,
+        y: -500,
+        zoom_scale: 1,
+      },
+    },
+    AgentPerp: {
+      type_data: {
+        mgoal_text: _._('goal_agent %s'),
+        ntitle: _._('New Agent!'),
+        ntext: _._('ntext_agent click on %s'),
+        buy_button_text: _._('agent buy_button'),
+        provided_perps_text: _._('contact_buy Knows %s contacts'),
+        provided_perps_button_text: _._('pusher buy_contact_button'),
+        perp_background: {
+          frameMap: {
+            active: {
+              height: 104,
+              pivotx: 50,
+              pivoty: 50,
+              width: 104,
+              x: 208,
+              y: 0,
+            },
+            drag: {
+              height: 104,
+              pivotx: 47,
+              pivoty: 50,
+              width: 104,
+              x: 312,
+              y: 0,
+            },
+            hover: {
+              height: 104,
+              pivotx: 50,
+              pivoty: 50,
+              width: 104,
+              x: 104,
+              y: 0,
+            },
+            normal: {
+              height: 100,
+              pivotx: 47,
+              pivoty: 47,
+              width: 100,
+              x: 2,
+              y: 2,
+            },
+          },
+          frameSrc: 'MainSprites.png',
+        },
+      },
+    },
+    ContactPerp: {
+      type_data: {
+        mgoal_text: _._('goal_contact %s'),
+        mgoal_text_charge_perp: _._('goal_contact Charge %s'),
+        ntitle: _._('New Contact!'),
+        ntext: _._('ntext_contact click on %s'),
+        button_text: _._('contact Make a Deal'),
+        buy_button_text: _._('contact buy_button'),
+        perp_background: {
+          frameMap: {
+            active: {
+              height: 82,
+              pivotx: 40,
+              pivoty: 40,
+              width: 82,
+              x: 164,
+              y: 416,
+            },
+            drag: {
+              height: 82,
+              pivotx: 38,
+              pivoty: 41,
+              width: 82,
+              x: 246,
+              y: 416,
+            },
+            hover: {
+              height: 82,
+              pivotx: 40,
+              pivoty: 40,
+              width: 82,
+              x: 82,
+              y: 416,
+            },
+            normal: {
+              height: 80,
+              pivotx: 38,
+              pivoty: 38,
+              width: 80,
+              x: 1,
+              y: 417,
+            },
+          },
+          frameSrc: 'MainSprites.png',
+        },
+      },
+    },
+    PusherPerp: {
+      type_data: {
+        mgoal_text: _._('goal_pusher %s'),
+        ntitle: _._('New Pusher!'),
+        ntext: _._('ntext_pusher click on %s'),
+        provided_perps_text: _._('pusher_buy Knows %s clients'),
+        buy_button_text: _._('pusher buy_button'),
+        perp_background: {
+          frameMap: {
+            active: {
+              height: 82,
+              pivotx: 40,
+              pivoty: 40,
+              width: 82,
+              x: 164,
+              y: 860,
+            },
+            drag: {
+              height: 82,
+              pivotx: 40,
+              pivoty: 41,
+              width: 82,
+              x: 246,
+              y: 860,
+            },
+            hover: {
+              height: 82,
+              pivotx: 40,
+              pivoty: 40,
+              width: 82,
+              x: 82,
+              y: 860,
+            },
+            normal: {
+              height: 80,
+              pivotx: 37,
+              pivoty: 37,
+              width: 80,
+              x: 1,
+              y: 861,
+            },
+          },
+          frameSrc: 'MainSprites.png',
+        },
+      },
+    },
+    ClientPerp: {
+      type_data: {
+        mgoal_text: _._('goal_client %s'),
+        mgoal_text_charge_perp: _._('goal_client Charge %s'),
+        ntitle: _._('New Client!'),
+        ntext: _._('ntext_client click on %s'),
+        button_text: _._('client Make a Deal'),
+        buy_button_text: _._('client buy_button'),
+        perp_background: {
+          frameMap: {
+            active: {
+              height: 104,
+              pivotx: 50,
+              pivoty: 50,
+              width: 104,
+              x: 208,
+              y: 208,
+            },
+            drag: {
+              height: 104,
+              pivotx: 47,
+              pivoty: 50,
+              width: 104,
+              x: 312,
+              y: 208,
+            },
+            hover: {
+              height: 104,
+              pivotx: 50,
+              pivoty: 50,
+              width: 104,
+              x: 104,
+              y: 208,
+            },
+            normal: {
+              height: 100,
+              pivotx: 47,
+              pivoty: 47,
+              width: 100,
+              x: 2,
+              y: 210,
+            },
+          },
+          frameSrc: 'MainSprites.png',
+        },
+      },
+    },
+    ProxyPerp: {
+      type_data: {
+        mgoal_text: _._('goal_proxy'),
+        ntitle: _._('New Proxy!'),
+        ntext: _._('ntext_proxy click on %s'),
+        buy_button_text: _._('proxy buy_button'),
+        perp_background: {
+          frameMap: {
+            active: {
+              height: 82,
+              pivotx: 40,
+              pivoty: 40,
+              width: 82,
+              x: 164,
+              y: 736,
+            },
+            drag: {
+              height: 82,
+              pivotx: 40,
+              pivoty: 41,
+              width: 82,
+              x: 246,
+              y: 736,
+            },
+            hover: {
+              height: 83,
+              pivotx: 40,
+              pivoty: 40,
+              width: 82,
+              x: 82,
+              y: 736,
+            },
+            normal: {
+              height: 80,
+              pivotx: 38,
+              pivoty: 37,
+              width: 80,
+              x: 1,
+              y: 739,
+            },
+          },
+          frameSrc: 'MainSprites.png',
+        },
+      },
+    },
+    CityPerp: {
+      type_data: {
+        mgoal_text: _._('goal_city %s'),
+        ntitle: _._('New City!'),
+        ntext: _._('ntext_city click on'),
+        buy_button_text: _._('city buy_button'),
+        perp_background: {
+          frameMap: {
+            active: {
+              height: 150,
+              pivotx: 60,
+              pivoty: 120,
+              width: 120,
+              x: 416,
+              y: 100,
+            },
+            drag: {
+              height: 150,
+              pivotx: 60,
+              pivoty: 120,
+              width: 120,
+              x: 656,
+              y: 100,
+            },
+            hover: {
+              height: 150,
+              pivotx: 60,
+              pivoty: 120,
+              width: 120,
+              x: 536,
+              y: 100,
+            },
+            normal: {
+              height: 150,
+              pivotx: 60,
+              pivoty: 120,
+              width: 120,
+              x: 416,
+              y: 100,
+            },
+          },
+          frameSrc: 'MainSprites.png',
+        },
+      },
+    },
+    TokenPerp: {
+      type_data: {
+        mgoal_text: _._('goal_token %s'),
+        mgoal_text_charge_perp: _._('goal_token Charge %s'),
+        mgoal_text_collect_perp: _._('goal_token Integrate %s'),
+        ntitle: _._('New Token!'),
+        ntext: _._('ntext_token click on upgrade in the database to get %s'),
+        buy_button_text: _._('token buy_button'),
+        perp_background: {
+          frameMap: {
+            active: {
+              height: 82,
+              pivotx: 40,
+              pivoty: 40,
+              width: 82,
+              x: 164,
+              y: 498,
+            },
+            drag: {
+              height: 82,
+              pivotx: 38,
+              pivoty: 41,
+              width: 82,
+              x: 164,
+              y: 498,
+            },
+            hover: {
+              height: 82,
+              pivotx: 40,
+              pivoty: 40,
+              width: 82,
+              x: 82,
+              y: 498,
+            },
+            normal: {
+              height: 80,
+              pivotx: 38,
+              pivoty: 38,
+              width: 80,
+              x: 1,
+              y: 499,
+            },
+            consumed: {
+              height: 80,
+              pivotx: 38,
+              pivoty: 38,
+              width: 80,
+              x: 247,
+              y: 499,
+            },
+          },
+          frameSrc: 'MainSprites.png',
+        },
+        perp_background2: {
+          frameMap: {
+            normal: {
+              height: 100,
+              width: 100,
+              pivotx: 49,
+              pivoty: 49,
+              x: 2,
+              y: 314,
+            },
+            hover: {
+              height: 104,
+              width: 104,
+              pivotx: 52,
+              pivoty: 52,
+              x: 104,
+              y: 312,
+            },
+            drag: {
+              height: 104,
+              width: 104,
+              pivotx: 50,
+              pivoty: 52,
+              x: 208,
+              y: 312,
+            },
+            consumed: {
+              height: 104,
+              width: 104,
+              pivotx: 52,
+              pivoty: 52,
+              x: 312,
+              y: 312,
+            },
+          },
+          frameSrc: 'MainSprites.png',
+        },
+      },
+    },
+    ProjectPerp: {
+      type_data: {
+        mgoal_text: _._('goal_project %s'),
+        mgoal_text_charge_perp: _._('goal_project Charge %s'),
+        ntitle: _._('New Project!'),
+        ntext: _._('ntext_project click on %s'),
+        button_text: _._('project Invest'),
+        buy_button_text: _._('project buy_button'),
+        upgrade_tab_text: _._('upgrade_tab text'),
+        ad_tab_text: _._('ad_tab text'),
+        server_tab_text: _._('server_tab text'),
+        teammember_tab_text: _._('teammember_tab text'),
+        powerup_slot_texts: {
+          upgrade: {
+            button_text: _._('upgrade buy_button'),
+            empty_slot_label: _._('upgrade empty_slot'),
+            add_slots_label: _._('upgrade add_slots label'),
+            title: _._('upgrade_slotbuy title'),
+            subtitle: _._('upgrade_slotbuy subtitle'),
+            description: _._('upgrade_slotbuy description'),
+            slot_button_text: _._('upgrade_slotbuy buttontext'),
+          },
+          ad: {
+            button_text: _._('ad buy_button'),
+            empty_slot_label: _._('ad empty_slot'),
+            add_slots_label: _._('ad add_slots label'),
+            title: _._('ad_slotbuy title'),
+            subtitle: _._('ad_slotbuy subtitle'),
+            description: _._('ad_slotbuy description'),
+            slot_button_text: _._('ad_slotbuy buttontext'),
+          },
+          server: {
+            button_text: _._('server buy_button'),
+            empty_slot_label: _._('server empty_slot'),
+            add_slots_label: _._('server add_slots label'),
+            title: _._('server_slotbuy title'),
+            subtitle: _._('server_slotbuy subtitle'),
+            description: _._('server_slotbuy description'),
+            slot_button_text: _._('server_slotbuy buttontext'),
+          },
+          teammember: {
+            button_text: _._('teammember buy_button'),
+            empty_slot_label: _._('teammember empty_slot'),
+            add_slots_label: _._('teammember add_slots label'),
+            title: _._('teammember_slotbuy title'),
+            subtitle: _._('teammember_slotbuy subtitle'),
+            description: _._('teammember_slotbuy description'),
+            slot_button_text: _._('teammember_slotbuy buttontext'),
+          },
+        },
+        perp_background: {
+          frameMap: {
+            active: {
+              height: 104,
+              pivotx: 50,
+              pivoty: 50,
+              width: 104,
+              x: 208,
+              y: 104,
+            },
+            drag: {
+              height: 104,
+              pivotx: 47,
+              pivoty: 50,
+              width: 104,
+              x: 312,
+              y: 104,
+            },
+            hover: {
+              height: 104,
+              pivotx: 50,
+              pivoty: 50,
+              width: 104,
+              x: 104,
+              y: 104,
+            },
+            normal: {
+              height: 100,
+              pivotx: 47,
+              pivoty: 47,
+              width: 100,
+              x: 2,
+              y: 106,
+            },
+          },
+          frameSrc: 'MainSprites.png',
+        },
+        slot_background: {
+          frameMap: {
+            free: {
+              height: 100,
+              pivotx: 0,
+              pivoty: 0,
+              width: 100,
+              x: 516,
+              y: 0,
+            },
+            locked: {
+              height: 100,
+              pivotx: 0,
+              pivoty: 0,
+              width: 100,
+              x: 716,
+              y: 0,
+            },
+            hover: {
+              height: 100,
+              pivotx: 0,
+              pivoty: 0,
+              width: 100,
+              x: 616,
+              y: 0,
+            },
+            normal: {
+              height: 100,
+              pivotx: 0,
+              pivoty: 0,
+              width: 100,
+              x: 416,
+              y: 0,
+            },
+          },
+          frameSrc: 'MainSprites.png',
+        },
+      },
+    },
+  };
+
+  return type_settings;
 };
 
 export function getTypeSettings() {

--- a/scripts/util.js
+++ b/scripts/util.js
@@ -5,7 +5,7 @@
 // module's top-level evaluation does not depend on $ existing yet.
 
 export function extend(C, P) {
-  var F = function() {};
+  var F = function () {};
   F.prototype = P.prototype;
   C.prototype = new F();
   C.prototype.constructor = C;
@@ -16,7 +16,7 @@ export function wait(delay) {
   console.warn('Asynchronously waiting for %s milliseconds.', delay);
   var $ = globalThis.jQuery || globalThis.$;
   var deferred = new $.Deferred();
-  setTimeout(function() {
+  setTimeout(function () {
     deferred.resolve();
   }, delay);
   return deferred.promise();

--- a/scripts/vendor-install.js
+++ b/scripts/vendor-install.js
@@ -26,12 +26,12 @@
 //   zynga-scroller:https://raw.githubusercontent.com/zynga/scroller/dadd850/src/Scroller.js
 //   sprintf:       https://raw.githubusercontent.com/alexei/sprintf.js/192bc60/src/sprintf.js
 
-import { execSync } from 'child_process';
-import { mkdirSync, copyFileSync, existsSync, readdirSync } from 'fs';
-import { join } from 'path';
-import { mkdtempSync } from 'fs';
-import { tmpdir } from 'os';
-import { fileURLToPath } from 'url';
+import { execSync } from 'node:child_process';
+import { copyFileSync, existsSync, mkdirSync, readdirSync } from 'node:fs';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const root = join(fileURLToPath(import.meta.url), '..', '..');
 const vendorDir = join(root, 'vendor');
@@ -54,7 +54,7 @@ function cp(src, dest) {
 }
 
 console.log('Installing npm-sourced vendor packages…');
-run(`npm init -y`);
+run('npm init -y');
 run(
   [
     'npm install --save-exact',

--- a/scripts/vendor-install.js
+++ b/scripts/vendor-install.js
@@ -45,33 +45,44 @@ function run(cmd) {
 
 function cp(src, dest) {
   const full = join(tmp, 'node_modules', src);
-  if (!existsSync(full)) { console.warn(`  WARN: ${src} not found — skipping`); return; }
+  if (!existsSync(full)) {
+    console.warn(`  WARN: ${src} not found — skipping`);
+    return;
+  }
   copyFileSync(full, join(vendorDir, dest));
   console.log(`  ✓ ${dest}`);
 }
 
 console.log('Installing npm-sourced vendor packages…');
 run(`npm init -y`);
-run([
-  'npm install --save-exact',
-  'jquery', 'jquery-migrate',
-  'underscore@1.5.1', 'numeral@1.4.5',
-  'easeljs', 'tweenjs', 'soundjs',
-  'sprintf-js',
-].join(' '));
+run(
+  [
+    'npm install --save-exact',
+    'jquery',
+    'jquery-migrate',
+    'underscore@1.5.1',
+    'numeral@1.4.5',
+    'easeljs',
+    'tweenjs',
+    'soundjs',
+    'sprintf-js',
+  ].join(' ')
+);
 
 console.log('\nCopying to vendor/…');
-cp('jquery/dist/jquery.min.js',                  'jquery.js');
-cp('jquery-migrate/dist/jquery-migrate.min.js',  'jquery-migrate.js');
-cp('underscore/underscore.js',                   'underscore.js');
-cp('numeral/numeral.js',                         'numeral.js');
-cp('numeral/languages/de-de.js',                 'numeral-de.js');
-cp('easeljs/lib/easeljs.min.js',                 'easeljs.js');
-cp('tweenjs/lib/tweenjs.min.js',                 'tweenjs.js');
-cp('soundjs/lib/soundjs.min.js',                 'soundjs.js');
-cp('sprintf-js/dist/sprintf.min.js',             'sprintf.js');
+cp('jquery/dist/jquery.min.js', 'jquery.js');
+cp('jquery-migrate/dist/jquery-migrate.min.js', 'jquery-migrate.js');
+cp('underscore/underscore.js', 'underscore.js');
+cp('numeral/numeral.js', 'numeral.js');
+cp('numeral/languages/de-de.js', 'numeral-de.js');
+cp('easeljs/lib/easeljs.min.js', 'easeljs.js');
+cp('tweenjs/lib/tweenjs.min.js', 'tweenjs.js');
+cp('soundjs/lib/soundjs.min.js', 'soundjs.js');
+cp('sprintf-js/dist/sprintf.min.js', 'sprintf.js');
 
 console.log('\nVendor population complete.');
 console.log('Vendored verbatim in repo: zynga-animate.js, zynga-scroller.js');
 console.log('\nFiles in vendor/:');
-readdirSync(vendorDir).sort().forEach(f => console.log('  ' + f));
+readdirSync(vendorDir)
+  .sort()
+  .forEach((f) => console.log('  ' + f));

--- a/scripts/webxdc-identity.js
+++ b/scripts/webxdc-identity.js
@@ -10,9 +10,13 @@
 // setDisplayName) so the change flows through state and observers cleanly.
 
 export function getMessengerDisplayNameChange(user) {
-  if (!user) { return null; }
+  if (!user) {
+    return null;
+  }
   var selfName = globalThis.webxdc.selfName;
-  if (user.display_name === selfName) { return null; }
+  if (user.display_name === selfName) {
+    return null;
+  }
   return selfName;
 }
 

--- a/scripts/webxdc-shim.ts
+++ b/scripts/webxdc-shim.ts
@@ -4,7 +4,7 @@
  * To turn this into a proper Node/vitest mock: drop the localStorage calls and
  * export window.webxdc as a module so tests can import and reset it between runs.
  */
-import type { SendingStatusUpdate, ReceivedStatusUpdate } from "@webxdc/types";
+import type { SendingStatusUpdate, ReceivedStatusUpdate } from '@webxdc/types';
 
 (function () {
   'use strict';
@@ -20,11 +20,15 @@ import type { SendingStatusUpdate, ReceivedStatusUpdate } from "@webxdc/types";
   // Restore persisted history so a page reload replays prior updates.
   try {
     const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored) { _updates = JSON.parse(stored); }
+    if (stored) {
+      _updates = JSON.parse(stored);
+    }
   } catch (_) {}
 
   function _persist(): void {
-    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(_updates)); } catch (_) {}
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(_updates));
+    } catch (_) {}
   }
 
   // Cast via `any` — this is a minimal dev scaffold, not a full Webxdc
@@ -33,7 +37,7 @@ import type { SendingStatusUpdate, ReceivedStatusUpdate } from "@webxdc/types";
     selfAddr: 'dev@local',
     selfName: 'Dev',
 
-    sendUpdate(update: SendingStatusUpdate<any>, _descr: ""): void {
+    sendUpdate(update: SendingStatusUpdate<any>, _descr: ''): void {
       const serial = _updates.length + 1;
       // payload and other fields are copied in from `update` below; cast
       // to satisfy the required-payload shape before the loop fills it in.
@@ -47,17 +51,21 @@ import type { SendingStatusUpdate, ReceivedStatusUpdate } from "@webxdc/types";
       entry.serial = serial;
       _updates.push(entry);
       _persist();
-      _listeners.forEach(function (cb) { cb(entry); });
+      _listeners.forEach(function (cb) {
+        cb(entry);
+      });
     },
 
     setUpdateListener(cb: (u: ReceivedStatusUpdate<any>) => void, serial?: number): Promise<void> {
-      const after = (typeof serial === 'number') ? serial : 0;
+      const after = typeof serial === 'number' ? serial : 0;
       // Replay history that arrived before this listener was registered.
       _updates.forEach(function (u) {
-        if (u.serial > after) { cb(u); }
+        if (u.serial > after) {
+          cb(u);
+        }
       });
       _listeners = [cb]; // last registration wins — matches real webxdc contract
       return Promise.resolve();
-    }
+    },
   };
-}());
+})();

--- a/scripts/webxdc-shim.ts
+++ b/scripts/webxdc-shim.ts
@@ -4,11 +4,9 @@
  * To turn this into a proper Node/vitest mock: drop the localStorage calls and
  * export window.webxdc as a module so tests can import and reset it between runs.
  */
-import type { SendingStatusUpdate, ReceivedStatusUpdate } from '@webxdc/types';
+import type { ReceivedStatusUpdate, SendingStatusUpdate } from '@webxdc/types';
 
 (function () {
-  'use strict';
-
   if (window.webxdc) return; // real messenger present — nothing to do
 
   console.log('[webxdc-shim] dev mode');

--- a/tests/assets/img-references.test.js
+++ b/tests/assets/img-references.test.js
@@ -1,10 +1,10 @@
 // @ts-nocheck — strict-TS quarantine; remove when this file is migrated to TS (issue #147)
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 // Asserts that every file in img/ is referenced from at least one shipped
 // source so that orphaned assets are caught at PR time.
-import { describe, it, expect } from 'vitest';
-import { readdirSync, readFileSync, statSync } from 'fs';
-import { join, dirname } from 'path';
-import { fileURLToPath } from 'url';
+import { describe, expect, it } from 'vitest';
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
 

--- a/tests/assets/img-references.test.js
+++ b/tests/assets/img-references.test.js
@@ -35,7 +35,7 @@ const shippedSrc = [
   readFile(join(root, 'manifest.toml')),
 ].join('\n');
 
-const images = readdirSync(join(root, 'img')).filter(f => /\.(png|jpg|gif|svg|webp)$/i.test(f));
+const images = readdirSync(join(root, 'img')).filter((f) => /\.(png|jpg|gif|svg|webp)$/i.test(f));
 
 describe('img/ asset references', () => {
   for (const img of images) {

--- a/tests/build/build.test.js
+++ b/tests/build/build.test.js
@@ -1,13 +1,13 @@
 // @ts-nocheck — strict-TS quarantine; remove when this file is migrated to TS (issue #147)
+import { execSync } from 'node:child_process';
+import { existsSync, statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 // Verifies that `pnpm build:all` completes without errors and produces the
 // expected dist/ layout and both `.xdc` variants. Runs the real build
 // script as a child process so that vite/rollup errors, missing files,
 // pngquant/oxipng failures in the casual pass, etc. are caught.
-import { describe, it, expect, beforeAll } from 'vitest';
-import { execSync } from 'child_process';
-import { existsSync, statSync } from 'fs';
-import { join, dirname } from 'path';
-import { fileURLToPath } from 'url';
+import { beforeAll, describe, expect, it } from 'vitest';
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
 
@@ -69,7 +69,7 @@ describe('dist/ structure', () => {
 
 describe('dist/index.html', () => {
   it('references esm-bundle.js with the vendor <script> chain', async () => {
-    const { readFileSync } = await import('fs');
+    const { readFileSync } = await import('node:fs');
     const html = readFileSync(join(root, 'dist', 'index.html'), 'utf8');
     expect(html).toContain('scripts/esm-bundle.js');
     expect(html).toContain('vendor/jquery.js');
@@ -81,7 +81,7 @@ describe('dist/index.html', () => {
 
 describe('dist/scripts/esm-bundle.js', () => {
   it('contains LocalEngine handler code', async () => {
-    const { readFileSync } = await import('fs');
+    const { readFileSync } = await import('node:fs');
     const bundle = readFileSync(join(root, 'dist', 'scripts', 'esm-bundle.js'), 'utf8');
     // Sanity-check that handler names from LocalEngine survived bundling
     // (they appear as string literals because LocalEngine builds a
@@ -91,7 +91,7 @@ describe('dist/scripts/esm-bundle.js', () => {
   });
 
   it('does NOT contain a `define.amd` AMD-bridge footer', async () => {
-    const { readFileSync } = await import('fs');
+    const { readFileSync } = await import('node:fs');
     const bundle = readFileSync(join(root, 'dist', 'scripts', 'esm-bundle.js'), 'utf8');
     expect(bundle).not.toContain('define.amd');
   });

--- a/tests/build/handler-state-mutation.test.js
+++ b/tests/build/handler-state-mutation.test.js
@@ -21,7 +21,7 @@ import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 
 const __filename = fileURLToPath(import.meta.url);
-const __dirname  = dirname(__filename);
+const __dirname = dirname(__filename);
 const enginePath = resolve(__dirname, '../../scripts/LocalEngine.ts');
 
 // Lines that may legitimately call setState. Each entry is a substring
@@ -64,13 +64,16 @@ describe('LocalEngine handlers do not call setState directly (closes #120)', () 
     });
 
     if (offenders.length) {
-      const msg = offenders.map(function (o) {
-        return '  scripts/LocalEngine.ts:' + o.line + '  ' + o.text;
-      }).join('\n');
+      const msg = offenders
+        .map(function (o) {
+          return '  scripts/LocalEngine.ts:' + o.line + '  ' + o.text;
+        })
+        .join('\n');
       throw new Error(
         'Found setState call(s) in scripts/LocalEngine.ts outside the\n' +
-        'allowlist. Handlers must compute deltas and call _persistDelta —\n' +
-        'they must NOT call setState directly. Offenders:\n' + msg
+          'allowlist. Handlers must compute deltas and call _persistDelta —\n' +
+          'they must NOT call setState directly. Offenders:\n' +
+          msg
       );
     }
     expect(offenders).toEqual([]);

--- a/tests/build/handler-state-mutation.test.js
+++ b/tests/build/handler-state-mutation.test.js
@@ -15,10 +15,10 @@
 //
 // Anything else calling setState in LocalEngine.ts fails CI.
 
-import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);

--- a/tests/build/type-settings-validation.test.js
+++ b/tests/build/type-settings-validation.test.js
@@ -26,16 +26,16 @@ let rulesetDe, rulesetEn, localeDe, localeEn;
 let goalsTextWorkflows, goalsTextMsgids, knownHandlerWorkflows;
 
 beforeAll(() => {
-  rulesetDe      = JSON.parse(readFileSync(join(root, 'data', 'ruleset_3.de.json'), 'utf8'));
-  rulesetEn      = JSON.parse(readFileSync(join(root, 'data', 'ruleset_3.en.json'), 'utf8'));
-  localeDe       = JSON.parse(readFileSync(join(root, 'i18n', 'de_AT.json'), 'utf8'));
-  localeEn       = JSON.parse(readFileSync(join(root, 'i18n', 'en_US.json'), 'utf8'));
+  rulesetDe = JSON.parse(readFileSync(join(root, 'data', 'ruleset_3.de.json'), 'utf8'));
+  rulesetEn = JSON.parse(readFileSync(join(root, 'data', 'ruleset_3.en.json'), 'utf8'));
+  localeDe = JSON.parse(readFileSync(join(root, 'i18n', 'de_AT.json'), 'utf8'));
+  localeEn = JSON.parse(readFileSync(join(root, 'i18n', 'en_US.json'), 'utf8'));
 
   var typeSettingsSrc = readFileSync(join(root, 'scripts', 'type_settings.js'), 'utf8');
-  var localEngineSrc  = readFileSync(join(root, 'scripts', 'LocalEngine.ts'), 'utf8');
-  goalsTextWorkflows     = extractGoalsTextWorkflows(typeSettingsSrc);
-  goalsTextMsgids        = extractGoalsTextMsgids(typeSettingsSrc);
-  knownHandlerWorkflows  = extractHandlerWorkflows(localEngineSrc);
+  var localEngineSrc = readFileSync(join(root, 'scripts', 'LocalEngine.ts'), 'utf8');
+  goalsTextWorkflows = extractGoalsTextWorkflows(typeSettingsSrc);
+  goalsTextMsgids = extractGoalsTextMsgids(typeSettingsSrc);
+  knownHandlerWorkflows = extractHandlerWorkflows(localEngineSrc);
 });
 
 // ── helper: extract goals_texts workflow keys from type_settings.js source ───
@@ -43,11 +43,11 @@ beforeAll(() => {
 function extractGoalsTextWorkflows(src) {
   // Find the goals_texts block and extract its keys.
   // Pattern: "goals_texts": { "key": ..., "key2": ... }
-  var match = src.match(/["']goals_texts["']\s*:\s*\{([^}]+)\}/);
+  var match = src.match(/["']?goals_texts["']?\s*:\s*\{([^}]+)\}/);
   if (!match) return [];
   var block = match[1];
   var keys = [];
-  var keyRe = /["']([a-z_]+)["']\s*:/g;
+  var keyRe = /["']?([a-z_]+)["']?\s*:/g;
   var m;
   while ((m = keyRe.exec(block)) !== null) {
     keys.push(m[1]);
@@ -61,7 +61,7 @@ function extractGoalsTextWorkflows(src) {
 // the msgid strings so we can verify they exist in the locale files.
 
 function extractGoalsTextMsgids(src) {
-  var match = src.match(/["']goals_texts["']\s*:\s*\{([^}]+)\}/);
+  var match = src.match(/["']?goals_texts["']?\s*:\s*\{([^}]+)\}/);
   if (!match) return [];
   var block = match[1];
   var msgids = [];
@@ -119,9 +119,11 @@ describe('LocalEngine.ts — handler workflow extraction', () => {
   });
 
   it('contains the core workflows that have always existed', () => {
-    ['buy_perp', 'charge_perp', 'collect_profiles', 'integrate_profiles', 'collect_cash'].forEach(function (w) {
-      expect(knownHandlerWorkflows.has(w)).toBe(true);
-    });
+    ['buy_perp', 'charge_perp', 'collect_profiles', 'integrate_profiles', 'collect_cash'].forEach(
+      function (w) {
+        expect(knownHandlerWorkflows.has(w)).toBe(true);
+      }
+    );
   });
 });
 
@@ -131,7 +133,9 @@ describe('type_settings.js — goals_texts workflow coverage', () => {
   });
 
   it('every goals_texts workflow key is a known handler workflow', () => {
-    var unknown = goalsTextWorkflows.filter(function (w) { return !knownHandlerWorkflows.has(w); });
+    var unknown = goalsTextWorkflows.filter(function (w) {
+      return !knownHandlerWorkflows.has(w);
+    });
     expect(unknown).toEqual([]);
   });
 
@@ -173,8 +177,8 @@ describe('ruleset (de) — mission-goal workflow validity', () => {
   });
 
   it('every mission-goal target gestalt exists in perps, tokens, or powerups', () => {
-    var allPerps    = Object.keys(rulesetDe.perps    || {});
-    var allTokens   = Object.keys(rulesetDe.tokens   || {});
+    var allPerps = Object.keys(rulesetDe.perps || {});
+    var allTokens = Object.keys(rulesetDe.tokens || {});
     var allPowerups = Object.keys(rulesetDe.powerups || {});
     var catalogue = new Set([].concat(allPerps, allTokens, allPowerups));
 
@@ -198,8 +202,8 @@ describe('ruleset (de) — mission-goal workflow validity', () => {
 
 describe('ruleset (en) — mission-goal target validity', () => {
   it('every mission-goal target gestalt exists in perps, tokens, or powerups', () => {
-    var allPerps    = Object.keys(rulesetEn.perps    || {});
-    var allTokens   = Object.keys(rulesetEn.tokens   || {});
+    var allPerps = Object.keys(rulesetEn.perps || {});
+    var allTokens = Object.keys(rulesetEn.tokens || {});
     var allPowerups = Object.keys(rulesetEn.powerups || {});
     var catalogue = new Set([].concat(allPerps, allTokens, allPowerups));
     var STAT_TARGETS = new Set(['xp_value', 'cash_value', 'karma_value', 'profiles_max']);
@@ -218,10 +222,16 @@ describe('ruleset (en) — mission-goal target validity', () => {
 
 describe('ruleset — mission reward targets', () => {
   it('every mission reward target is a known stat or gestalt (de)', () => {
-    var allPerps    = new Set(Object.keys(rulesetDe.perps  || {}));
-    var allTokens   = new Set(Object.keys(rulesetDe.tokens || {}));
-    var KNOWN_STATS = new Set(['xp_value', 'cash_value', 'karma_value', 'profiles_max',
-                               'ap_snapshot', 'ap_max']);
+    var allPerps = new Set(Object.keys(rulesetDe.perps || {}));
+    var allTokens = new Set(Object.keys(rulesetDe.tokens || {}));
+    var KNOWN_STATS = new Set([
+      'xp_value',
+      'cash_value',
+      'karma_value',
+      'profiles_max',
+      'ap_snapshot',
+      'ap_max',
+    ]);
 
     var invalid = [];
     (rulesetDe.missions || []).forEach(function (m) {
@@ -245,13 +255,17 @@ describe('goals_texts display strings — locale file coverage', () => {
 
   it('every goals_texts display string has a German translation in de_AT.json', () => {
     expect(goalsTextMsgids.length).toBeGreaterThan(0);
-    var missing = goalsTextMsgids.filter(function (id) { return !hasMsgstr(localeDe, id); });
+    var missing = goalsTextMsgids.filter(function (id) {
+      return !hasMsgstr(localeDe, id);
+    });
     expect(missing).toEqual([]);
   });
 
   it('every goals_texts display string has an English translation in en_US.json', () => {
     expect(goalsTextMsgids.length).toBeGreaterThan(0);
-    var missing = goalsTextMsgids.filter(function (id) { return !hasMsgstr(localeEn, id); });
+    var missing = goalsTextMsgids.filter(function (id) {
+      return !hasMsgstr(localeEn, id);
+    });
     expect(missing).toEqual([]);
   });
 });

--- a/tests/build/type-settings-validation.test.js
+++ b/tests/build/type-settings-validation.test.js
@@ -1,4 +1,7 @@
 // @ts-nocheck — strict-TS quarantine; remove when this file is migrated to TS (issue #147)
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 /**
  * Build-time validation of type_settings.js and the ruleset.
  *
@@ -13,10 +16,7 @@
  * type_settings.js is an AMD module; we analyse it as source text to avoid
  * RequireJS + jQuery dependencies in the Node test environment.
  */
-import { describe, it, expect, beforeAll } from 'vitest';
-import { readFileSync } from 'fs';
-import { join, dirname } from 'path';
-import { fileURLToPath } from 'url';
+import { beforeAll, describe, expect, it } from 'vitest';
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
 

--- a/tests/clock/clock.test.js
+++ b/tests/clock/clock.test.js
@@ -1,8 +1,8 @@
 // @ts-nocheck — strict-TS quarantine; remove when this file is migrated to TS (issue #147)
-import { describe, it, expect, afterEach } from 'vitest';
-import { now, setOverride, clearOverride, advance } from '../../scripts/clock.js';
-import { freshState, applyDelta } from '../../scripts/state.js';
+import { afterEach, describe, expect, it } from 'vitest';
+import { advance, clearOverride, now, setOverride } from '../../scripts/clock.js';
 import { materialize } from '../../scripts/materializer.js';
+import { applyDelta, freshState } from '../../scripts/state.js';
 
 // Always restore real clock after each test to prevent cross-test pollution.
 afterEach(() => {

--- a/tests/clock/clock.test.js
+++ b/tests/clock/clock.test.js
@@ -29,7 +29,7 @@ describe('now() — override lifecycle', () => {
     clearOverride();
     const before = Date.now();
     const result = now();
-    const after  = Date.now();
+    const after = Date.now();
     expect(result).toBeGreaterThanOrEqual(before);
     expect(result).toBeLessThanOrEqual(after);
   });
@@ -121,17 +121,20 @@ describe('clock-skew guard survives a backwards override', () => {
 
 describe('materializer integration with clock', () => {
   function baseState(overrides) {
-    return Object.assign({
-      nodes_charging: [],
-      nodes_collect:  [],
-      game_values: {
-        ap_snapshot:      0,
-        ap_update:        0,
-        ap_inc_value:     1,
-        ap_inc_interval:  1_000,
-        ap_max:           50,
-      }
-    }, overrides);
+    return Object.assign(
+      {
+        nodes_charging: [],
+        nodes_collect: [],
+        game_values: {
+          ap_snapshot: 0,
+          ap_update: 0,
+          ap_inc_value: 1,
+          ap_inc_interval: 1_000,
+          ap_max: 50,
+        },
+      },
+      overrides
+    );
   }
 
   function makeCharge(path, charge_end) {

--- a/tests/e2e/ap-bar.spec.ts
+++ b/tests/e2e/ap-bar.spec.ts
@@ -15,7 +15,7 @@
  * game_type=ContactPerp.
  */
 
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 const GESTALT = 'contact035';
 const PATH = `Imperium.${GESTALT}`;
@@ -45,7 +45,7 @@ test('energy bar: charge action decrements visual AP value and bar width', async
   const readBarWidth = async () =>
     page
       .locator('[data-testid="dd-ap-bar"]')
-      .evaluate((el) => parseFloat((el as HTMLElement).style.width || '0'));
+      .evaluate((el) => Number.parseFloat((el as HTMLElement).style.width || '0'));
   const initialBarWidth = await readBarWidth();
   expect(initialBarWidth).toBeGreaterThan(0);
 

--- a/tests/e2e/ap-bar.spec.ts
+++ b/tests/e2e/ap-bar.spec.ts
@@ -18,7 +18,7 @@
 import { test, expect } from '@playwright/test';
 
 const GESTALT = 'contact035';
-const PATH    = `Imperium.${GESTALT}`;
+const PATH = `Imperium.${GESTALT}`;
 
 test('energy bar: charge action decrements visual AP value and bar width', async ({ page }) => {
   await page.goto('/?devtools=1');
@@ -29,9 +29,7 @@ test('energy bar: charge action decrements visual AP value and bar width', async
 
   // ── 1. Read initial AP from the engine (authoritative) ───────────────────
   const initial = await page.evaluate(async () => {
-    const boot = await new Promise<any>((res, rej) =>
-      (window as any).require(['boot'], res, rej),
-    );
+    const boot = await new Promise<any>((res, rej) => (window as any).require(['boot'], res, rej));
     const gv = boot.getState().game_values;
     return { ap: gv.ap_snapshot as number, ap_max: gv.ap_max as number };
   });
@@ -45,20 +43,23 @@ test('energy bar: charge action decrements visual AP value and bar width', async
   // the value driven by D.AP_barsize and animated by FXSimpleCue. Reading
   // it as a string avoids races with the animation's interpolated frames.
   const readBarWidth = async () =>
-    page.locator('[data-testid="dd-ap-bar"]').evaluate((el) =>
-      parseFloat((el as HTMLElement).style.width || '0'),
-    );
+    page
+      .locator('[data-testid="dd-ap-bar"]')
+      .evaluate((el) => parseFloat((el as HTMLElement).style.width || '0'));
   const initialBarWidth = await readBarWidth();
   expect(initialBarWidth).toBeGreaterThan(0);
 
   // ── 3. Buy + charge contact035 — chargePerp consumes exactly 1 AP ────────
-  const chargeResult = await page.evaluate(async (args) => {
-    const eng = await new Promise<any>((res, rej) =>
-      (window as any).require(['LocalEngine'], res, rej),
-    );
-    await eng.buyPerp('Imperium', args.gestalt);
-    return eng.chargePerp(args.path);
-  }, { gestalt: GESTALT, path: PATH });
+  const chargeResult = await page.evaluate(
+    async (args) => {
+      const eng = await new Promise<any>((res, rej) =>
+        (window as any).require(['LocalEngine'], res, rej)
+      );
+      await eng.buyPerp('Imperium', args.gestalt);
+      return eng.chargePerp(args.path);
+    },
+    { gestalt: GESTALT, path: PATH }
+  );
 
   expect(chargeResult.result).not.toHaveProperty('error');
   const apAfter = chargeResult.result.game_values.ap_snapshot as number;
@@ -70,8 +71,7 @@ test('energy bar: charge action decrements visual AP value and bar width', async
   // ── 4. Sync the in-page Game layer so the statusbar template re-renders ──
   await page.evaluate((gv) => {
     const appModule: any = (window as any).require('app');
-    const game: any =
-      appModule && appModule.getApplication && appModule.getApplication().game;
+    const game: any = appModule && appModule.getApplication && appModule.getApplication().game;
     if (game) game.updateGameValues(gv);
   }, chargeResult.result.game_values);
 
@@ -88,7 +88,5 @@ test('energy bar: charge action decrements visual AP value and bar width', async
   // proportionally on every setAP — at ap_max-1 / ap_max the bar should be
   // strictly narrower than at full AP. Use expect.poll so the FXSimpleCue
   // animation (~250ms) is allowed to settle before the assertion.
-  await expect
-    .poll(readBarWidth, { timeout: 2_000 })
-    .toBeLessThan(initialBarWidth);
+  await expect.poll(readBarWidth, { timeout: 2_000 }).toBeLessThan(initialBarWidth);
 });

--- a/tests/e2e/boot.spec.ts
+++ b/tests/e2e/boot.spec.ts
@@ -9,7 +9,7 @@
  * real wall-clock time is never slept on.
  */
 
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 test('boot: loader disappears and game container is visible', async ({ page }) => {
   const jsErrors: string[] = [];

--- a/tests/e2e/boot.spec.ts
+++ b/tests/e2e/boot.spec.ts
@@ -49,7 +49,8 @@ test('boot: window.__dd clock hook is exposed with devtools=1', async ({ page })
   const hasHook = await page.evaluate(() => {
     return (
       typeof (window as Window & { __dd?: unknown }).__dd === 'object' &&
-      typeof (window as Window & { __dd?: { advanceNow?: unknown } }).__dd?.advanceNow === 'function'
+      typeof (window as Window & { __dd?: { advanceNow?: unknown } }).__dd?.advanceNow ===
+        'function'
     );
   });
   expect(hasHook, 'window.__dd.advanceNow should be available with ?devtools=1').toBe(true);

--- a/tests/e2e/buy-perp-error.spec.ts
+++ b/tests/e2e/buy-perp-error.spec.ts
@@ -23,7 +23,7 @@ test('buy-perp: insufficient cash returns error code 2', async ({ page }) => {
 
   const result = await page.evaluate(async () => {
     const eng = await new Promise<any>((res, rej) =>
-      (window as any).require(['LocalEngine'], res, rej),
+      (window as any).require(['LocalEngine'], res, rej)
     );
     // client006 costs 400 cash; starting cash is 270 → should fail.
     return eng.buyPerp('Imperium', 'client006');

--- a/tests/e2e/buy-perp-error.spec.ts
+++ b/tests/e2e/buy-perp-error.spec.ts
@@ -13,7 +13,7 @@
  * Starting cash: 270 (default_game.json) → 270 < 400 → error 2.
  */
 
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 test('buy-perp: insufficient cash returns error code 2', async ({ page }) => {
   await page.goto('/?devtools=1');

--- a/tests/e2e/collect-after-reload.spec.ts
+++ b/tests/e2e/collect-after-reload.spec.ts
@@ -49,14 +49,16 @@ async function waitForGameReady(page: import('@playwright/test').Page) {
   });
 }
 
-test.skip('collect-after-reload: collected perp does not reappear as collectable after reload (#114)', async ({ page }) => {
+test.skip('collect-after-reload: collected perp does not reappear as collectable after reload (#114)', async ({
+  page,
+}) => {
   await page.goto('/?devtools=1');
   await waitForGameReady(page);
 
   // ── 1. Buy contact035 (price=0) ──────────────────────────────────────────
   await page.evaluate(async (gestalt) => {
     const eng = await new Promise<any>((res, rej) =>
-      (window as any).require(['LocalEngine'], res, rej),
+      (window as any).require(['LocalEngine'], res, rej)
     );
     await eng.buyPerp('Imperium', gestalt);
   }, GESTALT);
@@ -64,7 +66,7 @@ test.skip('collect-after-reload: collected perp does not reappear as collectable
   // ── 2. Charge it ─────────────────────────────────────────────────────────
   await page.evaluate(async (path) => {
     const eng = await new Promise<any>((res, rej) =>
-      (window as any).require(['LocalEngine'], res, rej),
+      (window as any).require(['LocalEngine'], res, rej)
     );
     await eng.chargePerp(path);
   }, PATH);
@@ -77,7 +79,7 @@ test.skip('collect-after-reload: collected perp does not reappear as collectable
   // ── 4. Collect ───────────────────────────────────────────────────────────
   await page.evaluate(async (path) => {
     const eng = await new Promise<any>((res, rej) =>
-      (window as any).require(['LocalEngine'], res, rej),
+      (window as any).require(['LocalEngine'], res, rej)
     );
     await eng.collectPerp(path);
   }, PATH);
@@ -93,11 +95,9 @@ test.skip('collect-after-reload: collected perp does not reappear as collectable
   // back to inspecting engine state directly — both forms encode the same
   // contract from #114.
   const orphan = await page.evaluate(async (path) => {
-    const boot = await new Promise<any>((res, rej) =>
-      (window as any).require(['boot'], res, rej),
-    );
+    const boot = await new Promise<any>((res, rej) => (window as any).require(['boot'], res, rej));
     const s = boot.getState();
-    const inCollect  = (s.nodes_collect  || []).some((c: any) => c.path === path);
+    const inCollect = (s.nodes_collect || []).some((c: any) => c.path === path);
     const inCharging = (s.nodes_charging || []).some((c: any) => c.path === path);
     return { inCollect, inCharging };
   }, PATH);

--- a/tests/e2e/collect-after-reload.spec.ts
+++ b/tests/e2e/collect-after-reload.spec.ts
@@ -36,7 +36,7 @@
  * #120 is implemented.
  */
 
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 const GESTALT = 'contact035';
 const PATH = `Imperium.${GESTALT}`;

--- a/tests/e2e/collect-icon-after-charge.spec.ts
+++ b/tests/e2e/collect-icon-after-charge.spec.ts
@@ -58,7 +58,9 @@ async function waitForGameReady(page: import('@playwright/test').Page) {
   });
 }
 
-test('collect-icon: DecoratorReady appears after node_ready emit (no stuck clock)', async ({ page }) => {
+test('collect-icon: DecoratorReady appears after node_ready emit (no stuck clock)', async ({
+  page,
+}) => {
   await page.goto('/?devtools=1');
   await waitForGameReady(page);
 
@@ -68,7 +70,7 @@ test('collect-icon: DecoratorReady appears after node_ready emit (no stuck clock
   // charge and render the timer.
   await page.evaluate(async (gestalt) => {
     const eng = await new Promise<any>((res, rej) =>
-      (window as any).require(['LocalEngine'], res, rej),
+      (window as any).require(['LocalEngine'], res, rej)
     );
     await eng.buyPerp('Imperium', gestalt);
     await eng.chargePerp(`Imperium.${gestalt}`);
@@ -89,9 +91,9 @@ test('collect-icon: DecoratorReady appears after node_ready emit (no stuck clock
     const last = path.split('.').pop()!;
     const gnode = game && game.getById(last);
     return {
-      exists:        !!gnode,
+      exists: !!gnode,
       chargeRunning: !!(gnode && gnode.states && gnode.states.chargeRunning),
-      hasReady:      !!(gnode && gnode.renderReady),
+      hasReady: !!(gnode && gnode.renderReady),
     };
   }, PATH);
   expect(midState.exists).toBe(true);
@@ -105,12 +107,14 @@ test('collect-icon: DecoratorReady appears after node_ready emit (no stuck clock
   //       publish the event directly rather than waiting 30 s. ──────────
   await page.evaluate((gestalt) => {
     const $ = (window as any).jQuery || (window as any).$;
-    $(document).trigger('node_ready', [{
-      id:     gestalt,
-      type:   'ContactPerp',
-      path:   `Imperium.${gestalt}`,
-      result: { amount: 100 },
-    }]);
+    $(document).trigger('node_ready', [
+      {
+        id: gestalt,
+        type: 'ContactPerp',
+        path: `Imperium.${gestalt}`,
+        result: { amount: 100 },
+      },
+    ]);
   }, GESTALT);
 
   // ── 4. The contract: the collect-ready decorator must appear and the
@@ -125,7 +129,7 @@ test('collect-icon: DecoratorReady appears after node_ready emit (no stuck clock
     const gnode = game && game.getById(last);
     return {
       chargeRunning: !!(gnode && gnode.states && gnode.states.chargeRunning),
-      hasReady:      !!(gnode && gnode.renderReady),
+      hasReady: !!(gnode && gnode.renderReady),
     };
   }, PATH);
   expect(postState.chargeRunning).toBe(false);

--- a/tests/e2e/collect-icon-after-charge.spec.ts
+++ b/tests/e2e/collect-icon-after-charge.spec.ts
@@ -47,7 +47,7 @@
  *    false.  Both fail before the fix, both pass after.
  */
 
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 const GESTALT = 'contact035';
 const PATH = `Imperium.${GESTALT}`;
@@ -88,6 +88,7 @@ test('collect-icon: DecoratorReady appears after node_ready emit (no stuck clock
   const midState = await page.evaluate((path) => {
     const appMod = (window as any).require('app');
     const game = appMod.getApplication().game;
+    // biome-ignore lint/style/noNonNullAssertion: split('.').pop() on a non-empty path is always defined
     const last = path.split('.').pop()!;
     const gnode = game && game.getById(last);
     return {
@@ -125,6 +126,7 @@ test('collect-icon: DecoratorReady appears after node_ready emit (no stuck clock
   const postState = await page.evaluate((path) => {
     const appMod = (window as any).require('app');
     const game = appMod.getApplication().game;
+    // biome-ignore lint/style/noNonNullAssertion: split('.').pop() on a non-empty path is always defined
     const last = path.split('.').pop()!;
     const gnode = game && game.getById(last);
     return {

--- a/tests/e2e/energy-stat-silent-update.spec.ts
+++ b/tests/e2e/energy-stat-silent-update.spec.ts
@@ -5,7 +5,7 @@
  * `AP_val` prop stale until something else forced a re-render.
  */
 
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 test('energy stat: silent updateGameValues still refreshes statusbar text (issue #153)', async ({
   page,

--- a/tests/e2e/energy-stat-silent-update.spec.ts
+++ b/tests/e2e/energy-stat-silent-update.spec.ts
@@ -7,7 +7,9 @@
 
 import { test, expect } from '@playwright/test';
 
-test('energy stat: silent updateGameValues still refreshes statusbar text (issue #153)', async ({ page }) => {
+test('energy stat: silent updateGameValues still refreshes statusbar text (issue #153)', async ({
+  page,
+}) => {
   await page.goto('/?devtools=1');
   await expect(page.locator('[data-testid="game-container"]')).toBeVisible({
     timeout: 50_000,
@@ -15,9 +17,7 @@ test('energy stat: silent updateGameValues still refreshes statusbar text (issue
   await expect(page.locator('[data-testid="dd-ap-counter"]')).toBeVisible();
 
   const initial = await page.evaluate(async () => {
-    const boot = await new Promise<any>((res, rej) =>
-      (window as any).require(['boot'], res, rej),
-    );
+    const boot = await new Promise<any>((res, rej) => (window as any).require(['boot'], res, rej));
     const gv = boot.getState().game_values;
     return { ap: gv.ap_snapshot as number, ap_max: gv.ap_max as number };
   });
@@ -25,21 +25,23 @@ test('energy stat: silent updateGameValues still refreshes statusbar text (issue
 
   await expect(page.locator('[data-testid="dd-ap-value"]')).toHaveText(
     `${initial.ap}/${initial.ap_max}`,
-    { timeout: 2_000 },
+    { timeout: 2_000 }
   );
 
   const apAfter = initial.ap - 1;
-  await page.evaluate((args) => {
-    const appModule: any = (window as any).require('app');
-    const game: any =
-      appModule && appModule.getApplication && appModule.getApplication().game;
-    if (!game) throw new Error('game layer not initialised');
-    game.updateGameValues({ ap_snapshot: args.apAfter }, false, undefined, true);
-  }, { apAfter });
+  await page.evaluate(
+    (args) => {
+      const appModule: any = (window as any).require('app');
+      const game: any = appModule && appModule.getApplication && appModule.getApplication().game;
+      if (!game) throw new Error('game layer not initialised');
+      game.updateGameValues({ ap_snapshot: args.apAfter }, false, undefined, true);
+    },
+    { apAfter }
+  );
 
   await expect(page.locator('[data-testid="dd-ap-value"]')).toHaveText(
     `${apAfter}/${initial.ap_max}`,
-    { timeout: 2_000 },
+    { timeout: 2_000 }
   );
 
   const consistency = await page.evaluate(() => {

--- a/tests/e2e/gameplay.spec.ts
+++ b/tests/e2e/gameplay.spec.ts
@@ -24,7 +24,7 @@
  *   game_type:    ContactPerp → produces a db_queue entry on collectPerp
  */
 
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 // Gestalt and path of the perp used across this spec.
 const GESTALT = 'contact035';

--- a/tests/e2e/gameplay.spec.ts
+++ b/tests/e2e/gameplay.spec.ts
@@ -41,7 +41,9 @@ function amdGet(modId: string): Promise<unknown> {
   });
 }
 
-test('gameplay: buy→charge→skip→collect→integrate decreases cash and increases profileCount', async ({ page }) => {
+test('gameplay: buy→charge→skip→collect→integrate decreases cash and increases profileCount', async ({
+  page,
+}) => {
   await page.goto('/?devtools=1');
   await expect(page.locator('[data-testid="game-container"]')).toBeVisible({
     timeout: 50_000,
@@ -49,9 +51,9 @@ test('gameplay: buy→charge→skip→collect→integrate decreases cash and inc
 
   // ── 1. Read initial values from the engine (authoritative state) ──────────
   const initial = await page.evaluate(async () => {
-    const boot = await new Promise<{ getState(): { game_values: { cash_value: number; profiles_value: number } } }>(
-      (res, rej) => (window as any).require(['boot'], res, rej),
-    );
+    const boot = await new Promise<{
+      getState(): { game_values: { cash_value: number; profiles_value: number } };
+    }>((res, rej) => (window as any).require(['boot'], res, rej));
     const gv = boot.getState().game_values;
     return { cash: gv.cash_value, profiles: gv.profiles_value };
   });
@@ -62,7 +64,9 @@ test('gameplay: buy→charge→skip→collect→integrate decreases cash and inc
 
   // ── 2. Buy contact035 (price=0, no cash change) ───────────────────────────
   const buyResult = await page.evaluate(async (gestalt) => {
-    const eng = await new Promise<any>((res, rej) => (window as any).require(['LocalEngine'], res, rej));
+    const eng = await new Promise<any>((res, rej) =>
+      (window as any).require(['LocalEngine'], res, rej)
+    );
     const res = await eng.buyPerp('Imperium', gestalt);
     return res;
   }, GESTALT);
@@ -72,7 +76,9 @@ test('gameplay: buy→charge→skip→collect→integrate decreases cash and inc
 
   // ── 3. Charge the perp (charge_cost=60 → cash decreases) ─────────────────
   const chargeResult = await page.evaluate(async (path) => {
-    const eng = await new Promise<any>((res, rej) => (window as any).require(['LocalEngine'], res, rej));
+    const eng = await new Promise<any>((res, rej) =>
+      (window as any).require(['LocalEngine'], res, rej)
+    );
     const res = await eng.chargePerp(path);
     return res;
   }, PATH);
@@ -89,7 +95,9 @@ test('gameplay: buy→charge→skip→collect→integrate decreases cash and inc
 
   // ── 5. Collect (ContactPerp path: creates a db_queue entry) ──────────────
   const collectResult = await page.evaluate(async (path) => {
-    const eng = await new Promise<any>((res, rej) => (window as any).require(['LocalEngine'], res, rej));
+    const eng = await new Promise<any>((res, rej) =>
+      (window as any).require(['LocalEngine'], res, rej)
+    );
     const res = await eng.collectPerp(path);
     return res;
   }, PATH);
@@ -99,7 +107,9 @@ test('gameplay: buy→charge→skip→collect→integrate decreases cash and inc
 
   // ── 6. Integrate (increases profiles_value in state) ─────────────────────
   const intResult = await page.evaluate(async (id) => {
-    const eng = await new Promise<any>((res, rej) => (window as any).require(['LocalEngine'], res, rej));
+    const eng = await new Promise<any>((res, rej) =>
+      (window as any).require(['LocalEngine'], res, rej)
+    );
     const res = await eng.integrateCollected(id);
     return res;
   }, collectId);
@@ -123,5 +133,7 @@ test('gameplay: buy→charge→skip→collect→integrate decreases cash and inc
   // re-renders the template.  Use not.toHaveText with a short timeout so
   // Playwright waits for the animation rather than asserting immediately.
   await expect(page.locator('[data-testid="cash-value"]')).not.toHaveText('270', { timeout: 2000 });
-  await expect(page.locator('[data-testid="profiles-value"]')).not.toHaveText('0', { timeout: 2000 });
+  await expect(page.locator('[data-testid="profiles-value"]')).not.toHaveText('0', {
+    timeout: 2000,
+  });
 });

--- a/tests/e2e/persistence.spec.ts
+++ b/tests/e2e/persistence.spec.ts
@@ -20,7 +20,7 @@
  * Starting cash: 270 → 210 after charge.
  */
 
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 const GESTALT = 'contact035';
 const PATH = `Imperium.${GESTALT}`;

--- a/tests/e2e/persistence.spec.ts
+++ b/tests/e2e/persistence.spec.ts
@@ -37,12 +37,16 @@ test('persistence: state is restored after page reload', async ({ page }) => {
 
   // ── Buy then charge the perp ──────────────────────────────────────────────
   await page.evaluate(async (gestalt) => {
-    const eng = await new Promise<any>((res, rej) => (window as any).require(['LocalEngine'], res, rej));
+    const eng = await new Promise<any>((res, rej) =>
+      (window as any).require(['LocalEngine'], res, rej)
+    );
     await eng.buyPerp('Imperium', gestalt);
   }, GESTALT);
 
   const { cashAfterCharge } = await page.evaluate(async (path) => {
-    const eng = await new Promise<any>((res, rej) => (window as any).require(['LocalEngine'], res, rej));
+    const eng = await new Promise<any>((res, rej) =>
+      (window as any).require(['LocalEngine'], res, rej)
+    );
     const result = await eng.chargePerp(path);
     return { cashAfterCharge: result.result.game_values.cash_value };
   }, PATH);

--- a/tests/e2e/share-merge.spec.ts
+++ b/tests/e2e/share-merge.spec.ts
@@ -17,7 +17,7 @@
  * implementation, so this spec is a regression target for the fix.
  */
 
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 test.beforeEach(async ({ page }) => {
   await page.goto('/?devtools=1');
@@ -168,6 +168,7 @@ test('integrating the same profileset twice does not change shares (N = 0 dup re
   });
 
   expect(out.shareAfterFirst).toBeCloseTo(100, 6);
+  // biome-ignore lint/style/noNonNullAssertion: shareAfterFirst is always set by the evaluate block above
   expect(out.shareAfterReplay).toBeCloseTo(out.shareAfterFirst!, 6);
   expect(out.profilesAfterReplay).toBe(out.profilesAfterFirst);
 });

--- a/tests/e2e/share-merge.spec.ts
+++ b/tests/e2e/share-merge.spec.ts
@@ -36,7 +36,7 @@ test('integrate dilutes untouched token shares + crosssum stays under 100', asyn
       setState(s: any): void;
     }>((res, rej) => (window as any).require(['boot'], res, rej));
     const eng = await new Promise<any>((res, rej) =>
-      (window as any).require(['LocalEngine'], res, rej),
+      (window as any).require(['LocalEngine'], res, rej)
     );
 
     const state = boot.getState();
@@ -69,9 +69,7 @@ test('integrate dilutes untouched token shares + crosssum stays under 100', asyn
     await eng.integrateCollected('cq_test_a');
     await eng.integrateCollected('cq_test_b');
 
-    const finalNodes = boot.getState().nodes.filter(
-      (n: any) => n.game_type === 'TokenPerp',
-    );
+    const finalNodes = boot.getState().nodes.filter((n: any) => n.game_type === 'TokenPerp');
     const byGestalt: Record<string, number> = {};
     finalNodes.forEach((n: any) => {
       byGestalt[n.gestalt] = (n.instance_data && n.instance_data.amount) || 0;
@@ -79,9 +77,8 @@ test('integrate dilutes untouched token shares + crosssum stays under 100', asyn
     const crosssumDenom = finalNodes.length + 1;
     const crosssum =
       finalNodes.reduce(
-        (acc: number, n: any) =>
-          acc + ((n.instance_data && n.instance_data.amount) || 0),
-        0,
+        (acc: number, n: any) => acc + ((n.instance_data && n.instance_data.amount) || 0),
+        0
       ) / crosssumDenom;
     return {
       shares: byGestalt,
@@ -108,13 +105,13 @@ test('integrate dilutes untouched token shares + crosssum stays under 100', asyn
   expect(result.crosssum).toBeGreaterThan(0);
 });
 
-test('integrating the same profileset twice does not change shares (N = 0 dup replay)', async ({ page }) => {
+test('integrating the same profileset twice does not change shares (N = 0 dup replay)', async ({
+  page,
+}) => {
   const out = await page.evaluate(async () => {
-    const boot = await new Promise<any>((res, rej) =>
-      (window as any).require(['boot'], res, rej),
-    );
+    const boot = await new Promise<any>((res, rej) => (window as any).require(['boot'], res, rej));
     const eng = await new Promise<any>((res, rej) =>
-      (window as any).require(['LocalEngine'], res, rej),
+      (window as any).require(['LocalEngine'], res, rej)
     );
 
     const state = boot.getState();
@@ -122,42 +119,44 @@ test('integrating the same profileset twice does not change shares (N = 0 dup re
       ap_snapshot: 10,
       profiles_value: 0,
     });
-    state.db_queue = [{
-      origin: 'Imperium.test.contactA',
-      collect_id: 'cq_dup_test',
-      profile_set: {
-        profiles_value: 100,
-        tokens_map: { token008: { amount: 100 } },
+    state.db_queue = [
+      {
+        origin: 'Imperium.test.contactA',
+        collect_id: 'cq_dup_test',
+        profile_set: {
+          profiles_value: 100,
+          tokens_map: { token008: { amount: 100 } },
+        },
       },
-    }];
+    ];
     state.integrated_ids = {};
     boot.setState(state);
 
     await eng.integrateCollected('cq_dup_test');
     const afterFirst = boot.getState();
     const shareAfterFirst =
-      afterFirst.nodes.find((n: any) => n.gestalt === 'token008')?.instance_data
-        ?.amount ?? null;
+      afterFirst.nodes.find((n: any) => n.gestalt === 'token008')?.instance_data?.amount ?? null;
     const profilesAfterFirst = afterFirst.game_values.profiles_value;
 
     // Re-queue the same collect_id and replay — handler should treat it as a
     // duplicate (N = 0), neither growing profiles_value nor changing shares.
     const replayState = boot.getState();
-    replayState.db_queue = [{
-      origin: 'Imperium.test.contactA',
-      collect_id: 'cq_dup_test',
-      profile_set: {
-        profiles_value: 100,
-        tokens_map: { token008: { amount: 100 } },
+    replayState.db_queue = [
+      {
+        origin: 'Imperium.test.contactA',
+        collect_id: 'cq_dup_test',
+        profile_set: {
+          profiles_value: 100,
+          tokens_map: { token008: { amount: 100 } },
+        },
       },
-    }];
+    ];
     boot.setState(replayState);
 
     await eng.integrateCollected('cq_dup_test');
     const afterReplay = boot.getState();
     const shareAfterReplay =
-      afterReplay.nodes.find((n: any) => n.gestalt === 'token008')?.instance_data
-        ?.amount ?? null;
+      afterReplay.nodes.find((n: any) => n.gestalt === 'token008')?.instance_data?.amount ?? null;
     const profilesAfterReplay = afterReplay.game_values.profiles_value;
 
     return {

--- a/tests/e2e/sweepstakes-upgrade.spec.ts
+++ b/tests/e2e/sweepstakes-upgrade.spec.ts
@@ -21,7 +21,7 @@
  *   provided_upgrades[0]: { gestalt: 'upgrade001', price: 160, required_level: 2 }
  */
 
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 test('sweepstakes: buyPowerup succeeds with sufficient cash after buying project001', async ({
   page,

--- a/tests/e2e/sweepstakes-upgrade.spec.ts
+++ b/tests/e2e/sweepstakes-upgrade.spec.ts
@@ -23,7 +23,9 @@
 
 import { test, expect } from '@playwright/test';
 
-test('sweepstakes: buyPowerup succeeds with sufficient cash after buying project001', async ({ page }) => {
+test('sweepstakes: buyPowerup succeeds with sufficient cash after buying project001', async ({
+  page,
+}) => {
   await page.goto('/?devtools=1');
   await expect(page.locator('[data-testid="game-container"]')).toBeVisible({
     timeout: 50_000,
@@ -33,9 +35,7 @@ test('sweepstakes: buyPowerup succeeds with sufficient cash after buying project
   // project001 costs 300, upgrade001 costs 160; we need xp_level >= 2 to buy
   // project001 and to unlock upgrade001 in the ruleset.
   await page.evaluate(async () => {
-    const boot = await new Promise<any>((res, rej) =>
-      (window as any).require(['boot'], res, rej),
-    );
+    const boot = await new Promise<any>((res, rej) => (window as any).require(['boot'], res, rej));
     const state = boot.getState();
     boot.setState(
       Object.assign({}, state, {
@@ -44,14 +44,14 @@ test('sweepstakes: buyPowerup succeeds with sufficient cash after buying project
           xp_level: 2,
           xp_value: 20,
         }),
-      }),
+      })
     );
   });
 
   // ── Step 1: Buy project001 (the sweepstakes node) ─────────────────────────
   const buyPerpResult = await page.evaluate(async () => {
     const eng = await new Promise<any>((res, rej) =>
-      (window as any).require(['LocalEngine'], res, rej),
+      (window as any).require(['LocalEngine'], res, rej)
     );
     return eng.buyPerp('Imperium', 'project001');
   });
@@ -63,7 +63,7 @@ test('sweepstakes: buyPowerup succeeds with sufficient cash after buying project
   // ── Step 2: Buy upgrade001 on slot 0 — this is the reported failing path ──
   const buyPowerupResult = await page.evaluate(async () => {
     const eng = await new Promise<any>((res, rej) =>
-      (window as any).require(['LocalEngine'], res, rej),
+      (window as any).require(['LocalEngine'], res, rej)
     );
     // slot is intentionally passed as a string, matching what the browser UI
     // sends via data-button-data attributes.
@@ -92,9 +92,7 @@ test('sweepstakes: buyPowerup returns error 3 when cash is insufficient', async 
   // project001 costs 300; upgrade001 costs 160.  Give exactly 300 so after
   // buying the perp there is 0 cash left.
   await page.evaluate(async () => {
-    const boot = await new Promise<any>((res, rej) =>
-      (window as any).require(['boot'], res, rej),
-    );
+    const boot = await new Promise<any>((res, rej) => (window as any).require(['boot'], res, rej));
     const state = boot.getState();
     boot.setState(
       Object.assign({}, state, {
@@ -103,14 +101,14 @@ test('sweepstakes: buyPowerup returns error 3 when cash is insufficient', async 
           xp_level: 2,
           xp_value: 20,
         }),
-      }),
+      })
     );
   });
 
   // Buy the perp (spends all 300 cash).
   const buyPerpResult = await page.evaluate(async () => {
     const eng = await new Promise<any>((res, rej) =>
-      (window as any).require(['LocalEngine'], res, rej),
+      (window as any).require(['LocalEngine'], res, rej)
     );
     return eng.buyPerp('Imperium', 'project001');
   });
@@ -120,7 +118,7 @@ test('sweepstakes: buyPowerup returns error 3 when cash is insufficient', async 
   // Now try to buy upgrade001 — should fail with error 3 (insufficient cash).
   const buyPowerupResult = await page.evaluate(async () => {
     const eng = await new Promise<any>((res, rej) =>
-      (window as any).require(['LocalEngine'], res, rej),
+      (window as any).require(['LocalEngine'], res, rej)
     );
     return eng.buyPowerup('Imperium.project001', '0', 'upgrade001');
   });
@@ -136,7 +134,7 @@ test('sweepstakes: buyPowerup returns error 0 when node does not exist', async (
   // Do NOT buy project001 first — the node does not exist in state.
   const result = await page.evaluate(async () => {
     const eng = await new Promise<any>((res, rej) =>
-      (window as any).require(['LocalEngine'], res, rej),
+      (window as any).require(['LocalEngine'], res, rej)
     );
     return eng.buyPowerup('Imperium.project001', '0', 'upgrade001');
   });

--- a/tests/e2e/topscores.spec.ts
+++ b/tests/e2e/topscores.spec.ts
@@ -20,7 +20,7 @@
  * state.peers identity changes).
  */
 
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 type PeerSeed = {
   display_name: string;

--- a/tests/e2e/topscores.spec.ts
+++ b/tests/e2e/topscores.spec.ts
@@ -57,12 +57,12 @@ async function waitForGameReady(page: import('@playwright/test').Page) {
 async function seedAndRender(
   page: import('@playwright/test').Page,
   peers: Record<string, PeerSeed>,
-  selfAddr: string,
+  selfAddr: string
 ) {
   return await page.evaluate(
     async ({ peers, selfAddr }) => {
       const boot = await new Promise<any>((res, rej) =>
-        (window as any).require(['boot'], res, rej),
+        (window as any).require(['boot'], res, rej)
       );
       const app = (window as any).require('app').getApplication();
 
@@ -84,13 +84,11 @@ async function seedAndRender(
       await Promise.resolve();
       await new Promise((r) => setTimeout(r, 50));
     },
-    { peers, selfAddr },
+    { peers, selfAddr }
   );
 }
 
-test('topscores: renders one row per peer with addr-keyed testid', async ({
-  page,
-}) => {
+test('topscores: renders one row per peer with addr-keyed testid', async ({ page }) => {
   await page.goto('/?devtools=1');
   await waitForGameReady(page);
 
@@ -117,7 +115,7 @@ test('topscores: renders one row per peer with addr-keyed testid', async ({
         last_seen_ts: Date.now(),
       }),
     },
-    SELF,
+    SELF
   );
 
   // The Topscores ViewTab isn't surfaced until the user clicks the main-menu
@@ -125,23 +123,17 @@ test('topscores: renders one row per peer with addr-keyed testid', async ({
   // and live in the DOM (hidden via .hide()). toBeAttached suffices to prove
   // the rows render — visibility is a separate UI-routing concern.
   await expect(
-    page.locator('[data-testid="dd-leaderboard-row-alice@local"]').first(),
+    page.locator('[data-testid="dd-leaderboard-row-alice@local"]').first()
   ).toBeAttached();
-  await expect(
-    page.locator('[data-testid="dd-leaderboard-row-bob@test"]').first(),
-  ).toBeAttached();
+  await expect(page.locator('[data-testid="dd-leaderboard-row-bob@test"]').first()).toBeAttached();
 
   // Self row is highlighted via the `.user` class (set when score.self===true).
-  const aliceRow = page
-    .locator('[data-testid="dd-leaderboard-row-alice@local"]')
-    .first();
+  const aliceRow = page.locator('[data-testid="dd-leaderboard-row-alice@local"]').first();
   await expect(aliceRow).toHaveClass(/\buser\b/);
 
   // Display names render from the peer entry rather than falling back to addr.
   await expect(aliceRow.locator('.TopscoreDisplayname')).toHaveText('Alice');
-  const bobRow = page
-    .locator('[data-testid="dd-leaderboard-row-bob@test"]')
-    .first();
+  const bobRow = page.locator('[data-testid="dd-leaderboard-row-bob@test"]').first();
   await expect(bobRow.locator('.TopscoreDisplayname')).toHaveText('Bob');
 });
 
@@ -165,7 +157,7 @@ test('topscores: a state.peers mutation refreshes the leaderboard without manual
         last_seen_ts: Date.now(),
       }),
     },
-    SELF,
+    SELF
   );
 
   // Click the cash tab so that a Topscore renderNode is visible.
@@ -176,7 +168,7 @@ test('topscores: a state.peers mutation refreshes the leaderboard without manual
   await page.waitForTimeout(50);
 
   await expect(
-    page.locator('[data-testid="dd-leaderboard-row-alice@local"]').first(),
+    page.locator('[data-testid="dd-leaderboard-row-alice@local"]').first()
   ).toBeAttached();
 
   // Now push a new peer through setState — boot's peers-changed subscription
@@ -184,7 +176,7 @@ test('topscores: a state.peers mutation refreshes the leaderboard without manual
   await page.evaluate(
     async ({ self }) => {
       const boot = await new Promise<any>((res, rej) =>
-        (window as any).require(['boot'], res, rej),
+        (window as any).require(['boot'], res, rej)
       );
       const cur = boot.getState();
       const nextPeers = Object.assign({}, cur.peers, {
@@ -201,17 +193,15 @@ test('topscores: a state.peers mutation refreshes the leaderboard without manual
       });
       boot.setState(Object.assign({}, cur, { addr: self, peers: nextPeers }));
     },
-    { self: SELF },
+    { self: SELF }
   );
 
   // Bob's row should appear automatically — no click, no reload.
-  await expect(
-    page.locator('[data-testid="dd-leaderboard-row-bob@test"]').first(),
-  ).toBeAttached({ timeout: 5_000 });
+  await expect(page.locator('[data-testid="dd-leaderboard-row-bob@test"]').first()).toBeAttached({
+    timeout: 5_000,
+  });
 
   // Bob's cash is 999 → ranked first; check his rendered value contains 999.
-  const bobRow = page
-    .locator('[data-testid="dd-leaderboard-row-bob@test"]')
-    .first();
+  const bobRow = page.locator('[data-testid="dd-leaderboard-row-bob@test"]').first();
   await expect(bobRow.locator('.TopscoreValue')).toContainText('999');
 });

--- a/tests/e2e/zoom-controls.spec.ts
+++ b/tests/e2e/zoom-controls.spec.ts
@@ -19,7 +19,9 @@ interface DDHook {
   };
 }
 
-test('zoom-controls: Fullscreen button resets zoom to 1.0 from any zoom level', async ({ page }) => {
+test('zoom-controls: Fullscreen button resets zoom to 1.0 from any zoom level', async ({
+  page,
+}) => {
   await page.goto('/?devtools=1');
   await expect(page.locator('[data-testid="game-container"]')).toBeVisible({
     timeout: 50_000,
@@ -45,7 +47,7 @@ test('zoom-controls: Fullscreen button resets zoom to 1.0 from any zoom level', 
       return typeof w.__dd?.getZoom === 'function' && w.__dd.getZoom() !== null;
     },
     undefined,
-    { timeout: 50_000 },
+    { timeout: 50_000 }
   );
 
   const getZoom = () =>

--- a/tests/e2e/zoom-controls.spec.ts
+++ b/tests/e2e/zoom-controls.spec.ts
@@ -10,7 +10,7 @@
  * scroller publishes one tween, not two.  This test pins that behavior.
  */
 
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 interface DDHook {
   __dd?: {

--- a/tests/handlers/_fixtures.js
+++ b/tests/handlers/_fixtures.js
@@ -15,13 +15,23 @@ export const FIXED_NOW = 1_700_000_000_000;
  * @param {object} [overrides]
  */
 export function mkGv(overrides) {
-  return Object.assign({
-    xp_value: 5, xp_level: 1,
-    karma_value: 50, cash_value: 300, cash_spent: 0,
-    profiles_value: 0, profiles_max: 1,
-    ap_snapshot: 6, ap_update: FIXED_NOW,
-    ap_inc_value: 1, ap_inc_interval: 120000, ap_max: 6,
-  }, overrides || {});
+  return Object.assign(
+    {
+      xp_value: 5,
+      xp_level: 1,
+      karma_value: 50,
+      cash_value: 300,
+      cash_spent: 0,
+      profiles_value: 0,
+      profiles_max: 1,
+      ap_snapshot: 6,
+      ap_update: FIXED_NOW,
+      ap_inc_value: 1,
+      ap_inc_interval: 120000,
+      ap_max: 6,
+    },
+    overrides || {}
+  );
 }
 
 /**
@@ -47,11 +57,11 @@ export function mkNode(gameType, path, instData) {
   var parts = path.split('.');
   var gestalt = parts[parts.length - 1];
   return {
-    game_id:       'node_' + gestalt,
-    game_type:     gameType,
-    full_type:     gameType + ':' + gestalt,
-    gestalt:       gestalt,
-    full_path:     path,
+    game_id: 'node_' + gestalt,
+    game_type: gameType,
+    full_type: gameType + ':' + gestalt,
+    gestalt: gestalt,
+    full_path: path,
     instance_data: instData || {},
   };
 }
@@ -65,16 +75,16 @@ export function mkNode(gameType, path, instData) {
  * @param {number} [now]
  */
 export function mkChargingEntry(path, result, gameType, now) {
-  var t   = now !== undefined ? now : FIXED_NOW;
+  var t = now !== undefined ? now : FIXED_NOW;
   var dur = 120_000;
-  var parts   = path.split('.');
+  var parts = path.split('.');
   var gestalt = parts[parts.length - 1];
   return {
-    path:         path,
-    result:       result,
+    path: path,
+    result: result,
     charge_start: t - dur,
-    charge_end:   t + dur,
-    game_id:      'node_' + gestalt,
-    game_type:    gameType,
+    charge_end: t + dur,
+    game_id: 'node_' + gestalt,
+    game_type: gameType,
   };
 }

--- a/tests/handlers/achievements.test.js
+++ b/tests/handlers/achievements.test.js
@@ -13,8 +13,12 @@
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
-  buyPerp, integrateCollected, buyKarma,
-  setSendAchievement, setSendDelta, setEmitter
+  buyPerp,
+  integrateCollected,
+  buyKarma,
+  setSendAchievement,
+  setSendDelta,
+  setEmitter,
 } from '../../scripts/LocalEngine.js';
 import { getState, setState } from '../../scripts/boot.js';
 import { applyDelta, freshState } from '../../scripts/state.js';
@@ -30,7 +34,7 @@ function mkAchievementSpy() {
 }
 
 function callsOfKind(spy, achievementKind) {
-  return spy.mock.calls.filter(c => c[0].payload.achievement_kind === achievementKind);
+  return spy.mock.calls.filter((c) => c[0].payload.achievement_kind === achievementKind);
 }
 
 // ── Tier 1: mission completion via buyPerp ────────────────────────────────────
@@ -39,26 +43,30 @@ describe('achievement — Tier 1: mission completion via buyPerp', () => {
   // mission008 / Sick World — single seeded goal: buy_perp target client002.
   // Using locale 'en' so mission titles match the en ruleset.
   const MISSION_GESTALT = 'mission008';
-  const MISSION_TITLE   = 'Sick World'; // type_data.title in ruleset_3.en.json
+  const MISSION_TITLE = 'Sick World'; // type_data.title in ruleset_3.en.json
 
   beforeEach(() => {
     setOverride(FIXED_NOW);
-    setState(mkState({
-      display_name: 'Alice',
-      locale: 'en',
-      game_values: mkGv({ cash_value: 5000, xp_level: 1, xp_value: 5 }),
-      active_missions: [MISSION_GESTALT],
-      // Seed only this one goal so the mission completes immediately.
-      mission_goals: [{
-        mission:        MISSION_GESTALT,
-        workflow:       'buy_perp',
-        target:         'client002',
-        amount:         null,
-        position:       1,
-        current_amount: 0,
-        complete:       false
-      }]
-    }));
+    setState(
+      mkState({
+        display_name: 'Alice',
+        locale: 'en',
+        game_values: mkGv({ cash_value: 5000, xp_level: 1, xp_value: 5 }),
+        active_missions: [MISSION_GESTALT],
+        // Seed only this one goal so the mission completes immediately.
+        mission_goals: [
+          {
+            mission: MISSION_GESTALT,
+            workflow: 'buy_perp',
+            target: 'client002',
+            amount: null,
+            position: 1,
+            current_amount: 0,
+            complete: false,
+          },
+        ],
+      })
+    );
   });
 
   afterEach(() => {
@@ -114,33 +122,39 @@ describe('achievement — Tier 1: mission completion via buyPerp', () => {
 // ── Tier 1: mission completion via integrateCollected ─────────────────────────
 
 describe('achievement — Tier 1: mission completion via integrateCollected', () => {
-  const COLLECT_ID    = 'ach-test-cid-001';
-  const MISSION_GEST  = 'mission002';
+  const COLLECT_ID = 'ach-test-cid-001';
+  const MISSION_GEST = 'mission002';
   const MISSION_TITLE = 'Enter the Vault!'; // en ruleset title
 
   beforeEach(() => {
     setOverride(FIXED_NOW);
-    setState(mkState({
-      display_name: 'Bob',
-      locale: 'en',
-      game_values: mkGv({ profiles_value: 0, ap_snapshot: 6 }),
-      active_missions: [MISSION_GEST],
-      mission_goals: [{
-        mission:        MISSION_GEST,
-        workflow:       'integrate_profiles',
-        target:         'token008',
-        amount:         900,
-        position:       1,
-        current_amount: 0,
-        complete:       false
-      }],
-      db_queue: [{
-        origin:      'Imperium.City.Agent0.contact035',
-        collect_id:  COLLECT_ID,
-        profile_set: { profiles_value: 1100, tokens_map: { token008: { amount: 100 } } },
-        collect_dt:  FIXED_NOW
-      }]
-    }));
+    setState(
+      mkState({
+        display_name: 'Bob',
+        locale: 'en',
+        game_values: mkGv({ profiles_value: 0, ap_snapshot: 6 }),
+        active_missions: [MISSION_GEST],
+        mission_goals: [
+          {
+            mission: MISSION_GEST,
+            workflow: 'integrate_profiles',
+            target: 'token008',
+            amount: 900,
+            position: 1,
+            current_amount: 0,
+            complete: false,
+          },
+        ],
+        db_queue: [
+          {
+            origin: 'Imperium.City.Agent0.contact035',
+            collect_id: COLLECT_ID,
+            profile_set: { profiles_value: 1100, tokens_map: { token008: { amount: 100 } } },
+            collect_dt: FIXED_NOW,
+          },
+        ],
+      })
+    );
   });
 
   afterEach(() => {
@@ -180,11 +194,13 @@ describe('achievement — Tier 2: level-up via buyPerp', () => {
 
   beforeEach(() => {
     setOverride(FIXED_NOW);
-    setState(mkState({
-      display_name: 'Charlie',
-      locale: 'en',
-      game_values: mkGv({ xp_value: 10, xp_level: 1, cash_value: 5000 })
-    }));
+    setState(
+      mkState({
+        display_name: 'Charlie',
+        locale: 'en',
+        game_values: mkGv({ xp_value: 10, xp_level: 1, cash_value: 5000 }),
+      })
+    );
   });
 
   afterEach(() => {
@@ -214,11 +230,13 @@ describe('achievement — Tier 2: level-up via buyPerp', () => {
   });
 
   it('does not fire levelup when XP stays within the same level', async () => {
-    setState(mkState({
-      display_name: 'Charlie',
-      locale: 'en',
-      game_values: mkGv({ xp_value: 5, xp_level: 1, cash_value: 5000 })
-    }));
+    setState(
+      mkState({
+        display_name: 'Charlie',
+        locale: 'en',
+        game_values: mkGv({ xp_value: 5, xp_level: 1, cash_value: 5000 }),
+      })
+    );
     const spy = mkAchievementSpy();
     await buyPerp('Imperium', 'client007');
     expect(callsOfKind(spy, 'levelup')).toHaveLength(0);
@@ -227,14 +245,20 @@ describe('achievement — Tier 2: level-up via buyPerp', () => {
 
 describe('achievement — Tier 2: level-up via buyKarma', () => {
   beforeEach(() => setOverride(FIXED_NOW));
-  afterEach(() => { clearOverride(); setSendAchievement(null); setSendDelta(null); });
+  afterEach(() => {
+    clearOverride();
+    setSendAchievement(null);
+    setSendDelta(null);
+  });
 
   it('fires levelup when buyKarma crosses the level boundary', async () => {
-    setState(mkState({
-      display_name: 'Dana',
-      locale: 'en',
-      game_values: mkGv({ xp_value: 10, xp_level: 1, cash_value: 9999, karma_value: 50 })
-    }));
+    setState(
+      mkState({
+        display_name: 'Dana',
+        locale: 'en',
+        game_values: mkGv({ xp_value: 10, xp_level: 1, cash_value: 9999, karma_value: 50 }),
+      })
+    );
     const spy = mkAchievementSpy();
     const { result } = await buyKarma('karmalauter001');
     if (result.levelup) {
@@ -246,27 +270,34 @@ describe('achievement — Tier 2: level-up via buyKarma', () => {
   });
 });
 
-
 // ── Tier 3: profile milestone ─────────────────────────────────────────────────
 
 describe('achievement — Tier 3: profile milestone via integrateCollected', () => {
   const COLLECT_ID = 'ach-milestone-001';
 
   beforeEach(() => setOverride(FIXED_NOW));
-  afterEach(() => { clearOverride(); setSendAchievement(null); setSendDelta(null); });
+  afterEach(() => {
+    clearOverride();
+    setSendAchievement(null);
+    setSendDelta(null);
+  });
 
   it('fires profiles_milestone when crossing the 1k threshold', async () => {
-    setState(mkState({
-      display_name: 'Frank',
-      locale: 'en',
-      game_values: mkGv({ profiles_value: 900, ap_snapshot: 6 }),
-      db_queue: [{
-        origin:      'Imperium.City.contact035',
-        collect_id:  COLLECT_ID,
-        profile_set: { profiles_value: 200, tokens_map: {} },
-        collect_dt:  FIXED_NOW
-      }]
-    }));
+    setState(
+      mkState({
+        display_name: 'Frank',
+        locale: 'en',
+        game_values: mkGv({ profiles_value: 900, ap_snapshot: 6 }),
+        db_queue: [
+          {
+            origin: 'Imperium.City.contact035',
+            collect_id: COLLECT_ID,
+            profile_set: { profiles_value: 200, tokens_map: {} },
+            collect_dt: FIXED_NOW,
+          },
+        ],
+      })
+    );
     const spy = mkAchievementSpy();
     await integrateCollected(COLLECT_ID);
     const calls = callsOfKind(spy, 'profiles_milestone');
@@ -277,17 +308,21 @@ describe('achievement — Tier 3: profile milestone via integrateCollected', () 
   });
 
   it('does not fire milestone when threshold not reached', async () => {
-    setState(mkState({
-      display_name: 'Frank',
-      locale: 'en',
-      game_values: mkGv({ profiles_value: 700, ap_snapshot: 6 }),
-      db_queue: [{
-        origin:      'Imperium.City.contact035',
-        collect_id:  COLLECT_ID,
-        profile_set: { profiles_value: 200, tokens_map: {} },
-        collect_dt:  FIXED_NOW
-      }]
-    }));
+    setState(
+      mkState({
+        display_name: 'Frank',
+        locale: 'en',
+        game_values: mkGv({ profiles_value: 700, ap_snapshot: 6 }),
+        db_queue: [
+          {
+            origin: 'Imperium.City.contact035',
+            collect_id: COLLECT_ID,
+            profile_set: { profiles_value: 200, tokens_map: {} },
+            collect_dt: FIXED_NOW,
+          },
+        ],
+      })
+    );
     const spy = mkAchievementSpy();
     await integrateCollected(COLLECT_ID);
     expect(callsOfKind(spy, 'profiles_milestone')).toHaveLength(0);
@@ -305,19 +340,30 @@ describe('replay invariant — applyDelta never fires achievements', () => {
 
   it('applyDelta with a buyPerp delta does not invoke sendAchievement', async () => {
     setOverride(FIXED_NOW);
-    setState(mkState({
-      display_name: 'Ivan',
-      locale: 'en',
-      game_values: mkGv({ cash_value: 5000, xp_level: 1 }),
-      active_missions: ['mission008'],
-      mission_goals: [{
-        mission: 'mission008', workflow: 'buy_perp', target: 'client002',
-        amount: null, position: 1, current_amount: 0, complete: false
-      }]
-    }));
+    setState(
+      mkState({
+        display_name: 'Ivan',
+        locale: 'en',
+        game_values: mkGv({ cash_value: 5000, xp_level: 1 }),
+        active_missions: ['mission008'],
+        mission_goals: [
+          {
+            mission: 'mission008',
+            workflow: 'buy_perp',
+            target: 'client002',
+            amount: null,
+            position: 1,
+            current_amount: 0,
+            complete: false,
+          },
+        ],
+      })
+    );
 
     let capturedDelta = null;
-    setSendDelta(d => { capturedDelta = d; });
+    setSendDelta((d) => {
+      capturedDelta = d;
+    });
 
     // Run the handler — achievements fire at the action site (expected)
     await buyPerp('Imperium', 'client002');
@@ -333,24 +379,38 @@ describe('replay invariant — applyDelta never fires achievements', () => {
   it('applyDelta with an integrateCollected delta does not invoke sendAchievement', async () => {
     setOverride(FIXED_NOW);
     const COLLECT_ID = 'replay-test-cid';
-    setState(mkState({
-      display_name: 'Jules',
-      locale: 'en',
-      game_values: mkGv({ profiles_value: 0, ap_snapshot: 6 }),
-      active_missions: ['mission002'],
-      mission_goals: [{
-        mission: 'mission002', workflow: 'integrate_profiles', target: 'token008',
-        amount: 900, position: 1, current_amount: 0, complete: false
-      }],
-      db_queue: [{
-        origin: 'Imperium.City.Agent0.contact035', collect_id: COLLECT_ID,
-        profile_set: { profiles_value: 1100, tokens_map: { token008: { amount: 100 } } },
-        collect_dt: FIXED_NOW
-      }]
-    }));
+    setState(
+      mkState({
+        display_name: 'Jules',
+        locale: 'en',
+        game_values: mkGv({ profiles_value: 0, ap_snapshot: 6 }),
+        active_missions: ['mission002'],
+        mission_goals: [
+          {
+            mission: 'mission002',
+            workflow: 'integrate_profiles',
+            target: 'token008',
+            amount: 900,
+            position: 1,
+            current_amount: 0,
+            complete: false,
+          },
+        ],
+        db_queue: [
+          {
+            origin: 'Imperium.City.Agent0.contact035',
+            collect_id: COLLECT_ID,
+            profile_set: { profiles_value: 1100, tokens_map: { token008: { amount: 100 } } },
+            collect_dt: FIXED_NOW,
+          },
+        ],
+      })
+    );
 
     let capturedDelta = null;
-    setSendDelta(d => { capturedDelta = d; });
+    setSendDelta((d) => {
+      capturedDelta = d;
+    });
 
     await integrateCollected(COLLECT_ID);
     expect(capturedDelta).not.toBeNull();
@@ -363,14 +423,16 @@ describe('replay invariant — applyDelta never fires achievements', () => {
 
   it('replaying a sequence of deltas never fires sendAchievement', async () => {
     setOverride(FIXED_NOW);
-    setState(mkState({
-      display_name: 'Kim',
-      locale: 'en',
-      game_values: mkGv({ cash_value: 9999, xp_level: 1, xp_value: 10 })
-    }));
+    setState(
+      mkState({
+        display_name: 'Kim',
+        locale: 'en',
+        game_values: mkGv({ cash_value: 9999, xp_level: 1, xp_value: 10 }),
+      })
+    );
 
     const deltas = [];
-    setSendDelta(d => deltas.push(d));
+    setSendDelta((d) => deltas.push(d));
 
     await buyPerp('Imperium', 'client007');
     await buyPerp('Imperium', 'client002');
@@ -397,11 +459,13 @@ describe('achievement — i18n locale selection', () => {
 
   it('uses German strings when state.locale is "de" (default)', async () => {
     setOverride(FIXED_NOW);
-    setState(mkState({
-      display_name: 'Lena',
-      // locale omitted → defaults to 'de'
-      game_values: mkGv({ xp_value: 10, xp_level: 1, cash_value: 5000 })
-    }));
+    setState(
+      mkState({
+        display_name: 'Lena',
+        // locale omitted → defaults to 'de'
+        game_values: mkGv({ xp_value: 10, xp_level: 1, cash_value: 5000 }),
+      })
+    );
     const spy = mkAchievementSpy();
     await buyPerp('Imperium', 'client007');
     const levelupCall = callsOfKind(spy, 'levelup')[0];
@@ -412,11 +476,13 @@ describe('achievement — i18n locale selection', () => {
 
   it('uses English strings when state.locale is "en"', async () => {
     setOverride(FIXED_NOW);
-    setState(mkState({
-      display_name: 'Mike',
-      locale: 'en',
-      game_values: mkGv({ xp_value: 10, xp_level: 1, cash_value: 5000 })
-    }));
+    setState(
+      mkState({
+        display_name: 'Mike',
+        locale: 'en',
+        game_values: mkGv({ xp_value: 10, xp_level: 1, cash_value: 5000 }),
+      })
+    );
     const spy = mkAchievementSpy();
     await buyPerp('Imperium', 'client007');
     const levelupCall = callsOfKind(spy, 'levelup')[0];

--- a/tests/handlers/achievements.test.js
+++ b/tests/handlers/achievements.test.js
@@ -11,18 +11,18 @@
  *  - Tier 3 cosmetic milestones fire correctly.
  *  - payload.achievement_kind distinguishes subtypes for consumers.
  */
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  buyKarma,
   buyPerp,
   integrateCollected,
-  buyKarma,
+  setEmitter,
   setSendAchievement,
   setSendDelta,
-  setEmitter,
 } from '../../scripts/LocalEngine.js';
 import { getState, setState } from '../../scripts/boot.js';
+import { clearOverride, setOverride } from '../../scripts/clock.js';
 import { applyDelta, freshState } from '../../scripts/state.js';
-import { setOverride, clearOverride } from '../../scripts/clock.js';
 import { FIXED_NOW, mkGv, mkState } from './_fixtures.js';
 
 // ── Helpers ──────────────────────────────────────────────────────────────────

--- a/tests/handlers/chargePerp.test.js
+++ b/tests/handlers/chargePerp.test.js
@@ -1,8 +1,6 @@
 // @ts-nocheck — strict-TS quarantine; remove when this file is migrated to TS (issue #147)
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import {
-  chargePerp, loadGame, setSendDelta, setEmitter,
-} from '../../scripts/LocalEngine.js';
+import { chargePerp, loadGame, setSendDelta, setEmitter } from '../../scripts/LocalEngine.js';
 import { getState, setState } from '../../scripts/boot.js';
 import { freshState, applyDelta } from '../../scripts/state.js';
 import { setOverride, clearOverride } from '../../scripts/clock.js';
@@ -17,31 +15,33 @@ import { FIXED_NOW, mkNode as _mkNode, mkState as _mkBaseState } from './_fixtur
 //   collect_amount:  1100
 //   xp_inc:          1
 //   game_type:       ContactPerp
-const GESTALT     = 'contact035';
+const GESTALT = 'contact035';
 const CHARGE_TIME = 30_000;
 const CHARGE_COST = 60;
-const NODE_PATH   = 'Imperium.CityVienna.Agent0.contact035';
+const NODE_PATH = 'Imperium.CityVienna.Agent0.contact035';
 
 // chargePerp-specific game_values: lower starting cash (500) and AP (3) so
 // tests can exercise deduction and AP failure without extra overrides.
 var BASE_GV = {
-  cash_value:      500,
-  cash_spent:      0,
-  xp_value:        0,
-  ap_snapshot:     3,
+  cash_value: 500,
+  cash_spent: 0,
+  xp_value: 0,
+  ap_snapshot: 3,
   // ap_update at FIXED_NOW so the materialize-on-entry call regenerates
   // zero ticks (elapsed = 0). Tests that exercise regen explicitly
   // override this.
-  ap_update:       FIXED_NOW,
-  ap_inc_value:    1,
+  ap_update: FIXED_NOW,
+  ap_inc_value: 1,
   ap_inc_interval: 120_000,
-  ap_max:          6,
+  ap_max: 6,
 };
 
 function mkState(overrides) {
   overrides = overrides || {};
   var gv = Object.assign({}, BASE_GV, overrides.game_values || {});
-  return _mkBaseState(Object.assign({ nodes: [_mkNode('ContactPerp', NODE_PATH)] }, overrides, { game_values: gv }));
+  return _mkBaseState(
+    Object.assign({ nodes: [_mkNode('ContactPerp', NODE_PATH)] }, overrides, { game_values: gv })
+  );
 }
 
 // Reset injectable hooks after each test.
@@ -163,7 +163,7 @@ describe('chargePerp — delta replay', () => {
 
   it('calls the injected sendDelta function', async () => {
     const captured = [];
-    setSendDelta(d => captured.push(d));
+    setSendDelta((d) => captured.push(d));
     setState(mkState());
 
     await chargePerp(NODE_PATH);
@@ -173,7 +173,7 @@ describe('chargePerp — delta replay', () => {
 
   it('emitted delta has kind=delta and op=chargePerp', async () => {
     const captured = [];
-    setSendDelta(d => captured.push(d));
+    setSendDelta((d) => captured.push(d));
     setState(mkState());
 
     await chargePerp(NODE_PATH);
@@ -185,7 +185,7 @@ describe('chargePerp — delta replay', () => {
 
   it('emitted delta carries the charge entry in result', async () => {
     const captured = [];
-    setSendDelta(d => captured.push(d));
+    setSendDelta((d) => captured.push(d));
     setState(mkState());
 
     await chargePerp(NODE_PATH);
@@ -198,7 +198,7 @@ describe('chargePerp — delta replay', () => {
 
   it('applyDelta replay reconstructs the same state as the handler', async () => {
     const captured = [];
-    setSendDelta(d => captured.push(d));
+    setSendDelta((d) => captured.push(d));
 
     const initial = mkState();
     setState(initial);
@@ -218,8 +218,9 @@ describe('chargePerp — delta replay', () => {
     expect(replayed.nodes_charging).toHaveLength(1);
     expect(replayed.nodes_charging[0]).toEqual(handlerState.nodes_charging[0]);
     // charge_start set on node.
-    expect(replayed.nodes[0].instance_data.charge_start)
-      .toBe(handlerState.nodes[0].instance_data.charge_start);
+    expect(replayed.nodes[0].instance_data.charge_start).toBe(
+      handlerState.nodes[0].instance_data.charge_start
+    );
   });
 });
 
@@ -243,7 +244,7 @@ describe('chargePerp — materialization integration', () => {
 
   it('node_ready event carries the pre-computed charge result', async () => {
     await chargePerp(NODE_PATH);
-    const s        = getState();
+    const s = getState();
     const expected = s.nodes_charging[0].result;
 
     const mat = materialize(s, FIXED_NOW + CHARGE_TIME + 1);
@@ -303,7 +304,7 @@ describe('chargePerp — failure: insufficient cash', () => {
   it('does not call sendDelta on cash failure', async () => {
     setOverride(FIXED_NOW);
     const captured = [];
-    setSendDelta(d => captured.push(d));
+    setSendDelta((d) => captured.push(d));
     setState(mkState({ game_values: { cash_value: 0, ap_snapshot: 3 } }));
 
     await chargePerp(NODE_PATH);
@@ -369,7 +370,7 @@ describe('chargePerp — failure: non-chargeable node (no charge_time)', () => {
     // Use a StoryPerp gestalt (no charge_time in type_data)
     var nonChargeable = Object.assign({}, _mkNode('StoryPerp', 'Imperium.story001'), {
       full_type: 'StoryPerp:13fee24f6edc8f796903e5b1fad001d3000',
-      gestalt:   '13fee24f6edc8f796903e5b1fad001d3000',
+      gestalt: '13fee24f6edc8f796903e5b1fad001d3000',
     });
     var s = mkState({ nodes: [nonChargeable] });
     setState(s);
@@ -388,9 +389,11 @@ describe('chargePerp — failure: non-chargeable node (no charge_time)', () => {
 describe('chargePerp — level-up refills AP and advances xp_level', () => {
   beforeEach(() => {
     setOverride(FIXED_NOW);
-    setState(mkState({
-      game_values: { xp_value: 10, xp_level: 1, ap_snapshot: 3, ap_max: 6 }
-    }));
+    setState(
+      mkState({
+        game_values: { xp_value: 10, xp_level: 1, ap_snapshot: 3, ap_max: 6 },
+      })
+    );
   });
 
   it('returns levelup=true when xp_inc crosses the level threshold', async () => {
@@ -403,7 +406,7 @@ describe('chargePerp — level-up refills AP and advances xp_level', () => {
     expect(result.game_values.xp_level).toBe(2);
   });
 
-  it('refills ap_snapshot to the new level\'s ap_max (not -1 from charging)', async () => {
+  it("refills ap_snapshot to the new level's ap_max (not -1 from charging)", async () => {
     const { result } = await chargePerp(NODE_PATH);
     expect(result.game_values.ap_snapshot).toBe(8);
   });
@@ -412,9 +415,11 @@ describe('chargePerp — level-up refills AP and advances xp_level', () => {
 describe('chargePerp — no level-up keeps xp_level and decrements ap_snapshot', () => {
   it('xp gain inside the same level reports levelup=false and AP-1', async () => {
     setOverride(FIXED_NOW);
-    setState(mkState({
-      game_values: { xp_value: 5, xp_level: 1, ap_snapshot: 4, ap_max: 6 }
-    }));
+    setState(
+      mkState({
+        game_values: { xp_value: 5, xp_level: 1, ap_snapshot: 4, ap_max: 6 },
+      })
+    );
     const { result } = await chargePerp(NODE_PATH);
     expect(result.levelup).toBe(false);
     expect(result.game_values.xp_level).toBe(1);
@@ -446,13 +451,17 @@ describe('chargePerp — live-tick setTimeout', () => {
     const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
     await chargePerp(NODE_PATH);
     // contact035 charge_time = 30000 ms.
-    const matched = setTimeoutSpy.mock.calls.find(function (c) { return c[1] === CHARGE_TIME; });
+    const matched = setTimeoutSpy.mock.calls.find(function (c) {
+      return c[1] === CHARGE_TIME;
+    });
     expect(matched).toBeDefined();
   });
 
   it('emits node_ready when fake timers advance past charge_end', async () => {
     var events = [];
-    setEmitter(function (ev, payload) { events.push({ ev: ev, payload: payload }); });
+    setEmitter(function (ev, payload) {
+      events.push({ ev: ev, payload: payload });
+    });
 
     await chargePerp(NODE_PATH);
     // Advance the host wall clock that setTimeout reads, AND the injectable
@@ -460,7 +469,11 @@ describe('chargePerp — live-tick setTimeout', () => {
     setOverride(FIXED_NOW + CHARGE_TIME + 1);
     vi.advanceTimersByTime(CHARGE_TIME + 1);
 
-    expect(events.some(function (e) { return e.ev === 'node_ready'; })).toBe(true);
+    expect(
+      events.some(function (e) {
+        return e.ev === 'node_ready';
+      })
+    ).toBe(true);
     const s = getState();
     expect(s.nodes_charging.length).toBe(0);
     expect(s.nodes_collect.length).toBe(1);
@@ -469,19 +482,25 @@ describe('chargePerp — live-tick setTimeout', () => {
 
   it('loadGame re-arms timers for charges still in flight', async () => {
     // Seed state with an active charge whose charge_end is 30s from now.
-    setState(mkState({
-      nodes_charging: [{
-        path:         NODE_PATH,
-        result:       { amount: 1100 },
-        charge_start: FIXED_NOW,
-        charge_end:   FIXED_NOW + CHARGE_TIME,
-        game_id:      'node_contact035',
-        game_type:    'ContactPerp'
-      }]
-    }));
+    setState(
+      mkState({
+        nodes_charging: [
+          {
+            path: NODE_PATH,
+            result: { amount: 1100 },
+            charge_start: FIXED_NOW,
+            charge_end: FIXED_NOW + CHARGE_TIME,
+            game_id: 'node_contact035',
+            game_type: 'ContactPerp',
+          },
+        ],
+      })
+    );
 
     var events = [];
-    setEmitter(function (ev, payload) { events.push({ ev: ev, payload: payload }); });
+    setEmitter(function (ev, payload) {
+      events.push({ ev: ev, payload: payload });
+    });
 
     await loadGame();
     // Without rearm, advancing timers would not fire node_ready because no
@@ -489,20 +508,28 @@ describe('chargePerp — live-tick setTimeout', () => {
     setOverride(FIXED_NOW + CHARGE_TIME + 1);
     vi.advanceTimersByTime(CHARGE_TIME + 1);
 
-    expect(events.some(function (e) { return e.ev === 'node_ready'; })).toBe(true);
+    expect(
+      events.some(function (e) {
+        return e.ev === 'node_ready';
+      })
+    ).toBe(true);
   });
 
   it('calling loadGame twice does not duplicate node_ready emits for one charge', async () => {
-    setState(mkState({
-      nodes_charging: [{
-        path:         NODE_PATH,
-        result:       { amount: 1100 },
-        charge_start: FIXED_NOW,
-        charge_end:   FIXED_NOW + CHARGE_TIME,
-        game_id:      'node_contact035',
-        game_type:    'ContactPerp'
-      }]
-    }));
+    setState(
+      mkState({
+        nodes_charging: [
+          {
+            path: NODE_PATH,
+            result: { amount: 1100 },
+            charge_start: FIXED_NOW,
+            charge_end: FIXED_NOW + CHARGE_TIME,
+            game_id: 'node_contact035',
+            game_type: 'ContactPerp',
+          },
+        ],
+      })
+    );
 
     var events = [];
     setEmitter(function (ev, payload) {
@@ -528,16 +555,18 @@ describe('chargePerp — live-tick setTimeout', () => {
 describe('chargePerp — sees AP regen since the last materialize', () => {
   beforeEach(() => {
     setOverride(FIXED_NOW);
-    setState(mkState({
-      // ap_snapshot=0, ap_update set 2 minutes ago → one full tick ready.
-      game_values: Object.assign({}, BASE_GV, {
-        ap_snapshot: 0,
-        ap_update: FIXED_NOW - 120_000,
-        ap_inc_value: 1,
-        ap_inc_interval: 120_000,
-        ap_max: 6
+    setState(
+      mkState({
+        // ap_snapshot=0, ap_update set 2 minutes ago → one full tick ready.
+        game_values: Object.assign({}, BASE_GV, {
+          ap_snapshot: 0,
+          ap_update: FIXED_NOW - 120_000,
+          ap_inc_value: 1,
+          ap_inc_interval: 120_000,
+          ap_max: 6,
+        }),
       })
-    }));
+    );
   });
 
   afterEach(() => {
@@ -565,17 +594,21 @@ describe('chargePerp — ClientPerp uses income_base when collect_amount is miss
 
   beforeEach(() => {
     setOverride(FIXED_NOW);
-    setState(Object.assign({}, freshState('test@local'), {
-      nodes: [{
-        game_id: 'node_client007',
-        game_type: 'ClientPerp',
-        full_type: 'ClientPerp:client007',
-        gestalt: 'client007',
-        full_path: CAR_PATH,
-        instance_data: {}
-      }],
-      game_values: Object.assign({}, BASE_GV, { cash_value: 300, ap_snapshot: 6 })
-    }));
+    setState(
+      Object.assign({}, freshState('test@local'), {
+        nodes: [
+          {
+            game_id: 'node_client007',
+            game_type: 'ClientPerp',
+            full_type: 'ClientPerp:client007',
+            gestalt: 'client007',
+            full_path: CAR_PATH,
+            instance_data: {},
+          },
+        ],
+        game_values: Object.assign({}, BASE_GV, { cash_value: 300, ap_snapshot: 6 }),
+      })
+    );
   });
 
   afterEach(() => {
@@ -640,10 +673,15 @@ describe('chargePerp — clock catch-up: app closed for 7 days', () => {
     // current ap_max (e.g. old save loaded after ap_max was lowered or a
     // replay-order anomaly).  The materializer must enforce ap_snapshot ≤ ap_max.
     const s = mkState({
-      game_values: { ap_snapshot: 20, ap_max: 6, ap_update: FIXED_NOW,
-                     ap_inc_value: 1, ap_inc_interval: 120_000 }
+      game_values: {
+        ap_snapshot: 20,
+        ap_max: 6,
+        ap_update: FIXED_NOW,
+        ap_inc_value: 1,
+        ap_inc_interval: 120_000,
+      },
     });
-    const mat = materialize(s, FIXED_NOW);  // no elapsed time → 0 ticks
+    const mat = materialize(s, FIXED_NOW); // no elapsed time → 0 ticks
     expect(mat.state.game_values.ap_snapshot).toBe(6);
   });
 });
@@ -659,12 +697,12 @@ describe('chargePerp — 100+ simultaneous completed charges in one materialize(
     var charges = [];
     for (var i = 0; i < NUM_CHARGES; i++) {
       charges.push({
-        path:         'Imperium.CityVienna.Agent0.contact' + i,
-        result:       { amount: 1000 + i },
+        path: 'Imperium.CityVienna.Agent0.contact' + i,
+        result: { amount: 1000 + i },
         charge_start: FIXED_NOW,
-        charge_end:   FIXED_NOW + CHARGE_TIME,
-        game_id:      'node-' + i,
-        game_type:    'ContactPerp',
+        charge_end: FIXED_NOW + CHARGE_TIME,
+        game_id: 'node-' + i,
+        game_type: 'ContactPerp',
       });
     }
     const s = mkState({ nodes_charging: charges });
@@ -673,7 +711,9 @@ describe('chargePerp — 100+ simultaneous completed charges in one materialize(
     expect(mat.state.nodes_charging).toHaveLength(0);
     expect(mat.state.nodes_collect).toHaveLength(NUM_CHARGES);
     expect(mat.events).toHaveLength(NUM_CHARGES);
-    var paths = mat.state.nodes_collect.map(function (e) { return e.path; });
+    var paths = mat.state.nodes_collect.map(function (e) {
+      return e.path;
+    });
     expect(new Set(paths).size).toBe(NUM_CHARGES);
   });
 
@@ -682,12 +722,12 @@ describe('chargePerp — 100+ simultaneous completed charges in one materialize(
     var charges = [];
     for (var i = 0; i < NUM_CHARGES; i++) {
       charges.push({
-        path:         'Imperium.CityVienna.Agent0.contact' + i,
-        result:       { amount: 1000 + i },
+        path: 'Imperium.CityVienna.Agent0.contact' + i,
+        result: { amount: 1000 + i },
         charge_start: FIXED_NOW,
-        charge_end:   FIXED_NOW + CHARGE_TIME,
-        game_id:      'node-' + i,
-        game_type:    'ContactPerp',
+        charge_end: FIXED_NOW + CHARGE_TIME,
+        game_id: 'node-' + i,
+        game_type: 'ContactPerp',
       });
     }
     const s = mkState({ nodes_charging: charges });
@@ -710,18 +750,28 @@ describe('chargePerp — 100+ simultaneous completed charges in one materialize(
 describe('chargePerp — mixed-duration charges: events in ascending charge_end order', () => {
   it('shorter charge_end fires first when both charges complete in the same tick', () => {
     const SHORT_END = FIXED_NOW + 5_000;
-    const LONG_END  = FIXED_NOW + 10_000;
+    const LONG_END = FIXED_NOW + 10_000;
 
     // Insert entries out of order (longer first) to verify the sort.
     const s = mkState({
       nodes_charging: [
-        { path: 'Imperium.long',  result: { amount: 1000 },
-          charge_start: FIXED_NOW, charge_end: LONG_END,
-          game_id: 'node-long',  game_type: 'ContactPerp' },
-        { path: 'Imperium.short', result: { amount: 500 },
-          charge_start: FIXED_NOW, charge_end: SHORT_END,
-          game_id: 'node-short', game_type: 'ContactPerp' },
-      ]
+        {
+          path: 'Imperium.long',
+          result: { amount: 1000 },
+          charge_start: FIXED_NOW,
+          charge_end: LONG_END,
+          game_id: 'node-long',
+          game_type: 'ContactPerp',
+        },
+        {
+          path: 'Imperium.short',
+          result: { amount: 500 },
+          charge_start: FIXED_NOW,
+          charge_end: SHORT_END,
+          game_id: 'node-short',
+          game_type: 'ContactPerp',
+        },
+      ],
     });
 
     const mat = materialize(s, FIXED_NOW + 15_000);
@@ -732,19 +782,29 @@ describe('chargePerp — mixed-duration charges: events in ascending charge_end 
 
   it('nodes_collect preserves arrival order (pre-existing first, then by charge_end)', () => {
     const SHORT_END = FIXED_NOW + 5_000;
-    const LONG_END  = FIXED_NOW + 10_000;
+    const LONG_END = FIXED_NOW + 10_000;
 
     const preExisting = { path: 'Imperium.existing', result: { amount: 0 } };
     const s = mkState({
-      nodes_collect:  [preExisting],
+      nodes_collect: [preExisting],
       nodes_charging: [
-        { path: 'Imperium.long',  result: { amount: 1000 },
-          charge_start: FIXED_NOW, charge_end: LONG_END,
-          game_id: 'node-long',  game_type: 'ContactPerp' },
-        { path: 'Imperium.short', result: { amount: 500 },
-          charge_start: FIXED_NOW, charge_end: SHORT_END,
-          game_id: 'node-short', game_type: 'ContactPerp' },
-      ]
+        {
+          path: 'Imperium.long',
+          result: { amount: 1000 },
+          charge_start: FIXED_NOW,
+          charge_end: LONG_END,
+          game_id: 'node-long',
+          game_type: 'ContactPerp',
+        },
+        {
+          path: 'Imperium.short',
+          result: { amount: 500 },
+          charge_start: FIXED_NOW,
+          charge_end: SHORT_END,
+          game_id: 'node-short',
+          game_type: 'ContactPerp',
+        },
+      ],
     });
 
     const mat = materialize(s, FIXED_NOW + 15_000);
@@ -768,19 +828,23 @@ describe('chargePerp — mission003 charge_perp goal completion (end-to-end)', (
   beforeEach(() => setOverride(FIXED_NOW));
 
   it('charging client007 completes the mission003 charge_perp goal', async () => {
-    setState(mkState({
-      nodes: [_mkNode('ContactPerp', NODE_PATH), _mkNode('ClientPerp', CLIENT_PATH)],
-      active_missions: ['mission003'],
-      mission_goals: [{
-        mission:        'mission003',
-        workflow:       'charge_perp',
-        target:         'client007',
-        amount:         null,
-        position:       1,
-        current_amount: 0,
-        complete:       false,
-      }],
-    }));
+    setState(
+      mkState({
+        nodes: [_mkNode('ContactPerp', NODE_PATH), _mkNode('ClientPerp', CLIENT_PATH)],
+        active_missions: ['mission003'],
+        mission_goals: [
+          {
+            mission: 'mission003',
+            workflow: 'charge_perp',
+            target: 'client007',
+            amount: null,
+            position: 1,
+            current_amount: 0,
+            complete: false,
+          },
+        ],
+      })
+    );
 
     const { result } = await chargePerp(CLIENT_PATH);
 
@@ -788,34 +852,44 @@ describe('chargePerp — mission003 charge_perp goal completion (end-to-end)', (
     expect(result.missions).toBeDefined();
     expect(result.missions.complete_missions).toContain('mission003');
 
-    const goal = getState().mission_goals.find(function (g) { return g.mission === 'mission003'; });
+    const goal = getState().mission_goals.find(function (g) {
+      return g.mission === 'mission003';
+    });
     expect(goal).toBeDefined();
     expect(goal.complete).toBe(true);
   });
 
   it('charging a different perp does NOT complete the mission003 goal', async () => {
-    setState(mkState({
-      nodes: [_mkNode('ContactPerp', NODE_PATH)],  // contact035, not client007
-      active_missions: ['mission003'],
-      mission_goals: [{
-        mission:        'mission003',
-        workflow:       'charge_perp',
-        target:         'client007',
-        amount:         null,
-        position:       1,
-        current_amount: 0,
-        complete:       false,
-      }],
-    }));
+    setState(
+      mkState({
+        nodes: [_mkNode('ContactPerp', NODE_PATH)], // contact035, not client007
+        active_missions: ['mission003'],
+        mission_goals: [
+          {
+            mission: 'mission003',
+            workflow: 'charge_perp',
+            target: 'client007',
+            amount: null,
+            position: 1,
+            current_amount: 0,
+            complete: false,
+          },
+        ],
+      })
+    );
 
-    const { result } = await chargePerp(NODE_PATH);  // charges contact035
+    const { result } = await chargePerp(NODE_PATH); // charges contact035
 
     expect(result.error).toBeUndefined();
     // No mission completion — wrong target.
     const missions = result.missions;
-    expect(!missions || !missions.complete_missions || missions.complete_missions.length === 0).toBe(true);
+    expect(
+      !missions || !missions.complete_missions || missions.complete_missions.length === 0
+    ).toBe(true);
 
-    const goal = getState().mission_goals.find(function (g) { return g.mission === 'mission003'; });
+    const goal = getState().mission_goals.find(function (g) {
+      return g.mission === 'mission003';
+    });
     expect(goal.complete).toBe(false);
   });
 });

--- a/tests/handlers/chargePerp.test.js
+++ b/tests/handlers/chargePerp.test.js
@@ -1,11 +1,11 @@
 // @ts-nocheck — strict-TS quarantine; remove when this file is migrated to TS (issue #147)
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { chargePerp, loadGame, setSendDelta, setEmitter } from '../../scripts/LocalEngine.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { chargePerp, loadGame, setEmitter, setSendDelta } from '../../scripts/LocalEngine.js';
 import { getState, setState } from '../../scripts/boot.js';
-import { freshState, applyDelta } from '../../scripts/state.js';
-import { setOverride, clearOverride } from '../../scripts/clock.js';
+import { clearOverride, setOverride } from '../../scripts/clock.js';
 import { materialize } from '../../scripts/materializer.js';
-import { FIXED_NOW, mkNode as _mkNode, mkState as _mkBaseState } from './_fixtures.js';
+import { applyDelta, freshState } from '../../scripts/state.js';
+import { FIXED_NOW, mkState as _mkBaseState, mkNode as _mkNode } from './_fixtures.js';
 
 // ── fixtures ─────────────────────────────────────────────────────────────────
 

--- a/tests/handlers/collect-integrate.test.js
+++ b/tests/handlers/collect-integrate.test.js
@@ -6,23 +6,23 @@
  *   { amount: number } — Thread S chargePerp schema (PR #72).
  *   XP gain is derived from ruleset type_data.xp_inc, not stored in result.
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
-  collectPerp,
-  integrateCollected,
-  chargePerp,
   buyPerp,
   buyPowerup,
+  chargePerp,
+  collectPerp,
+  integrateCollected,
   loadGame,
   setEmitter,
   setPrngSeed,
   setSendDelta,
 } from '../../scripts/LocalEngine.js';
-import { setState, getState } from '../../scripts/boot.js';
+import { getState, setState } from '../../scripts/boot.js';
+import { advance, clearOverride, setOverride } from '../../scripts/clock.js';
 import { materialize } from '../../scripts/materializer.js';
 import { applyDelta } from '../../scripts/state.js';
-import { setOverride, clearOverride, advance } from '../../scripts/clock.js';
-import { FIXED_NOW, mkGv, mkState, mkNode, mkChargingEntry } from './_fixtures.js';
+import { FIXED_NOW, mkChargingEntry, mkGv, mkNode, mkState } from './_fixtures.js';
 
 // ── Fixtures ─────────────────────────────────────────────────────────────────
 

--- a/tests/handlers/collect-integrate.test.js
+++ b/tests/handlers/collect-integrate.test.js
@@ -8,8 +8,15 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
-  collectPerp, integrateCollected, chargePerp, buyPerp, buyPowerup, loadGame,
-  setEmitter, setPrngSeed, setSendDelta
+  collectPerp,
+  integrateCollected,
+  chargePerp,
+  buyPerp,
+  buyPowerup,
+  loadGame,
+  setEmitter,
+  setPrngSeed,
+  setSendDelta,
 } from '../../scripts/LocalEngine.js';
 import { setState, getState } from '../../scripts/boot.js';
 import { materialize } from '../../scripts/materializer.js';
@@ -19,7 +26,7 @@ import { FIXED_NOW, mkGv, mkState, mkNode, mkChargingEntry } from './_fixtures.j
 
 // ── Fixtures ─────────────────────────────────────────────────────────────────
 
-const CHARGE_DUR = 120_000;                    // 2 min charge
+const CHARGE_DUR = 120_000; // 2 min charge
 const CHARGE_END = FIXED_NOW + CHARGE_DUR;
 
 // ── Full flow: charge → advance clock → collect → integrate ──────────────────
@@ -29,23 +36,30 @@ describe('full flow: ContactPerp charge → collect → integrate', () => {
   const COLLECT_RESULT = { amount: 5 };
 
   beforeEach(() => setOverride(FIXED_NOW));
-  afterEach(() => { clearOverride(); setEmitter(null); });
+  afterEach(() => {
+    clearOverride();
+    setEmitter(null);
+  });
 
   it('collect before charge_end returns error 1', async () => {
-    setState(mkState({
-      nodes:          [mkNode('ContactPerp', PATH)],
-      nodes_charging: [mkChargingEntry(PATH, COLLECT_RESULT, 'ContactPerp')]
-    }));
+    setState(
+      mkState({
+        nodes: [mkNode('ContactPerp', PATH)],
+        nodes_charging: [mkChargingEntry(PATH, COLLECT_RESULT, 'ContactPerp')],
+      })
+    );
 
     const data = await collectPerp(PATH);
     expect(data.result.error).toBe(1);
   });
 
   it('collect after charge_end succeeds and puts entry in db_queue', async () => {
-    setState(mkState({
-      nodes:          [mkNode('ContactPerp', PATH)],
-      nodes_charging: [mkChargingEntry(PATH, COLLECT_RESULT, 'ContactPerp')]
-    }));
+    setState(
+      mkState({
+        nodes: [mkNode('ContactPerp', PATH)],
+        nodes_charging: [mkChargingEntry(PATH, COLLECT_RESULT, 'ContactPerp')],
+      })
+    );
 
     // Advance past charge_end
     setOverride(CHARGE_END + 1000);
@@ -61,10 +75,12 @@ describe('full flow: ContactPerp charge → collect → integrate', () => {
   });
 
   it('nodes_collect is cleared and db_queue gains one entry after collect', async () => {
-    setState(mkState({
-      nodes:          [mkNode('ContactPerp', PATH)],
-      nodes_charging: [mkChargingEntry(PATH, COLLECT_RESULT, 'ContactPerp')]
-    }));
+    setState(
+      mkState({
+        nodes: [mkNode('ContactPerp', PATH)],
+        nodes_charging: [mkChargingEntry(PATH, COLLECT_RESULT, 'ContactPerp')],
+      })
+    );
     setOverride(CHARGE_END + 1000);
 
     const { result } = await collectPerp(PATH);
@@ -79,10 +95,12 @@ describe('full flow: ContactPerp charge → collect → integrate', () => {
   });
 
   it('integrateCollected resolves the db_queue entry', async () => {
-    setState(mkState({
-      nodes:          [mkNode('ContactPerp', PATH)],
-      nodes_charging: [mkChargingEntry(PATH, COLLECT_RESULT, 'ContactPerp')]
-    }));
+    setState(
+      mkState({
+        nodes: [mkNode('ContactPerp', PATH)],
+        nodes_charging: [mkChargingEntry(PATH, COLLECT_RESULT, 'ContactPerp')],
+      })
+    );
     setOverride(CHARGE_END + 1000);
 
     const { result: colRes } = await collectPerp(PATH);
@@ -96,10 +114,12 @@ describe('full flow: ContactPerp charge → collect → integrate', () => {
   });
 
   it('re-integrating the same collect_id returns dup=profiles_value and increment=0', async () => {
-    setState(mkState({
-      nodes:          [mkNode('ContactPerp', PATH)],
-      nodes_charging: [mkChargingEntry(PATH, COLLECT_RESULT, 'ContactPerp')]
-    }));
+    setState(
+      mkState({
+        nodes: [mkNode('ContactPerp', PATH)],
+        nodes_charging: [mkChargingEntry(PATH, COLLECT_RESULT, 'ContactPerp')],
+      })
+    );
     setOverride(CHARGE_END + 1000);
 
     const { result: colRes } = await collectPerp(PATH);
@@ -111,9 +131,18 @@ describe('full flow: ContactPerp charge → collect → integrate', () => {
     // Manually re-insert the db_queue entry to simulate a retry.
     const { getState: gs, setState: ss } = await import('../../scripts/boot.js');
     const cur = gs();
-    ss(Object.assign({}, cur, {
-      db_queue: [{ origin: PATH, collect_id: collectId, profile_set: { profiles_value: 5, tokens_map: {} }, collect_dt: FIXED_NOW }]
-    }));
+    ss(
+      Object.assign({}, cur, {
+        db_queue: [
+          {
+            origin: PATH,
+            collect_id: collectId,
+            profile_set: { profiles_value: 5, tokens_map: {} },
+            collect_dt: FIXED_NOW,
+          },
+        ],
+      })
+    );
 
     const { result: intRes2 } = await integrateCollected(collectId);
     expect(intRes2.result.dup).toBe(5);
@@ -121,10 +150,12 @@ describe('full flow: ContactPerp charge → collect → integrate', () => {
   });
 
   it('xp_value is incremented by xp_gain after collect', async () => {
-    setState(mkState({
-      nodes:          [mkNode('ContactPerp', PATH)],
-      nodes_charging: [mkChargingEntry(PATH, COLLECT_RESULT, 'ContactPerp')]
-    }));
+    setState(
+      mkState({
+        nodes: [mkNode('ContactPerp', PATH)],
+        nodes_charging: [mkChargingEntry(PATH, COLLECT_RESULT, 'ContactPerp')],
+      })
+    );
     setOverride(CHARGE_END + 1000);
 
     const { result } = await collectPerp(PATH);
@@ -149,10 +180,12 @@ describe('collectPerp — ContactPerp', () => {
   afterEach(() => clearOverride());
 
   it('returns profile_set, origin, and collect_id in result.result', async () => {
-    setState(mkState({
-      nodes:         [mkNode('ContactPerp', PATH)],
-      nodes_collect: [{ path: PATH, result: { amount: 3 } }]
-    }));
+    setState(
+      mkState({
+        nodes: [mkNode('ContactPerp', PATH)],
+        nodes_collect: [{ path: PATH, result: { amount: 3 } }],
+      })
+    );
 
     const { result } = await collectPerp(PATH);
     expect(result.result.profile_set).toEqual({ profiles_value: 3, tokens_map: {} });
@@ -161,10 +194,12 @@ describe('collectPerp — ContactPerp', () => {
   });
 
   it('does not return cash or token_upgraded_amount', async () => {
-    setState(mkState({
-      nodes:         [mkNode('ContactPerp', PATH)],
-      nodes_collect: [{ path: PATH, result: { amount: 3 } }]
-    }));
+    setState(
+      mkState({
+        nodes: [mkNode('ContactPerp', PATH)],
+        nodes_collect: [{ path: PATH, result: { amount: 3 } }],
+      })
+    );
 
     const { result } = await collectPerp(PATH);
     expect(result.result.cash).toBeUndefined();
@@ -172,10 +207,12 @@ describe('collectPerp — ContactPerp', () => {
   });
 
   it('response carries game_values, levelup, and missions', async () => {
-    setState(mkState({
-      nodes:         [mkNode('ContactPerp', PATH)],
-      nodes_collect: [{ path: PATH, result: { amount: 3 } }]
-    }));
+    setState(
+      mkState({
+        nodes: [mkNode('ContactPerp', PATH)],
+        nodes_collect: [{ path: PATH, result: { amount: 3 } }],
+      })
+    );
 
     const { result } = await collectPerp(PATH);
     expect(result.game_values).toBeDefined();
@@ -193,10 +230,12 @@ describe('collectPerp — ProjectPerp', () => {
   afterEach(() => clearOverride());
 
   it('returns profile_set, origin, and collect_id', async () => {
-    setState(mkState({
-      nodes:         [mkNode('ProjectPerp', PATH)],
-      nodes_collect: [{ path: PATH, result: { amount: 10 } }]
-    }));
+    setState(
+      mkState({
+        nodes: [mkNode('ProjectPerp', PATH)],
+        nodes_collect: [{ path: PATH, result: { amount: 10 } }],
+      })
+    );
 
     const { result } = await collectPerp(PATH);
     expect(result.result.profile_set.profiles_value).toBe(10);
@@ -206,10 +245,12 @@ describe('collectPerp — ProjectPerp', () => {
   });
 
   it('pushes to db_queue with correct shape', async () => {
-    setState(mkState({
-      nodes:         [mkNode('ProjectPerp', PATH)],
-      nodes_collect: [{ path: PATH, result: { amount: 10 } }]
-    }));
+    setState(
+      mkState({
+        nodes: [mkNode('ProjectPerp', PATH)],
+        nodes_collect: [{ path: PATH, result: { amount: 10 } }],
+      })
+    );
 
     const { result } = await collectPerp(PATH);
     const { getState } = await import('../../scripts/boot.js');
@@ -233,11 +274,13 @@ describe('collectPerp — ClientPerp', () => {
   afterEach(() => clearOverride());
 
   it('returns cash (new cash_value) in result.result', async () => {
-    setState(mkState({
-      nodes:         [mkNode('ClientPerp', PATH)],
-      nodes_collect: [{ path: PATH, result: { amount: 100 } }],
-      game_values:   mkGv({ cash_value: 300 })
-    }));
+    setState(
+      mkState({
+        nodes: [mkNode('ClientPerp', PATH)],
+        nodes_collect: [{ path: PATH, result: { amount: 100 } }],
+        game_values: mkGv({ cash_value: 300 }),
+      })
+    );
 
     const { result } = await collectPerp(PATH);
     expect(result.result.cash).toBe(400);
@@ -245,10 +288,12 @@ describe('collectPerp — ClientPerp', () => {
   });
 
   it('does not return profile_set or token_upgraded_amount', async () => {
-    setState(mkState({
-      nodes:         [mkNode('ClientPerp', PATH)],
-      nodes_collect: [{ path: PATH, result: { amount: 50 } }]
-    }));
+    setState(
+      mkState({
+        nodes: [mkNode('ClientPerp', PATH)],
+        nodes_collect: [{ path: PATH, result: { amount: 50 } }],
+      })
+    );
 
     const { result } = await collectPerp(PATH);
     expect(result.result.profile_set).toBeUndefined();
@@ -256,10 +301,12 @@ describe('collectPerp — ClientPerp', () => {
   });
 
   it('does not push to db_queue', async () => {
-    setState(mkState({
-      nodes:         [mkNode('ClientPerp', PATH)],
-      nodes_collect: [{ path: PATH, result: { amount: 50 } }]
-    }));
+    setState(
+      mkState({
+        nodes: [mkNode('ClientPerp', PATH)],
+        nodes_collect: [{ path: PATH, result: { amount: 50 } }],
+      })
+    );
 
     await collectPerp(PATH);
     const { getState } = await import('../../scripts/boot.js');
@@ -276,32 +323,38 @@ describe('collectPerp — TokenPerp', () => {
   afterEach(() => clearOverride());
 
   it('returns token_upgraded_amount (prevAmount + amount_gain)', async () => {
-    setState(mkState({
-      nodes:         [mkNode('TokenPerp', PATH, { amount: 3 })],
-      nodes_collect: [{ path: PATH, result: { amount: 2 } }]
-    }));
+    setState(
+      mkState({
+        nodes: [mkNode('TokenPerp', PATH, { amount: 3 })],
+        nodes_collect: [{ path: PATH, result: { amount: 2 } }],
+      })
+    );
 
     const { result } = await collectPerp(PATH);
     expect(result.result.token_upgraded_amount).toBe(5);
   });
 
   it('updates instance_data.amount in state.nodes', async () => {
-    setState(mkState({
-      nodes:         [mkNode('TokenPerp', PATH, { amount: 3 })],
-      nodes_collect: [{ path: PATH, result: { amount: 2 } }]
-    }));
+    setState(
+      mkState({
+        nodes: [mkNode('TokenPerp', PATH, { amount: 3 })],
+        nodes_collect: [{ path: PATH, result: { amount: 2 } }],
+      })
+    );
 
     await collectPerp(PATH);
     const { getState } = await import('../../scripts/boot.js');
-    const node = getState().nodes.find(n => n.full_path === PATH);
+    const node = getState().nodes.find((n) => n.full_path === PATH);
     expect(node.instance_data.amount).toBe(5);
   });
 
   it('does not return profile_set or cash', async () => {
-    setState(mkState({
-      nodes:         [mkNode('TokenPerp', PATH, { amount: 0 })],
-      nodes_collect: [{ path: PATH, result: { amount: 4 } }]
-    }));
+    setState(
+      mkState({
+        nodes: [mkNode('TokenPerp', PATH, { amount: 0 })],
+        nodes_collect: [{ path: PATH, result: { amount: 4 } }],
+      })
+    );
 
     const { result } = await collectPerp(PATH);
     expect(result.result.profile_set).toBeUndefined();
@@ -323,12 +376,17 @@ describe('collectPerp — failure paths', () => {
 
   it('error 1 when charge_end is still in the future (materializer leaves it in nodes_charging)', async () => {
     const PATH = 'Imperium.City.contact_early';
-    setState(mkState({
-      nodes:          [mkNode('ContactPerp', PATH)],
-      // charge_end is 10 min from FIXED_NOW
-      nodes_charging: [Object.assign(mkChargingEntry(PATH, { amount: 1 }, 'ContactPerp'),
-                       { charge_end: FIXED_NOW + 600_000 })]
-    }));
+    setState(
+      mkState({
+        nodes: [mkNode('ContactPerp', PATH)],
+        // charge_end is 10 min from FIXED_NOW
+        nodes_charging: [
+          Object.assign(mkChargingEntry(PATH, { amount: 1 }, 'ContactPerp'), {
+            charge_end: FIXED_NOW + 600_000,
+          }),
+        ],
+      })
+    );
 
     const data = await collectPerp(PATH);
     expect(data.result.error).toBe(1);
@@ -336,10 +394,12 @@ describe('collectPerp — failure paths', () => {
 
   it('error 2 when path is in nodes_collect but node not in nodes array', async () => {
     const PATH = 'Imperium.City.ghost001';
-    setState(mkState({
-      nodes:         [],   // no matching node
-      nodes_collect: [{ path: PATH, result: { amount: 0 } }]
-    }));
+    setState(
+      mkState({
+        nodes: [], // no matching node
+        nodes_collect: [{ path: PATH, result: { amount: 0 } }],
+      })
+    );
     const data = await collectPerp(PATH);
     expect(data.result.error).toBe(2);
   });
@@ -351,14 +411,19 @@ describe('collectPerp — karma_incident', () => {
   const PATH = 'Imperium.City.Pusher0.client_karma';
 
   beforeEach(() => setOverride(FIXED_NOW));
-  afterEach(() => { clearOverride(); setPrngSeed(0xDEADBEEF); });
+  afterEach(() => {
+    clearOverride();
+    setPrngSeed(0xdeadbeef);
+  });
 
   it('karma_incident absent when karma_value >= 0', async () => {
-    setState(mkState({
-      nodes:         [mkNode('ClientPerp', PATH)],
-      nodes_collect: [{ path: PATH, result: { amount: 50 } }],
-      game_values:   mkGv({ karma_value: 50, xp_level: 5 })
-    }));
+    setState(
+      mkState({
+        nodes: [mkNode('ClientPerp', PATH)],
+        nodes_collect: [{ path: PATH, result: { amount: 50 } }],
+        game_values: mkGv({ karma_value: 50, xp_level: 5 }),
+      })
+    );
     setPrngSeed(42);
     const { result } = await collectPerp(PATH);
     expect(result.karma_incident).toBeUndefined();
@@ -367,11 +432,13 @@ describe('collectPerp — karma_incident', () => {
   it('seeded PRNG fires karma_incident and returns expected karmalizer gestalt', async () => {
     // karma=-80 → factor≈0.944; seed=42 first RNG value≈0.601 → fires
     // eligible at level=5: 4 karmalizers; seed=42 second RNG value picks karma014
-    setState(mkState({
-      nodes:         [mkNode('ClientPerp', PATH)],
-      nodes_collect: [{ path: PATH, result: { amount: 50 } }],
-      game_values:   mkGv({ karma_value: -80, xp_level: 5 })
-    }));
+    setState(
+      mkState({
+        nodes: [mkNode('ClientPerp', PATH)],
+        nodes_collect: [{ path: PATH, result: { amount: 50 } }],
+        game_values: mkGv({ karma_value: -80, xp_level: 5 }),
+      })
+    );
     setPrngSeed(42);
 
     const { result } = await collectPerp(PATH);
@@ -379,11 +446,13 @@ describe('collectPerp — karma_incident', () => {
   });
 
   it('karma_incident decreases karma_value within [-100, 100]', async () => {
-    setState(mkState({
-      nodes:         [mkNode('ClientPerp', PATH)],
-      nodes_collect: [{ path: PATH, result: { amount: 50 } }],
-      game_values:   mkGv({ karma_value: -80, xp_level: 5 })
-    }));
+    setState(
+      mkState({
+        nodes: [mkNode('ClientPerp', PATH)],
+        nodes_collect: [{ path: PATH, result: { amount: 50 } }],
+        game_values: mkGv({ karma_value: -80, xp_level: 5 }),
+      })
+    );
     setPrngSeed(42);
 
     const { result } = await collectPerp(PATH);
@@ -393,11 +462,13 @@ describe('collectPerp — karma_incident', () => {
 
   it('karma_incident absent when no eligible karmalizers (level 1)', async () => {
     // All karmalizers have required_level >= 5, so none eligible at level 1.
-    setState(mkState({
-      nodes:         [mkNode('ClientPerp', PATH)],
-      nodes_collect: [{ path: PATH, result: { amount: 50 } }],
-      game_values:   mkGv({ karma_value: -80, xp_level: 1 })
-    }));
+    setState(
+      mkState({
+        nodes: [mkNode('ClientPerp', PATH)],
+        nodes_collect: [{ path: PATH, result: { amount: 50 } }],
+        game_values: mkGv({ karma_value: -80, xp_level: 1 }),
+      })
+    );
     setPrngSeed(42);
 
     const { result } = await collectPerp(PATH);
@@ -422,16 +493,25 @@ describe('integrateCollected — token node updates', () => {
     // db_share = 2, ps_share = 3 → (2*6 + 3*4)/(6+4) = 24/10 = 2.4.
     const tokenNode = mkNode('TokenPerp', TOKEN_PATH, { amount: 2 });
     tokenNode.gestalt = 'token_a';
-    setState(mkState({
-      game_values: mkGv({ profiles_value: 6 }),
-      nodes: [tokenNode],
-      db_queue: [{
-        origin:      'Imperium.City.contact001',
-        collect_id:  COLLECT_ID,
-        profile_set: { profiles_value: 4, tokens_map: { token_a: { amount: 3 } }, xp_gain: 1, karma_gain: 0 },
-        collect_dt:  FIXED_NOW
-      }]
-    }));
+    setState(
+      mkState({
+        game_values: mkGv({ profiles_value: 6 }),
+        nodes: [tokenNode],
+        db_queue: [
+          {
+            origin: 'Imperium.City.contact001',
+            collect_id: COLLECT_ID,
+            profile_set: {
+              profiles_value: 4,
+              tokens_map: { token_a: { amount: 3 } },
+              xp_gain: 1,
+              karma_gain: 0,
+            },
+            collect_dt: FIXED_NOW,
+          },
+        ],
+      })
+    );
 
     const { result } = await integrateCollected(COLLECT_ID);
     expect(result.result.nodes).toHaveLength(1);
@@ -448,16 +528,20 @@ describe('integrateCollected — token node updates', () => {
     // = 149.5, clamped to 100.
     const tokenNode = mkNode('TokenPerp', TOKEN_PATH, { amount: 99 });
     tokenNode.gestalt = 'token_a';
-    setState(mkState({
-      game_values: mkGv({ profiles_value: 10 }),
-      nodes: [tokenNode],
-      db_queue: [{
-        origin:      'Imperium.City.contact001',
-        collect_id:  COLLECT_ID,
-        profile_set: { profiles_value: 10, tokens_map: { token_a: { amount: 200 } } },
-        collect_dt:  FIXED_NOW
-      }]
-    }));
+    setState(
+      mkState({
+        game_values: mkGv({ profiles_value: 10 }),
+        nodes: [tokenNode],
+        db_queue: [
+          {
+            origin: 'Imperium.City.contact001',
+            collect_id: COLLECT_ID,
+            profile_set: { profiles_value: 10, tokens_map: { token_a: { amount: 200 } } },
+            collect_dt: FIXED_NOW,
+          },
+        ],
+      })
+    );
 
     const { result } = await integrateCollected(COLLECT_ID);
     expect(result.result.nodes[0].instance_data.amount).toBe(100);
@@ -466,18 +550,22 @@ describe('integrateCollected — token node updates', () => {
   it('clamps a fresh-seeded TokenPerp at 100 too', async () => {
     // Seed share = ps_share * N / (M + N). With M=0 this collapses to ps_share,
     // so an over-100 ruleset row still hits the clamp at seed time.
-    setState(mkState({
-      locale: 'en',
-      db_queue: [{
-        origin:      'Imperium.City.contact001',
-        collect_id:  COLLECT_ID,
-        profile_set: { profiles_value: 50, tokens_map: { token008: { amount: 250 } } },
-        collect_dt:  FIXED_NOW
-      }]
-    }));
+    setState(
+      mkState({
+        locale: 'en',
+        db_queue: [
+          {
+            origin: 'Imperium.City.contact001',
+            collect_id: COLLECT_ID,
+            profile_set: { profiles_value: 50, tokens_map: { token008: { amount: 250 } } },
+            collect_dt: FIXED_NOW,
+          },
+        ],
+      })
+    );
 
     const { result } = await integrateCollected(COLLECT_ID);
-    const seeded = result.result.nodes.find(n => n.gestalt === 'token008');
+    const seeded = result.result.nodes.find((n) => n.gestalt === 'token008');
     expect(seeded.instance_data.amount).toBe(100);
   });
 
@@ -489,41 +577,49 @@ describe('integrateCollected — token node updates', () => {
     // Absolute count is preserved: M*old/100 = 8 == (M+N)*new/100.
     const tokenA = mkNode('TokenPerp', 'Imperium.Database.token_a', { amount: 80 });
     tokenA.gestalt = 'token_a';
-    setState(mkState({
-      game_values: mkGv({ profiles_value: 10 }),
-      nodes: [tokenA],
-      db_queue: [{
-        origin:      'Imperium.City.contact001',
-        collect_id:  COLLECT_ID,
-        profile_set: { profiles_value: 10, tokens_map: { token_b: { amount: 100 } } },
-        collect_dt:  FIXED_NOW
-      }]
-    }));
+    setState(
+      mkState({
+        game_values: mkGv({ profiles_value: 10 }),
+        nodes: [tokenA],
+        db_queue: [
+          {
+            origin: 'Imperium.City.contact001',
+            collect_id: COLLECT_ID,
+            profile_set: { profiles_value: 10, tokens_map: { token_b: { amount: 100 } } },
+            collect_dt: FIXED_NOW,
+          },
+        ],
+      })
+    );
 
     const { result } = await integrateCollected(COLLECT_ID);
-    const updatedA = result.result.nodes.find(n => n.gestalt === 'token_a');
+    const updatedA = result.result.nodes.find((n) => n.gestalt === 'token_a');
     expect(updatedA).toBeDefined();
     expect(updatedA.instance_data.amount).toBeCloseTo(40, 6);
     // Absolute count of token_a profiles must not regress.
     const absBefore = (10 * 80) / 100;
-    const absAfter  = ((10 + 10) * updatedA.instance_data.amount) / 100;
+    const absAfter = ((10 + 10) * updatedA.instance_data.amount) / 100;
     expect(absAfter).toBeCloseTo(absBefore, 6);
   });
 
   it('does not change shares on a duplicate collect_id replay (N = 0)', async () => {
     const tokenNode = mkNode('TokenPerp', TOKEN_PATH, { amount: 40 });
     tokenNode.gestalt = 'token_a';
-    setState(mkState({
-      game_values:    mkGv({ profiles_value: 10 }),
-      integrated_ids: { [COLLECT_ID]: true },
-      nodes: [tokenNode],
-      db_queue: [{
-        origin:      'Imperium.City.contact001',
-        collect_id:  COLLECT_ID,
-        profile_set: { profiles_value: 10, tokens_map: { token_a: { amount: 100 } } },
-        collect_dt:  FIXED_NOW
-      }]
-    }));
+    setState(
+      mkState({
+        game_values: mkGv({ profiles_value: 10 }),
+        integrated_ids: { [COLLECT_ID]: true },
+        nodes: [tokenNode],
+        db_queue: [
+          {
+            origin: 'Imperium.City.contact001',
+            collect_id: COLLECT_ID,
+            profile_set: { profiles_value: 10, tokens_map: { token_a: { amount: 100 } } },
+            collect_dt: FIXED_NOW,
+          },
+        ],
+      })
+    );
 
     const { result } = await integrateCollected(COLLECT_ID);
     expect(result.result.dup).toBe(10);
@@ -533,14 +629,18 @@ describe('integrateCollected — token node updates', () => {
   });
 
   it('returns game_values, levelup, and missions for server parity', async () => {
-    setState(mkState({
-      db_queue: [{
-        origin:      'Imperium.City.contact001',
-        collect_id:  COLLECT_ID,
-        profile_set: { profiles_value: 1, tokens_map: {} },
-        collect_dt:  FIXED_NOW
-      }]
-    }));
+    setState(
+      mkState({
+        db_queue: [
+          {
+            origin: 'Imperium.City.contact001',
+            collect_id: COLLECT_ID,
+            profile_set: { profiles_value: 1, tokens_map: {} },
+            collect_dt: FIXED_NOW,
+          },
+        ],
+      })
+    );
 
     const { result } = await integrateCollected(COLLECT_ID);
     expect(result.game_values).toBeDefined();
@@ -549,14 +649,18 @@ describe('integrateCollected — token node updates', () => {
   });
 
   it('drains db_queue after successful integration', async () => {
-    setState(mkState({
-      db_queue: [{
-        origin:      'Imperium.City.contact001',
-        collect_id:  COLLECT_ID,
-        profile_set: { profiles_value: 2, tokens_map: {} },
-        collect_dt:  FIXED_NOW
-      }]
-    }));
+    setState(
+      mkState({
+        db_queue: [
+          {
+            origin: 'Imperium.City.contact001',
+            collect_id: COLLECT_ID,
+            profile_set: { profiles_value: 2, tokens_map: {} },
+            collect_dt: FIXED_NOW,
+          },
+        ],
+      })
+    );
 
     await integrateCollected(COLLECT_ID);
     const { getState } = await import('../../scripts/boot.js');
@@ -566,39 +670,51 @@ describe('integrateCollected — token node updates', () => {
   it('appends a new TokenPerp node the first time a token type is integrated', async () => {
     // token008 is a real ruleset entry (mission002 targets it). State has no
     // node for it yet — integrateCollected must seed one under Database/.
-    setState(mkState({
-      locale: 'en',
-      db_queue: [{
-        origin:      'Imperium.City.contact001',
-        collect_id:  COLLECT_ID,
-        profile_set: { profiles_value: 50, tokens_map: { token008: { amount: 25 } } },
-        collect_dt:  FIXED_NOW
-      }]
-    }));
+    setState(
+      mkState({
+        locale: 'en',
+        db_queue: [
+          {
+            origin: 'Imperium.City.contact001',
+            collect_id: COLLECT_ID,
+            profile_set: { profiles_value: 50, tokens_map: { token008: { amount: 25 } } },
+            collect_dt: FIXED_NOW,
+          },
+        ],
+      })
+    );
 
     const { result } = await integrateCollected(COLLECT_ID);
-    const newEntry = result.result.nodes.find(function (n) { return n.gestalt === 'token008'; });
+    const newEntry = result.result.nodes.find(function (n) {
+      return n.gestalt === 'token008';
+    });
     expect(newEntry).toBeDefined();
     expect(newEntry.game_type).toBe('TokenPerp');
     expect(newEntry.full_path).toBe('Database.token008');
     expect(newEntry.instance_data.amount).toBe(25);
 
     const { getState } = await import('../../scripts/boot.js');
-    const persisted = getState().nodes.find(function (n) { return n.gestalt === 'token008'; });
+    const persisted = getState().nodes.find(function (n) {
+      return n.gestalt === 'token008';
+    });
     expect(persisted).toBeDefined();
     expect(persisted.full_path).toBe('Database.token008');
   });
 
   it('does not seed a node for a gestalt that is not in ruleset.tokens', async () => {
-    setState(mkState({
-      locale: 'en',
-      db_queue: [{
-        origin:      'Imperium.City.contact001',
-        collect_id:  COLLECT_ID,
-        profile_set: { profiles_value: 5, tokens_map: { not_a_real_token: { amount: 9 } } },
-        collect_dt:  FIXED_NOW
-      }]
-    }));
+    setState(
+      mkState({
+        locale: 'en',
+        db_queue: [
+          {
+            origin: 'Imperium.City.contact001',
+            collect_id: COLLECT_ID,
+            profile_set: { profiles_value: 5, tokens_map: { not_a_real_token: { amount: 9 } } },
+            collect_dt: FIXED_NOW,
+          },
+        ],
+      })
+    );
 
     const { result } = await integrateCollected(COLLECT_ID);
     expect(result.result.nodes).toHaveLength(0);
@@ -614,21 +730,34 @@ describe('collectPerp — level-up refills ap_snapshot to the new ap_max', () =>
   const PATH = 'Imperium.City.Agent0.contact001';
 
   beforeEach(() => setOverride(FIXED_NOW));
-  afterEach(() => { clearOverride(); setEmitter(null); });
+  afterEach(() => {
+    clearOverride();
+    setEmitter(null);
+  });
 
   it('crossing the xp_max threshold returns levelup=true and ap_snapshot=8', async () => {
-    setState(mkState({
-      // xp_value=10 + xp_inc=1 (contact001) = 11 → level 2.
-      game_values: Object.assign({}, mkGv(), {
-        xp_value: 10, xp_level: 1, ap_snapshot: 0, ap_max: 6
-      }),
-      nodes: [{
-        game_id: 'node_contact001', game_type: 'ContactPerp',
-        full_type: 'ContactPerp:contact001', gestalt: 'contact001',
-        full_path: PATH, instance_data: {}
-      }],
-      nodes_collect: [{ path: PATH, result: { amount: 5 } }]
-    }));
+    setState(
+      mkState({
+        // xp_value=10 + xp_inc=1 (contact001) = 11 → level 2.
+        game_values: Object.assign({}, mkGv(), {
+          xp_value: 10,
+          xp_level: 1,
+          ap_snapshot: 0,
+          ap_max: 6,
+        }),
+        nodes: [
+          {
+            game_id: 'node_contact001',
+            game_type: 'ContactPerp',
+            full_type: 'ContactPerp:contact001',
+            gestalt: 'contact001',
+            full_path: PATH,
+            instance_data: {},
+          },
+        ],
+        nodes_collect: [{ path: PATH, result: { amount: 5 } }],
+      })
+    );
 
     const { result } = await collectPerp(PATH);
     expect(result.levelup).toBe(true);
@@ -641,50 +770,68 @@ describe('integrateCollected — ap cost', () => {
   const COLLECT_ID = 'ap-cost-001';
 
   beforeEach(() => setOverride(FIXED_NOW));
-  afterEach(() => { clearOverride(); setEmitter(null); });
+  afterEach(() => {
+    clearOverride();
+    setEmitter(null);
+  });
 
   it('decrements ap_snapshot by 1', async () => {
-    setState(mkState({
-      game_values: Object.assign({}, mkGv(), { ap_snapshot: 5, ap_max: 6 }),
-      db_queue: [{
-        origin:      'Imperium.City.contact001',
-        collect_id:  COLLECT_ID,
-        profile_set: { profiles_value: 1, tokens_map: {} },
-        collect_dt:  FIXED_NOW
-      }]
-    }));
+    setState(
+      mkState({
+        game_values: Object.assign({}, mkGv(), { ap_snapshot: 5, ap_max: 6 }),
+        db_queue: [
+          {
+            origin: 'Imperium.City.contact001',
+            collect_id: COLLECT_ID,
+            profile_set: { profiles_value: 1, tokens_map: {} },
+            collect_dt: FIXED_NOW,
+          },
+        ],
+      })
+    );
 
     const { result } = await integrateCollected(COLLECT_ID);
     expect(result.game_values.ap_snapshot).toBe(4);
   });
 
   it('returns error 1 when ap_snapshot is 0 (parity with chargePerp)', async () => {
-    setState(mkState({
-      game_values: Object.assign({}, mkGv(), { ap_snapshot: 0, ap_max: 6 }),
-      db_queue: [{
-        origin:      'Imperium.City.contact001',
-        collect_id:  COLLECT_ID,
-        profile_set: { profiles_value: 1, tokens_map: {} },
-        collect_dt:  FIXED_NOW
-      }]
-    }));
+    setState(
+      mkState({
+        game_values: Object.assign({}, mkGv(), { ap_snapshot: 0, ap_max: 6 }),
+        db_queue: [
+          {
+            origin: 'Imperium.City.contact001',
+            collect_id: COLLECT_ID,
+            profile_set: { profiles_value: 1, tokens_map: {} },
+            collect_dt: FIXED_NOW,
+          },
+        ],
+      })
+    );
 
     const data = await integrateCollected(COLLECT_ID);
     expect(data.result.error).toBe(1);
   });
 
   it('level-up refill overrides the AP cost — full ap_max after crossing threshold', async () => {
-    setState(mkState({
-      game_values: Object.assign({}, mkGv(), {
-        xp_value: 10, xp_level: 1, ap_snapshot: 3, ap_max: 6
-      }),
-      db_queue: [{
-        origin:      'Imperium.City.contact001',
-        collect_id:  COLLECT_ID,
-        profile_set: { profiles_value: 1, tokens_map: {}, xp_gain: 10 },
-        collect_dt:  FIXED_NOW
-      }]
-    }));
+    setState(
+      mkState({
+        game_values: Object.assign({}, mkGv(), {
+          xp_value: 10,
+          xp_level: 1,
+          ap_snapshot: 3,
+          ap_max: 6,
+        }),
+        db_queue: [
+          {
+            origin: 'Imperium.City.contact001',
+            collect_id: COLLECT_ID,
+            profile_set: { profiles_value: 1, tokens_map: {}, xp_gain: 10 },
+            collect_dt: FIXED_NOW,
+          },
+        ],
+      })
+    );
 
     const { result } = await integrateCollected(COLLECT_ID);
     expect(result.levelup).toBe(true);
@@ -697,21 +844,31 @@ describe('integrateCollected — level-up refills ap_snapshot to the new ap_max'
   const COLLECT_ID = 'lvlup-integrate-001';
 
   beforeEach(() => setOverride(FIXED_NOW));
-  afterEach(() => { clearOverride(); setEmitter(null); });
+  afterEach(() => {
+    clearOverride();
+    setEmitter(null);
+  });
 
   it('crossing xp_max via xp_gain returns levelup=true and full AP', async () => {
-    setState(mkState({
-      game_values: Object.assign({}, mkGv(), {
-        xp_value: 5, xp_level: 1, ap_snapshot: 1, ap_max: 6
-      }),
-      db_queue: [{
-        origin: 'Imperium.City.contact001',
-        collect_id: COLLECT_ID,
-        // xp_gain on the profile_set drives xp gain on integrate.
-        profile_set: { profiles_value: 4, tokens_map: {}, xp_gain: 10, karma_gain: 0 },
-        collect_dt: FIXED_NOW
-      }]
-    }));
+    setState(
+      mkState({
+        game_values: Object.assign({}, mkGv(), {
+          xp_value: 5,
+          xp_level: 1,
+          ap_snapshot: 1,
+          ap_max: 6,
+        }),
+        db_queue: [
+          {
+            origin: 'Imperium.City.contact001',
+            collect_id: COLLECT_ID,
+            // xp_gain on the profile_set drives xp gain on integrate.
+            profile_set: { profiles_value: 4, tokens_map: {}, xp_gain: 10, karma_gain: 0 },
+            collect_dt: FIXED_NOW,
+          },
+        ],
+      })
+    );
 
     const { result } = await integrateCollected(COLLECT_ID);
     expect(result.levelup).toBe(true);
@@ -731,30 +888,47 @@ describe('collectPerp — tokens_map population from typeData.tokens', () => {
   const PATH = 'Imperium.City.Agent0.contact001';
 
   beforeEach(() => setOverride(FIXED_NOW));
-  afterEach(() => { clearOverride(); setEmitter(null); });
+  afterEach(() => {
+    clearOverride();
+    setEmitter(null);
+  });
 
   it('tokens_map carries an entry for every gestalt in typeData.tokens', async () => {
-    setState(mkState({
-      nodes:         [mkNode('ContactPerp', PATH)],
-      nodes_collect: [{ path: PATH, result: { amount: 10 } }]
-    }));
+    setState(
+      mkState({
+        nodes: [mkNode('ContactPerp', PATH)],
+        nodes_collect: [{ path: PATH, result: { amount: 10 } }],
+      })
+    );
 
     const { result } = await collectPerp(PATH);
     const tm = result.result.profile_set.tokens_map;
     // contact001 lists token001, token002, ..., token018, origin012 — 12 in total.
-    expect(Object.keys(tm).sort()).toEqual([
-      'origin012',
-      'token001', 'token002', 'token003', 'token004', 'token005',
-      'token006', 'token007', 'token014', 'token015', 'token017',
-      'token018'
-    ].sort());
+    expect(Object.keys(tm).sort()).toEqual(
+      [
+        'origin012',
+        'token001',
+        'token002',
+        'token003',
+        'token004',
+        'token005',
+        'token006',
+        'token007',
+        'token014',
+        'token015',
+        'token017',
+        'token018',
+      ].sort()
+    );
   });
 
   it('amount is the raw ruleset percentage (passed through unchanged)', async () => {
-    setState(mkState({
-      nodes:         [mkNode('ContactPerp', PATH)],
-      nodes_collect: [{ path: PATH, result: { amount: 10 } }]
-    }));
+    setState(
+      mkState({
+        nodes: [mkNode('ContactPerp', PATH)],
+        nodes_collect: [{ path: PATH, result: { amount: 10 } }],
+      })
+    );
 
     const { result } = await collectPerp(PATH);
     expect(result.result.profile_set.tokens_map.token001).toEqual({ amount: 100 });
@@ -763,10 +937,12 @@ describe('collectPerp — tokens_map population from typeData.tokens', () => {
 
   it('Jessica (contact035) yields token008 from her tokens list — unblocks mission002', async () => {
     const JPATH = 'Imperium.CityVienna.Agent0.contact035';
-    setState(mkState({
-      nodes:         [mkNode('ContactPerp', JPATH)],
-      nodes_collect: [{ path: JPATH, result: { amount: 1100 } }]
-    }));
+    setState(
+      mkState({
+        nodes: [mkNode('ContactPerp', JPATH)],
+        nodes_collect: [{ path: JPATH, result: { amount: 1100 } }],
+      })
+    );
 
     const { result } = await collectPerp(JPATH);
     // Jessica lists token008 at 100%; downstream absoluteAmount =
@@ -777,10 +953,12 @@ describe('collectPerp — tokens_map population from typeData.tokens', () => {
   it('tokens_map stays empty when typeData.tokens is missing', async () => {
     // contact002 is not in the ruleset → typeData undefined → tokens_map empty.
     const FPATH = 'Imperium.City.Agent0.contact002';
-    setState(mkState({
-      nodes:         [mkNode('ContactPerp', FPATH)],
-      nodes_collect: [{ path: FPATH, result: { amount: 5 } }]
-    }));
+    setState(
+      mkState({
+        nodes: [mkNode('ContactPerp', FPATH)],
+        nodes_collect: [{ path: FPATH, result: { amount: 5 } }],
+      })
+    );
 
     const { result } = await collectPerp(FPATH);
     expect(result.result.profile_set.tokens_map).toEqual({});
@@ -796,21 +974,30 @@ describe('integrateCollected — payload shape for newly seeded TokenPerps', () 
   const COLLECT_ID = 'shape-001';
 
   beforeEach(() => setOverride(FIXED_NOW));
-  afterEach(() => { clearOverride(); setEmitter(null); });
+  afterEach(() => {
+    clearOverride();
+    setEmitter(null);
+  });
 
   it('new node entries carry game_type=TokenPerp and full_type=TokenPerp:<gestalt>', async () => {
-    setState(mkState({
-      locale: 'en',
-      db_queue: [{
-        origin:      'Imperium.City.contact001',
-        collect_id:  COLLECT_ID,
-        profile_set: { profiles_value: 50, tokens_map: { token008: { amount: 25 } } },
-        collect_dt:  FIXED_NOW
-      }]
-    }));
+    setState(
+      mkState({
+        locale: 'en',
+        db_queue: [
+          {
+            origin: 'Imperium.City.contact001',
+            collect_id: COLLECT_ID,
+            profile_set: { profiles_value: 50, tokens_map: { token008: { amount: 25 } } },
+            collect_dt: FIXED_NOW,
+          },
+        ],
+      })
+    );
 
     const { result } = await integrateCollected(COLLECT_ID);
-    const newEntry = result.result.nodes.find(function (n) { return n.gestalt === 'token008'; });
+    const newEntry = result.result.nodes.find(function (n) {
+      return n.gestalt === 'token008';
+    });
     expect(newEntry).toBeDefined();
     expect(newEntry.game_type).toBe('TokenPerp');
     expect(newEntry.full_type).toBe('TokenPerp:token008');
@@ -819,19 +1006,25 @@ describe('integrateCollected — payload shape for newly seeded TokenPerps', () 
   });
 
   it('seeded entries replay correctly through applyDelta', async () => {
-    setState(mkState({
-      locale: 'en',
-      db_queue: [{
-        origin:      'Imperium.City.contact001',
-        collect_id:  COLLECT_ID,
-        profile_set: { profiles_value: 50, tokens_map: { token008: { amount: 25 } } },
-        collect_dt:  FIXED_NOW
-      }]
-    }));
+    setState(
+      mkState({
+        locale: 'en',
+        db_queue: [
+          {
+            origin: 'Imperium.City.contact001',
+            collect_id: COLLECT_ID,
+            profile_set: { profiles_value: 50, tokens_map: { token008: { amount: 25 } } },
+            collect_dt: FIXED_NOW,
+          },
+        ],
+      })
+    );
 
     await integrateCollected(COLLECT_ID);
     const { getState } = await import('../../scripts/boot.js');
-    const persisted = getState().nodes.find(function (n) { return n.gestalt === 'token008'; });
+    const persisted = getState().nodes.find(function (n) {
+      return n.gestalt === 'token008';
+    });
     expect(persisted.game_type).toBe('TokenPerp');
     expect(persisted.full_type).toBe('TokenPerp:token008');
   });
@@ -844,33 +1037,42 @@ describe('mission progression — integrate_profiles flow', () => {
   const COLLECT_ID = 'mission-progress-001';
 
   beforeEach(() => setOverride(FIXED_NOW));
-  afterEach(() => { clearOverride(); setEmitter(null); });
+  afterEach(() => {
+    clearOverride();
+    setEmitter(null);
+  });
 
   function seedMission002Active() {
-    setState(mkState({
-      active_missions: ['mission002'],
-      mission_goals: [{
-        mission: 'mission002',
-        workflow: 'integrate_profiles',
-        target: 'token008',
-        amount: 900,
-        position: 1,
-        current_amount: 0,
-        complete: false
-      }],
-      db_queue: [{
-        origin:      JESSICA,
-        collect_id:  COLLECT_ID,
-        profile_set: { profiles_value: 1100, tokens_map: { token008: { amount: 100 } } },
-        collect_dt:  FIXED_NOW
-      }]
-    }));
+    setState(
+      mkState({
+        active_missions: ['mission002'],
+        mission_goals: [
+          {
+            mission: 'mission002',
+            workflow: 'integrate_profiles',
+            target: 'token008',
+            amount: 900,
+            position: 1,
+            current_amount: 0,
+            complete: false,
+          },
+        ],
+        db_queue: [
+          {
+            origin: JESSICA,
+            collect_id: COLLECT_ID,
+            profile_set: { profiles_value: 1100, tokens_map: { token008: { amount: 100 } } },
+            collect_dt: FIXED_NOW,
+          },
+        ],
+      })
+    );
   }
 
   it('integrating Jessica advances mission002.current_amount to the absoluteAmount', async () => {
     seedMission002Active();
     const { result } = await integrateCollected(COLLECT_ID);
-    const goal = getState().mission_goals.find(g => g.mission === 'mission002');
+    const goal = getState().mission_goals.find((g) => g.mission === 'mission002');
     // profiles_value=1100, amount=100% → absolute=1100, capped at goal.amount=900.
     expect(goal.current_amount).toBe(900);
     expect(goal.complete).toBe(true);
@@ -879,27 +1081,33 @@ describe('mission progression — integrate_profiles flow', () => {
   });
 
   it('partial integrate (50% coverage) advances current_amount but stays incomplete', async () => {
-    setState(mkState({
-      active_missions: ['mission002'],
-      mission_goals: [{
-        mission: 'mission002',
-        workflow: 'integrate_profiles',
-        target: 'token008',
-        amount: 900,
-        position: 1,
-        current_amount: 0,
-        complete: false
-      }],
-      db_queue: [{
-        origin:      JESSICA,
-        collect_id:  COLLECT_ID,
-        profile_set: { profiles_value: 1000, tokens_map: { token008: { amount: 50 } } },
-        collect_dt:  FIXED_NOW
-      }]
-    }));
+    setState(
+      mkState({
+        active_missions: ['mission002'],
+        mission_goals: [
+          {
+            mission: 'mission002',
+            workflow: 'integrate_profiles',
+            target: 'token008',
+            amount: 900,
+            position: 1,
+            current_amount: 0,
+            complete: false,
+          },
+        ],
+        db_queue: [
+          {
+            origin: JESSICA,
+            collect_id: COLLECT_ID,
+            profile_set: { profiles_value: 1000, tokens_map: { token008: { amount: 50 } } },
+            collect_dt: FIXED_NOW,
+          },
+        ],
+      })
+    );
 
     await integrateCollected(COLLECT_ID);
-    const goal = getState().mission_goals.find(g => g.mission === 'mission002');
+    const goal = getState().mission_goals.find((g) => g.mission === 'mission002');
     // profiles_value=1000, amount=50% → absolute=500.
     expect(goal.current_amount).toBe(500);
     expect(goal.complete).toBe(false);
@@ -911,7 +1119,7 @@ describe('mission progression — integrate_profiles flow', () => {
     const s = getState();
     expect(s.active_missions).not.toContain('mission002');
     expect(s.active_missions).toContain('mission003');
-    const m3goal = s.mission_goals.find(g => g.mission === 'mission003');
+    const m3goal = s.mission_goals.find((g) => g.mission === 'mission003');
     expect(m3goal).toBeDefined();
     expect(m3goal.current_amount).toBe(0);
     expect(m3goal.complete).toBe(false);
@@ -924,7 +1132,7 @@ describe('mission progression — integrate_profiles flow', () => {
     const s1 = getState();
     setState(s1);
     await loadGame();
-    const goal = getState().mission_goals.find(g => g.mission === 'mission002');
+    const goal = getState().mission_goals.find((g) => g.mission === 'mission002');
     expect(goal.current_amount).toBe(900);
     expect(goal.complete).toBe(true);
   });
@@ -940,22 +1148,25 @@ describe('mission progression — integrate_profiles flow', () => {
     // db_queue entry whose profile_set has lower amount on token008, then
     // assert mission002.current_amount stays at the high-water mark.
     const s = getState();
-    s.mission_goals = s.mission_goals.map(g =>
+    s.mission_goals = s.mission_goals.map((g) =>
       g.mission === 'mission002'
         ? Object.assign({}, g, { current_amount: 500, complete: false })
         : g
     );
     s.active_missions = s.active_missions.concat(['mission002']);
-    s.db_queue = [{
-      origin: JESSICA, collect_id: 'second-integrate',
-      profile_set: { profiles_value: 100, tokens_map: { token008: { amount: 50 } } },
-      collect_dt: FIXED_NOW
-    }];
+    s.db_queue = [
+      {
+        origin: JESSICA,
+        collect_id: 'second-integrate',
+        profile_set: { profiles_value: 100, tokens_map: { token008: { amount: 50 } } },
+        collect_dt: FIXED_NOW,
+      },
+    ];
     setState(s);
 
     await integrateCollected('second-integrate');
     // 100 profiles × 50% = 50 absolute → would regress from 500 if not guarded.
-    const goal = getState().mission_goals.find(g => g.mission === 'mission002');
+    const goal = getState().mission_goals.find((g) => g.mission === 'mission002');
     expect(goal.current_amount).toBeGreaterThanOrEqual(500);
   });
 });
@@ -964,53 +1175,66 @@ describe('mission progression — collect_profiles flow', () => {
   const JESSICA = 'Imperium.City.Agent0.contact035';
 
   beforeEach(() => setOverride(FIXED_NOW));
-  afterEach(() => { clearOverride(); setEmitter(null); });
+  afterEach(() => {
+    clearOverride();
+    setEmitter(null);
+  });
 
   it('collecting Jessica advances mission001.current_amount by the collected profile count', async () => {
-    setState(mkState({
-      nodes: [mkNode('ContactPerp', JESSICA)],
-      nodes_collect: [{ path: JESSICA, result: { amount: 600 } }],
-      active_missions: ['mission001'],
-      mission_goals: [{
-        mission: 'mission001',
-        workflow: 'collect_profiles',
-        target: 'contact035',
-        amount: 900,
-        position: 2,
-        current_amount: 0,
-        complete: false
-      }]
-    }));
+    setState(
+      mkState({
+        nodes: [mkNode('ContactPerp', JESSICA)],
+        nodes_collect: [{ path: JESSICA, result: { amount: 600 } }],
+        active_missions: ['mission001'],
+        mission_goals: [
+          {
+            mission: 'mission001',
+            workflow: 'collect_profiles',
+            target: 'contact035',
+            amount: 900,
+            position: 2,
+            current_amount: 0,
+            complete: false,
+          },
+        ],
+      })
+    );
 
     await collectPerp(JESSICA);
-    const goal = getState().mission_goals.find(g => g.mission === 'mission001');
+    const goal = getState().mission_goals.find((g) => g.mission === 'mission001');
     expect(goal.current_amount).toBe(600);
     expect(goal.complete).toBe(false);
   });
 
   it('two collects from Jessica complete mission001 (cumulative)', async () => {
-    setState(mkState({
-      nodes: [mkNode('ContactPerp', JESSICA)],
-      nodes_collect: [{ path: JESSICA, result: { amount: 600 } }],
-      active_missions: ['mission001'],
-      mission_goals: [{
-        mission: 'mission001',
-        workflow: 'collect_profiles',
-        target: 'contact035',
-        amount: 900,
-        position: 2,
-        current_amount: 0,
-        complete: false
-      }]
-    }));
+    setState(
+      mkState({
+        nodes: [mkNode('ContactPerp', JESSICA)],
+        nodes_collect: [{ path: JESSICA, result: { amount: 600 } }],
+        active_missions: ['mission001'],
+        mission_goals: [
+          {
+            mission: 'mission001',
+            workflow: 'collect_profiles',
+            target: 'contact035',
+            amount: 900,
+            position: 2,
+            current_amount: 0,
+            complete: false,
+          },
+        ],
+      })
+    );
 
     await collectPerp(JESSICA);
-    setState(Object.assign({}, getState(), {
-      nodes_collect: [{ path: JESSICA, result: { amount: 600 } }]
-    }));
+    setState(
+      Object.assign({}, getState(), {
+        nodes_collect: [{ path: JESSICA, result: { amount: 600 } }],
+      })
+    );
     const { result } = await collectPerp(JESSICA);
 
-    const goal = getState().mission_goals.find(g => g.mission === 'mission001');
+    const goal = getState().mission_goals.find((g) => g.mission === 'mission001');
     expect(goal.current_amount).toBe(900);
     expect(goal.complete).toBe(true);
     expect(result.missions.complete_missions).toContain('mission001');
@@ -1018,23 +1242,27 @@ describe('mission progression — collect_profiles flow', () => {
 
   it('collecting from a non-target contact does not advance mission001', async () => {
     const HELEN = 'Imperium.City.Agent1.contact001';
-    setState(mkState({
-      nodes: [mkNode('ContactPerp', HELEN)],
-      nodes_collect: [{ path: HELEN, result: { amount: 1500 } }],
-      active_missions: ['mission001'],
-      mission_goals: [{
-        mission: 'mission001',
-        workflow: 'collect_profiles',
-        target: 'contact035',
-        amount: 900,
-        position: 2,
-        current_amount: 0,
-        complete: false
-      }]
-    }));
+    setState(
+      mkState({
+        nodes: [mkNode('ContactPerp', HELEN)],
+        nodes_collect: [{ path: HELEN, result: { amount: 1500 } }],
+        active_missions: ['mission001'],
+        mission_goals: [
+          {
+            mission: 'mission001',
+            workflow: 'collect_profiles',
+            target: 'contact035',
+            amount: 900,
+            position: 2,
+            current_amount: 0,
+            complete: false,
+          },
+        ],
+      })
+    );
 
     await collectPerp(HELEN);
-    const goal = getState().mission_goals.find(g => g.mission === 'mission001');
+    const goal = getState().mission_goals.find((g) => g.mission === 'mission001');
     expect(goal.current_amount).toBe(0);
     expect(goal.complete).toBe(false);
   });
@@ -1042,18 +1270,23 @@ describe('mission progression — collect_profiles flow', () => {
 
 describe('loadGame seeds mission_goals from active_missions', () => {
   beforeEach(() => setOverride(FIXED_NOW));
-  afterEach(() => { clearOverride(); setEmitter(null); });
+  afterEach(() => {
+    clearOverride();
+    setEmitter(null);
+  });
 
   it('fresh game with mission001 active gets goals seeded from ruleset on first loadGame', async () => {
-    setState(mkState({
-      active_missions: ['mission001'],
-      mission_goals: []
-    }));
+    setState(
+      mkState({
+        active_missions: ['mission001'],
+        mission_goals: [],
+      })
+    );
 
     await loadGame();
 
     const goals = getState().mission_goals;
-    const m1 = goals.find(g => g.mission === 'mission001');
+    const m1 = goals.find((g) => g.mission === 'mission001');
     expect(m1).toBeDefined();
     expect(m1.workflow).toBe('collect_profiles');
     expect(m1.target).toBe('contact035');
@@ -1063,10 +1296,12 @@ describe('loadGame seeds mission_goals from active_missions', () => {
   });
 
   it('idempotent — re-running loadGame does not duplicate goals', async () => {
-    setState(mkState({
-      active_missions: ['mission001'],
-      mission_goals: []
-    }));
+    setState(
+      mkState({
+        active_missions: ['mission001'],
+        mission_goals: [],
+      })
+    );
 
     await loadGame();
     const goalsAfterFirst = getState().mission_goals.length;
@@ -1081,15 +1316,20 @@ describe('cash invariants — collect/integrate must not deduct cash', () => {
   const PATH = 'Imperium.City.Agent0.contact001';
 
   beforeEach(() => setOverride(FIXED_NOW));
-  afterEach(() => { clearOverride(); setEmitter(null); });
+  afterEach(() => {
+    clearOverride();
+    setEmitter(null);
+  });
 
   it('ContactPerp collect leaves cash_value unchanged', async () => {
     const startCash = 270;
-    setState(mkState({
-      game_values: Object.assign({}, mkGv(), { cash_value: startCash }),
-      nodes: [mkNode('ContactPerp', PATH)],
-      nodes_collect: [{ path: PATH, result: { amount: 5 } }]
-    }));
+    setState(
+      mkState({
+        game_values: Object.assign({}, mkGv(), { cash_value: startCash }),
+        nodes: [mkNode('ContactPerp', PATH)],
+        nodes_collect: [{ path: PATH, result: { amount: 5 } }],
+      })
+    );
 
     const { result } = await collectPerp(PATH);
     expect(result.game_values.cash_value).toBe(startCash);
@@ -1098,14 +1338,19 @@ describe('cash invariants — collect/integrate must not deduct cash', () => {
 
   it('integrateCollected leaves cash_value unchanged when no rewards fire', async () => {
     const startCash = 270;
-    setState(mkState({
-      game_values: Object.assign({}, mkGv(), { cash_value: startCash }),
-      db_queue: [{
-        origin: PATH, collect_id: 'no-rewards',
-        profile_set: { profiles_value: 1, tokens_map: {} },
-        collect_dt: FIXED_NOW
-      }]
-    }));
+    setState(
+      mkState({
+        game_values: Object.assign({}, mkGv(), { cash_value: startCash }),
+        db_queue: [
+          {
+            origin: PATH,
+            collect_id: 'no-rewards',
+            profile_set: { profiles_value: 1, tokens_map: {} },
+            collect_dt: FIXED_NOW,
+          },
+        ],
+      })
+    );
 
     const { result } = await integrateCollected('no-rewards');
     expect(result.game_values.cash_value).toBe(startCash);
@@ -1117,31 +1362,42 @@ describe('mission rewards — apply on completion', () => {
   const COLLECT_ID = 'rewards-001';
 
   beforeEach(() => setOverride(FIXED_NOW));
-  afterEach(() => { clearOverride(); setEmitter(null); });
+  afterEach(() => {
+    clearOverride();
+    setEmitter(null);
+  });
 
   it('completing mission002 grants its 100 cash + 1 xp reward', async () => {
     const startCash = 200;
     const startXp = 0;
-    setState(mkState({
-      game_values: Object.assign({}, mkGv(), {
-        cash_value: startCash, xp_value: startXp
-      }),
-      active_missions: ['mission002'],
-      mission_goals: [{
-        mission: 'mission002',
-        workflow: 'integrate_profiles',
-        target: 'token008',
-        amount: 900,
-        position: 1,
-        current_amount: 0,
-        complete: false
-      }],
-      db_queue: [{
-        origin: JESSICA, collect_id: COLLECT_ID,
-        profile_set: { profiles_value: 1100, tokens_map: { token008: { amount: 100 } } },
-        collect_dt: FIXED_NOW
-      }]
-    }));
+    setState(
+      mkState({
+        game_values: Object.assign({}, mkGv(), {
+          cash_value: startCash,
+          xp_value: startXp,
+        }),
+        active_missions: ['mission002'],
+        mission_goals: [
+          {
+            mission: 'mission002',
+            workflow: 'integrate_profiles',
+            target: 'token008',
+            amount: 900,
+            position: 1,
+            current_amount: 0,
+            complete: false,
+          },
+        ],
+        db_queue: [
+          {
+            origin: JESSICA,
+            collect_id: COLLECT_ID,
+            profile_set: { profiles_value: 1100, tokens_map: { token008: { amount: 100 } } },
+            collect_dt: FIXED_NOW,
+          },
+        ],
+      })
+    );
 
     const { result } = await integrateCollected(COLLECT_ID);
     expect(result.game_values.cash_value).toBe(startCash + 100);
@@ -1150,24 +1406,31 @@ describe('mission rewards — apply on completion', () => {
 
   it('partial-progress integrate (no completion) yields no rewards', async () => {
     const startCash = 200;
-    setState(mkState({
-      game_values: Object.assign({}, mkGv(), { cash_value: startCash }),
-      active_missions: ['mission002'],
-      mission_goals: [{
-        mission: 'mission002',
-        workflow: 'integrate_profiles',
-        target: 'token008',
-        amount: 900,
-        position: 1,
-        current_amount: 0,
-        complete: false
-      }],
-      db_queue: [{
-        origin: JESSICA, collect_id: COLLECT_ID,
-        profile_set: { profiles_value: 500, tokens_map: { token008: { amount: 50 } } },
-        collect_dt: FIXED_NOW
-      }]
-    }));
+    setState(
+      mkState({
+        game_values: Object.assign({}, mkGv(), { cash_value: startCash }),
+        active_missions: ['mission002'],
+        mission_goals: [
+          {
+            mission: 'mission002',
+            workflow: 'integrate_profiles',
+            target: 'token008',
+            amount: 900,
+            position: 1,
+            current_amount: 0,
+            complete: false,
+          },
+        ],
+        db_queue: [
+          {
+            origin: JESSICA,
+            collect_id: COLLECT_ID,
+            profile_set: { profiles_value: 500, tokens_map: { token008: { amount: 50 } } },
+            collect_dt: FIXED_NOW,
+          },
+        ],
+      })
+    );
 
     const { result } = await integrateCollected(COLLECT_ID);
     expect(result.game_values.cash_value).toBe(startCash);
@@ -1175,17 +1438,25 @@ describe('mission rewards — apply on completion', () => {
 
   it('end-to-end: charge car company → wait → collect adds ~584 cash', async () => {
     const CAR_PATH = 'Imperium.City.Pusher0.client007';
-    setState(mkState({
-      game_values: Object.assign({}, mkGv(), {
-        cash_value: 100, ap_snapshot: 6, xp_level: 1
-      }),
-      nodes: [{
-        game_id: 'client007', game_type: 'ClientPerp',
-        full_type: 'ClientPerp:client007', gestalt: 'client007',
-        full_path: CAR_PATH,
-        instance_data: {}
-      }]
-    }));
+    setState(
+      mkState({
+        game_values: Object.assign({}, mkGv(), {
+          cash_value: 100,
+          ap_snapshot: 6,
+          xp_level: 1,
+        }),
+        nodes: [
+          {
+            game_id: 'client007',
+            game_type: 'ClientPerp',
+            full_type: 'ClientPerp:client007',
+            gestalt: 'client007',
+            full_path: CAR_PATH,
+            instance_data: {},
+          },
+        ],
+      })
+    );
 
     const chargeRes = await chargePerp(CAR_PATH);
     expect(chargeRes.result.error).toBeUndefined();
@@ -1211,21 +1482,25 @@ describe('mission rewards — apply on completion', () => {
 
   it('completing mission001 grants its xp reward via collectPerp', async () => {
     const startXp = 0;
-    setState(mkState({
-      game_values: Object.assign({}, mkGv(), { xp_value: startXp }),
-      nodes: [mkNode('ContactPerp', JESSICA)],
-      nodes_collect: [{ path: JESSICA, result: { amount: 1100 } }],
-      active_missions: ['mission001'],
-      mission_goals: [{
-        mission: 'mission001',
-        workflow: 'collect_profiles',
-        target: 'contact035',
-        amount: 900,
-        position: 2,
-        current_amount: 0,
-        complete: false
-      }]
-    }));
+    setState(
+      mkState({
+        game_values: Object.assign({}, mkGv(), { xp_value: startXp }),
+        nodes: [mkNode('ContactPerp', JESSICA)],
+        nodes_collect: [{ path: JESSICA, result: { amount: 1100 } }],
+        active_missions: ['mission001'],
+        mission_goals: [
+          {
+            mission: 'mission001',
+            workflow: 'collect_profiles',
+            target: 'contact035',
+            amount: 900,
+            position: 2,
+            current_amount: 0,
+            complete: false,
+          },
+        ],
+      })
+    );
 
     const { result } = await collectPerp(JESSICA);
     // contact035 xp_inc=1 + mission001 reward=2.
@@ -1245,14 +1520,14 @@ describe('mission rewards — apply on completion', () => {
 // handler(s), and asserts: goal progress · completion · reward · chain.
 
 // IDs for the hash-named missions (title in parentheses).
-var M_CASH_IN  = 'a388da08d87dc9fd6d543977a2047262000'; // Cash in!
-var M_DB_MACH  = 'e59302bed28769c3c76761c14516e764000'; // Database machine
-var M_PSYCHO   = 'e33a3ef9d70038e0a9c6d088f37d02cb000'; // Psycho
-var M_COUCH    = 'af1149c315321ef4f477893fcc1807e1000'; // Couch Potato
+var M_CASH_IN = 'a388da08d87dc9fd6d543977a2047262000'; // Cash in!
+var M_DB_MACH = 'e59302bed28769c3c76761c14516e764000'; // Database machine
+var M_PSYCHO = 'e33a3ef9d70038e0a9c6d088f37d02cb000'; // Psycho
+var M_COUCH = 'af1149c315321ef4f477893fcc1807e1000'; // Couch Potato
 var M_EMPLOYEE = 'b638f35b5ec6b0558981378c9037c3d3000'; // Employee Monitoring
-var M_IMAGE    = '9f5735d01587f640cc862e0a82280d3f000'; // Improve your image
-var M_COLLAB   = '16f302f84b84498a734dfdbe1a7794b9000'; // Unofficial collaboration
-var M_ALFONSO  = 'dc481d7863ceb18575c50d36e2c5ecfe000'; // Alfonso
+var M_IMAGE = '9f5735d01587f640cc862e0a82280d3f000'; // Improve your image
+var M_COLLAB = '16f302f84b84498a734dfdbe1a7794b9000'; // Unofficial collaboration
+var M_ALFONSO = 'dc481d7863ceb18575c50d36e2c5ecfe000'; // Alfonso
 
 // High-level game_values: enough cash/level/AP for all purchases in tests.
 function mkHighGv(overrides) {
@@ -1260,20 +1535,44 @@ function mkHighGv(overrides) {
 }
 
 function mkProjectNode(gestalt, path) {
-  return { game_id: gestalt, game_type: 'ProjectPerp', full_type: 'ProjectPerp:' + gestalt,
-    gestalt: gestalt, full_path: path, instance_data: {} };
+  return {
+    game_id: gestalt,
+    game_type: 'ProjectPerp',
+    full_type: 'ProjectPerp:' + gestalt,
+    gestalt: gestalt,
+    full_path: path,
+    instance_data: {},
+  };
 }
 function mkClientNode2(gestalt, path) {
-  return { game_id: gestalt, game_type: 'ClientPerp', full_type: 'ClientPerp:' + gestalt,
-    gestalt: gestalt, full_path: path, instance_data: {} };
+  return {
+    game_id: gestalt,
+    game_type: 'ClientPerp',
+    full_type: 'ClientPerp:' + gestalt,
+    gestalt: gestalt,
+    full_path: path,
+    instance_data: {},
+  };
 }
 function mkContactNode(gestalt, path) {
-  return { game_id: gestalt, game_type: 'ContactPerp', full_type: 'ContactPerp:' + gestalt,
-    gestalt: gestalt, full_path: path, instance_data: {} };
+  return {
+    game_id: gestalt,
+    game_type: 'ContactPerp',
+    full_type: 'ContactPerp:' + gestalt,
+    gestalt: gestalt,
+    full_path: path,
+    instance_data: {},
+  };
 }
 function mkTokenNode2(gestalt, path, amount) {
-  return { game_id: gestalt, game_type: 'TokenPerp', full_type: 'TokenPerp:' + gestalt,
-    gestalt: gestalt, full_path: path, instance_data: { amount: amount || 0 } };
+  return {
+    game_id: gestalt,
+    game_type: 'TokenPerp',
+    full_type: 'TokenPerp:' + gestalt,
+    gestalt: gestalt,
+    full_path: path,
+    instance_data: { amount: amount || 0 },
+  };
 }
 
 // ── mission003 — Rookie Dealer ───────────────────────────────────────────────
@@ -1283,31 +1582,43 @@ describe('mission progression — mission003 Rookie Dealer (charge_perp)', () =>
   const C007 = 'Imperium.City.Pusher0.client007';
 
   beforeEach(() => setOverride(FIXED_NOW));
-  afterEach(() => { clearOverride(); setEmitter(null); });
+  afterEach(() => {
+    clearOverride();
+    setEmitter(null);
+  });
 
   it('charging client007 completes goal, grants +600 cash reward, activates mission004', async () => {
-    setState(mkState({
-      game_values: mkHighGv(),
-      nodes: [mkClientNode2('client007', C007)],
-      active_missions: ['mission003'],
-      mission_goals: [{
-        mission: 'mission003', workflow: 'charge_perp', target: 'client007',
-        amount: null, position: 1, current_amount: 0, complete: false
-      }]
-    }));
+    setState(
+      mkState({
+        game_values: mkHighGv(),
+        nodes: [mkClientNode2('client007', C007)],
+        active_missions: ['mission003'],
+        mission_goals: [
+          {
+            mission: 'mission003',
+            workflow: 'charge_perp',
+            target: 'client007',
+            amount: null,
+            position: 1,
+            current_amount: 0,
+            complete: false,
+          },
+        ],
+      })
+    );
     const startCash = getState().game_values.cash_value;
 
     const { result } = await chargePerp(C007);
     expect(result.error).toBeUndefined();
 
     const s = getState();
-    const goal = s.mission_goals.find(g => g.mission === 'mission003');
+    const goal = s.mission_goals.find((g) => g.mission === 'mission003');
     expect(goal.complete).toBe(true);
     expect(s.active_missions).not.toContain('mission003');
     expect(s.active_missions).toContain('mission004');
     // client007 charge_cost=0; mission003 reward = +600 cash
     expect(s.game_values.cash_value).toBe(startCash + 600);
-    expect(s.mission_goals.filter(g => g.mission === 'mission004')).toHaveLength(2);
+    expect(s.mission_goals.filter((g) => g.mission === 'mission004')).toHaveLength(2);
   });
 });
 
@@ -1318,28 +1629,47 @@ describe("mission progression — mission004 You're a winner! (buy_perp + charge
   const P001 = 'Imperium.project001';
 
   beforeEach(() => setOverride(FIXED_NOW));
-  afterEach(() => { clearOverride(); setEmitter(null); });
+  afterEach(() => {
+    clearOverride();
+    setEmitter(null);
+  });
 
   function seedM004() {
-    setState(mkState({
-      game_values: mkHighGv({ xp_level: 2 }),
-      nodes: [],
-      active_missions: ['mission004'],
-      mission_goals: [
-        { mission: 'mission004', workflow: 'buy_perp', target: 'project001',
-          amount: null, position: 1, current_amount: 0, complete: false },
-        { mission: 'mission004', workflow: 'charge_perp', target: 'project001',
-          amount: null, position: 2, current_amount: 0, complete: false }
-      ]
-    }));
+    setState(
+      mkState({
+        game_values: mkHighGv({ xp_level: 2 }),
+        nodes: [],
+        active_missions: ['mission004'],
+        mission_goals: [
+          {
+            mission: 'mission004',
+            workflow: 'buy_perp',
+            target: 'project001',
+            amount: null,
+            position: 1,
+            current_amount: 0,
+            complete: false,
+          },
+          {
+            mission: 'mission004',
+            workflow: 'charge_perp',
+            target: 'project001',
+            amount: null,
+            position: 2,
+            current_amount: 0,
+            complete: false,
+          },
+        ],
+      })
+    );
   }
 
   it('buying project001 marks the buy_perp goal complete; mission stays active', async () => {
     seedM004();
     await buyPerp('Imperium', 'project001');
-    const goals = getState().mission_goals.filter(g => g.mission === 'mission004');
-    expect(goals.find(g => g.workflow === 'buy_perp').complete).toBe(true);
-    expect(goals.find(g => g.workflow === 'charge_perp').complete).toBe(false);
+    const goals = getState().mission_goals.filter((g) => g.mission === 'mission004');
+    expect(goals.find((g) => g.workflow === 'buy_perp').complete).toBe(true);
+    expect(goals.find((g) => g.workflow === 'charge_perp').complete).toBe(false);
     expect(getState().active_missions).toContain('mission004');
   });
 
@@ -1363,42 +1693,63 @@ describe('mission progression — M_CASH_IN Cash in! (collect_cash)', () => {
   const C007 = 'Imperium.City.Pusher0.client007';
 
   beforeEach(() => setOverride(FIXED_NOW));
-  afterEach(() => { clearOverride(); setEmitter(null); });
+  afterEach(() => {
+    clearOverride();
+    setEmitter(null);
+  });
 
   it('collecting 200 cash advances goal to 200 without completing mission', async () => {
-    setState(mkState({
-      game_values: mkHighGv({ cash_value: 0 }),
-      nodes: [mkClientNode2('client007', C007)],
-      nodes_collect: [{ path: C007, result: { amount: 200 } }],
-      active_missions: [M_CASH_IN],
-      mission_goals: [{
-        mission: M_CASH_IN, workflow: 'collect_cash', target: 'client007',
-        amount: 500, position: 1, current_amount: 0, complete: false
-      }]
-    }));
+    setState(
+      mkState({
+        game_values: mkHighGv({ cash_value: 0 }),
+        nodes: [mkClientNode2('client007', C007)],
+        nodes_collect: [{ path: C007, result: { amount: 200 } }],
+        active_missions: [M_CASH_IN],
+        mission_goals: [
+          {
+            mission: M_CASH_IN,
+            workflow: 'collect_cash',
+            target: 'client007',
+            amount: 500,
+            position: 1,
+            current_amount: 0,
+            complete: false,
+          },
+        ],
+      })
+    );
 
     await collectPerp(C007);
-    const goal = getState().mission_goals.find(g => g.mission === M_CASH_IN);
+    const goal = getState().mission_goals.find((g) => g.mission === M_CASH_IN);
     expect(goal.current_amount).toBe(200);
     expect(goal.complete).toBe(false);
     expect(getState().active_missions).toContain(M_CASH_IN);
   });
 
   it('collecting 600 fills the 500 goal, grants +200 cash reward, activates mission006', async () => {
-    setState(mkState({
-      game_values: mkHighGv({ cash_value: 0 }),
-      nodes: [mkClientNode2('client007', C007)],
-      nodes_collect: [{ path: C007, result: { amount: 600 } }],
-      active_missions: [M_CASH_IN],
-      mission_goals: [{
-        mission: M_CASH_IN, workflow: 'collect_cash', target: 'client007',
-        amount: 500, position: 1, current_amount: 0, complete: false
-      }]
-    }));
+    setState(
+      mkState({
+        game_values: mkHighGv({ cash_value: 0 }),
+        nodes: [mkClientNode2('client007', C007)],
+        nodes_collect: [{ path: C007, result: { amount: 600 } }],
+        active_missions: [M_CASH_IN],
+        mission_goals: [
+          {
+            mission: M_CASH_IN,
+            workflow: 'collect_cash',
+            target: 'client007',
+            amount: 500,
+            position: 1,
+            current_amount: 0,
+            complete: false,
+          },
+        ],
+      })
+    );
 
     const { result } = await collectPerp(C007);
     const s = getState();
-    const goal = s.mission_goals.find(g => g.mission === M_CASH_IN);
+    const goal = s.mission_goals.find((g) => g.mission === M_CASH_IN);
     expect(goal.current_amount).toBe(500); // capped at goal.amount
     expect(goal.complete).toBe(true);
     expect(s.active_missions).not.toContain(M_CASH_IN);
@@ -1416,50 +1767,101 @@ describe('mission progression — mission006 Upgrade raffle (buy_powerup x3)', (
   const P001 = 'Imperium.City.project001';
 
   beforeEach(() => setOverride(FIXED_NOW));
-  afterEach(() => { clearOverride(); setEmitter(null); });
+  afterEach(() => {
+    clearOverride();
+    setEmitter(null);
+  });
 
   it('buying upgrade001 marks goal 1 complete; mission still active', async () => {
-    setState(mkState({
-      game_values: mkHighGv({ xp_level: 2 }),
-      nodes: [mkProjectNode('project001', P001)],
-      active_missions: ['mission006'],
-      mission_goals: [
-        { mission: 'mission006', workflow: 'buy_powerup', target: 'upgrade001',
-          amount: null, position: 1, current_amount: 0, complete: false },
-        { mission: 'mission006', workflow: 'buy_powerup', target: 'ad002',
-          amount: null, position: 2, current_amount: 0, complete: false },
-        { mission: 'mission006', workflow: 'buy_powerup', target: 'teammember020',
-          amount: null, position: 3, current_amount: 0, complete: false }
-      ]
-    }));
+    setState(
+      mkState({
+        game_values: mkHighGv({ xp_level: 2 }),
+        nodes: [mkProjectNode('project001', P001)],
+        active_missions: ['mission006'],
+        mission_goals: [
+          {
+            mission: 'mission006',
+            workflow: 'buy_powerup',
+            target: 'upgrade001',
+            amount: null,
+            position: 1,
+            current_amount: 0,
+            complete: false,
+          },
+          {
+            mission: 'mission006',
+            workflow: 'buy_powerup',
+            target: 'ad002',
+            amount: null,
+            position: 2,
+            current_amount: 0,
+            complete: false,
+          },
+          {
+            mission: 'mission006',
+            workflow: 'buy_powerup',
+            target: 'teammember020',
+            amount: null,
+            position: 3,
+            current_amount: 0,
+            complete: false,
+          },
+        ],
+      })
+    );
     await buyPowerup(P001, 0, 'upgrade001');
-    const goals = getState().mission_goals.filter(g => g.mission === 'mission006');
-    expect(goals.find(g => g.target === 'upgrade001').complete).toBe(true);
-    expect(goals.find(g => g.target === 'ad002').complete).toBe(false);
+    const goals = getState().mission_goals.filter((g) => g.mission === 'mission006');
+    expect(goals.find((g) => g.target === 'upgrade001').complete).toBe(true);
+    expect(goals.find((g) => g.target === 'ad002').complete).toBe(false);
     expect(getState().active_missions).toContain('mission006');
   });
 
   it('buying all three powerups completes mission006, grants reward, activates mission007', async () => {
-    setState(mkState({
-      game_values: mkHighGv({ xp_level: 2 }),
-      nodes: [mkProjectNode('project001', P001)],
-      active_missions: ['mission006'],
-      mission_goals: [
-        { mission: 'mission006', workflow: 'buy_powerup', target: 'upgrade001',
-          amount: null, position: 1, current_amount: 0, complete: false },
-        { mission: 'mission006', workflow: 'buy_powerup', target: 'ad002',
-          amount: null, position: 2, current_amount: 0, complete: false },
-        { mission: 'mission006', workflow: 'buy_powerup', target: 'teammember020',
-          amount: null, position: 3, current_amount: 0, complete: false }
-      ]
-    }));
+    setState(
+      mkState({
+        game_values: mkHighGv({ xp_level: 2 }),
+        nodes: [mkProjectNode('project001', P001)],
+        active_missions: ['mission006'],
+        mission_goals: [
+          {
+            mission: 'mission006',
+            workflow: 'buy_powerup',
+            target: 'upgrade001',
+            amount: null,
+            position: 1,
+            current_amount: 0,
+            complete: false,
+          },
+          {
+            mission: 'mission006',
+            workflow: 'buy_powerup',
+            target: 'ad002',
+            amount: null,
+            position: 2,
+            current_amount: 0,
+            complete: false,
+          },
+          {
+            mission: 'mission006',
+            workflow: 'buy_powerup',
+            target: 'teammember020',
+            amount: null,
+            position: 3,
+            current_amount: 0,
+            complete: false,
+          },
+        ],
+      })
+    );
 
     await buyPowerup(P001, 0, 'upgrade001');
     await buyPowerup(P001, 1, 'ad002');
     const { result } = await buyPowerup(P001, 2, 'teammember020');
 
     const s = getState();
-    expect(s.mission_goals.filter(g => g.mission === 'mission006').every(g => g.complete)).toBe(true);
+    expect(s.mission_goals.filter((g) => g.mission === 'mission006').every((g) => g.complete)).toBe(
+      true
+    );
     expect(s.active_missions).not.toContain('mission006');
     expect(s.active_missions).toContain('mission007');
     expect(result.missions.complete_missions).toContain('mission006');
@@ -1473,29 +1875,56 @@ describe('mission progression — mission007 Nurse Helen (buy+collect+integrate)
   const CT1 = 'Imperium.contact001';
 
   beforeEach(() => setOverride(FIXED_NOW));
-  afterEach(() => { clearOverride(); setEmitter(null); });
+  afterEach(() => {
+    clearOverride();
+    setEmitter(null);
+  });
 
   function seedM007() {
-    setState(mkState({
-      game_values: mkHighGv({ xp_level: 3 }),
-      nodes: [],
-      active_missions: ['mission007'],
-      mission_goals: [
-        { mission: 'mission007', workflow: 'buy_perp', target: 'contact001',
-          amount: null, position: 1, current_amount: 0, complete: false },
-        { mission: 'mission007', workflow: 'collect_profiles', target: 'contact001',
-          amount: 3000, position: 2, current_amount: 0, complete: false },
-        { mission: 'mission007', workflow: 'integrate_profiles', target: 'token017',
-          amount: 3000, position: 3, current_amount: 0, complete: false }
-      ]
-    }));
+    setState(
+      mkState({
+        game_values: mkHighGv({ xp_level: 3 }),
+        nodes: [],
+        active_missions: ['mission007'],
+        mission_goals: [
+          {
+            mission: 'mission007',
+            workflow: 'buy_perp',
+            target: 'contact001',
+            amount: null,
+            position: 1,
+            current_amount: 0,
+            complete: false,
+          },
+          {
+            mission: 'mission007',
+            workflow: 'collect_profiles',
+            target: 'contact001',
+            amount: 3000,
+            position: 2,
+            current_amount: 0,
+            complete: false,
+          },
+          {
+            mission: 'mission007',
+            workflow: 'integrate_profiles',
+            target: 'token017',
+            amount: 3000,
+            position: 3,
+            current_amount: 0,
+            complete: false,
+          },
+        ],
+      })
+    );
   }
 
   it('buying contact001 marks buy_perp goal complete; mission stays active', async () => {
     seedM007();
     await buyPerp('Imperium', 'contact001');
     const goal = getState().mission_goals.find(
-      g => g.mission === 'mission007' && g.workflow === 'buy_perp');
+      (g) => g.mission === 'mission007' && g.workflow === 'buy_perp'
+    );
     expect(goal.complete).toBe(true);
     expect(getState().active_missions).toContain('mission007');
   });
@@ -1506,9 +1935,11 @@ describe('mission progression — mission007 Nurse Helen (buy+collect+integrate)
 
     // Seed collect entry for the node buyPerp just created.
     const s1 = getState();
-    setState(Object.assign({}, s1, {
-      nodes_collect: [{ path: CT1, result: { amount: 3000 } }]
-    }));
+    setState(
+      Object.assign({}, s1, {
+        nodes_collect: [{ path: CT1, result: { amount: 3000 } }],
+      })
+    );
 
     const { result: colRes } = await collectPerp(CT1);
     const collectId = colRes.result.collect_id;
@@ -1516,7 +1947,9 @@ describe('mission progression — mission007 Nurse Helen (buy+collect+integrate)
     const { result: intRes } = await integrateCollected(collectId);
 
     const s = getState();
-    expect(s.mission_goals.filter(g => g.mission === 'mission007').every(g => g.complete)).toBe(true);
+    expect(s.mission_goals.filter((g) => g.mission === 'mission007').every((g) => g.complete)).toBe(
+      true
+    );
     expect(s.active_missions).not.toContain('mission007');
     expect(s.active_missions).toContain(M_DB_MACH);
     expect(intRes.missions.complete_missions).toContain('mission007');
@@ -1530,25 +1963,37 @@ describe('mission progression — M_DB_MACH Database machine (upgrade_token)', (
   const T007 = 'Database.token007';
 
   beforeEach(() => setOverride(FIXED_NOW));
-  afterEach(() => { clearOverride(); setEmitter(null); });
+  afterEach(() => {
+    clearOverride();
+    setEmitter(null);
+  });
 
   it('collecting from token007 completes upgrade_token goal and activates mission008', async () => {
-    setState(mkState({
-      game_values: mkHighGv(),
-      nodes: [mkTokenNode2('token007', T007, 0)],
-      nodes_collect: [{ path: T007, result: { amount: 0 } }],
-      active_missions: [M_DB_MACH],
-      mission_goals: [{
-        mission: M_DB_MACH, workflow: 'upgrade_token', target: 'token007',
-        amount: null, position: 1, current_amount: 0, complete: false
-      }]
-    }));
+    setState(
+      mkState({
+        game_values: mkHighGv(),
+        nodes: [mkTokenNode2('token007', T007, 0)],
+        nodes_collect: [{ path: T007, result: { amount: 0 } }],
+        active_missions: [M_DB_MACH],
+        mission_goals: [
+          {
+            mission: M_DB_MACH,
+            workflow: 'upgrade_token',
+            target: 'token007',
+            amount: null,
+            position: 1,
+            current_amount: 0,
+            complete: false,
+          },
+        ],
+      })
+    );
 
     const { result } = await collectPerp(T007);
     expect(result.error).toBeUndefined();
 
     const s = getState();
-    const goal = s.mission_goals.find(g => g.mission === M_DB_MACH);
+    const goal = s.mission_goals.find((g) => g.mission === M_DB_MACH);
     expect(goal.complete).toBe(true);
     expect(s.active_missions).not.toContain(M_DB_MACH);
     expect(s.active_missions).toContain('mission008');
@@ -1563,22 +2008,48 @@ describe('mission progression — mission008 Sick World (buy+charge+buy)', () =>
   const C2 = 'Imperium.client002';
 
   beforeEach(() => setOverride(FIXED_NOW));
-  afterEach(() => { clearOverride(); setEmitter(null); });
+  afterEach(() => {
+    clearOverride();
+    setEmitter(null);
+  });
 
   function seedM008() {
-    setState(mkState({
-      game_values: mkHighGv({ xp_level: 4 }),
-      nodes: [],
-      active_missions: ['mission008'],
-      mission_goals: [
-        { mission: 'mission008', workflow: 'buy_perp', target: 'client002',
-          amount: null, position: 1, current_amount: 0, complete: false },
-        { mission: 'mission008', workflow: 'charge_perp', target: 'client002',
-          amount: null, position: 2, current_amount: 0, complete: false },
-        { mission: 'mission008', workflow: 'buy_perp', target: 'contact019',
-          amount: null, position: 3, current_amount: 0, complete: false }
-      ]
-    }));
+    setState(
+      mkState({
+        game_values: mkHighGv({ xp_level: 4 }),
+        nodes: [],
+        active_missions: ['mission008'],
+        mission_goals: [
+          {
+            mission: 'mission008',
+            workflow: 'buy_perp',
+            target: 'client002',
+            amount: null,
+            position: 1,
+            current_amount: 0,
+            complete: false,
+          },
+          {
+            mission: 'mission008',
+            workflow: 'charge_perp',
+            target: 'client002',
+            amount: null,
+            position: 2,
+            current_amount: 0,
+            complete: false,
+          },
+          {
+            mission: 'mission008',
+            workflow: 'buy_perp',
+            target: 'contact019',
+            amount: null,
+            position: 3,
+            current_amount: 0,
+            complete: false,
+          },
+        ],
+      })
+    );
   }
 
   it('buying client002 then charging then buying contact019 completes mission008 + activates mission005', async () => {
@@ -1588,7 +2059,9 @@ describe('mission progression — mission008 Sick World (buy+charge+buy)', () =>
     const { result } = await buyPerp('Imperium', 'contact019');
 
     const s = getState();
-    expect(s.mission_goals.filter(g => g.mission === 'mission008').every(g => g.complete)).toBe(true);
+    expect(s.mission_goals.filter((g) => g.mission === 'mission008').every((g) => g.complete)).toBe(
+      true
+    );
     expect(s.active_missions).not.toContain('mission008');
     expect(s.active_missions).toContain('mission005');
     expect(result.missions.complete_missions).toContain('mission008');
@@ -1603,66 +2076,125 @@ describe('mission progression — mission005 So green! (integrate_profiles + col
   const COLL_ID = 'so-green-001';
 
   beforeEach(() => setOverride(FIXED_NOW));
-  afterEach(() => { clearOverride(); setEmitter(null); });
+  afterEach(() => {
+    clearOverride();
+    setEmitter(null);
+  });
 
   function seedM005(extraGoalFields) {
-    setState(mkState({
-      game_values: mkHighGv({ cash_value: 0 }),
-      nodes: [mkClientNode2('client007', C007)],
-      active_missions: ['mission005'],
-      mission_goals: [
-        Object.assign({ mission: 'mission005', workflow: 'integrate_profiles', target: 'token084',
-          amount: 10000, position: 1, current_amount: 0, complete: false }, extraGoalFields || {}),
-        { mission: 'mission005', workflow: 'collect_cash', target: 'client007',
-          amount: 500, position: 2, current_amount: 0, complete: false }
-      ]
-    }));
+    setState(
+      mkState({
+        game_values: mkHighGv({ cash_value: 0 }),
+        nodes: [mkClientNode2('client007', C007)],
+        active_missions: ['mission005'],
+        mission_goals: [
+          Object.assign(
+            {
+              mission: 'mission005',
+              workflow: 'integrate_profiles',
+              target: 'token084',
+              amount: 10000,
+              position: 1,
+              current_amount: 0,
+              complete: false,
+            },
+            extraGoalFields || {}
+          ),
+          {
+            mission: 'mission005',
+            workflow: 'collect_cash',
+            target: 'client007',
+            amount: 500,
+            position: 2,
+            current_amount: 0,
+            complete: false,
+          },
+        ],
+      })
+    );
   }
 
   it('integrating 10000 profiles at 100% token084 fills integrate_profiles goal', async () => {
-    setState(mkState({
-      game_values: mkHighGv({ cash_value: 0 }),
-      nodes: [mkClientNode2('client007', C007)],
-      active_missions: ['mission005'],
-      mission_goals: [
-        { mission: 'mission005', workflow: 'integrate_profiles', target: 'token084',
-          amount: 10000, position: 1, current_amount: 0, complete: false },
-        { mission: 'mission005', workflow: 'collect_cash', target: 'client007',
-          amount: 500, position: 2, current_amount: 0, complete: false }
-      ],
-      db_queue: [{
-        origin: 'Imperium.City.contact001',
-        collect_id: COLL_ID,
-        profile_set: { profiles_value: 10000, tokens_map: { token084: { amount: 100 } } },
-        collect_dt: FIXED_NOW
-      }]
-    }));
+    setState(
+      mkState({
+        game_values: mkHighGv({ cash_value: 0 }),
+        nodes: [mkClientNode2('client007', C007)],
+        active_missions: ['mission005'],
+        mission_goals: [
+          {
+            mission: 'mission005',
+            workflow: 'integrate_profiles',
+            target: 'token084',
+            amount: 10000,
+            position: 1,
+            current_amount: 0,
+            complete: false,
+          },
+          {
+            mission: 'mission005',
+            workflow: 'collect_cash',
+            target: 'client007',
+            amount: 500,
+            position: 2,
+            current_amount: 0,
+            complete: false,
+          },
+        ],
+        db_queue: [
+          {
+            origin: 'Imperium.City.contact001',
+            collect_id: COLL_ID,
+            profile_set: { profiles_value: 10000, tokens_map: { token084: { amount: 100 } } },
+            collect_dt: FIXED_NOW,
+          },
+        ],
+      })
+    );
 
     await integrateCollected(COLL_ID);
     const goal = getState().mission_goals.find(
-      g => g.mission === 'mission005' && g.workflow === 'integrate_profiles');
+      (g) => g.mission === 'mission005' && g.workflow === 'integrate_profiles'
+    );
     expect(goal.current_amount).toBe(10000);
     expect(goal.complete).toBe(true);
     expect(getState().active_missions).toContain('mission005'); // cash goal still pending
   });
 
   it('collect_cash + integrate both complete → mission005 done, grants reward, activates M_PSYCHO', async () => {
-    setState(mkState({
-      game_values: mkHighGv({ cash_value: 0 }),
-      nodes: [mkClientNode2('client007', C007)],
-      nodes_collect: [{ path: C007, result: { amount: 600 } }],
-      active_missions: ['mission005'],
-      mission_goals: [
-        { mission: 'mission005', workflow: 'integrate_profiles', target: 'token084',
-          amount: 10000, position: 1, current_amount: 10000, complete: true },
-        { mission: 'mission005', workflow: 'collect_cash', target: 'client007',
-          amount: 500, position: 2, current_amount: 0, complete: false }
-      ]
-    }));
+    setState(
+      mkState({
+        game_values: mkHighGv({ cash_value: 0 }),
+        nodes: [mkClientNode2('client007', C007)],
+        nodes_collect: [{ path: C007, result: { amount: 600 } }],
+        active_missions: ['mission005'],
+        mission_goals: [
+          {
+            mission: 'mission005',
+            workflow: 'integrate_profiles',
+            target: 'token084',
+            amount: 10000,
+            position: 1,
+            current_amount: 10000,
+            complete: true,
+          },
+          {
+            mission: 'mission005',
+            workflow: 'collect_cash',
+            target: 'client007',
+            amount: 500,
+            position: 2,
+            current_amount: 0,
+            complete: false,
+          },
+        ],
+      })
+    );
 
     const { result } = await collectPerp(C007);
     const s = getState();
-    expect(s.mission_goals.filter(g => g.mission === 'mission005').every(g => g.complete)).toBe(true);
+    expect(s.mission_goals.filter((g) => g.mission === 'mission005').every((g) => g.complete)).toBe(
+      true
+    );
     expect(s.active_missions).not.toContain('mission005');
     expect(s.active_missions).toContain(M_PSYCHO);
     // start=0 + collect=600 + reward=1000 = 1600
@@ -1678,22 +2210,48 @@ describe('mission progression — M_PSYCHO Psycho (buy_perp + buy_powerup + char
   const P3 = 'Imperium.project003';
 
   beforeEach(() => setOverride(FIXED_NOW));
-  afterEach(() => { clearOverride(); setEmitter(null); });
+  afterEach(() => {
+    clearOverride();
+    setEmitter(null);
+  });
 
   it('all three goals complete → M_PSYCHO done, activates M_COUCH', async () => {
-    setState(mkState({
-      game_values: mkHighGv({ xp_level: 5 }),
-      nodes: [],
-      active_missions: [M_PSYCHO],
-      mission_goals: [
-        { mission: M_PSYCHO, workflow: 'buy_perp', target: 'project003',
-          amount: null, position: 1, current_amount: 0, complete: false },
-        { mission: M_PSYCHO, workflow: 'buy_powerup', target: 'upgrade015',
-          amount: null, position: 2, current_amount: 0, complete: false },
-        { mission: M_PSYCHO, workflow: 'charge_perp', target: 'project003',
-          amount: null, position: 3, current_amount: 0, complete: false }
-      ]
-    }));
+    setState(
+      mkState({
+        game_values: mkHighGv({ xp_level: 5 }),
+        nodes: [],
+        active_missions: [M_PSYCHO],
+        mission_goals: [
+          {
+            mission: M_PSYCHO,
+            workflow: 'buy_perp',
+            target: 'project003',
+            amount: null,
+            position: 1,
+            current_amount: 0,
+            complete: false,
+          },
+          {
+            mission: M_PSYCHO,
+            workflow: 'buy_powerup',
+            target: 'upgrade015',
+            amount: null,
+            position: 2,
+            current_amount: 0,
+            complete: false,
+          },
+          {
+            mission: M_PSYCHO,
+            workflow: 'charge_perp',
+            target: 'project003',
+            amount: null,
+            position: 3,
+            current_amount: 0,
+            complete: false,
+          },
+        ],
+      })
+    );
 
     await buyPerp('Imperium', 'project003');
     await buyPowerup(P3, 0, 'upgrade015');
@@ -1701,7 +2259,9 @@ describe('mission progression — M_PSYCHO Psycho (buy_perp + buy_powerup + char
     expect(result.error).toBeUndefined();
 
     const s = getState();
-    expect(s.mission_goals.filter(g => g.mission === M_PSYCHO).every(g => g.complete)).toBe(true);
+    expect(s.mission_goals.filter((g) => g.mission === M_PSYCHO).every((g) => g.complete)).toBe(
+      true
+    );
     expect(s.active_missions).not.toContain(M_PSYCHO);
     expect(s.active_missions).toContain(M_COUCH);
     expect(result.missions.complete_missions).toContain(M_PSYCHO);
@@ -1713,52 +2273,79 @@ describe('mission progression — M_PSYCHO Psycho (buy_perp + buy_powerup + char
 
 describe('mission progression — M_COUCH Couch Potato (collect+integrate+cash)', () => {
   const CT19 = 'Imperium.contact019';
-  const C2   = 'Imperium.City.Pusher0.client002';
+  const C2 = 'Imperium.City.Pusher0.client002';
   const COLL_ID = 'couch-001';
 
   beforeEach(() => setOverride(FIXED_NOW));
-  afterEach(() => { clearOverride(); setEmitter(null); });
+  afterEach(() => {
+    clearOverride();
+    setEmitter(null);
+  });
 
   it('all three goals complete → M_COUCH done, activates M_EMPLOYEE', async () => {
-    setState(mkState({
-      game_values: mkHighGv({ cash_value: 0 }),
-      nodes: [
-        mkContactNode('contact019', CT19),
-        mkClientNode2('client002', C2)
-      ],
-      nodes_collect: [
-        { path: CT19, result: { amount: 6000 } },
-        { path: C2,   result: { amount: 600  } }
-      ],
-      active_missions: [M_COUCH],
-      mission_goals: [
-        { mission: M_COUCH, workflow: 'collect_profiles', target: 'contact019',
-          amount: 6000, position: 1, current_amount: 0, complete: false },
-        { mission: M_COUCH, workflow: 'integrate_profiles', target: 'token088',
-          amount: 6000, position: 2, current_amount: 0, complete: false },
-        { mission: M_COUCH, workflow: 'collect_cash', target: 'client002',
-          amount: 500, position: 3, current_amount: 0, complete: false }
-      ]
-    }));
+    setState(
+      mkState({
+        game_values: mkHighGv({ cash_value: 0 }),
+        nodes: [mkContactNode('contact019', CT19), mkClientNode2('client002', C2)],
+        nodes_collect: [
+          { path: CT19, result: { amount: 6000 } },
+          { path: C2, result: { amount: 600 } },
+        ],
+        active_missions: [M_COUCH],
+        mission_goals: [
+          {
+            mission: M_COUCH,
+            workflow: 'collect_profiles',
+            target: 'contact019',
+            amount: 6000,
+            position: 1,
+            current_amount: 0,
+            complete: false,
+          },
+          {
+            mission: M_COUCH,
+            workflow: 'integrate_profiles',
+            target: 'token088',
+            amount: 6000,
+            position: 2,
+            current_amount: 0,
+            complete: false,
+          },
+          {
+            mission: M_COUCH,
+            workflow: 'collect_cash',
+            target: 'client002',
+            amount: 500,
+            position: 3,
+            current_amount: 0,
+            complete: false,
+          },
+        ],
+      })
+    );
 
     // Step 1: collect from contact019 — fills collect_profiles goal.
     const { result: c19Res } = await collectPerp(CT19);
     const collectId = c19Res.result.collect_id;
     const goal1 = getState().mission_goals.find(
-      g => g.mission === M_COUCH && g.workflow === 'collect_profiles');
+      (g) => g.mission === M_COUCH && g.workflow === 'collect_profiles'
+    );
     expect(goal1.current_amount).toBe(6000);
     expect(goal1.complete).toBe(true);
 
     // Step 2: integrate — fills integrate_profiles goal via token088 in tokens_map.
     await integrateCollected(collectId);
     const goal2 = getState().mission_goals.find(
-      g => g.mission === M_COUCH && g.workflow === 'integrate_profiles');
+      (g) => g.mission === M_COUCH && g.workflow === 'integrate_profiles'
+    );
     expect(goal2.complete).toBe(true);
 
     // Step 3: collect cash from client002.
     const { result } = await collectPerp(C2);
     const s = getState();
-    expect(s.mission_goals.filter(g => g.mission === M_COUCH).every(g => g.complete)).toBe(true);
+    expect(s.mission_goals.filter((g) => g.mission === M_COUCH).every((g) => g.complete)).toBe(
+      true
+    );
     expect(s.active_missions).not.toContain(M_COUCH);
     expect(s.active_missions).toContain(M_EMPLOYEE);
     expect(result.missions.complete_missions).toContain(M_COUCH);
@@ -1772,32 +2359,53 @@ describe('mission progression — M_EMPLOYEE Employee Monitoring (buy_perp + col
   const C6 = 'Imperium.client006';
 
   beforeEach(() => setOverride(FIXED_NOW));
-  afterEach(() => { clearOverride(); setEmitter(null); });
+  afterEach(() => {
+    clearOverride();
+    setEmitter(null);
+  });
 
   it('buying client006 then collecting 2000+ cash completes M_EMPLOYEE, activates M_IMAGE', async () => {
-    setState(mkState({
-      game_values: mkHighGv(),
-      nodes: [],
-      active_missions: [M_EMPLOYEE],
-      mission_goals: [
-        { mission: M_EMPLOYEE, workflow: 'buy_perp', target: 'client006',
-          amount: null, position: 1, current_amount: 0, complete: false },
-        { mission: M_EMPLOYEE, workflow: 'collect_cash', target: 'client006',
-          amount: 2000, position: 2, current_amount: 0, complete: false }
-      ]
-    }));
+    setState(
+      mkState({
+        game_values: mkHighGv(),
+        nodes: [],
+        active_missions: [M_EMPLOYEE],
+        mission_goals: [
+          {
+            mission: M_EMPLOYEE,
+            workflow: 'buy_perp',
+            target: 'client006',
+            amount: null,
+            position: 1,
+            current_amount: 0,
+            complete: false,
+          },
+          {
+            mission: M_EMPLOYEE,
+            workflow: 'collect_cash',
+            target: 'client006',
+            amount: 2000,
+            position: 2,
+            current_amount: 0,
+            complete: false,
+          },
+        ],
+      })
+    );
 
     await buyPerp('Imperium', 'client006');
     // Seed collect entry for the newly created node.
     const s1 = getState();
-    setState(Object.assign({}, s1, {
-      nodes_collect: [{ path: C6, result: { amount: 2500 } }]
-    }));
+    setState(
+      Object.assign({}, s1, {
+        nodes_collect: [{ path: C6, result: { amount: 2500 } }],
+      })
+    );
 
     const { result } = await collectPerp(C6);
     const s = getState();
-    const goals = s.mission_goals.filter(g => g.mission === M_EMPLOYEE);
-    expect(goals.every(g => g.complete)).toBe(true);
+    const goals = s.mission_goals.filter((g) => g.mission === M_EMPLOYEE);
+    expect(goals.every((g) => g.complete)).toBe(true);
     expect(s.active_missions).not.toContain(M_EMPLOYEE);
     expect(s.active_missions).toContain(M_IMAGE);
     expect(result.missions.complete_missions).toContain(M_EMPLOYEE);
@@ -1811,26 +2419,47 @@ describe('mission progression — M_IMAGE Improve your image (buy_powerup x2)', 
   const P3 = 'Imperium.City.project003';
 
   beforeEach(() => setOverride(FIXED_NOW));
-  afterEach(() => { clearOverride(); setEmitter(null); });
+  afterEach(() => {
+    clearOverride();
+    setEmitter(null);
+  });
 
   it('buying teammember043 then ad006 on project003 completes M_IMAGE, activates M_COLLAB', async () => {
-    setState(mkState({
-      game_values: mkHighGv({ xp_level: 5 }),
-      nodes: [mkProjectNode('project003', P3)],
-      active_missions: [M_IMAGE],
-      mission_goals: [
-        { mission: M_IMAGE, workflow: 'buy_powerup', target: 'teammember043',
-          amount: null, position: 1, current_amount: 0, complete: false },
-        { mission: M_IMAGE, workflow: 'buy_powerup', target: 'ad006',
-          amount: null, position: 2, current_amount: 0, complete: false }
-      ]
-    }));
+    setState(
+      mkState({
+        game_values: mkHighGv({ xp_level: 5 }),
+        nodes: [mkProjectNode('project003', P3)],
+        active_missions: [M_IMAGE],
+        mission_goals: [
+          {
+            mission: M_IMAGE,
+            workflow: 'buy_powerup',
+            target: 'teammember043',
+            amount: null,
+            position: 1,
+            current_amount: 0,
+            complete: false,
+          },
+          {
+            mission: M_IMAGE,
+            workflow: 'buy_powerup',
+            target: 'ad006',
+            amount: null,
+            position: 2,
+            current_amount: 0,
+            complete: false,
+          },
+        ],
+      })
+    );
 
     await buyPowerup(P3, 0, 'teammember043');
     const { result } = await buyPowerup(P3, 1, 'ad006');
 
     const s = getState();
-    expect(s.mission_goals.filter(g => g.mission === M_IMAGE).every(g => g.complete)).toBe(true);
+    expect(s.mission_goals.filter((g) => g.mission === M_IMAGE).every((g) => g.complete)).toBe(
+      true
+    );
     expect(s.active_missions).not.toContain(M_IMAGE);
     expect(s.active_missions).toContain(M_COLLAB);
     expect(result.missions.complete_missions).toContain(M_IMAGE);
@@ -1842,26 +2471,47 @@ describe('mission progression — M_IMAGE Improve your image (buy_powerup x2)', 
 
 describe('mission progression — M_COLLAB Unofficial collaboration (buy_perp x2)', () => {
   beforeEach(() => setOverride(FIXED_NOW));
-  afterEach(() => { clearOverride(); setEmitter(null); });
+  afterEach(() => {
+    clearOverride();
+    setEmitter(null);
+  });
 
   it('buying agent004 then contact026 completes M_COLLAB, activates M_ALFONSO', async () => {
-    setState(mkState({
-      game_values: mkHighGv({ xp_level: 7 }),
-      nodes: [],
-      active_missions: [M_COLLAB],
-      mission_goals: [
-        { mission: M_COLLAB, workflow: 'buy_perp', target: 'agent004',
-          amount: null, position: 1, current_amount: 0, complete: false },
-        { mission: M_COLLAB, workflow: 'buy_perp', target: 'contact026',
-          amount: null, position: 2, current_amount: 0, complete: false }
-      ]
-    }));
+    setState(
+      mkState({
+        game_values: mkHighGv({ xp_level: 7 }),
+        nodes: [],
+        active_missions: [M_COLLAB],
+        mission_goals: [
+          {
+            mission: M_COLLAB,
+            workflow: 'buy_perp',
+            target: 'agent004',
+            amount: null,
+            position: 1,
+            current_amount: 0,
+            complete: false,
+          },
+          {
+            mission: M_COLLAB,
+            workflow: 'buy_perp',
+            target: 'contact026',
+            amount: null,
+            position: 2,
+            current_amount: 0,
+            complete: false,
+          },
+        ],
+      })
+    );
 
     await buyPerp('Imperium', 'agent004');
     const { result } = await buyPerp('Imperium', 'contact026');
 
     const s = getState();
-    expect(s.mission_goals.filter(g => g.mission === M_COLLAB).every(g => g.complete)).toBe(true);
+    expect(s.mission_goals.filter((g) => g.mission === M_COLLAB).every((g) => g.complete)).toBe(
+      true
+    );
     expect(s.active_missions).not.toContain(M_COLLAB);
     expect(s.active_missions).toContain(M_ALFONSO);
     expect(result.missions.complete_missions).toContain(M_COLLAB);
@@ -1873,23 +2523,35 @@ describe('mission progression — M_COLLAB Unofficial collaboration (buy_perp x2
 
 describe('mission progression — M_ALFONSO Alfonso (buy_perp)', () => {
   beforeEach(() => setOverride(FIXED_NOW));
-  afterEach(() => { clearOverride(); setEmitter(null); });
+  afterEach(() => {
+    clearOverride();
+    setEmitter(null);
+  });
 
   it('buying pusher003 completes M_ALFONSO, grants reward, activates 3cb94923... chain', async () => {
     const M_BOGUS = '3cb9492322191121ebf7a10aafd0fc4a000';
-    setState(mkState({
-      game_values: mkHighGv(),
-      nodes: [],
-      active_missions: [M_ALFONSO],
-      mission_goals: [{
-        mission: M_ALFONSO, workflow: 'buy_perp', target: 'pusher003',
-        amount: null, position: 1, current_amount: 0, complete: false
-      }]
-    }));
+    setState(
+      mkState({
+        game_values: mkHighGv(),
+        nodes: [],
+        active_missions: [M_ALFONSO],
+        mission_goals: [
+          {
+            mission: M_ALFONSO,
+            workflow: 'buy_perp',
+            target: 'pusher003',
+            amount: null,
+            position: 1,
+            current_amount: 0,
+            complete: false,
+          },
+        ],
+      })
+    );
 
     const { result } = await buyPerp('Imperium', 'pusher003');
     const s = getState();
-    expect(s.mission_goals.find(g => g.mission === M_ALFONSO).complete).toBe(true);
+    expect(s.mission_goals.find((g) => g.mission === M_ALFONSO).complete).toBe(true);
     expect(s.active_missions).not.toContain(M_ALFONSO);
     expect(s.active_missions).toContain(M_BOGUS);
     expect(result.missions.complete_missions).toContain(M_ALFONSO);
@@ -1901,25 +2563,37 @@ describe('mission progression — M_ALFONSO Alfonso (buy_perp)', () => {
 
 describe('mission progression — M_BOGUS Bogus company tangle (buy_perp)', () => {
   var M_BOGUS = '3cb9492322191121ebf7a10aafd0fc4a000';
-  var M_MULT  = '1da63b8adf60878f693dfb9d9f73690f000';
+  var M_MULT = '1da63b8adf60878f693dfb9d9f73690f000';
 
   beforeEach(() => setOverride(FIXED_NOW));
-  afterEach(() => { clearOverride(); setEmitter(null); });
+  afterEach(() => {
+    clearOverride();
+    setEmitter(null);
+  });
 
   it('buying proxy004 completes M_BOGUS and activates M_MULT (Multiplication 101)', async () => {
-    setState(mkState({
-      game_values: mkHighGv({ xp_level: 9 }),
-      nodes: [],
-      active_missions: [M_BOGUS],
-      mission_goals: [{
-        mission: M_BOGUS, workflow: 'buy_perp', target: 'proxy004',
-        amount: null, position: 1, current_amount: 0, complete: false
-      }]
-    }));
+    setState(
+      mkState({
+        game_values: mkHighGv({ xp_level: 9 }),
+        nodes: [],
+        active_missions: [M_BOGUS],
+        mission_goals: [
+          {
+            mission: M_BOGUS,
+            workflow: 'buy_perp',
+            target: 'proxy004',
+            amount: null,
+            position: 1,
+            current_amount: 0,
+            complete: false,
+          },
+        ],
+      })
+    );
 
     const { result } = await buyPerp('Imperium', 'proxy004');
     const s = getState();
-    expect(s.mission_goals.find(g => g.mission === M_BOGUS).complete).toBe(true);
+    expect(s.mission_goals.find((g) => g.mission === M_BOGUS).complete).toBe(true);
     expect(s.active_missions).not.toContain(M_BOGUS);
     expect(s.active_missions).toContain(M_MULT);
     expect(result.missions.complete_missions).toContain(M_BOGUS);
@@ -1930,32 +2604,52 @@ describe('mission progression — M_BOGUS Bogus company tangle (buy_perp)', () =
 // buy_perp(token055) + upgrade_token(token055)
 
 describe('mission progression — M_MULT Multiplication 101 (buy_perp + upgrade_token)', () => {
-  var M_MULT   = '1da63b8adf60878f693dfb9d9f73690f000';
+  var M_MULT = '1da63b8adf60878f693dfb9d9f73690f000';
   var M_BIGAPPLE = '2f59d10a67ca7ee9006dfe5db31a4c5f000';
   const T055 = 'Imperium.token055';
 
   beforeEach(() => setOverride(FIXED_NOW));
-  afterEach(() => { clearOverride(); setEmitter(null); });
+  afterEach(() => {
+    clearOverride();
+    setEmitter(null);
+  });
 
   function seedMMult() {
-    setState(mkState({
-      game_values: mkHighGv({ xp_level: 7 }),
-      nodes: [],
-      active_missions: [M_MULT],
-      mission_goals: [
-        { mission: M_MULT, workflow: 'buy_perp', target: 'token055',
-          amount: null, position: 1, current_amount: 0, complete: false },
-        { mission: M_MULT, workflow: 'upgrade_token', target: 'token055',
-          amount: null, position: 2, current_amount: 0, complete: false }
-      ]
-    }));
+    setState(
+      mkState({
+        game_values: mkHighGv({ xp_level: 7 }),
+        nodes: [],
+        active_missions: [M_MULT],
+        mission_goals: [
+          {
+            mission: M_MULT,
+            workflow: 'buy_perp',
+            target: 'token055',
+            amount: null,
+            position: 1,
+            current_amount: 0,
+            complete: false,
+          },
+          {
+            mission: M_MULT,
+            workflow: 'upgrade_token',
+            target: 'token055',
+            amount: null,
+            position: 2,
+            current_amount: 0,
+            complete: false,
+          },
+        ],
+      })
+    );
   }
 
   it('buying token055 marks buy_perp goal complete; mission stays active', async () => {
     seedMMult();
     await buyPerp('Imperium', 'token055');
     const goal = getState().mission_goals.find(
-      g => g.mission === M_MULT && g.workflow === 'buy_perp');
+      (g) => g.mission === M_MULT && g.workflow === 'buy_perp'
+    );
     expect(goal.complete).toBe(true);
     expect(getState().active_missions).toContain(M_MULT);
   });
@@ -1966,13 +2660,15 @@ describe('mission progression — M_MULT Multiplication 101 (buy_perp + upgrade_
 
     // Seed collect entry for the TokenPerp node buyPerp created.
     const s1 = getState();
-    setState(Object.assign({}, s1, {
-      nodes_collect: [{ path: T055, result: { amount: 0 } }]
-    }));
+    setState(
+      Object.assign({}, s1, {
+        nodes_collect: [{ path: T055, result: { amount: 0 } }],
+      })
+    );
 
     const { result } = await collectPerp(T055);
     const s = getState();
-    expect(s.mission_goals.filter(g => g.mission === M_MULT).every(g => g.complete)).toBe(true);
+    expect(s.mission_goals.filter((g) => g.mission === M_MULT).every((g) => g.complete)).toBe(true);
     expect(s.active_missions).not.toContain(M_MULT);
     expect(s.active_missions).toContain(M_BIGAPPLE);
     expect(result.missions.complete_missions).toContain(M_MULT);
@@ -1986,22 +2682,34 @@ describe('mission progression — M_BIGAPPLE Big Apple, Big Data! (buy_perp)', (
   var M_BIGAPPLE = '2f59d10a67ca7ee9006dfe5db31a4c5f000';
 
   beforeEach(() => setOverride(FIXED_NOW));
-  afterEach(() => { clearOverride(); setEmitter(null); });
+  afterEach(() => {
+    clearOverride();
+    setEmitter(null);
+  });
 
   it('buying city004 completes M_BIGAPPLE (last mission — no chain follow-up)', async () => {
-    setState(mkState({
-      game_values: mkHighGv({ xp_level: 11 }),
-      nodes: [],
-      active_missions: [M_BIGAPPLE],
-      mission_goals: [{
-        mission: M_BIGAPPLE, workflow: 'buy_perp', target: 'city004',
-        amount: null, position: 1, current_amount: 0, complete: false
-      }]
-    }));
+    setState(
+      mkState({
+        game_values: mkHighGv({ xp_level: 11 }),
+        nodes: [],
+        active_missions: [M_BIGAPPLE],
+        mission_goals: [
+          {
+            mission: M_BIGAPPLE,
+            workflow: 'buy_perp',
+            target: 'city004',
+            amount: null,
+            position: 1,
+            current_amount: 0,
+            complete: false,
+          },
+        ],
+      })
+    );
 
     const { result } = await buyPerp('Imperium', 'city004');
     const s = getState();
-    expect(s.mission_goals.find(g => g.mission === M_BIGAPPLE).complete).toBe(true);
+    expect(s.mission_goals.find((g) => g.mission === M_BIGAPPLE).complete).toBe(true);
     expect(s.active_missions).not.toContain(M_BIGAPPLE);
     expect(result.missions.complete_missions).toContain(M_BIGAPPLE);
     // No required_mission points to M_BIGAPPLE, so no new mission activates.
@@ -2019,22 +2727,35 @@ describe('cold-start replay — chargePerp mission progress survives applyDelta'
   const C007 = 'Imperium.City.Pusher0.client007';
 
   beforeEach(() => setOverride(FIXED_NOW));
-  afterEach(() => { clearOverride(); setEmitter(null); setSendDelta(null); });
+  afterEach(() => {
+    clearOverride();
+    setEmitter(null);
+    setSendDelta(null);
+  });
 
   it('chargePerp delta carries missions so mission003 goal survives reload', async () => {
     const initialState = mkState({
       game_values: mkHighGv(),
       nodes: [mkClientNode2('client007', C007)],
       active_missions: ['mission003'],
-      mission_goals: [{
-        mission: 'mission003', workflow: 'charge_perp', target: 'client007',
-        amount: null, position: 1, current_amount: 0, complete: false
-      }]
+      mission_goals: [
+        {
+          mission: 'mission003',
+          workflow: 'charge_perp',
+          target: 'client007',
+          amount: null,
+          position: 1,
+          current_amount: 0,
+          complete: false,
+        },
+      ],
     });
     setState(initialState);
 
     var capturedDelta = null;
-    setSendDelta(function (d) { capturedDelta = d; });
+    setSendDelta(function (d) {
+      capturedDelta = d;
+    });
 
     await chargePerp(C007);
     expect(capturedDelta).not.toBeNull();
@@ -2042,7 +2763,7 @@ describe('cold-start replay — chargePerp mission progress survives applyDelta'
     // Simulate cold-start: replay the delta against the state that existed
     // before the charge (as if the app was killed and restarted mid-session).
     const replayed = applyDelta(initialState, capturedDelta);
-    const goal = replayed.mission_goals.find(g => g.mission === 'mission003');
+    const goal = replayed.mission_goals.find((g) => g.mission === 'mission003');
     expect(goal).toBeDefined();
     expect(goal.complete).toBe(true);
     expect(replayed.active_missions).not.toContain('mission003');
@@ -2054,7 +2775,11 @@ describe('cold-start replay — buyPowerup mission progress survives applyDelta'
   const P001 = 'Imperium.City.project001';
 
   beforeEach(() => setOverride(FIXED_NOW));
-  afterEach(() => { clearOverride(); setEmitter(null); setSendDelta(null); });
+  afterEach(() => {
+    clearOverride();
+    setEmitter(null);
+    setSendDelta(null);
+  });
 
   it('buyPowerup delta carries missions so mission006 partial progress survives reload', async () => {
     const initialState = mkState({
@@ -2062,27 +2787,50 @@ describe('cold-start replay — buyPowerup mission progress survives applyDelta'
       nodes: [mkProjectNode('project001', P001)],
       active_missions: ['mission006'],
       mission_goals: [
-        { mission: 'mission006', workflow: 'buy_powerup', target: 'upgrade001',
-          amount: null, position: 1, current_amount: 0, complete: false },
-        { mission: 'mission006', workflow: 'buy_powerup', target: 'ad002',
-          amount: null, position: 2, current_amount: 0, complete: false },
-        { mission: 'mission006', workflow: 'buy_powerup', target: 'teammember020',
-          amount: null, position: 3, current_amount: 0, complete: false }
-      ]
+        {
+          mission: 'mission006',
+          workflow: 'buy_powerup',
+          target: 'upgrade001',
+          amount: null,
+          position: 1,
+          current_amount: 0,
+          complete: false,
+        },
+        {
+          mission: 'mission006',
+          workflow: 'buy_powerup',
+          target: 'ad002',
+          amount: null,
+          position: 2,
+          current_amount: 0,
+          complete: false,
+        },
+        {
+          mission: 'mission006',
+          workflow: 'buy_powerup',
+          target: 'teammember020',
+          amount: null,
+          position: 3,
+          current_amount: 0,
+          complete: false,
+        },
+      ],
     });
     setState(initialState);
 
     var capturedDelta = null;
-    setSendDelta(function (d) { capturedDelta = d; });
+    setSendDelta(function (d) {
+      capturedDelta = d;
+    });
 
     await buyPowerup(P001, 0, 'upgrade001');
     expect(capturedDelta).not.toBeNull();
 
     // Replay the delta against the initial state (cold-start simulation).
     const replayed = applyDelta(initialState, capturedDelta);
-    const goals = replayed.mission_goals.filter(g => g.mission === 'mission006');
-    expect(goals.find(g => g.target === 'upgrade001').complete).toBe(true);
-    expect(goals.find(g => g.target === 'ad002').complete).toBe(false);
+    const goals = replayed.mission_goals.filter((g) => g.mission === 'mission006');
+    expect(goals.find((g) => g.target === 'upgrade001').complete).toBe(true);
+    expect(goals.find((g) => g.target === 'ad002').complete).toBe(false);
     // Mission still active — only one of three goals complete.
     expect(replayed.active_missions).toContain('mission006');
   });
@@ -2105,14 +2853,20 @@ describe('collectPerp — level-up refills AP to new ap_max', () => {
   const PATH = 'Imperium.City.Agent0.contact001';
 
   beforeEach(() => setOverride(FIXED_NOW));
-  afterEach(() => { clearOverride(); setSendDelta(null); setEmitter(null); });
+  afterEach(() => {
+    clearOverride();
+    setSendDelta(null);
+    setEmitter(null);
+  });
 
   it('ap_snapshot refills to new level ap_max when XP crosses level boundary', async () => {
-    setState(mkState({
-      game_values: mkGv({ xp_value: 10, xp_level: 1, ap_snapshot: 3, ap_max: 6 }),
-      nodes:        [mkNode('ContactPerp', PATH)],
-      nodes_collect: [{ path: PATH, result: { amount: 5 } }]
-    }));
+    setState(
+      mkState({
+        game_values: mkGv({ xp_value: 10, xp_level: 1, ap_snapshot: 3, ap_max: 6 }),
+        nodes: [mkNode('ContactPerp', PATH)],
+        nodes_collect: [{ path: PATH, result: { amount: 5 } }],
+      })
+    );
 
     const data = await collectPerp(PATH);
 
@@ -2120,15 +2874,17 @@ describe('collectPerp — level-up refills AP to new ap_max', () => {
     // collectPerp returns { result: { result: innerResult, game_values, levelup, … } }
     expect(data.result.levelup).toBe(true);
     expect(data.result.game_values.xp_level).toBe(2);
-    expect(data.result.game_values.ap_snapshot).toBe(8);  // level 2 ap_max
+    expect(data.result.game_values.ap_snapshot).toBe(8); // level 2 ap_max
   });
 
   it('ap_snapshot is NOT decremented when level-up occurs (override, not cost subtract)', async () => {
-    setState(mkState({
-      game_values: mkGv({ xp_value: 10, xp_level: 1, ap_snapshot: 3, ap_max: 6 }),
-      nodes:        [mkNode('ContactPerp', PATH)],
-      nodes_collect: [{ path: PATH, result: { amount: 5 } }]
-    }));
+    setState(
+      mkState({
+        game_values: mkGv({ xp_value: 10, xp_level: 1, ap_snapshot: 3, ap_max: 6 }),
+        nodes: [mkNode('ContactPerp', PATH)],
+        nodes_collect: [{ path: PATH, result: { amount: 5 } }],
+      })
+    );
 
     const data = await collectPerp(PATH);
     // ap_snapshot must be the new ap_max (8), not the old value (3)
@@ -2138,16 +2894,18 @@ describe('collectPerp — level-up refills AP to new ap_max', () => {
   });
 
   it('no level-up: ap_snapshot is unchanged when XP stays within same level', async () => {
-    setState(mkState({
-      game_values: mkGv({ xp_value: 5, xp_level: 1, ap_snapshot: 3, ap_max: 6 }),
-      nodes:        [mkNode('ContactPerp', PATH)],
-      nodes_collect: [{ path: PATH, result: { amount: 5 } }]
-    }));
+    setState(
+      mkState({
+        game_values: mkGv({ xp_value: 5, xp_level: 1, ap_snapshot: 3, ap_max: 6 }),
+        nodes: [mkNode('ContactPerp', PATH)],
+        nodes_collect: [{ path: PATH, result: { amount: 5 } }],
+      })
+    );
 
     const data = await collectPerp(PATH);
     // contact001 xp_inc=1: 5+1=6 → still level 1 (xp_max=10)
     expect(data.result.levelup).toBe(false);
-    expect(data.result.game_values.ap_snapshot).toBe(3);  // unchanged
+    expect(data.result.game_values.ap_snapshot).toBe(3); // unchanged
   });
 });
 
@@ -2168,19 +2926,25 @@ describe('collectPerp — replay from zero leaves no orphan nodes_charging', () 
   const C007 = 'Imperium.City.Pusher0.client007';
 
   beforeEach(() => setOverride(FIXED_NOW));
-  afterEach(() => { clearOverride(); setEmitter(null); setSendDelta(null); });
+  afterEach(() => {
+    clearOverride();
+    setEmitter(null);
+    setSendDelta(null);
+  });
 
   it('replay(chargePerp) + replay(collectPerp) + materialize does not leak into nodes_collect', async () => {
     // ── Setup: build a starting state with the node seeded ────────────────
     const initialState = mkState({
       game_values: mkHighGv(),
-      nodes:       [mkClientNode2('client007', C007)]
+      nodes: [mkClientNode2('client007', C007)],
     });
     setState(initialState);
 
     // ── Capture deltas for chargePerp and collectPerp via setSendDelta ────
     const captured = [];
-    setSendDelta(function (d) { captured.push(d); });
+    setSendDelta(function (d) {
+      captured.push(d);
+    });
 
     // 1) Charge — produces a delta that adds a nodes_charging entry.
     const chargeRes = await chargePerp(C007);
@@ -2188,14 +2952,16 @@ describe('collectPerp — replay from zero leaves no orphan nodes_charging', () 
 
     // 2) Advance the clock past charge_end so collectPerp succeeds.
     const liveState = getState();
-    const chargeEntry = (liveState.nodes_charging || []).find(c => c.path === C007)
-                     || (liveState.nodes_collect  || []).find(c => c.path === C007);
+    const chargeEntry =
+      (liveState.nodes_charging || []).find((c) => c.path === C007) ||
+      (liveState.nodes_collect || []).find((c) => c.path === C007);
     // After the live materialize step the entry has moved to nodes_collect;
     // we still want a clock value strictly past charge_end for replay's
     // materialize call to fire Rule 1 unambiguously.
-    const chargeEnd = chargeEntry && typeof chargeEntry.charge_end === 'number'
-      ? chargeEntry.charge_end
-      : FIXED_NOW + 60_000;
+    const chargeEnd =
+      chargeEntry && typeof chargeEntry.charge_end === 'number'
+        ? chargeEntry.charge_end
+        : FIXED_NOW + 60_000;
     setOverride(chargeEnd + 1000);
 
     // 3) Collect — produces a delta that drains nodes_collect.
@@ -2208,8 +2974,8 @@ describe('collectPerp — replay from zero leaves no orphan nodes_charging', () 
     // The materializer strips nodes_charging in-memory before the
     // collectPerp delta is built, so the live committed state has no orphan.
     const liveAfter = getState();
-    const liveCharging = (liveAfter.nodes_charging || []).filter(c => c.path === C007);
-    const liveCollect  = (liveAfter.nodes_collect  || []).filter(c => c.path === C007);
+    const liveCharging = (liveAfter.nodes_charging || []).filter((c) => c.path === C007);
+    const liveCollect = (liveAfter.nodes_collect || []).filter((c) => c.path === C007);
     expect(liveCharging).toHaveLength(0);
     expect(liveCollect).toHaveLength(0);
 
@@ -2218,7 +2984,7 @@ describe('collectPerp — replay from zero leaves no orphan nodes_charging', () 
     // log without the in-memory materialize step that the live path does.
     let replayed = mkState({
       game_values: mkHighGv(),
-      nodes:       [mkClientNode2('client007', C007)]
+      nodes: [mkClientNode2('client007', C007)],
     });
     for (var i = 0; i < captured.length; i++) {
       replayed = applyDelta(replayed, captured[i]);
@@ -2231,8 +2997,8 @@ describe('collectPerp — replay from zero leaves no orphan nodes_charging', () 
     // ── The bug: nodes_charging still holds the entry, and materialize
     //    re-promotes it into nodes_collect, so the UI marks the perp as
     //    collectable again after a reload.
-    const orphanCharging = (mat.state.nodes_charging || []).filter(c => c.path === C007);
-    const orphanCollect  = (mat.state.nodes_collect  || []).filter(c => c.path === C007);
+    const orphanCharging = (mat.state.nodes_charging || []).filter((c) => c.path === C007);
+    const orphanCollect = (mat.state.nodes_collect || []).filter((c) => c.path === C007);
     expect(orphanCharging).toHaveLength(0);
     expect(orphanCollect).toHaveLength(0);
   });

--- a/tests/handlers/handlers.test.js
+++ b/tests/handlers/handlers.test.js
@@ -1,10 +1,23 @@
 // @ts-nocheck — strict-TS quarantine; remove when this file is migrated to TS (issue #147)
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
-  getToken, ping, getSessionLocale, setLocale, loadGame, getRanking, setEmitter,
-  setDisplayName, setPerpCoordinates, buyKarma,
-  buyPowerup, sellPowerup, buySlots, buyPerp,
-  dismissMissionBriefing, markTokenSeen, recheckMissions
+  getToken,
+  ping,
+  getSessionLocale,
+  setLocale,
+  loadGame,
+  getRanking,
+  setEmitter,
+  setDisplayName,
+  setPerpCoordinates,
+  buyKarma,
+  buyPowerup,
+  sellPowerup,
+  buySlots,
+  buyPerp,
+  dismissMissionBriefing,
+  markTokenSeen,
+  recheckMissions,
 } from '../../scripts/LocalEngine.js';
 import { getState, setState } from '../../scripts/boot.js';
 import { freshState, applyDelta } from '../../scripts/state.js';
@@ -19,7 +32,7 @@ import { FIXED_NOW, mkState } from './_fixtures.js';
 // set below so the two sources stay consistent.  Includes `spent` (cash_spent)
 // to cover the Investor tab registered in type_settings.js.
 function mkRankingState() {
-  var base = mkState();  // freshState('test@local')
+  var base = mkState(); // freshState('test@local')
   var selfAddr = 'test@local';
   return Object.assign({}, base, {
     display_name: 'TestUser',
@@ -177,7 +190,7 @@ describe('loadGame — fresh state', () => {
       game_id: 'Imperium',
       full_path: 'Imperium',
       instance_data: expect.any(Object),
-      type_data: expect.any(Object)
+      type_data: expect.any(Object),
     });
   });
 
@@ -187,7 +200,7 @@ describe('loadGame — fresh state', () => {
       game_id: 'Database',
       full_path: 'Database',
       instance_data: expect.any(Object),
-      type_data: expect.any(Object)
+      type_data: expect.any(Object),
     });
   });
 
@@ -251,8 +264,12 @@ describe('loadGame — replayed state', () => {
     var s = freshState('player@example');
     // Simulate a prior loadGame having bumped cash_value via a delta.
     var delta = {
-      kind: 'delta', addr: 'player@example',
-      op: 'loadGame', args: [], result: {}, ts: Date.now()
+      kind: 'delta',
+      addr: 'player@example',
+      op: 'loadGame',
+      args: [],
+      result: {},
+      ts: Date.now(),
     };
     var evolved = applyDelta(s, delta);
     // The stub reducer returns state unchanged — but addr and schema_version persist.
@@ -279,18 +296,26 @@ describe('loadGame — replayed state', () => {
 
 // karma001: price=250, karma_points=5, required_level=5
 const KARMA_GESTALT = 'karma001';
-const KARMA_PRICE   = 250;
-const KARMA_POINTS  = 5;
+const KARMA_PRICE = 250;
+const KARMA_POINTS = 5;
 
 describe('buyKarma — happy path', () => {
   beforeEach(() => {
-    setState(mkState({
-      game_values: {
-        xp_value: 1, xp_level: 1, cash_value: 1000, cash_spent: 0,
-        karma_value: 50, profiles_value: 0, profiles_max: 1,
-        ap_snapshot: 6, ap_update: null
-      }
-    }));
+    setState(
+      mkState({
+        game_values: {
+          xp_value: 1,
+          xp_level: 1,
+          cash_value: 1000,
+          cash_spent: 0,
+          karma_value: 50,
+          profiles_value: 0,
+          profiles_max: 1,
+          ap_snapshot: 6,
+          ap_update: null,
+        },
+      })
+    );
   });
 
   it('resolves to an object with a result property', async () => {
@@ -336,26 +361,42 @@ describe('buyKarma — happy path', () => {
   });
 
   it('clamps karma_value at 100 when already near the cap', async () => {
-    setState(mkState({
-      game_values: {
-        xp_value: 1, xp_level: 1, cash_value: 9999, cash_spent: 0,
-        karma_value: 98, profiles_value: 0, profiles_max: 1,
-        ap_snapshot: 6, ap_update: null
-      }
-    }));
+    setState(
+      mkState({
+        game_values: {
+          xp_value: 1,
+          xp_level: 1,
+          cash_value: 9999,
+          cash_spent: 0,
+          karma_value: 98,
+          profiles_value: 0,
+          profiles_max: 1,
+          ap_snapshot: 6,
+          ap_update: null,
+        },
+      })
+    );
     // karma001 karma_points=5; 98+5=103 → clamped to 100
     const { result } = await buyKarma(KARMA_GESTALT);
     expect(result.game_values.karma_value).toBe(100);
   });
 
   it('clamps karma_value at -100 when already below the floor', async () => {
-    setState(mkState({
-      game_values: {
-        xp_value: 1, xp_level: 1, cash_value: 9999, cash_spent: 0,
-        karma_value: -106, profiles_value: 0, profiles_max: 1,
-        ap_snapshot: 6, ap_update: null
-      }
-    }));
+    setState(
+      mkState({
+        game_values: {
+          xp_value: 1,
+          xp_level: 1,
+          cash_value: 9999,
+          cash_spent: 0,
+          karma_value: -106,
+          profiles_value: 0,
+          profiles_max: 1,
+          ap_snapshot: 6,
+          ap_update: null,
+        },
+      })
+    );
     // karma001 karma_points=5; -106+5=-101 → clamped to -100
     const { result } = await buyKarma(KARMA_GESTALT);
     expect(result.game_values.karma_value).toBe(-100);
@@ -364,13 +405,21 @@ describe('buyKarma — happy path', () => {
 
 describe('buyKarma — failure: insufficient cash', () => {
   beforeEach(() => {
-    setState(mkState({
-      game_values: {
-        xp_value: 1, xp_level: 1, cash_value: 10, cash_spent: 0,
-        karma_value: 0, profiles_value: 0, profiles_max: 1,
-        ap_snapshot: 6, ap_update: null
-      }
-    }));
+    setState(
+      mkState({
+        game_values: {
+          xp_value: 1,
+          xp_level: 1,
+          cash_value: 10,
+          cash_spent: 0,
+          karma_value: 0,
+          profiles_value: 0,
+          profiles_max: 1,
+          ap_snapshot: 6,
+          ap_update: null,
+        },
+      })
+    );
   });
 
   it('resolves with error when cash is below price', async () => {
@@ -387,13 +436,21 @@ describe('buyKarma — failure: insufficient cash', () => {
 
 describe('buyKarma — failure: unknown karmalauter', () => {
   beforeEach(() => {
-    setState(mkState({
-      game_values: {
-        xp_value: 1, xp_level: 1, cash_value: 9999, cash_spent: 0,
-        karma_value: 0, profiles_value: 0, profiles_max: 1,
-        ap_snapshot: 6, ap_update: null
-      }
-    }));
+    setState(
+      mkState({
+        game_values: {
+          xp_value: 1,
+          xp_level: 1,
+          cash_value: 9999,
+          cash_spent: 0,
+          karma_value: 0,
+          profiles_value: 0,
+          profiles_max: 1,
+          ap_snapshot: 6,
+          ap_update: null,
+        },
+      })
+    );
   });
 
   it('resolves with error for an unknown gestalt', async () => {
@@ -413,18 +470,22 @@ describe('materialization on boot', () => {
 
   it('emits a node_ready event for a charge that completed during the away window', async () => {
     const emitted = [];
-    setEmitter(function(ev, pl) { emitted.push({ ev, pl }); });
+    setEmitter(function (ev, pl) {
+      emitted.push({ ev, pl });
+    });
 
     const chargeEnd = FIXED_NOW - 10000; // completed 10 s before frozen "now"
     const s = mkState({
-      nodes_charging: [{
-        path: 'Imperium.City.contact001',
-        result: { value: 42 },
-        charge_start: chargeEnd - 120000,
-        charge_end: chargeEnd,
-        game_id: 'abc123',
-        game_type: 'ContactPerp'
-      }]
+      nodes_charging: [
+        {
+          path: 'Imperium.City.contact001',
+          result: { value: 42 },
+          charge_start: chargeEnd - 120000,
+          charge_end: chargeEnd,
+          game_id: 'abc123',
+          game_type: 'ContactPerp',
+        },
+      ],
     });
     setState(s);
 
@@ -436,25 +497,27 @@ describe('materialization on boot', () => {
     expect(emitted).toHaveLength(1);
     expect(emitted[0].ev).toBe('node_ready');
     expect(emitted[0].pl).toMatchObject({
-      id:   'abc123',
+      id: 'abc123',
       type: 'ContactPerp',
-      path: 'Imperium.City.contact001'
+      path: 'Imperium.City.contact001',
     });
   });
 
   it('moves the completed charge to nodes_collect in the persisted state', async () => {
-    setEmitter(function() {});
+    setEmitter(function () {});
 
     const chargeEnd = FIXED_NOW - 5000;
     const s = mkState({
-      nodes_charging: [{
-        path: 'Imperium.City.contact002',
-        result: { value: 10 },
-        charge_start: chargeEnd - 60000,
-        charge_end: chargeEnd,
-        game_id: 'def456',
-        game_type: 'ContactPerp'
-      }]
+      nodes_charging: [
+        {
+          path: 'Imperium.City.contact002',
+          result: { value: 10 },
+          charge_start: chargeEnd - 60000,
+          charge_end: chargeEnd,
+          game_id: 'def456',
+          game_type: 'ContactPerp',
+        },
+      ],
     });
     setState(s);
 
@@ -470,7 +533,9 @@ describe('materialization on boot', () => {
 
   it('emits no events when there are no completed charges', async () => {
     const emitted = [];
-    setEmitter(function(ev, pl) { emitted.push({ ev, pl }); });
+    setEmitter(function (ev, pl) {
+      emitted.push({ ev, pl });
+    });
 
     setState(mkState());
     await loadGame();
@@ -481,11 +546,14 @@ describe('materialization on boot', () => {
 
   it('AP regen survives reload — first loadGame seeds the clock, second ticks', async () => {
     setOverride(FIXED_NOW);
-    setState(mkState({
-      game_values: Object.assign({}, freshState('test@local').game_values, {
-        ap_snapshot: 0, ap_update: null
+    setState(
+      mkState({
+        game_values: Object.assign({}, freshState('test@local').game_values, {
+          ap_snapshot: 0,
+          ap_update: null,
+        }),
       })
-    }));
+    );
 
     // First load seeds ap_update without granting any ticks.
     await loadGame();
@@ -555,18 +623,20 @@ function mkStateWithNodes() {
   return mkState({
     nodes: [
       {
-        game_id: 'n1', game_type: 'ContactPerp',
+        game_id: 'n1',
+        game_type: 'ContactPerp',
         full_path: 'Imperium.City.Agent0',
         full_type: 'ContactPerp:Agent0',
-        instance_data: { x: 0, y: 0 }
+        instance_data: { x: 0, y: 0 },
       },
       {
-        game_id: 'n2', game_type: 'ProjectPerp',
+        game_id: 'n2',
+        game_type: 'ProjectPerp',
         full_path: 'Imperium.City.Project1',
         full_type: 'ProjectPerp:Project1',
-        instance_data: { x: 10, y: 20 }
-      }
-    ]
+        instance_data: { x: 10, y: 20 },
+      },
+    ],
   });
 }
 
@@ -574,29 +644,25 @@ describe('setPerpCoordinates — happy path', () => {
   beforeEach(() => setState(mkStateWithNodes()));
 
   it('returns {result: 1}', async () => {
-    const data = await setPerpCoordinates([
-      ['Imperium.City.Agent0', { x: 5, y: 7 }]
-    ]);
+    const data = await setPerpCoordinates([['Imperium.City.Agent0', { x: 5, y: 7 }]]);
     expect(data).toEqual({ result: 1 });
   });
 
   it('updates x/y on matched node', async () => {
-    await setPerpCoordinates([
-      ['Imperium.City.Agent0', { x: 42, y: 99 }]
-    ]);
-    const node = getState().nodes.find(n => n.full_path === 'Imperium.City.Agent0');
+    await setPerpCoordinates([['Imperium.City.Agent0', { x: 42, y: 99 }]]);
+    const node = getState().nodes.find((n) => n.full_path === 'Imperium.City.Agent0');
     expect(node.instance_data.x).toBe(42);
     expect(node.instance_data.y).toBe(99);
   });
 
   it('updates multiple nodes in a single call', async () => {
     await setPerpCoordinates([
-      ['Imperium.City.Agent0',   { x: 1, y: 2 }],
-      ['Imperium.City.Project1', { x: 3, y: 4 }]
+      ['Imperium.City.Agent0', { x: 1, y: 2 }],
+      ['Imperium.City.Project1', { x: 3, y: 4 }],
     ]);
     const nodes = getState().nodes;
-    const a = nodes.find(n => n.full_path === 'Imperium.City.Agent0');
-    const p = nodes.find(n => n.full_path === 'Imperium.City.Project1');
+    const a = nodes.find((n) => n.full_path === 'Imperium.City.Agent0');
+    const p = nodes.find((n) => n.full_path === 'Imperium.City.Project1');
     expect(a.instance_data).toMatchObject({ x: 1, y: 2 });
     expect(p.instance_data).toMatchObject({ x: 3, y: 4 });
   });
@@ -613,18 +679,16 @@ describe('setPerpCoordinates — failure modes', () => {
   it('silently skips a malformed entry (non-array element)', async () => {
     const data = await setPerpCoordinates([
       'not-an-array',
-      ['Imperium.City.Agent0', { x: 7, y: 8 }]
+      ['Imperium.City.Agent0', { x: 7, y: 8 }],
     ]);
     expect(data).toEqual({ result: 1 });
-    const node = getState().nodes.find(n => n.full_path === 'Imperium.City.Agent0');
+    const node = getState().nodes.find((n) => n.full_path === 'Imperium.City.Agent0');
     expect(node.instance_data.x).toBe(7);
   });
 
   it('leaves unmatched nodes unchanged', async () => {
-    await setPerpCoordinates([
-      ['Imperium.City.NoSuchNode', { x: 99, y: 99 }]
-    ]);
-    const node = getState().nodes.find(n => n.full_path === 'Imperium.City.Agent0');
+    await setPerpCoordinates([['Imperium.City.NoSuchNode', { x: 99, y: 99 }]]);
+    const node = getState().nodes.find((n) => n.full_path === 'Imperium.City.Agent0');
     expect(node.instance_data.x).toBe(0);
     expect(node.instance_data.y).toBe(0);
   });
@@ -635,15 +699,16 @@ describe('setPerpCoordinates — failure modes', () => {
 // A minimal ProjectPerp node using the real project001 ruleset entry.
 // Starts with empty powerups and default ad_slots from type_data (3).
 var PROJECT_NODE = {
-  game_id:       'proj001',
-  game_type:     'ProjectPerp',
-  full_path:     'Imperium.CityVienna.proj001',
-  full_type:     'ProjectPerp:project001',
-  gestalt:       'project001',
+  game_id: 'proj001',
+  game_type: 'ProjectPerp',
+  full_path: 'Imperium.CityVienna.proj001',
+  full_type: 'ProjectPerp:project001',
+  gestalt: 'project001',
   instance_data: {
-    x: 100, y: 100,
-    powerups: []
-  }
+    x: 100,
+    y: 100,
+    powerups: [],
+  },
 };
 
 // State with enough cash for any normal purchase (default seed: 270).
@@ -720,7 +785,7 @@ describe('buyPowerup — happy path', () => {
 describe('buyPowerup — failure: slot occupied', () => {
   it('returns error:1 when the requested slot already holds a powerup of the same type', async () => {
     const occupiedNode = Object.assign({}, PROJECT_NODE, {
-      instance_data: { powerups: [{ slot: 0, gestalt: 'ad002', full_type: 'AdPowerup:ad002' }] }
+      instance_data: { powerups: [{ slot: 0, gestalt: 'ad002', full_type: 'AdPowerup:ad002' }] },
     });
     setState(Object.assign({}, freshState('test@local'), { nodes: [occupiedNode] }));
     const { result } = await buyPowerup(PROJECT_NODE.full_path, 0, 'ad003');
@@ -730,7 +795,7 @@ describe('buyPowerup — failure: slot occupied', () => {
   it('does NOT block slot 0 for a different powerup type even if same slot index is taken', async () => {
     // Ad slot 0 is occupied; upgrade slot 0 is independent and must remain free.
     const occupiedNode = Object.assign({}, PROJECT_NODE, {
-      instance_data: { powerups: [{ slot: 0, gestalt: 'ad002', full_type: 'AdPowerup:ad002' }] }
+      instance_data: { powerups: [{ slot: 0, gestalt: 'ad002', full_type: 'AdPowerup:ad002' }] },
     });
     setState(Object.assign({}, freshState('test@local'), { nodes: [occupiedNode] }));
     const { result } = await buyPowerup(PROJECT_NODE.full_path, 0, 'upgrade001');
@@ -741,7 +806,7 @@ describe('buyPowerup — failure: slot occupied', () => {
 describe('buyPowerup — failure: insufficient cash', () => {
   it('returns error:3 when cash_value < powerup price', async () => {
     const broke = mkProjectState({
-      game_values: Object.assign({}, freshState('test@local').game_values, { cash_value: 5 })
+      game_values: Object.assign({}, freshState('test@local').game_values, { cash_value: 5 }),
     });
     setState(broke);
     const { result } = await buyPowerup(PROJECT_NODE.full_path, 0, 'ad002');
@@ -755,12 +820,13 @@ describe('buyPowerup — failure: insufficient cash', () => {
 function mkStateWithPowerup() {
   var nodeWithPu = Object.assign({}, PROJECT_NODE, {
     instance_data: {
-      x: 100, y: 100,
+      x: 100,
+      y: 100,
       powerups: [{ slot: 0, gestalt: 'ad002', full_type: 'AdPowerup:ad002' }],
-      charge_cost:    225,  // after ad002 modifiers
+      charge_cost: 225, // after ad002 modifiers
       collect_amount: 3760,
-      collect_risk:   2
-    }
+      collect_risk: 2,
+    },
   });
   return Object.assign({}, freshState('test@local'), { nodes: [nodeWithPu] });
 }
@@ -835,14 +901,23 @@ describe('sellPowerup — failure: slot empty', () => {
 
 function mkBuyPerpState(overrides) {
   // Level-3 player with ample cash; no nodes yet.
-  return Object.assign(freshState('buyer@local'), {
-    game_values: {
-      xp_value: 15, xp_level: 3,
-      cash_value: 10000, cash_spent: 0,
-      karma_value: 0, profiles_value: 0, profiles_max: 1,
-      ap_snapshot: 6, ap_update: null
-    }
-  }, overrides || {});
+  return Object.assign(
+    freshState('buyer@local'),
+    {
+      game_values: {
+        xp_value: 15,
+        xp_level: 3,
+        cash_value: 10000,
+        cash_spent: 0,
+        karma_value: 0,
+        profiles_value: 0,
+        profiles_max: 1,
+        ap_snapshot: 6,
+        ap_update: null,
+      },
+    },
+    overrides || {}
+  );
 }
 
 describe('buyPerp — happy path (contact gestalt)', () => {
@@ -868,7 +943,7 @@ describe('buyPerp — happy path (contact gestalt)', () => {
       full_type: 'ContactPerp:contact001',
       gestalt: 'contact001',
       full_path: 'Imperium.contact001',
-      instance_data: expect.any(Object)
+      instance_data: expect.any(Object),
     });
   });
 
@@ -912,8 +987,10 @@ describe('buyPerp — happy path (contact gestalt)', () => {
     // city002: required_level 1, price 0 — always accessible
     await buyPerp('Imperium', 'city002');
     const s = getState();
-    const ids = s.nodes.map(function(n) { return n.game_id; });
-    expect(new Set(ids).size).toBe(ids.length);  // all unique (seed + 2 buys)
+    const ids = s.nodes.map(function (n) {
+      return n.game_id;
+    });
+    expect(new Set(ids).size).toBe(ids.length); // all unique (seed + 2 buys)
     expect(r1.result.node.game_id).toBe('contact001');
   });
 });
@@ -946,7 +1023,7 @@ describe('buyPerp — happy path delta replay (applyDelta roundtrip)', () => {
     const replayBase = freshState('buyer@local');
     // We seed game_values so cash floor is satisfied in the reducer.
     const seedState = Object.assign({}, replayBase, {
-      game_values: initialState.game_values
+      game_values: initialState.game_values,
     });
 
     const delta = {
@@ -955,7 +1032,7 @@ describe('buyPerp — happy path delta replay (applyDelta roundtrip)', () => {
       op: 'buyPerp',
       args: ['Imperium', 'contact001'],
       result: result,
-      ts: Date.now()
+      ts: Date.now(),
     };
 
     const replayed = applyDelta(seedState, delta);
@@ -968,23 +1045,41 @@ describe('buyPerp — happy path delta replay (applyDelta roundtrip)', () => {
 
 describe('buyPerp — failure: insufficient cash', () => {
   it('returns error 2 when cash_value < price', async () => {
-    setState(mkBuyPerpState({ game_values: {
-      xp_value: 15, xp_level: 3,
-      cash_value: 100, cash_spent: 0,  // contact001 costs 400
-      karma_value: 0, profiles_value: 0, profiles_max: 1,
-      ap_snapshot: 6, ap_update: null
-    }}));
+    setState(
+      mkBuyPerpState({
+        game_values: {
+          xp_value: 15,
+          xp_level: 3,
+          cash_value: 100,
+          cash_spent: 0, // contact001 costs 400
+          karma_value: 0,
+          profiles_value: 0,
+          profiles_max: 1,
+          ap_snapshot: 6,
+          ap_update: null,
+        },
+      })
+    );
     const { result } = await buyPerp('Imperium', 'contact001');
     expect(result.error).toBe(2);
   });
 
   it('does not add a node on cash failure', async () => {
-    setState(mkBuyPerpState({ game_values: {
-      xp_value: 15, xp_level: 3,
-      cash_value: 50, cash_spent: 0,
-      karma_value: 0, profiles_value: 0, profiles_max: 1,
-      ap_snapshot: 6, ap_update: null
-    }}));
+    setState(
+      mkBuyPerpState({
+        game_values: {
+          xp_value: 15,
+          xp_level: 3,
+          cash_value: 50,
+          cash_spent: 0,
+          karma_value: 0,
+          profiles_value: 0,
+          profiles_max: 1,
+          ap_snapshot: 6,
+          ap_update: null,
+        },
+      })
+    );
     await buyPerp('Imperium', 'contact001');
     expect(getState().nodes.find((n) => n.gestalt === 'contact001')).toBeUndefined();
   });
@@ -993,12 +1088,21 @@ describe('buyPerp — failure: insufficient cash', () => {
 describe('buyPerp — failure: level too low', () => {
   it('returns error 1 when xp_level < required_level', async () => {
     // contact001 requires level 3; state is level 1
-    setState(mkBuyPerpState({ game_values: {
-      xp_value: 0, xp_level: 1,
-      cash_value: 10000, cash_spent: 0,
-      karma_value: 0, profiles_value: 0, profiles_max: 1,
-      ap_snapshot: 6, ap_update: null
-    }}));
+    setState(
+      mkBuyPerpState({
+        game_values: {
+          xp_value: 0,
+          xp_level: 1,
+          cash_value: 10000,
+          cash_spent: 0,
+          karma_value: 0,
+          profiles_value: 0,
+          profiles_max: 1,
+          ap_snapshot: 6,
+          ap_update: null,
+        },
+      })
+    );
     const { result } = await buyPerp('Imperium', 'contact001');
     expect(result.error).toBe(1);
   });
@@ -1052,7 +1156,7 @@ describe('buySlots — happy path', () => {
 describe('buySlots — failure: insufficient cash', () => {
   it('returns error:3 when cash_value < slot cost', async () => {
     const broke = mkProjectState({
-      game_values: Object.assign({}, freshState('test@local').game_values, { cash_value: 0 })
+      game_values: Object.assign({}, freshState('test@local').game_values, { cash_value: 0 }),
     });
     setState(broke);
     const { result } = await buySlots(PROJECT_NODE.full_path, 'ad', 1);
@@ -1064,21 +1168,33 @@ describe('buyPerp — failure: ProxyPerp slot full', () => {
   it('returns error 3 when proxy max_slots is reached', async () => {
     // proxy001 has max_slots=3.  Pre-fill 3 project children.
     const proxyNode = {
-      game_id: 'node_0', game_type: 'ProxyPerp',
-      full_type: 'ProxyPerp:proxy001', gestalt: 'proxy001',
-      full_path: 'Imperium.proxy001', instance_data: {}
+      game_id: 'node_0',
+      game_type: 'ProxyPerp',
+      full_type: 'ProxyPerp:proxy001',
+      gestalt: 'proxy001',
+      full_path: 'Imperium.proxy001',
+      instance_data: {},
     };
-    const childNodes = ['project001','project002','project003'].map(function(g, i) {
+    const childNodes = ['project001', 'project002', 'project003'].map(function (g, i) {
       return {
-        game_id: 'node_c' + i, game_type: 'ProjectPerp',
-        full_type: 'ProjectPerp:' + g, gestalt: g,
-        full_path: 'Imperium.proxy001.' + g, instance_data: {}
+        game_id: 'node_c' + i,
+        game_type: 'ProjectPerp',
+        full_type: 'ProjectPerp:' + g,
+        gestalt: g,
+        full_path: 'Imperium.proxy001.' + g,
+        instance_data: {},
       };
     });
     // project005 requires level 7 — boost xp_level so level check passes
     // and only the slot check (error 3) triggers.
-    const highLevelValues = Object.assign({}, mkBuyPerpState().game_values, { xp_level: 7, xp_value: 200, cash_value: 10000 });
-    setState(mkBuyPerpState({ nodes: [proxyNode].concat(childNodes), game_values: highLevelValues }));
+    const highLevelValues = Object.assign({}, mkBuyPerpState().game_values, {
+      xp_level: 7,
+      xp_value: 200,
+      cash_value: 10000,
+    });
+    setState(
+      mkBuyPerpState({ nodes: [proxyNode].concat(childNodes), game_values: highLevelValues })
+    );
 
     // Try to buy a 4th project (project005 is also in proxy001 provided_perps)
     const { result } = await buyPerp('Imperium.proxy001', 'project005');
@@ -1089,9 +1205,12 @@ describe('buyPerp — failure: ProxyPerp slot full', () => {
 describe('buyPerp — failure: duplicate gestalt', () => {
   it('returns error 4 when gestalt already exists under parent', async () => {
     const existing = {
-      game_id: 'node_1', game_type: 'ContactPerp',
-      full_type: 'ContactPerp:contact001', gestalt: 'contact001',
-      full_path: 'Imperium.contact001', instance_data: {}
+      game_id: 'node_1',
+      game_type: 'ContactPerp',
+      full_type: 'ContactPerp:contact001',
+      gestalt: 'contact001',
+      full_path: 'Imperium.contact001',
+      instance_data: {},
     };
     setState(mkBuyPerpState({ nodes: [existing] }));
     const { result } = await buyPerp('Imperium', 'contact001');
@@ -1115,14 +1234,21 @@ describe('buyPerp — failure: unknown gestalt', () => {
 
 describe('buyPerp — level-up refills ap_snapshot', () => {
   beforeEach(() => {
-    setState(Object.assign(mkBuyPerpState(), {
-      game_values: {
-        xp_value: 54, xp_level: 3,
-        cash_value: 10000, cash_spent: 0,
-        karma_value: 0, profiles_value: 0, profiles_max: 1,
-        ap_snapshot: 1, ap_update: null
-      }
-    }));
+    setState(
+      Object.assign(mkBuyPerpState(), {
+        game_values: {
+          xp_value: 54,
+          xp_level: 3,
+          cash_value: 10000,
+          cash_spent: 0,
+          karma_value: 0,
+          profiles_value: 0,
+          profiles_max: 1,
+          ap_snapshot: 1,
+          ap_update: null,
+        },
+      })
+    );
   });
 
   it('returns levelup=true', async () => {
@@ -1131,7 +1257,7 @@ describe('buyPerp — level-up refills ap_snapshot', () => {
     expect(result.levelup).toBe(true);
   });
 
-  it('advances xp_level and refills AP to the new level\'s ap_max', async () => {
+  it("advances xp_level and refills AP to the new level's ap_max", async () => {
     const { result } = await buyPerp('Imperium', 'contact001');
     expect(result.game_values.xp_level).toBe(4);
     expect(result.game_values.ap_snapshot).toBe(14);
@@ -1142,29 +1268,33 @@ describe('buyPerp — level-up refills ap_snapshot', () => {
 // ── buyPerp — stuck mission repair ───────────────────────────────────────────
 
 const NURSE_NODE = {
-  game_id:       'contact001',
-  game_type:     'ContactPerp',
-  full_type:     'ContactPerp:contact001',
-  gestalt:       'contact001',
-  full_path:     'Imperium.contact001',
-  instance_data: {}
+  game_id: 'contact001',
+  game_type: 'ContactPerp',
+  full_type: 'ContactPerp:contact001',
+  gestalt: 'contact001',
+  full_path: 'Imperium.contact001',
+  instance_data: {},
 };
 
 describe('buyPerp — loadGame repairs stuck buy_perp goal', () => {
   it('marks buy_perp goal complete when target node is already owned at load time', async () => {
-    setState(Object.assign(mkBuyPerpState(), {
-      active_missions: ['mission007'],
-      mission_goals: [{
-        mission:        'mission007',
-        workflow:       'buy_perp',
-        target:         'contact001',
-        amount:         null,
-        position:       1,
-        current_amount: 0,
-        complete:       false
-      }],
-      nodes: mkBuyPerpState().nodes.concat([NURSE_NODE])
-    }));
+    setState(
+      Object.assign(mkBuyPerpState(), {
+        active_missions: ['mission007'],
+        mission_goals: [
+          {
+            mission: 'mission007',
+            workflow: 'buy_perp',
+            target: 'contact001',
+            amount: null,
+            position: 1,
+            current_amount: 0,
+            complete: false,
+          },
+        ],
+        nodes: mkBuyPerpState().nodes.concat([NURSE_NODE]),
+      })
+    );
 
     await loadGame();
 
@@ -1176,18 +1306,22 @@ describe('buyPerp — loadGame repairs stuck buy_perp goal', () => {
   });
 
   it('does not alter buy_perp goals when the target is not yet owned', async () => {
-    setState(Object.assign(mkBuyPerpState(), {
-      active_missions: ['mission007'],
-      mission_goals: [{
-        mission:        'mission007',
-        workflow:       'buy_perp',
-        target:         'contact001',
-        amount:         null,
-        position:       1,
-        current_amount: 0,
-        complete:       false
-      }]
-    }));
+    setState(
+      Object.assign(mkBuyPerpState(), {
+        active_missions: ['mission007'],
+        mission_goals: [
+          {
+            mission: 'mission007',
+            workflow: 'buy_perp',
+            target: 'contact001',
+            amount: null,
+            position: 1,
+            current_amount: 0,
+            complete: false,
+          },
+        ],
+      })
+    );
 
     await loadGame();
 
@@ -1201,14 +1335,40 @@ describe('buyPerp — loadGame repairs stuck buy_perp goal', () => {
 
 describe('recheckMissions — recovers stuck goals (current_amount >= amount)', () => {
   it('flips a stuck integrate_profiles goal to complete and finishes the mission', async () => {
-    setState(Object.assign(mkBuyPerpState(), {
-      active_missions: ['mission007'],
-      mission_goals: [
-        { mission: 'mission007', workflow: 'buy_perp',           target: 'contact001', amount: null, position: 1, current_amount: 1,    complete: true  },
-        { mission: 'mission007', workflow: 'collect_profiles',   target: 'contact001', amount: 3000, position: 2, current_amount: 3000, complete: true  },
-        { mission: 'mission007', workflow: 'integrate_profiles', target: 'token017',   amount: 3000, position: 3, current_amount: 3000, complete: false },
-      ],
-    }));
+    setState(
+      Object.assign(mkBuyPerpState(), {
+        active_missions: ['mission007'],
+        mission_goals: [
+          {
+            mission: 'mission007',
+            workflow: 'buy_perp',
+            target: 'contact001',
+            amount: null,
+            position: 1,
+            current_amount: 1,
+            complete: true,
+          },
+          {
+            mission: 'mission007',
+            workflow: 'collect_profiles',
+            target: 'contact001',
+            amount: 3000,
+            position: 2,
+            current_amount: 3000,
+            complete: true,
+          },
+          {
+            mission: 'mission007',
+            workflow: 'integrate_profiles',
+            target: 'token017',
+            amount: 3000,
+            position: 3,
+            current_amount: 3000,
+            complete: false,
+          },
+        ],
+      })
+    );
 
     const { result } = await recheckMissions();
 
@@ -1222,12 +1382,22 @@ describe('recheckMissions — recovers stuck goals (current_amount >= amount)', 
   });
 
   it('is a no-op when no goal is stuck', async () => {
-    setState(Object.assign(mkBuyPerpState(), {
-      active_missions: ['mission007'],
-      mission_goals: [
-        { mission: 'mission007', workflow: 'collect_profiles',   target: 'contact001', amount: 3000, position: 2, current_amount: 1500, complete: false },
-      ],
-    }));
+    setState(
+      Object.assign(mkBuyPerpState(), {
+        active_missions: ['mission007'],
+        mission_goals: [
+          {
+            mission: 'mission007',
+            workflow: 'collect_profiles',
+            target: 'contact001',
+            amount: 3000,
+            position: 2,
+            current_amount: 1500,
+            complete: false,
+          },
+        ],
+      })
+    );
 
     const { result } = await recheckMissions();
     expect(result.repaired).toBe(false);
@@ -1235,14 +1405,40 @@ describe('recheckMissions — recovers stuck goals (current_amount >= amount)', 
   });
 
   it('replaying the recheckMissions delta does not double-apply rewards', async () => {
-    setState(Object.assign(mkBuyPerpState(), {
-      active_missions: ['mission007'],
-      mission_goals: [
-        { mission: 'mission007', workflow: 'buy_perp',           target: 'contact001', amount: null, position: 1, current_amount: 1,    complete: true  },
-        { mission: 'mission007', workflow: 'collect_profiles',   target: 'contact001', amount: 3000, position: 2, current_amount: 3000, complete: true  },
-        { mission: 'mission007', workflow: 'integrate_profiles', target: 'token017',   amount: 3000, position: 3, current_amount: 3000, complete: false },
-      ],
-    }));
+    setState(
+      Object.assign(mkBuyPerpState(), {
+        active_missions: ['mission007'],
+        mission_goals: [
+          {
+            mission: 'mission007',
+            workflow: 'buy_perp',
+            target: 'contact001',
+            amount: null,
+            position: 1,
+            current_amount: 1,
+            complete: true,
+          },
+          {
+            mission: 'mission007',
+            workflow: 'collect_profiles',
+            target: 'contact001',
+            amount: 3000,
+            position: 2,
+            current_amount: 3000,
+            complete: true,
+          },
+          {
+            mission: 'mission007',
+            workflow: 'integrate_profiles',
+            target: 'token017',
+            amount: 3000,
+            position: 3,
+            current_amount: 3000,
+            complete: false,
+          },
+        ],
+      })
+    );
 
     await recheckMissions();
     const xpAfterFirst = getState().game_values.xp_value;
@@ -1254,14 +1450,40 @@ describe('recheckMissions — recovers stuck goals (current_amount >= amount)', 
 
 describe('loadGame — repairs stuck integrate_profiles goal at startup', () => {
   it('marks goal complete and removes mission from active_missions on load', async () => {
-    setState(Object.assign(mkBuyPerpState(), {
-      active_missions: ['mission007'],
-      mission_goals: [
-        { mission: 'mission007', workflow: 'buy_perp',           target: 'contact001', amount: null, position: 1, current_amount: 1,    complete: true  },
-        { mission: 'mission007', workflow: 'collect_profiles',   target: 'contact001', amount: 3000, position: 2, current_amount: 3000, complete: true  },
-        { mission: 'mission007', workflow: 'integrate_profiles', target: 'token017',   amount: 3000, position: 3, current_amount: 3000, complete: false },
-      ],
-    }));
+    setState(
+      Object.assign(mkBuyPerpState(), {
+        active_missions: ['mission007'],
+        mission_goals: [
+          {
+            mission: 'mission007',
+            workflow: 'buy_perp',
+            target: 'contact001',
+            amount: null,
+            position: 1,
+            current_amount: 1,
+            complete: true,
+          },
+          {
+            mission: 'mission007',
+            workflow: 'collect_profiles',
+            target: 'contact001',
+            amount: 3000,
+            position: 2,
+            current_amount: 3000,
+            complete: true,
+          },
+          {
+            mission: 'mission007',
+            workflow: 'integrate_profiles',
+            target: 'token017',
+            amount: 3000,
+            position: 3,
+            current_amount: 3000,
+            complete: false,
+          },
+        ],
+      })
+    );
 
     await loadGame();
 
@@ -1275,15 +1497,41 @@ describe('loadGame — repairs stuck integrate_profiles goal at startup', () => 
 
 describe('buyPerp — mission activating after nurse already owned seeds goal as complete', () => {
   beforeEach(() => {
-    setState(Object.assign(mkBuyPerpState(), {
-      active_missions: ['mission006'],
-      mission_goals: [
-        { mission: 'mission006', workflow: 'buy_powerup', target: 'upgrade001',    amount: null, position: 1, current_amount: 1, complete: true  },
-        { mission: 'mission006', workflow: 'buy_powerup', target: 'ad002',         amount: null, position: 2, current_amount: 1, complete: true  },
-        { mission: 'mission006', workflow: 'buy_powerup', target: 'teammember020', amount: null, position: 3, current_amount: 0, complete: false }
-      ],
-      nodes: mkBuyPerpState().nodes.concat([PROJECT_NODE, NURSE_NODE])
-    }));
+    setState(
+      Object.assign(mkBuyPerpState(), {
+        active_missions: ['mission006'],
+        mission_goals: [
+          {
+            mission: 'mission006',
+            workflow: 'buy_powerup',
+            target: 'upgrade001',
+            amount: null,
+            position: 1,
+            current_amount: 1,
+            complete: true,
+          },
+          {
+            mission: 'mission006',
+            workflow: 'buy_powerup',
+            target: 'ad002',
+            amount: null,
+            position: 2,
+            current_amount: 1,
+            complete: true,
+          },
+          {
+            mission: 'mission006',
+            workflow: 'buy_powerup',
+            target: 'teammember020',
+            amount: null,
+            position: 3,
+            current_amount: 0,
+            complete: false,
+          },
+        ],
+        nodes: mkBuyPerpState().nodes.concat([PROJECT_NODE, NURSE_NODE]),
+      })
+    );
   });
 
   it('mission007 is added to active_missions after buying the final mission006 powerup', async () => {
@@ -1393,7 +1641,7 @@ describe('dismissMissionBriefing — happy path', () => {
     await dismissMissionBriefing('mission003');
     expect(getState().mission_briefings_seen).toEqual({
       mission002: true,
-      mission003: true
+      mission003: true,
     });
   });
 });
@@ -1441,7 +1689,7 @@ describe('dismissMissionBriefing — reload guard (issue #83)', () => {
       op: 'dismissMissionBriefing',
       args: ['mission001'],
       result: {},
-      ts: Date.now()
+      ts: Date.now(),
     };
     const replayed = applyDelta(freshState(addr), dismissDelta);
     setState(replayed);
@@ -1517,7 +1765,7 @@ describe('buyPowerup — error: exactly one coin short of powerup price', () => 
   it('returns error:3 when cash_value is price − 1 (ad002 price=90, cash=89)', async () => {
     // ad002 price = 90; state has 89 — one coin short.
     const oneCoinShort = mkProjectState({
-      game_values: Object.assign({}, freshState('test@local').game_values, { cash_value: 89 })
+      game_values: Object.assign({}, freshState('test@local').game_values, { cash_value: 89 }),
     });
     setState(oneCoinShort);
     const { result } = await buyPowerup(PROJECT_NODE.full_path, 0, 'ad002');
@@ -1526,7 +1774,7 @@ describe('buyPowerup — error: exactly one coin short of powerup price', () => 
 
   it('does not mutate state on partial-funds failure', async () => {
     const oneCoinShort = mkProjectState({
-      game_values: Object.assign({}, freshState('test@local').game_values, { cash_value: 89 })
+      game_values: Object.assign({}, freshState('test@local').game_values, { cash_value: 89 }),
     });
     setState(oneCoinShort);
     const before = getState().game_values.cash_value;
@@ -1541,7 +1789,7 @@ describe('buySlots — error: exactly one coin short of slot cost', () => {
   // cash=12 is one coin short.
   it('returns error:3 when cash_value is slot cost − 1', async () => {
     const oneCoinShort = mkProjectState({
-      game_values: Object.assign({}, freshState('test@local').game_values, { cash_value: 12 })
+      game_values: Object.assign({}, freshState('test@local').game_values, { cash_value: 12 }),
     });
     setState(oneCoinShort);
     const { result } = await buySlots(PROJECT_NODE.full_path, 'ad', 1);
@@ -1550,7 +1798,7 @@ describe('buySlots — error: exactly one coin short of slot cost', () => {
 
   it('does not mutate state on partial-funds failure', async () => {
     const oneCoinShort = mkProjectState({
-      game_values: Object.assign({}, freshState('test@local').game_values, { cash_value: 12 })
+      game_values: Object.assign({}, freshState('test@local').game_values, { cash_value: 12 }),
     });
     setState(oneCoinShort);
     const before = getState().game_values.cash_value;

--- a/tests/handlers/handlers.test.js
+++ b/tests/handlers/handlers.test.js
@@ -1,27 +1,27 @@
 // @ts-nocheck — strict-TS quarantine; remove when this file is migrated to TS (issue #147)
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
-  getToken,
-  ping,
-  getSessionLocale,
-  setLocale,
-  loadGame,
-  getRanking,
-  setEmitter,
-  setDisplayName,
-  setPerpCoordinates,
   buyKarma,
-  buyPowerup,
-  sellPowerup,
-  buySlots,
   buyPerp,
+  buyPowerup,
+  buySlots,
   dismissMissionBriefing,
+  getRanking,
+  getSessionLocale,
+  getToken,
+  loadGame,
   markTokenSeen,
+  ping,
   recheckMissions,
+  sellPowerup,
+  setDisplayName,
+  setEmitter,
+  setLocale,
+  setPerpCoordinates,
 } from '../../scripts/LocalEngine.js';
 import { getState, setState } from '../../scripts/boot.js';
-import { freshState, applyDelta } from '../../scripts/state.js';
-import { setOverride, clearOverride } from '../../scripts/clock.js';
+import { clearOverride, setOverride } from '../../scripts/clock.js';
+import { applyDelta, freshState } from '../../scripts/state.js';
 import { FIXED_NOW, mkState } from './_fixtures.js';
 
 // ── getRanking ───────────────────────────────────────────────────────────────

--- a/tests/handlers/listener-echo.test.js
+++ b/tests/handlers/listener-echo.test.js
@@ -45,9 +45,16 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
-  chargePerp, buyKarma, buyPerp, collectPerp, integrateCollected,
-  buyPowerup, sellPowerup, buySlots,
-  setSendDelta, setEmitter
+  chargePerp,
+  buyKarma,
+  buyPerp,
+  collectPerp,
+  integrateCollected,
+  buyPowerup,
+  sellPowerup,
+  buySlots,
+  setSendDelta,
+  setEmitter,
 } from '../../scripts/LocalEngine.js';
 import { getState, setState } from '../../scripts/boot.js';
 import { freshState, applyDelta } from '../../scripts/state.js';
@@ -58,8 +65,12 @@ import { FIXED_NOW, mkGv, mkState, mkNode, mkChargingEntry } from './_fixtures.j
 // ── shared fixtures ─────────────────────────────────────────────────────────
 
 const ECONOMY_FIELDS = [
-  'cash_value', 'cash_spent', 'xp_value',
-  'karma_value', 'profiles_value', 'ap_snapshot'
+  'cash_value',
+  'cash_spent',
+  'xp_value',
+  'karma_value',
+  'profiles_value',
+  'ap_snapshot',
 ];
 
 function expectEconomyUnchanged(echoed, handlerState) {
@@ -83,31 +94,31 @@ afterEach(() => {
 // When the listener echoes the own delta back, this re-applies on top of the
 // already-deducted state — KNOWN bug from PR #119.
 
-const CHARGE_GESTALT  = 'contact035';
-const CHARGE_TIME     = 30_000;
-const CHARGE_COST     = 60;
-const CHARGE_PATH     = 'Imperium.CityVienna.Agent0.contact035';
+const CHARGE_GESTALT = 'contact035';
+const CHARGE_TIME = 30_000;
+const CHARGE_COST = 60;
+const CHARGE_PATH = 'Imperium.CityVienna.Agent0.contact035';
 
 function mkChargeNode() {
   return {
-    game_id:       'node-abc123',
-    game_type:     'ContactPerp',
-    full_path:     CHARGE_PATH,
-    full_type:     'ContactPerp:' + CHARGE_GESTALT,
-    gestalt:       CHARGE_GESTALT,
+    game_id: 'node-abc123',
+    game_type: 'ContactPerp',
+    full_path: CHARGE_PATH,
+    full_type: 'ContactPerp:' + CHARGE_GESTALT,
+    gestalt: CHARGE_GESTALT,
     instance_data: {},
   };
 }
 
 const CHARGE_BASE_GV = {
-  cash_value:      500,
-  cash_spent:      0,
-  xp_value:        0,
-  ap_snapshot:     3,
-  ap_update:       FIXED_NOW,
-  ap_inc_value:    1,
+  cash_value: 500,
+  cash_spent: 0,
+  xp_value: 0,
+  ap_snapshot: 3,
+  ap_update: FIXED_NOW,
+  ap_inc_value: 1,
   ap_inc_interval: 120_000,
-  ap_max:          6,
+  ap_max: 6,
 };
 
 function mkChargeState(overrides) {
@@ -121,7 +132,7 @@ describe('chargePerp — listener echo idempotence', () => {
 
   it('listener echo does not double-deduct cash_value', async () => {
     const captured = [];
-    setSendDelta(d => captured.push(d));
+    setSendDelta((d) => captured.push(d));
     setState(mkChargeState());
 
     await chargePerp(CHARGE_PATH);
@@ -133,7 +144,7 @@ describe('chargePerp — listener echo idempotence', () => {
 
   it('listener echo does not double-add cash_spent', async () => {
     const captured = [];
-    setSendDelta(d => captured.push(d));
+    setSendDelta((d) => captured.push(d));
     setState(mkChargeState());
 
     await chargePerp(CHARGE_PATH);
@@ -145,7 +156,7 @@ describe('chargePerp — listener echo idempotence', () => {
 
   it('listener echo does not double-decrement ap_snapshot', async () => {
     const captured = [];
-    setSendDelta(d => captured.push(d));
+    setSendDelta((d) => captured.push(d));
     setState(mkChargeState());
 
     await chargePerp(CHARGE_PATH);
@@ -157,7 +168,7 @@ describe('chargePerp — listener echo idempotence', () => {
 
   it('listener echo does not double-add xp_value', async () => {
     const captured = [];
-    setSendDelta(d => captured.push(d));
+    setSendDelta((d) => captured.push(d));
     setState(mkChargeState());
 
     await chargePerp(CHARGE_PATH);
@@ -169,7 +180,7 @@ describe('chargePerp — listener echo idempotence', () => {
 
   it('all economy fields stable across echo', async () => {
     const captured = [];
-    setSendDelta(d => captured.push(d));
+    setSendDelta((d) => captured.push(d));
     setState(mkChargeState());
 
     await chargePerp(CHARGE_PATH);
@@ -190,17 +201,23 @@ function mkKarmaState() {
   var base = freshState('test@local');
   return Object.assign({}, base, {
     game_values: Object.assign({}, base.game_values, {
-      xp_value: 1, xp_level: 1, cash_value: 1000, cash_spent: 0,
-      karma_value: 50, profiles_value: 0, profiles_max: 1,
-      ap_snapshot: 6, ap_update: null
-    })
+      xp_value: 1,
+      xp_level: 1,
+      cash_value: 1000,
+      cash_spent: 0,
+      karma_value: 50,
+      profiles_value: 0,
+      profiles_max: 1,
+      ap_snapshot: 6,
+      ap_update: null,
+    }),
   });
 }
 
 describe('buyKarma — listener echo idempotence (regression guard)', () => {
   it('listener echo does not double-deduct cash_value', async () => {
     const captured = [];
-    setSendDelta(d => captured.push(d));
+    setSendDelta((d) => captured.push(d));
     setState(mkKarmaState());
 
     await buyKarma(KARMA_GESTALT);
@@ -213,7 +230,7 @@ describe('buyKarma — listener echo idempotence (regression guard)', () => {
 
   it('listener echo does not double-add karma_value', async () => {
     const captured = [];
-    setSendDelta(d => captured.push(d));
+    setSendDelta((d) => captured.push(d));
     setState(mkKarmaState());
 
     await buyKarma(KARMA_GESTALT);
@@ -225,7 +242,7 @@ describe('buyKarma — listener echo idempotence (regression guard)', () => {
 
   it('all economy fields stable across echo', async () => {
     const captured = [];
-    setSendDelta(d => captured.push(d));
+    setSendDelta((d) => captured.push(d));
     setState(mkKarmaState());
 
     await buyKarma(KARMA_GESTALT);
@@ -244,20 +261,29 @@ describe('buyKarma — listener echo idempotence (regression guard)', () => {
 // length. node_counter behavior is intentionally NOT asserted here.
 
 function mkBuyPerpState(overrides) {
-  return Object.assign(freshState('buyer@local'), {
-    game_values: {
-      xp_value: 15, xp_level: 3,
-      cash_value: 10000, cash_spent: 0,
-      karma_value: 0, profiles_value: 0, profiles_max: 1,
-      ap_snapshot: 6, ap_update: null
-    }
-  }, overrides || {});
+  return Object.assign(
+    freshState('buyer@local'),
+    {
+      game_values: {
+        xp_value: 15,
+        xp_level: 3,
+        cash_value: 10000,
+        cash_spent: 0,
+        karma_value: 0,
+        profiles_value: 0,
+        profiles_max: 1,
+        ap_snapshot: 6,
+        ap_update: null,
+      },
+    },
+    overrides || {}
+  );
 }
 
 describe('buyPerp — listener echo idempotence (regression guard)', () => {
   it('listener echo does not double-deduct cash on a successful buy', async () => {
     const captured = [];
-    setSendDelta(d => captured.push(d));
+    setSendDelta((d) => captured.push(d));
     setState(mkBuyPerpState());
 
     await buyPerp('Imperium', 'contact001');
@@ -271,7 +297,7 @@ describe('buyPerp — listener echo idempotence (regression guard)', () => {
 
   it('listener echo does not double-grow nodes array (de-dup by full_path)', async () => {
     const captured = [];
-    setSendDelta(d => captured.push(d));
+    setSendDelta((d) => captured.push(d));
     setState(mkBuyPerpState());
 
     await buyPerp('Imperium', 'contact001');
@@ -283,7 +309,7 @@ describe('buyPerp — listener echo idempotence (regression guard)', () => {
 
   it('listener echo does not double-grow db_queue for contact gestalt', async () => {
     const captured = [];
-    setSendDelta(d => captured.push(d));
+    setSendDelta((d) => captured.push(d));
     setState(mkBuyPerpState());
 
     await buyPerp('Imperium', 'contact001');
@@ -295,7 +321,7 @@ describe('buyPerp — listener echo idempotence (regression guard)', () => {
 
   it('all economy fields stable across echo', async () => {
     const captured = [];
-    setSendDelta(d => captured.push(d));
+    setSendDelta((d) => captured.push(d));
     setState(mkBuyPerpState());
 
     await buyPerp('Imperium', 'contact001');
@@ -310,17 +336,17 @@ describe('buyPerp — listener echo idempotence (regression guard)', () => {
 // Reducer applies snapshot-style game_values merge. db_queue and
 // nodes_collect have explicit de-dup. Regression guard.
 
-const COLLECT_PATH    = 'Imperium.City.Agent0.contact001';
-const COLLECT_DUR     = 120_000;
-const COLLECT_END     = FIXED_NOW + COLLECT_DUR;
+const COLLECT_PATH = 'Imperium.City.Agent0.contact001';
+const COLLECT_DUR = 120_000;
+const COLLECT_END = FIXED_NOW + COLLECT_DUR;
 
 describe('collectPerp — listener echo idempotence (regression guard)', () => {
   beforeEach(() => setOverride(FIXED_NOW));
 
   function setupCharged() {
     var s = mkState({
-      nodes:          [mkNode('ContactPerp', COLLECT_PATH)],
-      nodes_charging: [mkChargingEntry(COLLECT_PATH, { amount: 5 }, 'ContactPerp')]
+      nodes: [mkNode('ContactPerp', COLLECT_PATH)],
+      nodes_charging: [mkChargingEntry(COLLECT_PATH, { amount: 5 }, 'ContactPerp')],
     });
     setState(s);
     // Materialize so nodes_collect has the entry collectPerp expects.
@@ -332,7 +358,7 @@ describe('collectPerp — listener echo idempotence (regression guard)', () => {
   it('listener echo does not double-add xp_value or profiles_value', async () => {
     setupCharged();
     const captured = [];
-    setSendDelta(d => captured.push(d));
+    setSendDelta((d) => captured.push(d));
 
     await collectPerp(COLLECT_PATH);
     const handlerState = getState();
@@ -345,7 +371,7 @@ describe('collectPerp — listener echo idempotence (regression guard)', () => {
   it('listener echo does not double-grow db_queue', async () => {
     setupCharged();
     const captured = [];
-    setSendDelta(d => captured.push(d));
+    setSendDelta((d) => captured.push(d));
 
     await collectPerp(COLLECT_PATH);
     const handlerState = getState();
@@ -357,7 +383,7 @@ describe('collectPerp — listener echo idempotence (regression guard)', () => {
   it('listener echo does not double-shrink nodes_collect', async () => {
     setupCharged();
     const captured = [];
-    setSendDelta(d => captured.push(d));
+    setSendDelta((d) => captured.push(d));
 
     await collectPerp(COLLECT_PATH);
     const handlerState = getState();
@@ -369,7 +395,7 @@ describe('collectPerp — listener echo idempotence (regression guard)', () => {
   it('all economy fields stable across echo', async () => {
     setupCharged();
     const captured = [];
-    setSendDelta(d => captured.push(d));
+    setSendDelta((d) => captured.push(d));
 
     await collectPerp(COLLECT_PATH);
     const handlerState = getState();
@@ -388,8 +414,8 @@ describe('integrateCollected — listener echo idempotence (regression guard)', 
 
   async function chargeCollectAndCapture() {
     var s = mkState({
-      nodes:          [mkNode('ContactPerp', COLLECT_PATH)],
-      nodes_charging: [mkChargingEntry(COLLECT_PATH, { amount: 5 }, 'ContactPerp')]
+      nodes: [mkNode('ContactPerp', COLLECT_PATH)],
+      nodes_charging: [mkChargingEntry(COLLECT_PATH, { amount: 5 }, 'ContactPerp')],
     });
     setState(s);
     setOverride(COLLECT_END + 1000);
@@ -403,7 +429,7 @@ describe('integrateCollected — listener echo idempotence (regression guard)', 
   it('listener echo does not double-add profiles_value or xp_value', async () => {
     const collectId = await chargeCollectAndCapture();
     const captured = [];
-    setSendDelta(d => captured.push(d));
+    setSendDelta((d) => captured.push(d));
 
     await integrateCollected(collectId);
     const handlerState = getState();
@@ -416,7 +442,7 @@ describe('integrateCollected — listener echo idempotence (regression guard)', 
   it('listener echo does not re-add the entry to db_queue', async () => {
     const collectId = await chargeCollectAndCapture();
     const captured = [];
-    setSendDelta(d => captured.push(d));
+    setSendDelta((d) => captured.push(d));
 
     await integrateCollected(collectId);
     const handlerState = getState();
@@ -428,7 +454,7 @@ describe('integrateCollected — listener echo idempotence (regression guard)', 
   it('listener echo does not double-grow nodes (TokenPerp first integration)', async () => {
     const collectId = await chargeCollectAndCapture();
     const captured = [];
-    setSendDelta(d => captured.push(d));
+    setSendDelta((d) => captured.push(d));
 
     await integrateCollected(collectId);
     const handlerState = getState();
@@ -440,7 +466,7 @@ describe('integrateCollected — listener echo idempotence (regression guard)', 
   it('all economy fields stable across echo', async () => {
     const collectId = await chargeCollectAndCapture();
     const captured = [];
-    setSendDelta(d => captured.push(d));
+    setSendDelta((d) => captured.push(d));
 
     await integrateCollected(collectId);
     const handlerState = getState();
@@ -456,12 +482,12 @@ describe('integrateCollected — listener echo idempotence (regression guard)', 
 // IFF the delta carries a full snapshot. Regression guards.
 
 var PROJECT_NODE = {
-  game_id:       'proj001',
-  game_type:     'ProjectPerp',
-  full_path:     'Imperium.CityVienna.proj001',
-  full_type:     'ProjectPerp:project001',
-  gestalt:       'project001',
-  instance_data: { x: 100, y: 100, powerups: [] }
+  game_id: 'proj001',
+  game_type: 'ProjectPerp',
+  full_path: 'Imperium.CityVienna.proj001',
+  full_type: 'ProjectPerp:project001',
+  gestalt: 'project001',
+  instance_data: { x: 100, y: 100, powerups: [] },
 };
 
 function mkProjectState(overrides) {
@@ -472,12 +498,13 @@ function mkProjectState(overrides) {
 function mkStateWithPowerup() {
   var nodeWithPu = Object.assign({}, PROJECT_NODE, {
     instance_data: {
-      x: 100, y: 100,
+      x: 100,
+      y: 100,
       powerups: [{ slot: 0, gestalt: 'ad002', full_type: 'AdPowerup:ad002' }],
-      charge_cost:    225,
+      charge_cost: 225,
       collect_amount: 3760,
-      collect_risk:   2
-    }
+      collect_risk: 2,
+    },
   });
   return Object.assign({}, freshState('test@local'), { nodes: [nodeWithPu] });
 }
@@ -488,7 +515,7 @@ describe('buyPowerup — listener echo idempotence (regression guard)', () => {
   it('listener echo does not double-deduct cash on powerup buy', async () => {
     setState(mkProjectState());
     const captured = [];
-    setSendDelta(d => captured.push(d));
+    setSendDelta((d) => captured.push(d));
 
     await buyPowerup(PROJECT_NODE.full_path, 0, 'ad002');
     const handlerState = getState();
@@ -501,7 +528,7 @@ describe('buyPowerup — listener echo idempotence (regression guard)', () => {
   it('listener echo does not double-add xp_value or karma_value', async () => {
     setState(mkProjectState());
     const captured = [];
-    setSendDelta(d => captured.push(d));
+    setSendDelta((d) => captured.push(d));
 
     await buyPowerup(PROJECT_NODE.full_path, 0, 'ad002');
     const handlerState = getState();
@@ -514,7 +541,7 @@ describe('buyPowerup — listener echo idempotence (regression guard)', () => {
   it('all economy fields stable across echo', async () => {
     setState(mkProjectState());
     const captured = [];
-    setSendDelta(d => captured.push(d));
+    setSendDelta((d) => captured.push(d));
 
     await buyPowerup(PROJECT_NODE.full_path, 0, 'ad002');
     const handlerState = getState();
@@ -530,7 +557,7 @@ describe('sellPowerup — listener echo idempotence (regression guard)', () => {
   it('listener echo does not double-refund cash on powerup sell', async () => {
     setState(mkStateWithPowerup());
     const captured = [];
-    setSendDelta(d => captured.push(d));
+    setSendDelta((d) => captured.push(d));
 
     await sellPowerup(PROJECT_NODE.full_path, 0, 'ad002');
     const handlerState = getState();
@@ -542,7 +569,7 @@ describe('sellPowerup — listener echo idempotence (regression guard)', () => {
   it('listener echo does not double-add xp_value', async () => {
     setState(mkStateWithPowerup());
     const captured = [];
-    setSendDelta(d => captured.push(d));
+    setSendDelta((d) => captured.push(d));
 
     await sellPowerup(PROJECT_NODE.full_path, 0, 'ad002');
     const handlerState = getState();
@@ -554,7 +581,7 @@ describe('sellPowerup — listener echo idempotence (regression guard)', () => {
   it('all economy fields stable across echo', async () => {
     setState(mkStateWithPowerup());
     const captured = [];
-    setSendDelta(d => captured.push(d));
+    setSendDelta((d) => captured.push(d));
 
     await sellPowerup(PROJECT_NODE.full_path, 0, 'ad002');
     const handlerState = getState();
@@ -570,7 +597,7 @@ describe('buySlots — listener echo idempotence (regression guard)', () => {
   it('listener echo does not double-deduct cash on slot purchase', async () => {
     setState(mkProjectState());
     const captured = [];
-    setSendDelta(d => captured.push(d));
+    setSendDelta((d) => captured.push(d));
 
     await buySlots(PROJECT_NODE.full_path, 'ad', 1);
     const handlerState = getState();
@@ -583,7 +610,7 @@ describe('buySlots — listener echo idempotence (regression guard)', () => {
   it('listener echo does not double-add xp_value', async () => {
     setState(mkProjectState());
     const captured = [];
-    setSendDelta(d => captured.push(d));
+    setSendDelta((d) => captured.push(d));
 
     await buySlots(PROJECT_NODE.full_path, 'ad', 1);
     const handlerState = getState();
@@ -595,7 +622,7 @@ describe('buySlots — listener echo idempotence (regression guard)', () => {
   it('all economy fields stable across echo', async () => {
     setState(mkProjectState());
     const captured = [];
-    setSendDelta(d => captured.push(d));
+    setSendDelta((d) => captured.push(d));
 
     await buySlots(PROJECT_NODE.full_path, 'ad', 1);
     const handlerState = getState();

--- a/tests/handlers/listener-echo.test.js
+++ b/tests/handlers/listener-echo.test.js
@@ -43,24 +43,24 @@
  * unskipped in #120 Phase 2 once the snapshot-based delta convention was
  * applied to every handler. Now the regression suite for the bug class.
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
-  chargePerp,
   buyKarma,
   buyPerp,
+  buyPowerup,
+  buySlots,
+  chargePerp,
   collectPerp,
   integrateCollected,
-  buyPowerup,
   sellPowerup,
-  buySlots,
-  setSendDelta,
   setEmitter,
+  setSendDelta,
 } from '../../scripts/LocalEngine.js';
 import { getState, setState } from '../../scripts/boot.js';
-import { freshState, applyDelta } from '../../scripts/state.js';
-import { setOverride, clearOverride } from '../../scripts/clock.js';
+import { clearOverride, setOverride } from '../../scripts/clock.js';
 import { materialize } from '../../scripts/materializer.js';
-import { FIXED_NOW, mkGv, mkState, mkNode, mkChargingEntry } from './_fixtures.js';
+import { applyDelta, freshState } from '../../scripts/state.js';
+import { FIXED_NOW, mkChargingEntry, mkGv, mkNode, mkState } from './_fixtures.js';
 
 // ── shared fixtures ─────────────────────────────────────────────────────────
 

--- a/tests/handlers/peer-aggregator.test.js
+++ b/tests/handlers/peer-aggregator.test.js
@@ -25,21 +25,20 @@ function mkGv(overrides) {
 // Minimal delta that carries a game_values snapshot.
 function mkDelta(addr, op, gvOverrides, ts) {
   return {
-    kind:   'delta',
-    addr:   addr,
-    op:     op || 'buyKarma',
-    args:   [],
+    kind: 'delta',
+    addr: addr,
+    op: op || 'buyKarma',
+    args: [],
     result: { game_values: mkGv(gvOverrides) },
-    ts:     typeof ts === 'number' ? ts : 1000,
+    ts: typeof ts === 'number' ? ts : 1000,
   };
 }
 
 // Replay an ordered list of deltas from a fresh state seeded with selfAddr.
 function replay(selfAddr, deltas) {
-  return deltas.reduce(
-    function (s, d) { return applyDelta(s, d); },
-    freshState(selfAddr)
-  );
+  return deltas.reduce(function (s, d) {
+    return applyDelta(s, d);
+  }, freshState(selfAddr));
 }
 
 // ── state.peers population ────────────────────────────────────────────────────
@@ -53,7 +52,12 @@ describe('state.peers — initialisation', () => {
 describe('state.peers — aggregation from own deltas', () => {
   it('populates self entry from game_values', () => {
     const s = replay('alice@test', [
-      mkDelta('alice@test', 'buyKarma', { cash_value: 100, profiles_value: 5, xp_value: 10, xp_level: 2 }, 1000),
+      mkDelta(
+        'alice@test',
+        'buyKarma',
+        { cash_value: 100, profiles_value: 5, xp_value: 10, xp_level: 2 },
+        1000
+      ),
     ]);
     expect(s.peers['alice@test']).toMatchObject({ cash: 100, profiles: 5, xp: 10, level: 2 });
   });
@@ -74,7 +78,14 @@ describe('state.peers — aggregation from own deltas', () => {
 
   it('tracks display_name from own setDisplayName delta', () => {
     const s = replay('alice@test', [
-      { kind: 'delta', addr: 'alice@test', op: 'setDisplayName', args: ['Alice'], result: {}, ts: 1000 },
+      {
+        kind: 'delta',
+        addr: 'alice@test',
+        op: 'setDisplayName',
+        args: ['Alice'],
+        result: {},
+        ts: 1000,
+      },
     ]);
     expect(s.peers['alice@test'].display_name).toBe('Alice');
   });
@@ -84,12 +95,22 @@ describe('state.peers — aggregation from own deltas', () => {
       mkDelta('alice@test', 'chargePerp', { cash_value: 100, xp_value: 10, xp_level: 1 }, 1000),
       mkDelta('alice@test', 'collectPerp', { cash_value: 150, xp_value: 15, xp_level: 2 }, 2000),
     ]);
-    expect(s.peers['alice@test']).toMatchObject({ cash: 150, xp: 15, level: 2, last_seen_ts: 2000 });
+    expect(s.peers['alice@test']).toMatchObject({
+      cash: 150,
+      xp: 15,
+      level: 2,
+      last_seen_ts: 2000,
+    });
   });
 
   it('tracks cash_spent as peer.spent', () => {
     const s = replay('alice@test', [
-      mkDelta('alice@test', 'chargePerp', { cash_value: 100, xp_value: 5, xp_level: 1, cash_spent: 40 }, 1000),
+      mkDelta(
+        'alice@test',
+        'chargePerp',
+        { cash_value: 100, xp_value: 5, xp_level: 1, cash_spent: 40 },
+        1000
+      ),
     ]);
     expect(s.peers['alice@test'].spent).toBe(40);
   });
@@ -105,15 +126,20 @@ describe('state.peers — timestamp-LWW stale-delta guard', () => {
     // Replay newer delta first, then an older one — stale should be ignored.
     const s = replay('alice@test', [
       mkDelta('alice@test', 'collectPerp', { cash_value: 200, xp_value: 20, xp_level: 2 }, 2000),
-      mkDelta('alice@test', 'chargePerp',  { cash_value:  50, xp_value:  5, xp_level: 1 }, 1000),
+      mkDelta('alice@test', 'chargePerp', { cash_value: 50, xp_value: 5, xp_level: 1 }, 1000),
     ]);
     // Stale delta (ts=1000) must not clobber the newer snapshot (ts=2000).
-    expect(s.peers['alice@test']).toMatchObject({ cash: 200, xp: 20, level: 2, last_seen_ts: 2000 });
+    expect(s.peers['alice@test']).toMatchObject({
+      cash: 200,
+      xp: 20,
+      level: 2,
+      last_seen_ts: 2000,
+    });
   });
 
   it('accepts a delta with ts equal to last_seen_ts (idempotent re-delivery)', () => {
     const s = replay('alice@test', [
-      mkDelta('alice@test', 'chargePerp',  { cash_value: 100, xp_value: 10, xp_level: 1 }, 1000),
+      mkDelta('alice@test', 'chargePerp', { cash_value: 100, xp_value: 10, xp_level: 1 }, 1000),
       mkDelta('alice@test', 'collectPerp', { cash_value: 150, xp_value: 15, xp_level: 2 }, 1000),
     ]);
     // Same ts — second delta is NOT stale, so it is processed.
@@ -125,7 +151,7 @@ describe('state.peers — timestamp-LWW stale-delta guard', () => {
     // The ts guard is per-peer, so a stale bob delta is independent of alice.
     const s = replay('alice@test', [
       mkDelta('bob@test', 'collectPerp', { cash_value: 200, xp_value: 20, xp_level: 2 }, 2000),
-      mkDelta('bob@test', 'chargePerp',  { cash_value:  50, xp_value:  5, xp_level: 1 }, 1000),
+      mkDelta('bob@test', 'chargePerp', { cash_value: 50, xp_value: 5, xp_level: 1 }, 1000),
     ]);
     expect(s.peers['bob@test']).toMatchObject({ cash: 200, xp: 20, level: 2, last_seen_ts: 2000 });
   });
@@ -134,21 +160,40 @@ describe('state.peers — timestamp-LWW stale-delta guard', () => {
 describe('state.peers — aggregation from peer deltas', () => {
   it('populates foreign-peer entry from game_values', () => {
     const s = replay('alice@test', [
-      mkDelta('bob@test', 'buyKarma', { cash_value: 200, profiles_value: 10, xp_value: 20, xp_level: 3 }, 2000),
+      mkDelta(
+        'bob@test',
+        'buyKarma',
+        { cash_value: 200, profiles_value: 10, xp_value: 20, xp_level: 3 },
+        2000
+      ),
     ]);
     expect(s.peers['bob@test']).toMatchObject({ cash: 200, profiles: 10, xp: 20, level: 3 });
   });
 
   it('tracks foreign peer display_name from setDisplayName', () => {
     const s = replay('alice@test', [
-      { kind: 'delta', addr: 'bob@test', op: 'setDisplayName', args: ['Bob'], result: {}, ts: 2000 },
+      {
+        kind: 'delta',
+        addr: 'bob@test',
+        op: 'setDisplayName',
+        args: ['Bob'],
+        result: {},
+        ts: 2000,
+      },
     ]);
     expect(s.peers['bob@test'].display_name).toBe('Bob');
   });
 
   it('does NOT mutate self display_name from a foreign setDisplayName', () => {
     const s = replay('alice@test', [
-      { kind: 'delta', addr: 'bob@test', op: 'setDisplayName', args: ['Bob'], result: {}, ts: 2000 },
+      {
+        kind: 'delta',
+        addr: 'bob@test',
+        op: 'setDisplayName',
+        args: ['Bob'],
+        result: {},
+        ts: 2000,
+      },
     ]);
     // alice's own top-level display_name is unchanged
     expect(s.display_name).toBe('');
@@ -169,9 +214,24 @@ describe('state.peers — aggregation from peer deltas', () => {
 
   it('aggregates 3 peers independently', () => {
     const deltas = [
-      mkDelta('alice@test', 'buyKarma', { cash_value: 100, profiles_value:  5, xp_value: 10, xp_level: 1 }, 1000),
-      mkDelta('bob@test',   'buyKarma', { cash_value: 200, profiles_value: 15, xp_value: 20, xp_level: 2 }, 2000),
-      mkDelta('carol@test', 'buyKarma', { cash_value: 300, profiles_value: 25, xp_value: 30, xp_level: 3 }, 3000),
+      mkDelta(
+        'alice@test',
+        'buyKarma',
+        { cash_value: 100, profiles_value: 5, xp_value: 10, xp_level: 1 },
+        1000
+      ),
+      mkDelta(
+        'bob@test',
+        'buyKarma',
+        { cash_value: 200, profiles_value: 15, xp_value: 20, xp_level: 2 },
+        2000
+      ),
+      mkDelta(
+        'carol@test',
+        'buyKarma',
+        { cash_value: 300, profiles_value: 25, xp_value: 30, xp_level: 3 },
+        3000
+      ),
     ];
     const s = replay('alice@test', deltas);
     expect(Object.keys(s.peers)).toHaveLength(3);
@@ -182,7 +242,7 @@ describe('state.peers — aggregation from peer deltas', () => {
 
   it('later delta overwrites earlier peer values for the same addr', () => {
     const s = replay('alice@test', [
-      mkDelta('bob@test', 'chargePerp', { cash_value: 50,  xp_value: 5,  xp_level: 1 }, 1000),
+      mkDelta('bob@test', 'chargePerp', { cash_value: 50, xp_value: 5, xp_level: 1 }, 1000),
       mkDelta('bob@test', 'collectPerp', { cash_value: 80, xp_value: 12, xp_level: 2 }, 2000),
     ]);
     expect(s.peers['bob@test']).toMatchObject({ cash: 80, xp: 12, level: 2, last_seen_ts: 2000 });
@@ -198,13 +258,28 @@ describe('state.peers — convergence (arrival-order independence)', () => {
 
   const SELF = 'alice@test';
   const deltas = [
-    mkDelta('alice@test', 'buyKarma',  { cash_value: 100, profiles_value:  5, xp_value: 10, xp_level: 1 }, 1000),
-    mkDelta('bob@test',   'chargePerp', { cash_value:  50, profiles_value: 20, xp_value:  5, xp_level: 1 }, 2000),
-    mkDelta('carol@test', 'collectPerp', { cash_value: 200, profiles_value: 10, xp_value: 30, xp_level: 3 }, 3000),
+    mkDelta(
+      'alice@test',
+      'buyKarma',
+      { cash_value: 100, profiles_value: 5, xp_value: 10, xp_level: 1 },
+      1000
+    ),
+    mkDelta(
+      'bob@test',
+      'chargePerp',
+      { cash_value: 50, profiles_value: 20, xp_value: 5, xp_level: 1 },
+      2000
+    ),
+    mkDelta(
+      'carol@test',
+      'collectPerp',
+      { cash_value: 200, profiles_value: 10, xp_value: 30, xp_level: 3 },
+      3000
+    ),
   ];
 
   it('produces identical peers for forward vs reverse order', () => {
-    const forward  = replay(SELF, deltas);
+    const forward = replay(SELF, deltas);
     const reversed = replay(SELF, deltas.slice().reverse());
     expect(forward.peers).toEqual(reversed.peers);
   });
@@ -219,7 +294,9 @@ describe('state.peers — convergence (arrival-order independence)', () => {
       [c, a, b],
       [c, b, a],
     ];
-    const results = permutations.map(function (perm) { return replay(SELF, perm).peers; });
+    const results = permutations.map(function (perm) {
+      return replay(SELF, perm).peers;
+    });
     for (var i = 1; i < results.length; i++) {
       expect(results[i]).toEqual(results[0]);
     }
@@ -239,10 +316,30 @@ describe('state.peers — convergence with 4 deltas from 2 addresses', () => {
   const SELF = 'alice@test';
 
   // alice sends two deltas at ts=1000 and ts=3000; bob sends two at ts=2000 and ts=4000.
-  const d_alice_1 = mkDelta('alice@test', 'chargePerp',  { cash_value: 50,  xp_value: 5,  xp_level: 1 }, 1000);
-  const d_alice_2 = mkDelta('alice@test', 'collectPerp', { cash_value: 120, xp_value: 12, xp_level: 1 }, 3000);
-  const d_bob_1   = mkDelta('bob@test',   'chargePerp',  { cash_value: 80,  xp_value: 8,  xp_level: 1 }, 2000);
-  const d_bob_2   = mkDelta('bob@test',   'collectPerp', { cash_value: 200, xp_value: 20, xp_level: 2 }, 4000);
+  const d_alice_1 = mkDelta(
+    'alice@test',
+    'chargePerp',
+    { cash_value: 50, xp_value: 5, xp_level: 1 },
+    1000
+  );
+  const d_alice_2 = mkDelta(
+    'alice@test',
+    'collectPerp',
+    { cash_value: 120, xp_value: 12, xp_level: 1 },
+    3000
+  );
+  const d_bob_1 = mkDelta(
+    'bob@test',
+    'chargePerp',
+    { cash_value: 80, xp_value: 8, xp_level: 1 },
+    2000
+  );
+  const d_bob_2 = mkDelta(
+    'bob@test',
+    'collectPerp',
+    { cash_value: 200, xp_value: 20, xp_level: 2 },
+    4000
+  );
 
   const allFour = [d_alice_1, d_alice_2, d_bob_1, d_bob_2];
 
@@ -254,13 +351,15 @@ describe('state.peers — convergence with 4 deltas from 2 addresses', () => {
         if (b === a) continue;
         for (var c = 0; c < 4; c++) {
           if (c === a || c === b) continue;
-          var d = [0, 1, 2, 3].find(function (x) { return x !== a && x !== b && x !== c; });
+          var d = [0, 1, 2, 3].find(function (x) {
+            return x !== a && x !== b && x !== c;
+          });
           result.push([allFour[a], allFour[b], allFour[c], allFour[d]]);
         }
       }
     }
     return result;
-  }());
+  })();
 
   it('final peers.alice is the highest-ts alice snapshot regardless of delta order', () => {
     allPerms.forEach(function (perm) {
@@ -274,7 +373,12 @@ describe('state.peers — convergence with 4 deltas from 2 addresses', () => {
     allPerms.forEach(function (perm) {
       var s = replay(SELF, perm);
       // bob's latest delta is ts=4000 (cash=200, xp=20, level=2).
-      expect(s.peers['bob@test']).toMatchObject({ cash: 200, xp: 20, level: 2, last_seen_ts: 4000 });
+      expect(s.peers['bob@test']).toMatchObject({
+        cash: 200,
+        xp: 20,
+        level: 2,
+        last_seen_ts: 4000,
+      });
     });
   });
 
@@ -291,20 +395,58 @@ describe('state.peers — convergence with 4 deltas from 2 addresses', () => {
     setState(Object.assign(freshState(SELF), { peers: replay(SELF, perms[0]).peers }));
     const r1 = await getRanking('xp');
 
-    setState(Object.assign(freshState(SELF), { peers: replay(SELF, perms[perms.length - 1]).peers }));
+    setState(
+      Object.assign(freshState(SELF), { peers: replay(SELF, perms[perms.length - 1]).peers })
+    );
     const r2 = await getRanking('xp');
 
-    expect(r1.result.top.map(function (r) { return r.addr; }).sort())
-      .toEqual(r2.result.top.map(function (r) { return r.addr; }).sort());
-    expect(r1.result.top.map(function (r) { return r.value; }).sort(function (a, b) { return b - a; }))
-      .toEqual(r2.result.top.map(function (r) { return r.value; }).sort(function (a, b) { return b - a; }));
+    expect(
+      r1.result.top
+        .map(function (r) {
+          return r.addr;
+        })
+        .sort()
+    ).toEqual(
+      r2.result.top
+        .map(function (r) {
+          return r.addr;
+        })
+        .sort()
+    );
+    expect(
+      r1.result.top
+        .map(function (r) {
+          return r.value;
+        })
+        .sort(function (a, b) {
+          return b - a;
+        })
+    ).toEqual(
+      r2.result.top
+        .map(function (r) {
+          return r.value;
+        })
+        .sort(function (a, b) {
+          return b - a;
+        })
+    );
   });
 
   it('tie (same-ts): last-processed delta wins for alice when both have ts=3000', () => {
     // Both alice deltas share ts=3000; LWW allows overwrite at equal ts.
     // The second delta processed is the one that sticks.
-    const d_tie_1 = mkDelta('alice@test', 'chargePerp',  { cash_value: 50,  xp_value: 5,  xp_level: 1 }, 3000);
-    const d_tie_2 = mkDelta('alice@test', 'collectPerp', { cash_value: 120, xp_value: 12, xp_level: 1 }, 3000);
+    const d_tie_1 = mkDelta(
+      'alice@test',
+      'chargePerp',
+      { cash_value: 50, xp_value: 5, xp_level: 1 },
+      3000
+    );
+    const d_tie_2 = mkDelta(
+      'alice@test',
+      'collectPerp',
+      { cash_value: 120, xp_value: 12, xp_level: 1 },
+      3000
+    );
 
     var s1 = replay('alice@test', [d_tie_1, d_tie_2]);
     var s2 = replay('alice@test', [d_tie_2, d_tie_1]);
@@ -322,7 +464,7 @@ describe('state.peers — convergence with 4 deltas from 2 addresses', () => {
     // The ts=1000 delta is stale and must not overwrite the ts=3000 snapshot.
     var s = replay('alice@test', [
       mkDelta('alice@test', 'collectPerp', { cash_value: 120, xp_value: 12, xp_level: 1 }, 3000),
-      mkDelta('alice@test', 'chargePerp',  { cash_value: 50,  xp_value: 5,  xp_level: 1 }, 1000),
+      mkDelta('alice@test', 'chargePerp', { cash_value: 50, xp_value: 5, xp_level: 1 }, 1000),
     ]);
     expect(s.peers['alice@test']).toMatchObject({ cash: 120, xp: 12, last_seen_ts: 3000 });
   });
@@ -333,59 +475,87 @@ describe('state.peers — convergence with 4 deltas from 2 addresses', () => {
 describe('getRanking with multi-peer state', () => {
   beforeEach(() => {
     // Seed state directly: 3 peers with different scores.
-    setState(Object.assign(freshState('alice@test'), {
-      display_name: 'Alice',
-      peers: {
-        'alice@test': { display_name: 'Alice', cash: 100, profiles:  5, xp: 10, level: 1, spent:  20, last_seen_ts: 1000, last_seen_serial: null },
-        'bob@test':   { display_name: 'Bob',   cash: 200, profiles: 15, xp: 30, level: 3, spent: 150, last_seen_ts: 2000, last_seen_serial: null },
-        'carol@test': { display_name: 'Carol', cash:  50, profiles: 20, xp: 20, level: 2, spent:  80, last_seen_ts: 3000, last_seen_serial: null },
-      },
-    }));
+    setState(
+      Object.assign(freshState('alice@test'), {
+        display_name: 'Alice',
+        peers: {
+          'alice@test': {
+            display_name: 'Alice',
+            cash: 100,
+            profiles: 5,
+            xp: 10,
+            level: 1,
+            spent: 20,
+            last_seen_ts: 1000,
+            last_seen_serial: null,
+          },
+          'bob@test': {
+            display_name: 'Bob',
+            cash: 200,
+            profiles: 15,
+            xp: 30,
+            level: 3,
+            spent: 150,
+            last_seen_ts: 2000,
+            last_seen_serial: null,
+          },
+          'carol@test': {
+            display_name: 'Carol',
+            cash: 50,
+            profiles: 20,
+            xp: 20,
+            level: 2,
+            spent: 80,
+            last_seen_ts: 3000,
+            last_seen_serial: null,
+          },
+        },
+      })
+    );
   });
 
   it('sorts by cash descending', async () => {
     const { result } = await getRanking('cash');
-    expect(result.top.map(r => r.display_name)).toEqual(['Bob', 'Alice', 'Carol']);
-    expect(result.top.map(r => r.value)).toEqual([200, 100, 50]);
+    expect(result.top.map((r) => r.display_name)).toEqual(['Bob', 'Alice', 'Carol']);
+    expect(result.top.map((r) => r.value)).toEqual([200, 100, 50]);
   });
 
   it('sorts by xp descending', async () => {
     const { result } = await getRanking('xp');
-    expect(result.top.map(r => r.display_name)).toEqual(['Bob', 'Carol', 'Alice']);
+    expect(result.top.map((r) => r.display_name)).toEqual(['Bob', 'Carol', 'Alice']);
   });
 
   it('sorts by profiles descending', async () => {
     const { result } = await getRanking('profiles');
-    expect(result.top.map(r => r.display_name)).toEqual(['Carol', 'Bob', 'Alice']);
+    expect(result.top.map((r) => r.display_name)).toEqual(['Carol', 'Bob', 'Alice']);
   });
 
   it('sorts by level descending', async () => {
     const { result } = await getRanking('level');
-    expect(result.top.map(r => r.display_name)).toEqual(['Bob', 'Carol', 'Alice']);
+    expect(result.top.map((r) => r.display_name)).toEqual(['Bob', 'Carol', 'Alice']);
   });
 
   it('sorts by spent descending (Investor tab — cash_spent)', async () => {
     const { result } = await getRanking('spent');
-    expect(result.top.map(r => r.display_name)).toEqual(['Bob', 'Carol', 'Alice']);
-    expect(result.top.map(r => r.value)).toEqual([150, 80, 20]);
+    expect(result.top.map((r) => r.display_name)).toEqual(['Bob', 'Carol', 'Alice']);
+    expect(result.top.map((r) => r.value)).toEqual([150, 80, 20]);
   });
 
   it('tags the self row with self: true', async () => {
     const { result } = await getRanking('cash');
-    const selfRow = result.top.find(r => r.self === true);
+    const selfRow = result.top.find((r) => r.self === true);
     expect(selfRow).toBeDefined();
     expect(selfRow.display_name).toBe('Alice');
   });
 
   it('tags exactly one row as self', async () => {
     const { result } = await getRanking('cash');
-    expect(result.top.filter(r => r.self === true)).toHaveLength(1);
+    expect(result.top.filter((r) => r.self === true)).toHaveLength(1);
   });
 
   it('non-self rows have self falsy', async () => {
     const { result } = await getRanking('cash');
-    result.top.filter(r => r.display_name !== 'Alice')
-      .forEach(r => expect(r.self).toBeFalsy());
+    result.top.filter((r) => r.display_name !== 'Alice').forEach((r) => expect(r.self).toBeFalsy());
   });
 
   it('returns top + user_rank shape', async () => {
@@ -398,29 +568,65 @@ describe('getRanking with multi-peer state', () => {
 
   it('user_rank is 1 when self is first', async () => {
     // Override state so alice is the top scorer.
-    setState(Object.assign(freshState('alice@test'), {
-      peers: {
-        'alice@test': { display_name: 'Alice', cash: 999, xp: 999, profiles: 999, level: 9, last_seen_ts: 1, last_seen_serial: null },
-        'bob@test':   { display_name: 'Bob',   cash:  50, xp:  50, profiles:  50, level: 1, last_seen_ts: 2, last_seen_serial: null },
-      },
-    }));
+    setState(
+      Object.assign(freshState('alice@test'), {
+        peers: {
+          'alice@test': {
+            display_name: 'Alice',
+            cash: 999,
+            xp: 999,
+            profiles: 999,
+            level: 9,
+            last_seen_ts: 1,
+            last_seen_serial: null,
+          },
+          'bob@test': {
+            display_name: 'Bob',
+            cash: 50,
+            xp: 50,
+            profiles: 50,
+            level: 1,
+            last_seen_ts: 2,
+            last_seen_serial: null,
+          },
+        },
+      })
+    );
     const { result } = await getRanking('cash');
     expect(result.user_rank).toBe(1);
   });
 
   it('emits addr on every row so the testid template can target peers', async () => {
     const { result } = await getRanking('cash');
-    const addrs = result.top.map(r => r.addr).sort();
+    const addrs = result.top.map((r) => r.addr).sort();
     expect(addrs).toEqual(['alice@test', 'bob@test', 'carol@test']);
   });
 
   it('user_rank is 0 when self is last', async () => {
-    setState(Object.assign(freshState('alice@test'), {
-      peers: {
-        'alice@test': { display_name: 'Alice', cash:   1, xp:   1, profiles:   1, level: 1, last_seen_ts: 1, last_seen_serial: null },
-        'bob@test':   { display_name: 'Bob',   cash: 999, xp: 999, profiles: 999, level: 9, last_seen_ts: 2, last_seen_serial: null },
-      },
-    }));
+    setState(
+      Object.assign(freshState('alice@test'), {
+        peers: {
+          'alice@test': {
+            display_name: 'Alice',
+            cash: 1,
+            xp: 1,
+            profiles: 1,
+            level: 1,
+            last_seen_ts: 1,
+            last_seen_serial: null,
+          },
+          'bob@test': {
+            display_name: 'Bob',
+            cash: 999,
+            xp: 999,
+            profiles: 999,
+            level: 9,
+            last_seen_ts: 2,
+            last_seen_serial: null,
+          },
+        },
+      })
+    );
     const { result } = await getRanking('cash');
     expect(result.user_rank).toBe(0);
   });

--- a/tests/handlers/peer-aggregator.test.js
+++ b/tests/handlers/peer-aggregator.test.js
@@ -8,10 +8,10 @@
  *   3. Property: final state.peers is independent of delta arrival order
  *      (convergence / replay-safety).
  */
-import { describe, it, expect, beforeEach } from 'vitest';
-import { freshState, applyDelta } from '../../scripts/state.js';
-import { getState, setState } from '../../scripts/boot.js';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { getRanking } from '../../scripts/LocalEngine.js';
+import { getState, setState } from '../../scripts/boot.js';
+import { applyDelta, freshState } from '../../scripts/state.js';
 
 // ── fixtures ──────────────────────────────────────────────────────────────────
 

--- a/tests/handlers/ruleset-queries.test.js
+++ b/tests/handlers/ruleset-queries.test.js
@@ -1,6 +1,6 @@
 // @ts-nocheck — strict-TS quarantine; remove when this file is migrated to TS (issue #147)
-import { describe, it, expect, beforeEach } from 'vitest';
-import { getProvidedPerps, getPowerups } from '../../scripts/LocalEngine.js';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { getPowerups, getProvidedPerps } from '../../scripts/LocalEngine.js';
 import { setState } from '../../scripts/boot.js';
 import { freshState } from '../../scripts/state.js';
 

--- a/tests/handlers/ruleset-queries.test.js
+++ b/tests/handlers/ruleset-queries.test.js
@@ -13,7 +13,7 @@ function mkNode(gestalt, gameType, fullPath) {
     gestalt: gestalt,
     full_type: gameType + ':' + gestalt,
     full_path: fullPath,
-    instance_data: {}
+    instance_data: {},
   };
 }
 
@@ -41,10 +41,12 @@ const cityNode = mkNode('city002', 'CityPerp', CITY_PATH);
 
 describe('getProvidedPerps — happy path', () => {
   beforeEach(() => {
-    setState(mkState({
-      nodes: [agentNode],
-      game_values: { xp_level: 1 }
-    }));
+    setState(
+      mkState({
+        nodes: [agentNode],
+        game_values: { xp_level: 1 },
+      })
+    );
   });
 
   it('resolves to an object with result.buyable array', async () => {
@@ -57,20 +59,22 @@ describe('getProvidedPerps — happy path', () => {
     // xp_level: 1 — only contact035 (required_level 1) should pass
     const { result } = await getProvidedPerps(AGENT_PATH);
     expect(result.buyable).toContain('contact035');
-    expect(result.buyable).not.toContain('contact001');  // level 3
-    expect(result.buyable).not.toContain('contact019');  // level 4
-    expect(result.buyable).not.toContain('contact022');  // level 6
+    expect(result.buyable).not.toContain('contact001'); // level 3
+    expect(result.buyable).not.toContain('contact019'); // level 4
+    expect(result.buyable).not.toContain('contact022'); // level 6
   });
 
   it('includes additional gestalts when player level is higher', async () => {
-    setState(mkState({
-      nodes: [agentNode],
-      game_values: { xp_level: 3 }
-    }));
+    setState(
+      mkState({
+        nodes: [agentNode],
+        game_values: { xp_level: 3 },
+      })
+    );
     const { result } = await getProvidedPerps(AGENT_PATH);
     expect(result.buyable).toContain('contact035');
     expect(result.buyable).toContain('contact001');
-    expect(result.buyable).not.toContain('contact019');  // level 4
+    expect(result.buyable).not.toContain('contact019'); // level 4
   });
 
   it('result contains gestalt strings, not objects', async () => {
@@ -85,10 +89,12 @@ describe('getProvidedPerps — happy path', () => {
 
 describe('getProvidedPerps — prerequisite filtering', () => {
   it('excludes perps whose required_providers are not owned', async () => {
-    setState(mkState({
-      nodes: [cityNode],
-      game_values: { xp_level: 3 }
-    }));
+    setState(
+      mkState({
+        nodes: [cityNode],
+        game_values: { xp_level: 3 },
+      })
+    );
     const { result } = await getProvidedPerps(CITY_PATH);
     // pusher004 needs project002, contact035, etc. — none owned
     expect(result.buyable).not.toContain('pusher004');
@@ -98,14 +104,16 @@ describe('getProvidedPerps — prerequisite filtering', () => {
 
   it('includes perp once all required_providers are owned', async () => {
     // pusher003 requires contact026 and contact008
-    setState(mkState({
-      nodes: [
-        cityNode,
-        mkNode('contact026', 'ContactPerp', 'Imperium.City.contact026'),
-        mkNode('contact008', 'ContactPerp', 'Imperium.City.contact008')
-      ],
-      game_values: { xp_level: 3 }
-    }));
+    setState(
+      mkState({
+        nodes: [
+          cityNode,
+          mkNode('contact026', 'ContactPerp', 'Imperium.City.contact026'),
+          mkNode('contact008', 'ContactPerp', 'Imperium.City.contact008'),
+        ],
+        game_values: { xp_level: 3 },
+      })
+    );
     const { result } = await getProvidedPerps(CITY_PATH);
     expect(result.buyable).toContain('pusher003');
   });
@@ -130,10 +138,12 @@ describe('getProvidedPerps — edge cases', () => {
   it('returns empty buyable array for a perp with no provided_perps', async () => {
     // ContactPerp nodes have no provided_perps
     const contactNode = mkNode('contact001', 'ContactPerp', 'Imperium.City.contact001');
-    setState(mkState({
-      nodes: [contactNode],
-      game_values: { xp_level: 10 }
-    }));
+    setState(
+      mkState({
+        nodes: [contactNode],
+        game_values: { xp_level: 10 },
+      })
+    );
     const { result } = await getProvidedPerps('Imperium.City.contact001');
     expect(result.buyable).toEqual([]);
   });
@@ -144,13 +154,15 @@ describe('getProvidedPerps — edge cases', () => {
       game_type: 'AgentPerp',
       full_type: 'AgentPerp:agent002',
       full_path: AGENT_PATH,
-      instance_data: {}
+      instance_data: {},
       // intentionally omit gestalt
     };
-    setState(mkState({
-      nodes: [nodeNoGestalt],
-      game_values: { xp_level: 1 }
-    }));
+    setState(
+      mkState({
+        nodes: [nodeNoGestalt],
+        game_values: { xp_level: 1 },
+      })
+    );
     const { result } = await getProvidedPerps(AGENT_PATH);
     expect(Array.isArray(result.buyable)).toBe(true);
     expect(result.buyable).toContain('contact035');
@@ -161,22 +173,26 @@ describe('getProvidedPerps — edge cases', () => {
 
 describe('getProvidedPerps — locale fallback', () => {
   it('uses EN ruleset when state.locale is "en"', async () => {
-    setState(mkState({
-      locale: 'en',
-      nodes: [agentNode],
-      game_values: { xp_level: 1 }
-    }));
+    setState(
+      mkState({
+        locale: 'en',
+        nodes: [agentNode],
+        game_values: { xp_level: 1 },
+      })
+    );
     // EN ruleset has same gesture structure; handler must not throw or error out
     const data = await getProvidedPerps(AGENT_PATH);
     expect(Array.isArray(data.result.buyable)).toBe(true);
   });
 
   it('falls back to DE ruleset for unknown locale values', async () => {
-    setState(mkState({
-      locale: 'fr',  // unknown locale → falls back to DE
-      nodes: [agentNode],
-      game_values: { xp_level: 1 }
-    }));
+    setState(
+      mkState({
+        locale: 'fr', // unknown locale → falls back to DE
+        nodes: [agentNode],
+        game_values: { xp_level: 1 },
+      })
+    );
     const data = await getProvidedPerps(AGENT_PATH);
     expect(Array.isArray(data.result.buyable)).toBe(true);
     expect(data.result.buyable).toContain('contact035');
@@ -229,7 +245,9 @@ describe('getPowerups — happy path', () => {
 
   it('result covers all three slot categories (ads + upgrades + teammembers)', async () => {
     const { result } = await getPowerups('project001', '1');
-    const types = result.map(function (item) { return item.game_type; });
+    const types = result.map(function (item) {
+      return item.game_type;
+    });
     expect(types).toContain('AdPowerup');
     expect(types).toContain('UpgradePowerup');
     expect(types).toContain('TeamMemberPowerup');
@@ -261,7 +279,9 @@ describe('getPowerups — edge cases', () => {
     // project005 has provided_ads: [] in the DE ruleset
     const { result } = await getPowerups('project005', '1');
     expect(result.length).toBeGreaterThan(0);
-    const types = result.map(function (i) { return i.game_type; });
+    const types = result.map(function (i) {
+      return i.game_type;
+    });
     expect(types).not.toContain('AdPowerup');
     expect(types).toContain('UpgradePowerup');
     expect(types).toContain('TeamMemberPowerup');

--- a/tests/materializer/materializer.test.js
+++ b/tests/materializer/materializer.test.js
@@ -5,27 +5,30 @@ import { materialize } from '../../scripts/materializer.js';
 // ── test fixtures ────────────────────────────────────────────────────────────
 
 function baseState(overrides) {
-  return Object.assign({
-    nodes_charging: [],
-    nodes_collect:  [],
-    game_values: {
-      ap_snapshot:     10,
-      ap_update:        0,
-      ap_inc_value:     1,
-      ap_inc_interval:  60000,  // 1 AP per minute
-      ap_max:          20,
-    }
-  }, overrides);
+  return Object.assign(
+    {
+      nodes_charging: [],
+      nodes_collect: [],
+      game_values: {
+        ap_snapshot: 10,
+        ap_update: 0,
+        ap_inc_value: 1,
+        ap_inc_interval: 60000, // 1 AP per minute
+        ap_max: 20,
+      },
+    },
+    overrides
+  );
 }
 
 function charge(path, charge_end, game_id, game_type) {
   return {
-    path:         path      || 'Imperium.City.Agent0',
-    result:       { value: 10 },
+    path: path || 'Imperium.City.Agent0',
+    result: { value: 10 },
     charge_start: 0,
-    charge_end:   charge_end != null ? charge_end : 5000,
-    game_id:      game_id   || 'abc123',
-    game_type:    game_type || 'ContactPerp',
+    charge_end: charge_end != null ? charge_end : 5000,
+    game_id: game_id || 'abc123',
+    game_type: game_type || 'ContactPerp',
   };
 }
 
@@ -62,7 +65,7 @@ describe('chargePerpReady rule', () => {
     expect(r.events).toHaveLength(1);
     expect(r.events[0]).toEqual({
       ev: 'node_ready',
-      pl: { id: 'id1', type: 'ContactPerp', path: 'p.a', result: c.result }
+      pl: { id: 'id1', type: 'ContactPerp', path: 'p.a', result: c.result },
     });
   });
 
@@ -72,17 +75,17 @@ describe('chargePerpReady rule', () => {
         charge('p.b', 8000, 'id2', 'T'),
         charge('p.a', 5000, 'id1', 'T'),
         charge('p.c', 3000, 'id3', 'T'),
-      ]
+      ],
     });
     const r = materialize(s, 10000);
-    expect(r.events.map(e => e.pl.path)).toEqual(['p.c', 'p.a', 'p.b']);
+    expect(r.events.map((e) => e.pl.path)).toEqual(['p.c', 'p.a', 'p.b']);
   });
 
   it('preserves pre-existing nodes_collect entries', () => {
     const existing = { path: 'p.x', result: { value: 5 } };
     const s = baseState({
       nodes_charging: [charge('p.a', 5000)],
-      nodes_collect:  [existing],
+      nodes_collect: [existing],
     });
     const r = materialize(s, 5000);
     expect(r.state.nodes_collect).toHaveLength(2);
@@ -93,7 +96,7 @@ describe('chargePerpReady rule', () => {
     // Guard: if somehow both arrays contain the same path, don't double-add.
     const s = baseState({
       nodes_charging: [charge('p.a', 5000)],
-      nodes_collect:  [{ path: 'p.a', result: { value: 10 } }],
+      nodes_collect: [{ path: 'p.a', result: { value: 10 } }],
     });
     const r = materialize(s, 5000);
     expect(r.state.nodes_collect).toHaveLength(1);
@@ -103,10 +106,7 @@ describe('chargePerpReady rule', () => {
 
   it('keeps still-charging entries in nodes_charging', () => {
     const s = baseState({
-      nodes_charging: [
-        charge('p.done',  1000),
-        charge('p.later', 9000),
-      ]
+      nodes_charging: [charge('p.done', 1000), charge('p.later', 9000)],
     });
     const r = materialize(s, 5000);
     expect(r.state.nodes_charging).toHaveLength(1);
@@ -121,26 +121,41 @@ describe('chargePerpReady rule', () => {
 describe('AP regen rule', () => {
   it('advances AP by the correct number of ticks', () => {
     const s = baseState({
-      game_values: { ap_snapshot: 5, ap_update: 0,
-                     ap_inc_value: 2, ap_inc_interval: 1000, ap_max: 100 }
+      game_values: {
+        ap_snapshot: 5,
+        ap_update: 0,
+        ap_inc_value: 2,
+        ap_inc_interval: 1000,
+        ap_max: 100,
+      },
     });
-    const r = materialize(s, 3000);  // 3 ticks × 2 = 6
+    const r = materialize(s, 3000); // 3 ticks × 2 = 6
     expect(r.state.game_values.ap_snapshot).toBe(11);
     expect(r.state.game_values.ap_update).toBe(3000);
   });
 
   it('caps AP at ap_max', () => {
     const s = baseState({
-      game_values: { ap_snapshot: 18, ap_update: 0,
-                     ap_inc_value: 5, ap_inc_interval: 1000, ap_max: 20 }
+      game_values: {
+        ap_snapshot: 18,
+        ap_update: 0,
+        ap_inc_value: 5,
+        ap_inc_interval: 1000,
+        ap_max: 20,
+      },
     });
     expect(materialize(s, 5000).state.game_values.ap_snapshot).toBe(20);
   });
 
   it('does not advance AP before a full interval elapses', () => {
     const s = baseState({
-      game_values: { ap_snapshot: 5, ap_update: 0,
-                     ap_inc_value: 1, ap_inc_interval: 1000, ap_max: 20 }
+      game_values: {
+        ap_snapshot: 5,
+        ap_update: 0,
+        ap_inc_value: 1,
+        ap_inc_interval: 1000,
+        ap_max: 20,
+      },
     });
     expect(materialize(s, 999).state.game_values.ap_snapshot).toBe(5);
   });
@@ -153,16 +168,26 @@ describe('AP regen rule', () => {
 
   it('does not regress AP when now < ap_update', () => {
     const s = baseState({
-      game_values: { ap_snapshot: 10, ap_update: 5000,
-                     ap_inc_value: 1, ap_inc_interval: 1000, ap_max: 20 }
+      game_values: {
+        ap_snapshot: 10,
+        ap_update: 5000,
+        ap_inc_value: 1,
+        ap_inc_interval: 1000,
+        ap_max: 20,
+      },
     });
     expect(materialize(s, 3000).state.game_values.ap_snapshot).toBe(10);
   });
 
   it('null ap_update seeds the regen clock from now (no immediate ticks)', () => {
     const s = baseState({
-      game_values: { ap_snapshot: 5, ap_update: null,
-                     ap_inc_value: 1, ap_inc_interval: 1000, ap_max: 20 }
+      game_values: {
+        ap_snapshot: 5,
+        ap_update: null,
+        ap_inc_value: 1,
+        ap_inc_interval: 1000,
+        ap_max: 20,
+      },
     });
     const r = materialize(s, 7000);
     expect(r.state.game_values.ap_snapshot).toBe(5); // no time has passed since seed
@@ -171,14 +196,19 @@ describe('AP regen rule', () => {
 
   it('seeded clock ticks correctly on subsequent materialize', () => {
     const seed = baseState({
-      game_values: { ap_snapshot: 0, ap_update: null,
-                     ap_inc_value: 1, ap_inc_interval: 1000, ap_max: 20 }
+      game_values: {
+        ap_snapshot: 0,
+        ap_update: null,
+        ap_inc_value: 1,
+        ap_inc_interval: 1000,
+        ap_max: 20,
+      },
     });
     const s1 = materialize(seed, 1000).state;
     expect(s1.game_values.ap_update).toBe(1000);
     const s2 = materialize(s1, 4500).state;
-    expect(s2.game_values.ap_snapshot).toBe(3);    // 3 full ticks
-    expect(s2.game_values.ap_update).toBe(4000);   // last full-tick boundary
+    expect(s2.game_values.ap_snapshot).toBe(3); // 3 full ticks
+    expect(s2.game_values.ap_update).toBe(4000); // last full-tick boundary
   });
 });
 
@@ -207,14 +237,18 @@ describe('idempotence', () => {
 
   it('AP snapshot does not drift on repeated same-t calls', () => {
     const s = baseState({
-      game_values: { ap_snapshot: 0, ap_update: 0,
-                     ap_inc_value: 1, ap_inc_interval: 1000, ap_max: 50 }
+      game_values: {
+        ap_snapshot: 0,
+        ap_update: 0,
+        ap_inc_value: 1,
+        ap_inc_interval: 1000,
+        ap_max: 50,
+      },
     });
     const t = 5000;
     const r1 = materialize(s, t);
     const r2 = materialize(r1.state, t);
-    expect(r2.state.game_values.ap_snapshot)
-      .toBe(r1.state.game_values.ap_snapshot);
+    expect(r2.state.game_values.ap_snapshot).toBe(r1.state.game_values.ap_snapshot);
   });
 });
 
@@ -226,11 +260,7 @@ describe('idempotence', () => {
 describe('monotonicity', () => {
   it('nodes_collect count is non-decreasing as t increases', () => {
     const s = baseState({
-      nodes_charging: [
-        charge('p.a', 1000),
-        charge('p.b', 3000),
-        charge('p.c', 5000),
-      ]
+      nodes_charging: [charge('p.a', 1000), charge('p.b', 3000), charge('p.c', 5000)],
     });
     const times = [0, 500, 1000, 2000, 3000, 4000, 5000, 10000];
     let prev = 0;
@@ -243,8 +273,13 @@ describe('monotonicity', () => {
 
   it('AP is non-decreasing as t increases', () => {
     const s = baseState({
-      game_values: { ap_snapshot: 0, ap_update: 0,
-                     ap_inc_value: 1, ap_inc_interval: 1000, ap_max: 10 }
+      game_values: {
+        ap_snapshot: 0,
+        ap_update: 0,
+        ap_inc_value: 1,
+        ap_inc_interval: 1000,
+        ap_max: 10,
+      },
     });
     const times = [0, 1000, 2000, 5000, 9000, 10000, 20000];
     let prev = 0;
@@ -266,8 +301,13 @@ describe('composability', () => {
   it('two-step state equals big-step state', () => {
     const s = baseState({
       nodes_charging: [charge('p.a', 2000), charge('p.b', 7000)],
-      game_values: { ap_snapshot: 0, ap_update: 0,
-                     ap_inc_value: 1, ap_inc_interval: 1000, ap_max: 50 }
+      game_values: {
+        ap_snapshot: 0,
+        ap_update: 0,
+        ap_inc_value: 1,
+        ap_inc_interval: 1000,
+        ap_max: 50,
+      },
     });
     const r1 = materialize(s, 3000);
     const r2 = materialize(r1.state, 9000);
@@ -276,10 +316,7 @@ describe('composability', () => {
 
   it('accumulated two-step events equal big-step events', () => {
     const s = baseState({
-      nodes_charging: [
-        charge('p.a', 2000, 'id1', 'T'),
-        charge('p.b', 7000, 'id2', 'T'),
-      ]
+      nodes_charging: [charge('p.a', 2000, 'id1', 'T'), charge('p.b', 7000, 'id2', 'T')],
     });
     const r1 = materialize(s, 3000);
     const r2 = materialize(r1.state, 9000);
@@ -288,13 +325,14 @@ describe('composability', () => {
 
   it('five-step state equals big-step state', () => {
     const s = baseState({
-      nodes_charging: [
-        charge('p.a', 1500),
-        charge('p.b', 3500),
-        charge('p.c', 7000),
-      ],
-      game_values: { ap_snapshot: 3, ap_update: 0,
-                     ap_inc_value: 2, ap_inc_interval: 1000, ap_max: 100 }
+      nodes_charging: [charge('p.a', 1500), charge('p.b', 3500), charge('p.c', 7000)],
+      game_values: {
+        ap_snapshot: 3,
+        ap_update: 0,
+        ap_inc_value: 2,
+        ap_inc_interval: 1000,
+        ap_max: 100,
+      },
     });
     let cur = s;
     for (const t of [1000, 2000, 4000, 6000, 8000]) {
@@ -316,13 +354,21 @@ describe('idempotence under stress — 50+ completed charges', () => {
     var NUM = 52;
     var charges = [];
     for (var i = 0; i < NUM; i++) {
-      charges.push({ path: 'p.' + i, result: { value: i }, charge_start: 0, charge_end: 1000,
-                     game_id: 'id' + i, game_type: 'ContactPerp' });
+      charges.push({
+        path: 'p.' + i,
+        result: { value: i },
+        charge_start: 0,
+        charge_end: 1000,
+        game_id: 'id' + i,
+        game_type: 'ContactPerp',
+      });
     }
     const r = materialize(baseState({ nodes_charging: charges }), 2000);
     expect(r.state.nodes_charging).toHaveLength(0);
     expect(r.state.nodes_collect).toHaveLength(NUM);
-    var paths = r.state.nodes_collect.map(function (e) { return e.path; });
+    var paths = r.state.nodes_collect.map(function (e) {
+      return e.path;
+    });
     expect(new Set(paths).size).toBe(NUM);
   });
 
@@ -330,8 +376,14 @@ describe('idempotence under stress — 50+ completed charges', () => {
     var NUM = 52;
     var charges = [];
     for (var i = 0; i < NUM; i++) {
-      charges.push({ path: 'p.' + i, result: { value: i }, charge_start: 0, charge_end: 1000,
-                     game_id: 'id' + i, game_type: 'ContactPerp' });
+      charges.push({
+        path: 'p.' + i,
+        result: { value: i },
+        charge_start: 0,
+        charge_end: 1000,
+        game_id: 'id' + i,
+        game_type: 'ContactPerp',
+      });
     }
     const t = 2000;
     const r1 = materialize(baseState({ nodes_charging: charges }), t);
@@ -346,15 +398,23 @@ describe('idempotence under stress — 50+ completed charges', () => {
     var NUM = 55;
     var charges = [];
     for (var i = 0; i < NUM; i++) {
-      charges.push({ path: 'p.' + i, result: { value: i }, charge_start: 0, charge_end: 1000,
-                     game_id: 'id' + i, game_type: 'ContactPerp' });
+      charges.push({
+        path: 'p.' + i,
+        result: { value: i },
+        charge_start: 0,
+        charge_end: 1000,
+        game_id: 'id' + i,
+        game_type: 'ContactPerp',
+      });
     }
     const r1 = materialize(baseState({ nodes_charging: charges }), 2000);
     const r2 = materialize(r1.state, 2000);
 
     const allEvents = r1.events.concat(r2.events);
-    expect(allEvents).toHaveLength(NUM);  // exactly once per charge, none on second call
-    var eventPaths = allEvents.map(function (e) { return e.pl.path; });
+    expect(allEvents).toHaveLength(NUM); // exactly once per charge, none on second call
+    var eventPaths = allEvents.map(function (e) {
+      return e.pl.path;
+    });
     expect(new Set(eventPaths).size).toBe(NUM);
   });
 
@@ -365,17 +425,31 @@ describe('idempotence under stress — 50+ completed charges', () => {
       { path: 'p.1', result: { value: 1 } },
     ];
     var charges = existing.map(function (e, idx) {
-      return { path: e.path, result: e.result, charge_start: 0, charge_end: 1000,
-               game_id: 'id' + idx, game_type: 'ContactPerp' };
+      return {
+        path: e.path,
+        result: e.result,
+        charge_start: 0,
+        charge_end: 1000,
+        game_id: 'id' + idx,
+        game_type: 'ContactPerp',
+      };
     });
     for (var i = 2; i < 52; i++) {
-      charges.push({ path: 'p.' + i, result: { value: i }, charge_start: 0, charge_end: 1000,
-                     game_id: 'id' + i, game_type: 'ContactPerp' });
+      charges.push({
+        path: 'p.' + i,
+        result: { value: i },
+        charge_start: 0,
+        charge_end: 1000,
+        game_id: 'id' + i,
+        game_type: 'ContactPerp',
+      });
     }
 
     const r = materialize(baseState({ nodes_charging: charges, nodes_collect: existing }), 2000);
-    expect(r.state.nodes_collect).toHaveLength(52);  // 50 new + 2 pre-existing, no double-adds
-    var paths = r.state.nodes_collect.map(function (e) { return e.path; });
+    expect(r.state.nodes_collect).toHaveLength(52); // 50 new + 2 pre-existing, no double-adds
+    var paths = r.state.nodes_collect.map(function (e) {
+      return e.path;
+    });
     expect(new Set(paths).size).toBe(52);
   });
 });
@@ -389,8 +463,13 @@ describe('idempotence under stress — 50+ completed charges', () => {
 describe('AP regen — ap_snapshot > ap_max invariant', () => {
   it('clamps ap_snapshot to ap_max when snapshot starts above cap (no elapsed time)', () => {
     const s = baseState({
-      game_values: { ap_snapshot: 10, ap_update: 0,
-                     ap_inc_value: 1, ap_inc_interval: 1000, ap_max: 6 }
+      game_values: {
+        ap_snapshot: 10,
+        ap_update: 0,
+        ap_inc_value: 1,
+        ap_inc_interval: 1000,
+        ap_max: 6,
+      },
     });
     // now == ap_update → 0 ticks; Math.min(6, 10 + 0) = 6
     expect(materialize(s, 0).state.game_values.ap_snapshot).toBe(6);
@@ -398,8 +477,13 @@ describe('AP regen — ap_snapshot > ap_max invariant', () => {
 
   it('clamps even when additional regen ticks would push it further over cap', () => {
     const s = baseState({
-      game_values: { ap_snapshot: 10, ap_update: 0,
-                     ap_inc_value: 2, ap_inc_interval: 1000, ap_max: 6 }
+      game_values: {
+        ap_snapshot: 10,
+        ap_update: 0,
+        ap_inc_value: 2,
+        ap_inc_interval: 1000,
+        ap_max: 6,
+      },
     });
     // 5 ticks × 2 = 10 added to already-excessive 10 → still capped at 6
     expect(materialize(s, 5000).state.game_values.ap_snapshot).toBe(6);
@@ -419,12 +503,12 @@ describe('property — random delta sequences', () => {
     let s = seed >>> 0;
     return function rand() {
       s = (Math.imul(1664525, s) + 1013904223) >>> 0;
-      return s / 0xFFFFFFFF;
+      return s / 0xffffffff;
     };
   }
 
   it('N random stepwise advances produce the same final state as one big jump', () => {
-    const rand = prng(0xDEADBEEF);
+    const rand = prng(0xdeadbeef);
 
     for (let trial = 0; trial < 50; trial++) {
       // Random charge entries (1–5) with charge_ends in 0–100 s
@@ -437,12 +521,12 @@ describe('property — random delta sequences', () => {
       const s = baseState({
         nodes_charging: charges,
         game_values: {
-          ap_snapshot:     0,
-          ap_update:       0,
-          ap_inc_value:    Math.floor(rand() * 3) + 1,
+          ap_snapshot: 0,
+          ap_update: 0,
+          ap_inc_value: Math.floor(rand() * 3) + 1,
           ap_inc_interval: Math.floor(rand() * 5000) + 1000,
-          ap_max:          Math.floor(rand() * 50) + 10,
-        }
+          ap_max: Math.floor(rand() * 50) + 10,
+        },
       });
 
       const tFinal = Math.floor(rand() * 150000);
@@ -454,7 +538,7 @@ describe('property — random delta sequences', () => {
         steps.push(Math.floor(rand() * tFinal));
       }
       steps.sort((a, b) => a - b);
-      steps.push(tFinal);   // always end exactly at tFinal
+      steps.push(tFinal); // always end exactly at tFinal
 
       // Stepwise path
       let cur = s;

--- a/tests/materializer/materializer.test.js
+++ b/tests/materializer/materializer.test.js
@@ -1,5 +1,5 @@
 // @ts-nocheck — strict-TS quarantine; remove when this file is migrated to TS (issue #147)
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { materialize } from '../../scripts/materializer.js';
 
 // ── test fixtures ────────────────────────────────────────────────────────────

--- a/tests/state/state.test.js
+++ b/tests/state/state.test.js
@@ -123,7 +123,6 @@ describe('applyDelta — schema-version mismatch (acceptance criterion B)', () =
     const result = applyDelta(oldState, makeDelta(addr, 'buyPerp', 1000));
     expect(result.schema_version).toBe(SCHEMA_VERSION);
   });
-
 });
 
 describe('applyDelta — chargePerp keys nodes by path', () => {
@@ -131,15 +130,37 @@ describe('applyDelta — chargePerp keys nodes by path', () => {
 
   it('charges the node matching chargeEntry.path even when nodes are reordered', () => {
     const base = freshState(addr);
-    const nodeA = { game_id: 'a', game_type: 'ContactPerp', full_path: 'Imperium.A', gestalt: 'a', instance_data: {} };
-    const nodeB = { game_id: 'b', game_type: 'ContactPerp', full_path: 'Imperium.B', gestalt: 'b', instance_data: {} };
+    const nodeA = {
+      game_id: 'a',
+      game_type: 'ContactPerp',
+      full_path: 'Imperium.A',
+      gestalt: 'a',
+      instance_data: {},
+    };
+    const nodeB = {
+      game_id: 'b',
+      game_type: 'ContactPerp',
+      full_path: 'Imperium.B',
+      gestalt: 'b',
+      instance_data: {},
+    };
     const state = Object.assign({}, base, { nodes: [nodeA, nodeB] });
 
     const delta = {
-      kind: 'delta', addr, op: 'chargePerp', args: ['Imperium.B'], ts: 1000,
+      kind: 'delta',
+      addr,
+      op: 'chargePerp',
+      args: ['Imperium.B'],
+      ts: 1000,
       result: {
-        chargeEntry: { path: 'Imperium.B', charge_start: 1000, charge_end: 31000, result: { amount: 100 } },
-        cashDelta: 60, xpInc: 1,
+        chargeEntry: {
+          path: 'Imperium.B',
+          charge_start: 1000,
+          charge_end: 31000,
+          result: { amount: 100 },
+        },
+        cashDelta: 60,
+        xpInc: 1,
       },
     };
     const out = applyDelta(state, delta);
@@ -264,7 +285,6 @@ describe('applyDelta — setLocale reducer', () => {
     const result = applyDelta(s, makeLocaleDelta(addr, 'en', 2000));
     expect(result.locale).toBe('en');
   });
-
 });
 
 // ---------------------------------------------------------------------------
@@ -275,7 +295,13 @@ describe('applyDelta — dismissMissionBriefing reducer', () => {
   const addr = 'alice@example.com';
 
   function makeDismissDelta(addr, gestalt, ts) {
-    return { kind: 'delta', addr, op: 'dismissMissionBriefing', args: [gestalt], ts: ts || Date.now() };
+    return {
+      kind: 'delta',
+      addr,
+      op: 'dismissMissionBriefing',
+      args: [gestalt],
+      ts: ts || Date.now(),
+    };
   }
 
   it('freshState seeds mission_briefings_seen as an empty object', () => {
@@ -320,7 +346,6 @@ describe('applyDelta — dismissMissionBriefing reducer', () => {
     expect(applyDelta(s, makeDismissDelta(addr, 42)).mission_briefings_seen).toEqual({});
     expect(applyDelta(s, makeDismissDelta(addr, null)).mission_briefings_seen).toEqual({});
   });
-
 });
 
 // ---------------------------------------------------------------------------
@@ -369,7 +394,6 @@ describe('applyDelta — markTokenSeen reducer', () => {
     expect(applyDelta(s, makeSeenDelta(addr, '')).tokens_seen).toEqual({});
     expect(applyDelta(s, makeSeenDelta(addr, 42)).tokens_seen).toEqual({});
   });
-
 });
 
 // ---------------------------------------------------------------------------
@@ -397,7 +421,13 @@ describe('applyDelta — addr guard and pre-boot replay (#117 / #130)', () => {
     // because state.addr is unknown.  This reinforces that boot.js MUST seed
     // selfAddr before replay (closes #130: foreign deltas must not do it).
     var s = freshState('');
-    var delta = { kind: 'delta', addr: 'alice@local', op: 'markTokenSeen', args: ['token008'], ts: 1 };
+    var delta = {
+      kind: 'delta',
+      addr: 'alice@local',
+      op: 'markTokenSeen',
+      args: ['token008'],
+      ts: 1,
+    };
     var result = applyDelta(s, delta);
     expect(result.addr).toBe('');
     expect(result.tokens_seen).toEqual({});

--- a/tests/state/state.test.js
+++ b/tests/state/state.test.js
@@ -1,6 +1,6 @@
 // @ts-nocheck — strict-TS quarantine; remove when this file is migrated to TS (issue #147)
-import { describe, it, expect } from 'vitest';
-import { freshState, applyDelta, SCHEMA_VERSION } from '../../scripts/state.js';
+import { describe, expect, it } from 'vitest';
+import { SCHEMA_VERSION, applyDelta, freshState } from '../../scripts/state.js';
 
 // Required acceptance criteria from issue #10:
 //   A. Two divergent replay sequences with the same delta-set converge to identical state.

--- a/tests/toolchain.test.js
+++ b/tests/toolchain.test.js
@@ -1,10 +1,10 @@
 // @ts-nocheck — strict-TS quarantine; remove when this file is migrated to TS (issue #147)
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 // Smoke test: verifies the toolchain itself is wired up correctly.
 // Real unit tests for state.js / materializer.js land in #45 / #10 / #11.
-import { describe, it, expect } from 'vitest';
-import { existsSync } from 'fs';
-import { join, dirname } from 'path';
-import { fileURLToPath } from 'url';
+import { describe, expect, it } from 'vitest';
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..');
 

--- a/tests/toolchain.test.js
+++ b/tests/toolchain.test.js
@@ -11,9 +11,17 @@ const root = join(dirname(fileURLToPath(import.meta.url)), '..');
 describe('vendor files', () => {
   // The libs index.html `<script>`-loads, in dependency order.
   const required = [
-    'jquery.js', 'jquery-migrate.js', 'underscore.js', 'numeral.js', 'numeral-de.js',
-    'easeljs.js', 'tweenjs.js', 'soundjs.js',
-    'sprintf.js', 'zynga-animate.js', 'zynga-scroller.js',
+    'jquery.js',
+    'jquery-migrate.js',
+    'underscore.js',
+    'numeral.js',
+    'numeral-de.js',
+    'easeljs.js',
+    'tweenjs.js',
+    'soundjs.js',
+    'sprintf.js',
+    'zynga-animate.js',
+    'zynga-scroller.js',
   ];
   for (const f of required) {
     it(`vendor/${f} exists`, () => {
@@ -22,7 +30,14 @@ describe('vendor files', () => {
   }
 
   // The legacy AMD plumbing must not regress back into vendor/.
-  const removed = ['requirejs.js', 'almond.js', 'text.js', 'tpl.js', 'jquery-mobile.js', 'native-console.js'];
+  const removed = [
+    'requirejs.js',
+    'almond.js',
+    'text.js',
+    'tpl.js',
+    'jquery-mobile.js',
+    'native-console.js',
+  ];
   for (const f of removed) {
     it(`vendor/${f} no longer exists`, () => {
       expect(existsSync(join(root, 'vendor', f))).toBe(false);

--- a/tests/webxdc-identity.test.js
+++ b/tests/webxdc-identity.test.js
@@ -1,5 +1,5 @@
 // @ts-nocheck — strict-TS quarantine; remove when this file is migrated to TS (issue #147)
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { getMessengerDisplayNameChange } from '../scripts/webxdc-identity.js';
 
 describe('webxdc identity', () => {

--- a/tools/quantize-assets.mjs
+++ b/tools/quantize-assets.mjs
@@ -22,10 +22,14 @@ function sh(cmd, { tolerate = [] } = {}) {
     execSync(cmd, { cwd: root, stdio: 'inherit' });
   } catch (err) {
     if (tolerate.includes(err.status)) {
-      console.warn(`[quantize-assets] ${cmd.split(' ')[0]} exited ${err.status} (some files kept as-is); continuing`);
+      console.warn(
+        `[quantize-assets] ${cmd.split(' ')[0]} exited ${err.status} (some files kept as-is); continuing`
+      );
       return;
     }
-    throw new Error(`[quantize-assets] ${cmd.split(' ')[0]} failed (exit ${err.status}). Is it installed? See README.md.`);
+    throw new Error(
+      `[quantize-assets] ${cmd.split(' ')[0]} failed (exit ${err.status}). Is it installed? See README.md.`
+    );
   }
 }
 
@@ -36,8 +40,10 @@ cpSync(join(root, 'img'), join(root, 'img-casual'), { recursive: true });
 copyFileSync(join(root, 'icon.png'), join(root, 'icon-casual.png'));
 
 console.log('[quantize-assets] pngquant pass');
-sh('pngquant --quality 40-95 --strip --skip-if-larger --force --ext .png img-casual/*.png icon-casual.png',
-  { tolerate: [...TOLERATED_PNGQUANT_EXIT] });
+sh(
+  'pngquant --quality 40-95 --strip --skip-if-larger --force --ext .png img-casual/*.png icon-casual.png',
+  { tolerate: [...TOLERATED_PNGQUANT_EXIT] }
+);
 
 console.log('[quantize-assets] oxipng -o max --strip safe pass');
 sh('oxipng -o max --strip safe img-casual/*.png icon-casual.png');

--- a/types/env.d.ts
+++ b/types/env.d.ts
@@ -1,6 +1,6 @@
 // Pull in the official webxdc global types (window.webxdc: Webxdc<…>).
-import type { Webxdc } from "@webxdc/types";
-import "@webxdc/types/global";
+import type { Webxdc } from '@webxdc/types';
+import '@webxdc/types/global';
 
 declare global {
   // Declare webxdc as a bare global in addition to window.webxdc.  Scripts in

--- a/vite.config.js
+++ b/vite.config.js
@@ -38,14 +38,16 @@ function swapInCasualAssets() {
       if (!existsSync(srcImg) || !existsSync(srcIcon)) {
         throw new Error(
           `[swap-in-casual-assets] missing pre-quantized assets at ${srcImg} / ${srcIcon}. ` +
-          `Run \`pnpm quantize-assets\` to (re)generate them.`,
+            `Run \`pnpm quantize-assets\` to (re)generate them.`
         );
       }
       rmSync(distImg, { recursive: true, force: true });
       cpSync(srcImg, distImg, { recursive: true });
       rmSync(distIcon, { force: true });
       cpSync(srcIcon, distIcon);
-      console.log('[swap-in-casual-assets] dist/img/ and dist/icon.png replaced with casual variants');
+      console.log(
+        '[swap-in-casual-assets] dist/img/ and dist/icon.png replaced with casual variants'
+      );
     },
   };
 }
@@ -55,7 +57,7 @@ function swapInCasualAssets() {
 function mockWebxdc() {
   const src = readFileSync(
     fileURLToPath(new URL('./node_modules/@webxdc/vite-plugins/src/webxdc.js', import.meta.url)),
-    'utf-8',
+    'utf-8'
   );
   return {
     name: 'webxdc-mock',
@@ -101,8 +103,9 @@ function bundleEsmDev() {
             },
           },
         });
-        const out = (Array.isArray(result) ? result[0] : result).output
-          .find((o) => o.fileName === 'esm-bundle.js');
+        const out = (Array.isArray(result) ? result[0] : result).output.find(
+          (o) => o.fileName === 'esm-bundle.js'
+        );
         bundleSrc = out ? out.code : null;
       } finally {
         buildPromise = null;
@@ -156,7 +159,6 @@ function bundleEsmDev() {
     },
   };
 }
-
 
 export default defineConfig({
   root: '.',

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,8 +1,8 @@
 import { cpSync, existsSync, readFileSync, rmSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
+import { buildXDC } from '@webxdc/vite-plugins';
 import { build, defineConfig } from 'vite';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
-import { buildXDC } from '@webxdc/vite-plugins';
 
 // 'hq' (default): ship the canonical sources as-is — bit-exact lossless
 // cartoon-art pixels.  'casual': ship the pre-quantized counterparts
@@ -38,7 +38,7 @@ function swapInCasualAssets() {
       if (!existsSync(srcImg) || !existsSync(srcIcon)) {
         throw new Error(
           `[swap-in-casual-assets] missing pre-quantized assets at ${srcImg} / ${srcIcon}. ` +
-            `Run \`pnpm quantize-assets\` to (re)generate them.`
+            'Run `pnpm quantize-assets` to (re)generate them.'
         );
       }
       rmSync(distImg, { recursive: true, force: true });


### PR DESCRIPTION
Closes #33.

Two logically distinct commits on this branch:

---

### Commit 1: `chore(biome): add config + apply formatter (no lint changes)`

- Add `biome.json` with project conventions: 2-space indent, single quotes, semicolons, trailing commas es5, line width 100, LF endings
- Add `@biomejs/biome@1.9.4` to devDependencies
- Run `biome format --write .` across all JS/TS/CSS sources (44 files reformatted)
- Ignore `css/Render.css` — contains IE-legacy `filter: progid:...` syntax that Biome's CSS parser rejects
- Fix test regex in `type-settings-validation.test.js` to handle unquoted object keys produced by the formatter
- Linter remains **disabled** in this commit

---

### Commit 2: `chore(biome): enable linter + CI gate + pre-commit hook`

**Linter config** (`biome.json`):
- Enable recommended ruleset
- Disable high-churn legacy rules that would require a full codebase rewrite: `noVar`, `noInnerDeclarations`, `useOptionalChain`, `useTemplate`, `noPrototypeBuiltins`, `noAssignInExpressions`, `noRedeclare`, `noInvalidUseBeforeDeclaration`, `noDelete`, `noUselessElse`, `noParameterAssign`, `useSingleVarDeclarator`, `noArguments`, `noCommaOperator`
- Goal: catch new bugs in new code, not rewrite the 5k-line legacy modules

**Violations fixed / suppressed:**
- `node:` import protocol on all test/config/tool files
- `Math.pow()` → `**` exponentiation operator in scripts/
- `cableType == 'in'/'out'` → `===` (safe string comparisons in Game.js)
- `biome-ignore` with reasons for: legacy `Set` class (×2), always-true guard, unreachable dead code, self-assign no-op, control-char regex (intentional), `!` non-null assertions in TS (×3), `-khtml-user-select` vendor prefix in CSS

**CI:** Add `pnpm exec biome check .` step to `test.yml` before `tsc --noEmit`

**Pre-commit hook:** `lefthook.yml` runs `biome check` on staged JS/TS/CSS files. Installs automatically on `pnpm install`.

**Convenience scripts:** `pnpm lint` / `pnpm lint:fix`

**Docs:** CONTRIBUTING.md expanded with Biome section (commands, hook install, `biome-ignore` pattern)

---

## Test plan

- [ ] `pnpm exec biome check .` → clean (no errors)
- [ ] `pnpm test` → 615/615 passing
- [ ] `pnpm typecheck` → clean
- [ ] `pnpm build:all` → both `.xdc` variants produced
- [ ] Pre-commit hook fires on `git commit` and blocks if Biome finds errors

---
_Generated by [Claude Code](https://claude.ai/code/session_01TJDsMBhtCYNJjnpx9ckxSC)_