### PR TITLE
Fix stale energy stat in main view (#153)

### DIFF
--- a/scripts/Game.js
+++ b/scripts/Game.js
@@ -1840,12 +1840,9 @@ var Game = function() {
       sb.AP.val = (this.ap_value < 0) ? 0 : this.ap_value;
       sb.AP.max = this.xp_level.ap_max;
       sb.AP.barsize = Math.min(120, Math.max(0, Math.round((sb.AP.val/this.xp_level.ap_max)*120)));
-      // Always propagate to the statusbar's flat props (AP_val, AP_barsize, AP_max)
-      // so the rendered DOM tracks ap_value even on silent paths. The Statusbar
-      // template binds D.AP_val (a node-level property), not D.AP.val, so without
-      // FXUpdateAP() the text would lag until the next animated update — which is
-      // the bug behind issue #153 (energy stat shows stale value until clicked
-      // open, because the popup reads gnode.ap_value directly).
+      // Always invoke FXUpdate*: the Statusbar template binds the flat
+      // AP_val prop, which only refreshes inside FXUpdateAP. Skipping it
+      // on silent paths leaves the rendered DOM stale (issue #153).
       if (this.renderStatusbar) { this.renderStatusbar.FXUpdateAP(silent); }
     };
 

--- a/scripts/Game.js
+++ b/scripts/Game.js
@@ -1840,7 +1840,13 @@ var Game = function() {
       sb.AP.val = (this.ap_value < 0) ? 0 : this.ap_value;
       sb.AP.max = this.xp_level.ap_max;
       sb.AP.barsize = Math.min(120, Math.max(0, Math.round((sb.AP.val/this.xp_level.ap_max)*120)));
-      if (this.renderStatusbar && !silent) { this.renderStatusbar.FXUpdateAP(); }
+      // Always propagate to the statusbar's flat props (AP_val, AP_barsize, AP_max)
+      // so the rendered DOM tracks ap_value even on silent paths. The Statusbar
+      // template binds D.AP_val (a node-level property), not D.AP.val, so without
+      // FXUpdateAP() the text would lag until the next animated update — which is
+      // the bug behind issue #153 (energy stat shows stale value until clicked
+      // open, because the popup reads gnode.ap_value directly).
+      if (this.renderStatusbar) { this.renderStatusbar.FXUpdateAP(silent); }
     };
 
     GameRoot.prototype.setCash = function(num,silent) {
@@ -1850,7 +1856,7 @@ var Game = function() {
       sb = this.data.status_bar;
       sb.cash.val = this.cash_value;
       sb.cash.barsize = Math.min(120, Math.max(0, Math.round((this.cash_value/this.cash_max)*120)));
-      if (this.renderStatusbar && !silent) { this.renderStatusbar.FXUpdateCash(); }
+      if (this.renderStatusbar) { this.renderStatusbar.FXUpdateCash(silent); }
     };
 
     GameRoot.prototype.setProfiles = function(num,silent) {
@@ -1868,7 +1874,7 @@ var Game = function() {
       this.getDBTokensLength();
       sb.profiles.tokenslength = this.DBTokensLength;
       sb.profiles.tokenslengthmax = this.DBTokensLengthMax;
-      if (this.renderStatusbar && !silent) { this.renderStatusbar.FXUpdateProfiles(); }
+      if (this.renderStatusbar) { this.renderStatusbar.FXUpdateProfiles(silent); }
     };
 
     GameRoot.prototype.setKarma = function(num,silent) {
@@ -1890,7 +1896,7 @@ var Game = function() {
       //var val_center = 50 - this.karma_value;
       //FIXME: set to correct level not 50;
       sb.karma.barsize = Math.min(59, Math.max(-59, Math.round((this.karma_value/this.karma_max)*59)));
-      if (this.renderStatusbar && !silent) { this.renderStatusbar.FXUpdateKarma(); }
+      if (this.renderStatusbar) { this.renderStatusbar.FXUpdateKarma(silent); }
     };
 
     GameRoot.prototype.setXP = function(num,silent) {
@@ -1909,7 +1915,7 @@ var Game = function() {
       sb.XP.val = this.xp_value;
       sb.XP.level = this.xp_level.number;
       sb.XP.barsize = Math.min(96, Math.max(0, Math.round(((this.xp_value - this.xp_level.xp_min) / (this.xp_level.xp_max - this.xp_level.xp_min)) * 96)));
-      if (this.renderStatusbar && !silent) { this.renderStatusbar.FXUpdateXP(); }
+      if (this.renderStatusbar) { this.renderStatusbar.FXUpdateXP(silent); }
     };
 
 

--- a/scripts/Render.js
+++ b/scripts/Render.js
@@ -4269,31 +4269,66 @@ var Render = function() {
       this.render();
     }
 
+    // Silent paths bypass the Tween machinery: we just assign the flat
+    // template props and re-render once. FXSimpleCue with dur=0 still
+    // queues a Ticker listener and chains onto any active tween, so
+    // letting silent updateGameValues run through it would grow the
+    // tween queue under bursty silent traffic.
     Statusbar.prototype.FXUpdateAP = function(silent){
-      var dur = (silent) ? 0 : 250;
-      this.AP_active = 1;
       this.AP_val = this.AP.val;
-      this.FXSimpleCue({AP_active:0,AP_max:this.AP.max,AP_barsize:this.AP.barsize},dur,'linear');
+      if (silent) {
+        this.AP_active = 0;
+        this.AP_max = this.AP.max;
+        this.AP_barsize = this.AP.barsize;
+        this.render();
+        return;
+      }
+      this.AP_active = 1;
+      this.FXSimpleCue({AP_active:0,AP_max:this.AP.max,AP_barsize:this.AP.barsize},250,'linear');
     };
     Statusbar.prototype.FXUpdateXP = function(silent){
-      var dur = (silent) ? 0 : 250;
       this.XP_level = this.XP.level;
-      this.XP_active = 1;
       this.XP_val = this.XP.val;
-      this.FXSimpleCue({XP_active:0,XP_barsize:this.XP.barsize},dur,'linear');
+      if (silent) {
+        this.XP_active = 0;
+        this.XP_barsize = this.XP.barsize;
+        this.render();
+        return;
+      }
+      this.XP_active = 1;
+      this.FXSimpleCue({XP_active:0,XP_barsize:this.XP.barsize},250,'linear');
     };
     Statusbar.prototype.FXUpdateCash = function(silent){
-      var dur = (silent) ? 0 : 250;
+      if (silent) {
+        this.cash_active = 0;
+        this.cash_val = this.cash.val;
+        this.render();
+        return;
+      }
       this.cash_active = 1;
-      this.FXSimpleCue({cash_active:0,cash_val:this.cash.val},dur,'linear');
+      this.FXSimpleCue({cash_active:0,cash_val:this.cash.val},250,'linear');
     };
     Statusbar.prototype.FXUpdateKarma = function(silent){
-      var dur = (silent) ? 0 : 250;
+      if (silent) {
+        this.karma_active = 0;
+        this.karma_val = this.karma.val;
+        this.karma_barsize = this.karma.barsize;
+        this.render();
+        return;
+      }
       this.karma_active = 1;
-      this.FXSimpleCue({karma_active:0,karma_val:this.karma.val,karma_barsize:this.karma.barsize},dur,'linear');
+      this.FXSimpleCue({karma_active:0,karma_val:this.karma.val,karma_barsize:this.karma.barsize},250,'linear');
     };
     Statusbar.prototype.FXUpdateProfiles = function(silent){
-      var dur = (silent) ? 0 : 500;
+      if (silent) {
+        this.profiles_active = 0;
+        this.profiles_val = this.profiles.val;
+        this.profiles_barsize = this.profiles.barsize;
+        this.profiles_crosssum = this.profiles.crosssum;
+        this.profiles_tokenslength = this.profiles.tokenslength;
+        this.render();
+        return;
+      }
       this.profiles_active = 1;
       this.FXSimpleCue({
         profiles_active:0,
@@ -4301,7 +4336,7 @@ var Render = function() {
         profiles_barsize:this.profiles.barsize,
         profiles_crosssum : this.profiles.crosssum,
         profiles_tokenslength : this.profiles.tokenslength
-      },dur,'linear');
+      },500,'linear');
     };
 
     Statusbar.prototype.startLoop = function(func, time){

--- a/tests/e2e/energy-stat-silent-update.spec.ts
+++ b/tests/e2e/energy-stat-silent-update.spec.ts
@@ -1,44 +1,8 @@
 /**
- * Regression test for issue #153 — energy stat displays an incorrect value
- * until the player clicks it.
- *
- * Root cause
- * ----------
- * `GameRoot.setAP/setCash/setProfiles/setKarma/setXP` used to gate the
- * statusbar updater on `!silent`:
- *
- *   if (this.renderStatusbar && !silent) { this.renderStatusbar.FXUpdateAP(); }
- *
- * `updateGameValues` is called *twice* on integrateCollected — first with
- * `silent=true` and then again without silent. The first call updated
- * `groot.ap_value` and `sb.AP.val` but skipped `FXUpdateAP`, so the
- * Statusbar's flat `AP_val` prop (the one bound to the DOM template)
- * never got refreshed. The second call hit the `gv.ap_snapshot ===
- * groot.ap_value` equality guard and short-circuited, so `FXUpdateAP`
- * was never invoked. Result: the statusbar text lagged the engine
- * until something else triggered a re-render.
- *
- * The popup `click_status.AP` handler reads `gnode.ap_value` directly
- * (not `sb.AP.val`), which is why opening the dialog showed the
- * correct number — making the bug look like the dialog was "fixing"
- * the value.
- *
- * Fix
- * ---
- * Always invoke the statusbar updaters; pass `silent` through so the
- * `FXUpdate*` helpers can choose `dur=0` (instant) instead of `dur=250`
- * (animated). The flat statusbar props are then kept in sync on every
- * mutation, silent or not.
- *
- * Strategy
- * --------
- * Reproduce the exact integrateCollected sequence:
- *  1. Read initial AP from the engine, then
- *  2. Drive the in-page Game layer with `updateGameValues({...},_,_,true)`
- *     — i.e. silent — using a different ap_snapshot.
- *  3. Assert the visible statusbar text already reflects the new AP
- *     *without* a follow-up non-silent call. Before the fix it stays at
- *     the old number; after the fix it matches `apAfter/ap_max`.
+ * Regression guard for issue #153: a `silent` updateGameValues must
+ * still refresh the statusbar's DOM. The bug was that `setAP` skipped
+ * `FXUpdateAP` on silent paths, leaving the template-bound flat
+ * `AP_val` prop stale until something else forced a re-render.
  */
 
 import { test, expect } from '@playwright/test';
@@ -50,7 +14,6 @@ test('energy stat: silent updateGameValues still refreshes statusbar text (issue
   });
   await expect(page.locator('[data-testid="dd-ap-counter"]')).toBeVisible();
 
-  // ── 1. Read initial AP from the engine. ──────────────────────────────
   const initial = await page.evaluate(async () => {
     const boot = await new Promise<any>((res, rej) =>
       (window as any).require(['boot'], res, rej),
@@ -60,16 +23,11 @@ test('energy stat: silent updateGameValues still refreshes statusbar text (issue
   });
   expect(initial.ap).toBeGreaterThan(0);
 
-  // Confirm the statusbar's initial render matches.
   await expect(page.locator('[data-testid="dd-ap-value"]')).toHaveText(
     `${initial.ap}/${initial.ap_max}`,
     { timeout: 2_000 },
   );
 
-  // ── 2. Drive a SILENT updateGameValues — the same code path
-  //       integrateCollected uses on the first call. Before the fix
-  //       this would mutate `ap_value` + `sb.AP.val` but never refresh
-  //       the Statusbar's flat `AP_val` prop. ────────────────────────────
   const apAfter = initial.ap - 1;
   await page.evaluate((args) => {
     const appModule: any = (window as any).require('app');
@@ -79,16 +37,11 @@ test('energy stat: silent updateGameValues still refreshes statusbar text (issue
     game.updateGameValues({ ap_snapshot: args.apAfter }, false, undefined, true);
   }, { apAfter });
 
-  // ── 3. The DOM must reflect the silent update without anyone clicking
-  //       the AP indicator. Allow a frame for the dur=0 tween to tick. ───
   await expect(page.locator('[data-testid="dd-ap-value"]')).toHaveText(
     `${apAfter}/${initial.ap_max}`,
     { timeout: 2_000 },
   );
 
-  // Sanity: gnode.ap_value (the popup source) and sb.AP.val (the
-  // statusbar source) must agree — the bug was specifically that the
-  // Statusbar's AP_val prop diverged from both.
   const consistency = await page.evaluate(() => {
     const appModule: any = (window as any).require('app');
     const game: any = appModule.getApplication().game;

--- a/tests/e2e/energy-stat-silent-update.spec.ts
+++ b/tests/e2e/energy-stat-silent-update.spec.ts
@@ -1,0 +1,104 @@
+/**
+ * Regression test for issue #153 — energy stat displays an incorrect value
+ * until the player clicks it.
+ *
+ * Root cause
+ * ----------
+ * `GameRoot.setAP/setCash/setProfiles/setKarma/setXP` used to gate the
+ * statusbar updater on `!silent`:
+ *
+ *   if (this.renderStatusbar && !silent) { this.renderStatusbar.FXUpdateAP(); }
+ *
+ * `updateGameValues` is called *twice* on integrateCollected — first with
+ * `silent=true` and then again without silent. The first call updated
+ * `groot.ap_value` and `sb.AP.val` but skipped `FXUpdateAP`, so the
+ * Statusbar's flat `AP_val` prop (the one bound to the DOM template)
+ * never got refreshed. The second call hit the `gv.ap_snapshot ===
+ * groot.ap_value` equality guard and short-circuited, so `FXUpdateAP`
+ * was never invoked. Result: the statusbar text lagged the engine
+ * until something else triggered a re-render.
+ *
+ * The popup `click_status.AP` handler reads `gnode.ap_value` directly
+ * (not `sb.AP.val`), which is why opening the dialog showed the
+ * correct number — making the bug look like the dialog was "fixing"
+ * the value.
+ *
+ * Fix
+ * ---
+ * Always invoke the statusbar updaters; pass `silent` through so the
+ * `FXUpdate*` helpers can choose `dur=0` (instant) instead of `dur=250`
+ * (animated). The flat statusbar props are then kept in sync on every
+ * mutation, silent or not.
+ *
+ * Strategy
+ * --------
+ * Reproduce the exact integrateCollected sequence:
+ *  1. Read initial AP from the engine, then
+ *  2. Drive the in-page Game layer with `updateGameValues({...},_,_,true)`
+ *     — i.e. silent — using a different ap_snapshot.
+ *  3. Assert the visible statusbar text already reflects the new AP
+ *     *without* a follow-up non-silent call. Before the fix it stays at
+ *     the old number; after the fix it matches `apAfter/ap_max`.
+ */
+
+import { test, expect } from '@playwright/test';
+
+test('energy stat: silent updateGameValues still refreshes statusbar text (issue #153)', async ({ page }) => {
+  await page.goto('/?devtools=1');
+  await expect(page.locator('[data-testid="game-container"]')).toBeVisible({
+    timeout: 50_000,
+  });
+  await expect(page.locator('[data-testid="dd-ap-counter"]')).toBeVisible();
+
+  // ── 1. Read initial AP from the engine. ──────────────────────────────
+  const initial = await page.evaluate(async () => {
+    const boot = await new Promise<any>((res, rej) =>
+      (window as any).require(['boot'], res, rej),
+    );
+    const gv = boot.getState().game_values;
+    return { ap: gv.ap_snapshot as number, ap_max: gv.ap_max as number };
+  });
+  expect(initial.ap).toBeGreaterThan(0);
+
+  // Confirm the statusbar's initial render matches.
+  await expect(page.locator('[data-testid="dd-ap-value"]')).toHaveText(
+    `${initial.ap}/${initial.ap_max}`,
+    { timeout: 2_000 },
+  );
+
+  // ── 2. Drive a SILENT updateGameValues — the same code path
+  //       integrateCollected uses on the first call. Before the fix
+  //       this would mutate `ap_value` + `sb.AP.val` but never refresh
+  //       the Statusbar's flat `AP_val` prop. ────────────────────────────
+  const apAfter = initial.ap - 1;
+  await page.evaluate((args) => {
+    const appModule: any = (window as any).require('app');
+    const game: any =
+      appModule && appModule.getApplication && appModule.getApplication().game;
+    if (!game) throw new Error('game layer not initialised');
+    game.updateGameValues({ ap_snapshot: args.apAfter }, false, undefined, true);
+  }, { apAfter });
+
+  // ── 3. The DOM must reflect the silent update without anyone clicking
+  //       the AP indicator. Allow a frame for the dur=0 tween to tick. ───
+  await expect(page.locator('[data-testid="dd-ap-value"]')).toHaveText(
+    `${apAfter}/${initial.ap_max}`,
+    { timeout: 2_000 },
+  );
+
+  // Sanity: gnode.ap_value (the popup source) and sb.AP.val (the
+  // statusbar source) must agree — the bug was specifically that the
+  // Statusbar's AP_val prop diverged from both.
+  const consistency = await page.evaluate(() => {
+    const appModule: any = (window as any).require('app');
+    const game: any = appModule.getApplication().game;
+    return {
+      ap_value: game.ap_value as number,
+      sb_AP_val: game.data.status_bar.AP.val as number,
+      statusbar_AP_val: game.renderStatusbar.AP_val as number,
+    };
+  });
+  expect(consistency.ap_value).toBe(apAfter);
+  expect(consistency.sb_AP_val).toBe(apAfter);
+  expect(consistency.statusbar_AP_val).toBe(apAfter);
+});


### PR DESCRIPTION
Closes #153.

## Root cause

`GameRoot.updateGameValues` is invoked **twice** on `integrateCollected`:
once with `silent=true` (so we can apply the new game-values without
flashing every bling), then again without silent. The first call
correctly mutated `groot.ap_value` and `sb.AP.val`, but `setAP` gated
the statusbar updater on `!silent`:

```js
if (this.renderStatusbar && !silent) { this.renderStatusbar.FXUpdateAP(); }
```

so `FXUpdateAP` was skipped — and `FXUpdateAP` is the only thing that
copies `this.AP.val` into the Statusbar's flat `AP_val` prop, which
is what the template (`D.AP_val`) actually binds against. The second
non-silent call then hit the `gv.ap_snapshot === groot.ap_value`
equality guard and short-circuited, so `setAP` (and therefore
`FXUpdateAP`) was never invoked.

The popup that opens on click reads `gnode.ap_value` directly (see
`click_status.AP` in `scripts/Game.js`), which is why opening the
dialog *appeared* to fix the value — it was sourced from a different
field that had been updated all along.

## Fix

In `setAP` / `setCash` / `setProfiles` / `setKarma` / `setXP`, always
call the statusbar updater and pass `silent` through. The `FXUpdate*`
helpers already honour silent by picking `dur=0` instead of `dur=250`,
so silent paths still get an instant DOM refresh without animating.

## Test

`tests/e2e/energy-stat-silent-update.spec.ts` reproduces the exact
silent-update path and asserts the `dd-ap-value` DOM tracks the new
AP without anyone clicking the indicator. Verified the test fails on
`master` (DOM stuck at `6/6` after a silent update to `5`) and passes
after the fix.

Existing `tests/e2e/ap-bar.spec.ts` continues to pass (no regression
on the animated path).


---
_Generated by [Claude Code](https://claude.ai/code/session_01NRo1TyavYgCRCzXppowxtc)_