### PR TITLE
Remove Internet Explorer compatibility code

### DIFF
--- a/css/Render.css
+++ b/css/Render.css
@@ -53,7 +53,6 @@
   background-position: -329px -860px;
   -webkit-animation: AniRotate 1s linear infinite;
   -moz-animation: AniRotate 1s linear infinite;
-  -ms-animation: AniRotate 1s linear infinite;
   animation: AniRotate 1s linear infinite;
   margin: 0px 8px -6px 8px;
 }
@@ -79,7 +78,6 @@
 .UserButton:hover {
   -webkit-transform: scale(1.1,1.1);
   -moz-transform: scale(1.1,1.1);
-  -ms-transform: scale(1.1,1.1);
   transform: scale(1.1,1.1);
 }
 .Stage {
@@ -148,7 +146,6 @@
   z-index:1;
   -webkit-transition: background-position 0.2s, -webkit-transform 0.2s, top 0.2s ease 0.3s;
   -moz-transition: background-position 0.2s, -moz-transform 0.2s, top 0.2s ease 0.3s;
-  -ms-transition: background-position 0.2s, -ms-transform 0.2s, top 0.2s ease 0.3s;
   transition: background-position 0.2s, transform 0.2s, top 0.2s ease 0.3s;
   opacity:1;
 }
@@ -178,14 +175,12 @@
   background-position:-479px -630px;
   -webkit-transform: scale(1.08);
   -moz-transform: scale(1.08);
-  -ms-transform: scale(1.08);
   transform: scale(1.08);
 }
 
 .DatabaseQueueItem.merging {
   -webkit-transition: none;
   -moz-transition: none;
-  -ms-transition: none;
   transition: none;
   background-position:-579px -630px;
 }
@@ -395,7 +390,6 @@
 .StatusItem:hover .StatusIcon {
   -webkit-transform:scale(1.1,1.1);
   -moz-transform:scale(1.1,1.1);
-  -ms-transform:scale(1.1,1.1);
   transform:scale(1.1,1.1);
 }
 
@@ -404,14 +398,12 @@
 .StatusItem.active .StatusIcon.inactive {
   -webkit-transform:scale(1,1);
   -moz-transform:scale(1,1);
-  -ms-transform:scale(1,1);
   transform:scale(1,1);
 }
 
 .StatusItem.active .StatusIcon {
   -webkit-transform:scale(1.15,1.15);
   -moz-transform:scale(1.15,1.15);
-  -ms-transform:scale(1.15,1.15);
   transform:scale(1.15,1.15);
 }
 
@@ -539,7 +531,6 @@
   overflow: hidden;
   -webkit-transition: opacity 0.2s linear, visibility 0.2s linear;
   -moz-transition: opacity 0.2s linear, visibility 0.2s linear;
-  -ms-transition: opacity 0.2s linear, visibility 0.2s linear;
   transition: opacity 0.2s linear, visibility 0.2s linear;
   width:100%;
   height:100%;
@@ -550,7 +541,6 @@
   z-index: -2;
   -webkit-backface-visibility: hidden;
   -moz-backface-visibility: hidden;
-  -ms-backface-visibility: hidden;
   backface-visibility: hidden;
 }
 
@@ -598,7 +588,6 @@
 .ZoomControls div:hover {
   -webkit-transform: scale(1.1,1.1);
   -moz-transform: scale(1.1,1.1);
-  -ms-transform: scale(1.1,1.1);
   transform: scale(1.1,1.1);
 }
 
@@ -616,7 +605,6 @@
   height: 100%;
   -webkit-transition: background 0.25s linear, visibility 0.25s linear, box-shadow 0.25s;
   -moz-transition: background 0.25s linear, visibility 0.25s linear, box-shadow 0.25s;
-  -ms-transition: background 0.25s linear, visibility 0.25s linear, box-shadow 0.25s;
   transition: background 0.25s;
 }
 .PopupContainer.lockOn {
@@ -626,7 +614,6 @@
   box-shadow: 0px 0px 256px #000 inset;
   -webkit-transition: none;
   -moz-transition: none;
-  -ms-transition: none;
   transition: none;
 }
 .PopupContainer.Top {
@@ -658,7 +645,6 @@
   transition: background 0.15s linear, visibility 0.15s linear, box-shadow 0.15s;
   -moz-transition: background 0.15s linear, visibility 0.15s linear, box-shadow 0.15s;
   -webkit-transition: background 0.15s linear, visibility 0.15s linear, box-shadow 0.15s;
-  -ms-transition: background 0.15s linear, visibility 0.15s linear, box-shadow 0.15s;
 }
 
 .MainMenu {
@@ -672,7 +658,6 @@
   background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#001111), color-stop(100%,#06546c));
   background: -webkit-linear-gradient(top,  #001111 0%,#06546c 100%);
   background: -o-linear-gradient(top,  #001111 0%,#06546c 100%);
-  background: -ms-linear-gradient(top,  #001111 0%,#06546c 100%);
   background: linear-gradient(to bottom,  #001111 0%,#06546c 100%);
   filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#001111', endColorstr='#06546c',GradientType=0 );
 }
@@ -711,7 +696,6 @@
   box-shadow:3px 3px 0px #009FD9;
   -webkit-transition: top 0.2s linear;
   -moz-transition: top 0.2s linear;
-  -ms-transition: top 0.2s linear;
   transition: top 0.2s linear;
   text-shadow:0px 0px 0px white, 1px 1px 0px white, 2px 2px 0px white, 3px 3px 0px white;
 }
@@ -720,7 +704,6 @@
 .MainMenuButton.active {
   -webkit-transition: top 0 linear;
   -moz-transition: top 0 linear;
-  -ms-transition: top 0 linear;
   transition: top 0 linear;
   background:#ECF8FC;
   color: #E48931;
@@ -902,7 +885,6 @@
   z-index:-1;
   -webkit-animation: AniJump 6s linear infinite normal;
   -moz-animation: AniJump 6s linear infinite normal;
-  -ms-animation: AniJump 6s linear infinite normal;
   animation: AniJump 6s linear infinite normal;
 }
 
@@ -944,7 +926,6 @@
   z-index:1000;
   -webkit-transform-origin:50% 50% !important;
   -moz-transform-origin:50% 50% !important;
-  -ms-transform-origin:50% 50% !important;
   transform-origin:50% 50% !important;
   height:auto;
   width:600px;
@@ -954,7 +935,6 @@
   box-shadow:none;
   -webkit-transition: visibility 0.2s;
   -moz-transition: visibility 0.2s;
-  -ms-transition: visibility 0.2s;
   transition: visibility 0.2s;
   visibility:hidden;
 }
@@ -965,9 +945,6 @@
   -webkit-transform-origin:50% 50% !important;
   -moz-transform:scale(2,0) !important;
   -moz-transition: -moz-transform 0.2s;
-  -ms-transition: -ms-transform 0.2s;
-  -ms-transform:scale(2,0) !important;
-  -ms-transform-origin:50% 50% !important;
   transition: transform 0.2s;
   transform:scale(2,0) !important;
   transform-origin:50% 50% !important;
@@ -986,7 +963,6 @@
   background: -webkit-gradient(linear, left top, right top, color-stop(0%,#ffffff), color-stop(100%,#eeeeee));
   background: -webkit-linear-gradient(left,  #ffffff 0%,#eeeeee 100%);
   background: -o-linear-gradient(left,  #ffffff 0%,#eeeeee 100%);
-  background: -ms-linear-gradient(left,  #ffffff 0%,#eeeeee 100%);
   background: linear-gradient(to right,  #ffffff 0%,#eeeeee 100%);
   filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#ffffff', endColorstr='#eeeeee',GradientType=1 );
 }
@@ -1023,7 +999,6 @@
   position:relative;
   -webkit-transition: left 0.4s ease-out;
   -moz-transition: left 0.4s ease-out;
-  -ms-transition: left 0.4s ease-out;
   transition: left 0.4s ease-out;
 }
 .PopupPage {
@@ -1033,7 +1008,6 @@
   height: 254px;
   -webkit-transition: opacity 0.4s ease-out, -webkit-transform 0.4s ease-out;
   -moz-transition: opacity 0.4s ease-out, -moz-transform 0.4s ease-out;
-  -ms-transition: opacity 0.4s ease-out, -ms-transform 0.4s ease-out;
   transition: opacity 0.4s ease-out, transform 0.4s ease-out;
 }
 .Pagination.half .PopupPage {
@@ -1051,7 +1025,6 @@
   opacity:0;
   -webkit-transform: scale(0.5);
   -moz-transform: scale(0.5);
-  -ms-transform: scale(0.5);
   transform: scale(0.5);
 }
 .PopupPage.PerpPage,
@@ -1061,7 +1034,6 @@
 .PopupPage.PowerupPage.hidden {
   -webkit-transform: scale(1);
   -moz-transform: scale(1);
-  -ms-transform: scale(1);
   transform: scale(1);
 }
 
@@ -1342,14 +1314,12 @@
 .MissionGoal.small .MissionGoalSprite {
   -webkit-transform: scale(0.25);
   -moz-transform: scale(0.25);
-  -ms-transform: scale(0.25);
   transform: scale(0.25);
 }
 
 .MissionGoalSprite {
   -webkit-transform: scale(0.4);
   -moz-transform: scale(0.4);
-  -ms-transform: scale(0.4);
   transform: scale(0.4);
   position: absolute;
   top: -6px;
@@ -1358,7 +1328,6 @@
   height: 180px;
   -webkit-transform-origin: 0px 0px;
   -moz-transform-origin: 0px 0px;
-  -ms-transform-origin: 0px 0px;
   transform-origin: 0px 0px;
 }
 
@@ -1380,7 +1349,6 @@
 .MissionGoal.small .MissionGoalStatus {
   -webkit-transform: scale(0.75);
   -moz-transform: scale(0.75);
-  -ms-transform: scale(0.75);
   -o-transform: scale(0.75);
   transform: scale(0.75);
 }
@@ -1424,31 +1392,26 @@
 .MissionBody.Complete .MissionReward .RenderSprite {
   -webkit-animation: AniNew 0.3s linear infinite alternate;
   -moz-animation: AniNew 0.3s linear infinite alternate;
-  -ms-animation: AniNew 0.3s linear infinite alternate;
   animation: AniNew 0.3s linear infinite alternate;
 }
 .MissionBody.Complete .MissionReward.Cash .RenderSPrite {
   -webkit-animation: AniNew 0.3s linear infinite alternate;
   -moz-animation: AniNew 0.3s linear infinite alternate;
-  -ms-animation: AniNew 0.3s linear infinite alternate;
   animation: AniNew 0.3s linear infinite alternate;
 }
 .MissionBody.Complete .MissionReward.Risk .RenderSprite {
   -webkit-animation: AniNew 0.31s linear infinite alternate;
   -moz-animation: AniNew 0.31s linear infinite alternate;
-  -ms-animation: AniNew 0.31s linear infinite alternate;
   animation: AniNew 0.31s linear infinite alternate;
 }
 .MissionBody.Complete .MissionReward.Profiles .RenderSprite {
   -webkit-animation: AniNew 0.32s linear infinite alternate;
   -moz-animation: AniNew 0.32s linear infinite alternate;
-  -ms-animation: AniNew 0.32s linear infinite alternate;
   animation: AniNew 0.32s linear infinite alternate;
 }
 .MissionBody.Complete .MissionReward.XP .RenderSprite {
   -webkit-animation: AniNew 0.33s linear infinite alternate;
   -moz-animation: AniNew 0.33s linear infinite alternate;
-  -ms-animation: AniNew 0.33s linear infinite alternate;
   animation: AniNew 0.33s linear infinite alternate;
 }
 
@@ -1486,7 +1449,6 @@
 #DisplayName.error {
   -webkit-animation: AniErrorText 0.4s linear;
   -moz-animation: AniErrorText 0.4s linear;
-  -ms-animation: AniErrorText 0.4s linear;
   animation: AniErrorText 0.4s linear;
 }
 
@@ -1616,20 +1578,17 @@
   height: 40px;
   -webkit-transform: scale(0.6);
   -moz-transform: scale(0.6);
-  -ms-transform: scale(0.6);
   transform: scale(0.6);
   margin-left: -5px;
   margin-top: -12px;
   width: 40px;
   -webkit-transform-origin: 40px 40px;
   -moz-transform-origin: 40px 40px;
-  -ms-transform-origin: 40px 40px;
   transform-origin: 40px 40px;
 }
 .small .PopupTokenPerp:hover {
   -webkit-transform:scale(0.68,0.68);
   -moz-transform:scale(0.68,0.68);
-  -ms-transform:scale(0.68,0.68);
   transform:scale(0.68,0.68);
 }
 
@@ -1643,7 +1602,6 @@
 .PopupToken.locked:hover .PopupTokenPerp {
   -webkit-transform:inherit;
   -moz-transform:inherit;
-  -ms-transform:inherit;
   transform:inherit;
 }
 
@@ -1652,14 +1610,12 @@
   height:80px;
   -webkit-transform-origin:50% 50%;
   -moz-transform-origin:50% 50%;
-  -ms-transform-origin:50% 50%;
   transform-origin:50% 50%;
 }
 
 .PopupTokenPerp:hover {
   -webkit-transform:scale(1.08,1.08);
   -moz-transform:scale(1.08,1.08);
-  -ms-transform:scale(1.08,1.08);
   transform:scale(1.08,1.08);
 }
 
@@ -1731,7 +1687,6 @@
   line-height:32px;
   -webkit-transition: none;
   -moz-transition: none;
-  -ms-transition: none;
   transition: none;
   z-index: 1000;
 }
@@ -1745,12 +1700,10 @@
 .PopupClose:hover {
   -webkit-transition: none;
   -moz-transition: none;
-  -ms-transition: none;
   transition: none;
   box-shadow: 2px 2px 0px #700, 0px 2px 8px rgba(0,0,0,0.5), 3px 3px 0px #009FD9, 0px 0px 16px #009FD9, 3px 3px 16px #009FD9;
   -webkit-transform:scale(1.1,1.1);
   -moz-transform:scale(1.1,1.1);
-  -ms-transform:scale(1.1,1.1);
   transform:scale(1.1,1.1);
 }
 .PopupLogo {
@@ -2004,7 +1957,6 @@
   left: 12px;
   -webkit-animation: AniJump 6s linear infinite normal;
   -moz-animation: AniJump 6s linear infinite normal;
-  -ms-animation: AniJump 6s linear infinite normal;
   animation: AniJump 6s linear infinite normal;
 }
 
@@ -2051,7 +2003,6 @@
   box-shadow: 0px 0px 2px #404040 inset;
   -webkit-transition: opacity 0.2s linear 0.2s, visibility 0.2s;
   -moz-transition: opacity 0.2s linear 0.2s, visibility 0.2s;
-  -ms-transition: opacity 0.2s linear 0.2s, visibility 0.2s;
   transition: opacity 0.2s linear 0.2s, visibility 0.2s;
   opacity:0;
   z-index:10000;
@@ -2065,7 +2016,6 @@
   visibility:visible;
   -webkit-transition: opacity 0s;
   -moz-transition: opacity 0s;
-  -ms-transition: opacity 0s;
   transition: opacity 0s;
   opacity:1;
 }
@@ -2102,9 +2052,6 @@
   -webkit-transform-origin: 50% 100%;
   -moz-transition: -moz-transform 0.2s;
   -moz-transform: scale(0,0);
-  -ms-transition: -ms-transform 0.2s;
-  -ms-transform: scale(0,0);
-  -ms-transform-origin: 50% 100%;
   transition: transform 0.2s;
   transform: scale(0,0);
   transform-origin: 50% 100%;
@@ -2146,8 +2093,6 @@
   -webkit-transform: scale(1,1);
   -moz-transition: -moz-transform 0.1s;
   -moz-transform: scale(1,1);
-  -ms-transition: -ms-transform 0.1s;
-  -ms-transform: scale(1,1);
   transition: transform 0.1s;
   transform: scale(1,1);
 }
@@ -2224,7 +2169,6 @@
 .Powerup:hover .PowerupPerp {
   -webkit-transform: scale(1.05);
   -moz-transform: scale(1.05);
-  -ms-transform: scale(1.05);
   transform: scale(1.05);
 }
 .Powerup.taken:hover .PowerupBackground .RenderSprite {
@@ -2258,7 +2202,6 @@
   opacity:0.3;
   -webkit-transform: scale(1);
   -moz-transform: scale(1);
-  -ms-transform: scale(1);
   transform: scale(1);
 }
 
@@ -2275,7 +2218,6 @@
 
 .PowerupPerp {
   -webkit-transform-origin:50% 50%;
-  -ms-transform-origin:50% 50%;
   transform-origin:50% 50%;
   width:100px;
   height:100px;
@@ -2284,7 +2226,6 @@
 .Powerup.updating .PowerupPerp {
   -webkit-animation: AniPlugIn2 0.4s linear;
   -moz-animation: AniPlugIn2 0.4s linear;
-  -ms-animation: AniPlugIn2 0.4s linear;
   animation: AniPlugIn2 0.4s linear;
 }
 .Powerup.updating.hide .PowerupSprite {
@@ -2295,7 +2236,6 @@
 .Powerup.updating.hide .PowerupPerp {
   -webkit-animation: AniPlugOut2 0.2s ease;
   -moz-animation: AniPlugOut2 0.2s ease;
-  -ms-animation: AniPlugOut2 0.2s ease;
   animation: AniPlugOut2 0.2s ease;
   opacity:0;
 }
@@ -2579,8 +2519,6 @@
   -webkit-animation: AniNew 0.3s linear infinite alternate;
   -moz-transform: rotate(1deg);
   -moz-animation: AniNew 0.3s linear infinite alternate;
-  -ms-transform: rotate(1deg);
-  -ms-animation: AniNew 0.3s linear infinite alternate;
   transform: rotate(1deg);
   animation: AniNew 0.3s linear infinite alternate;
 }
@@ -2606,8 +2544,6 @@
   -webkit-animation: AniNewRot 0.3s linear infinite alternate;
   -moz-transform:rotate(-16deg);
   -moz-animation: AniNewRot 0.3s linear infinite alternate;
-  -ms-transform:rotate(-16deg);
-  -ms-animation: AniNewRot 0.3s linear infinite alternate;
   transform:rotate(-16deg);
   animation: AniNewRot 0.3s linear infinite alternate;
 }
@@ -2631,7 +2567,6 @@
   background: -webkit-gradient(linear, left top, right bottom, color-stop(0%,#009fd9), color-stop(100%,#00739e));
   background: -webkit-linear-gradient(-45deg, #009fd9 0%,#00739e 100%);
   background: -o-linear-gradient(-45deg, #009fd9 0%,#00739e 100%);
-  background: -ms-linear-gradient(-45deg, #009fd9 0%,#00739e 100%);
   background: linear-gradient(135deg, #009fd9 0%,#00739e 100%);
   filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#009fd9', endColorstr='#00739e',GradientType=1 );
   border-radius: 12px;
@@ -2711,7 +2646,6 @@
   box-shadow: 0px 3px 12px rgba(0,0,0,0.3);
   -webkit-animation: AniScaleOpacity 0.2s reverse;
   -moz-animation: AniScaleOpacity 0.2s reverse;
-  -ms-animation: AniScaleOpacity 0.2s reverse;
   animation: AniScaleOpacity 0.2s reverse;
   height: 174px;
   padding:0px;
@@ -2745,7 +2679,6 @@
   /*text-shadow:2px 2px 1px white,-2px -2px 1px white,2px -2px 1px white,-2px 2px 1px white;*/
   -webkit-transition: color 0.2s, background 0.2s, border 0.2s, box-shadow 0.2s;
   -moz-transition: color 0.2s, background 0.2s, border 0.2s, box-shadow 0.2s;
-  -ms-transition: color 0.2s, background 0.2s, border 0.2s, box-shadow 0.2s;
   transition: color 0.2s, background 0.2s, border 0.2s, box-shadow 0.2s;
   text-shadow:0px 0px 0px white, 1px 1px 0px white, 2px 2px 0px white, 3px 3px 0px white;
 }
@@ -2755,7 +2688,6 @@
 .ButtonDec:hover {
   -webkit-transform:scale(1.08,1.08);
   -moz-transform:scale(1.08,1.08);
-  -ms-transform:scale(1.08,1.08);
   transform:scale(1.08,1.08);
   background:#C6EFFF;
 }
@@ -2784,9 +2716,6 @@
   -moz-transition: none;
   -moz-transform:scale(1.08,1.08);
   -moz-animation: AniPulsate 0.3s linear infinite alternate;
-  -ms-transition: none;
-  -ms-transform:scale(1.08,1.08);
-  -ms-animation: AniPulsate 0.3s linear infinite alternate;
   transition: none;
   transform:scale(1.08,1.08);
   animation: AniPulsate 0.3s linear infinite alternate;
@@ -2805,7 +2734,6 @@
 .UserButton.disabled:hover {
   -webkit-transform:inherit;
   -moz-transform:inherit;
-  -ms-transform:inherit;
   transform:inherit;
   opacity:0.5;
 }
@@ -2858,7 +2786,6 @@
 .Button.disabled:hover {
   -webkit-transform:none;
   -moz-transform:none;
-  -ms-transform:none;
   transform:none;
 }
 
@@ -2964,17 +2891,14 @@
 @keyframes AniRotate {
   0% {
     -moz-transform:rotate(0deg) scale(1);
-    -ms-transform:rotate(0deg) scale(1);
     transform:rotate(0deg) scale(1);
   }
   50% {
     -moz-transform: rotate(180deg) scale(0.6);
-    -ms-transform: rotate(180deg) scale(0.6);
     transform: rotate(180deg) scale(0.6);
   }
   100% {
     -moz-transform: rotate(360deg) scale(1);
-    -ms-transform: rotate(360deg) scale(1);
     transform: rotate(360deg) scale(1);
   }
 }
@@ -2992,12 +2916,10 @@
 @keyframes AniScaleOpacity {
   0% {
     -moz-transform: scale(1); opacity:1;
-    -ms-transform: scale(1); opacity:1;
     transform: scale(1); opacity:1;
   }
   100% {
     -moz-transform: scale(2,0); opacity:0;
-    -ms-transform: scale(2,0); opacity:0;
     transform: scale(2,0); opacity:0;
   }
 }
@@ -3015,12 +2937,10 @@
 @keyframes AniPulsate {
   0% {
     -moz-transform:scale(1.08,1.08);
-    -ms-transform:scale(1.08,1.08);
     transform:scale(1.08,1.08);
   }
   100% {
     -moz-transform:scale(1.02,1.02);
-    -ms-transform:scale(1.02,1.02);
     transform:scale(1.02,1.02);
   }
 }
@@ -3038,12 +2958,10 @@
 @keyframes AniNewRot {
   0% {
     -moz-transform:scale(1.08,1.08) rotate(-16deg);
-    -ms-transform:scale(1.08,1.08) rotate(-16deg);
     transform:scale(1.08,1.08) rotate(-16deg);
   }
   100% {
     -moz-transform:scale(1.02,1.02) rotate(-16deg);
-    -ms-transform:scale(1.02,1.02) rotate(-16deg);
     transform:scale(1.02,1.02) rotate(-16deg);
   }
 }
@@ -3082,12 +3000,10 @@
 @keyframes AniNew {
   0% {
     -moz-transform:scale(1.06,1.06);
-    -ms-transform:scale(1.06,1.06);
     transform:scale(1.06,1.06);
   }
   100% {
     -moz-transform:scale(1,1);
-    -ms-transform:scale(1,1);
     transform:scale(1,1);
   }
 }
@@ -3114,27 +3030,22 @@
 @keyframes AniJump {
   0% {
     -moz-transform: translateY(0px);
-    -ms-transform: translateY(0px);
     transform: translateY(0px);
   }
   2% {
     -moz-transform: translateY(-10px);
-    -ms-transform: translateY(-10px);
     transform: translateY(-10px);
   }
   4% {
     -moz-transform: translateY(0px);
-    -ms-transform: translateY(0px);
     transform: translateY(0px);
   }
   6% {
     -moz-transform: translateY(-7px);
-    -ms-transform: translateY(-7px);
     transform: translateY(-7px);
   }
   8% {
     -moz-transform: translateY(0px);
-    -ms-transform: translateY(0px);
     transform: translateY(0px);
   }
 }
@@ -3167,37 +3078,30 @@
 @keyframes AniPlugIn2 {
   0% {
     -moz-transform:scale(0,0); opacity:0;
-    -ms-transform:scale(0,0); opacity:0;
     transform:scale(0,0); opacity:0;
   }
   60% {
     -moz-transform:scale(1.2,1.2); opacity:1;
-    -ms-transform:scale(1.2,1.2); opacity:1;
     transform:scale(1.2,1.2); opacity:1;
   }
   70% {
     -moz-transform:scale(1,1);
-    -ms-transform:scale(1,1);
     transform:scale(1,1);
   }
   80% {
     -moz-transform:scale(1.1,1.1);
-    -ms-transform:scale(1.1,1.1);
     transform:scale(1.1,1.1);
   }
   90% {
     -moz-transform:scale(1,1);
-    -ms-transform:scale(1,1);
     transform:scale(1,1);
   }
   95% {
     -moz-transform:scale(1.05,1.05);
-    -ms-transform:scale(1.05,1.05);
     transform:scale(1.05,1.05);
   }
   100% {
     -moz-transform:scale(1,1); opacity:1;
-    -ms-transform:scale(1,1); opacity:1;
     transform:scale(1,1); opacity:1;
   }
 }
@@ -3217,17 +3121,14 @@
 @keyframes AniPlugOut2 {
   0% {
     -moz-transform: scale(1,1); opacity:1;
-    -ms-transform: scale(1,1); opacity:1;
     transform: scale(1,1); opacity:1;
   }
   15% {
     -moz-transform: scale(1.2,1.2); opacity:1;
-    -ms-transform: scale(1.2,1.2); opacity:1;
     transform: scale(1.2,1.2); opacity:1;
   }
   100% {
     -moz-transform: scale(0,0); opactiy:0;
-    -ms-transform: scale(0,0); opactiy:0;
     transform: scale(0,0); opactiy:0;
   }
 }

--- a/scripts/Render.js
+++ b/scripts/Render.js
@@ -56,13 +56,6 @@ var Render = function() {
       viewMapStopZone : setup.viewMapStopZone
     };
 
-    /* FIXME: IE checks in renderengine
-    var IE = false;
-    if (!$.support.style) {
-      IE = true;
-    }
-    */
-
     Ticker.setFPS(renderConf.tickerFramerate);
     Ticker.useRAF = true;
 
@@ -912,9 +905,6 @@ var Render = function() {
         "-webkit-transform": "rotateZ("+this.rotate+"deg) scale3d("+this.scaleX+","+this.scaleY+",1) translate3d("+ (this.transX) +"px,"+ (this.transY) +"px,0px)",
         "-moz-transform": "rotateZ("+this.rotate+"deg) scale3d("+this.scaleX+","+this.scaleY+",1) translate3d("+ (this.transX) +"px,"+ (this.transY) +"px,0px)",
         //"-moz-transform": "rotate("+this.rotate+"deg) scale("+this.scaleX+","+this.scaleY+") translate("+ (this.transX) +"px,"+ (this.transY) +"px)",
-        // FIXME IE 2D
-        //"-ms-transform": "rotate("+this.rotate+"deg) scale("+this.scaleX+","+this.scaleY+") translate("+ (this.transX) +"px,"+ (this.transY) +"px)",
-        "-ms-transform": "rotateZ("+this.rotate+"deg) scale3d("+this.scaleX+","+this.scaleY+",1) translate3d("+ (this.transX) +"px,"+ (this.transY) +"px,0px)",
         "-transform": "rotateZ("+this.rotate+"deg) scale3d("+this.scaleX+","+this.scaleY+",1) translate3d("+ (this.transX) +"px,"+ (this.transY) +"px,0px)"
       });
     };


### PR DESCRIPTION
## Summary
- Drop 99 `-ms-` prefixed CSS declarations from `css/Render.css` (transforms, transitions, animations, gradients targeting IE 9–10 / pre-Chromium Edge).
- Remove the dead commented `$.support.style` IE detection block from `scripts/Render.js`.
- Remove the leftover `// FIXME IE 2D` comment and the active `-ms-transform` jQuery `.css()` key.

IE11 is end-of-life and `tsconfig.json` already targets ES2020. Every removed `-ms-` declaration sits next to an unprefixed equivalent, so no visual behavior changes for supported browsers.

Closes #164

## Test plan
- [ ] Load the app in Chrome/Firefox/Safari and confirm rendering, animations, and transitions look unchanged.
- [ ] Spot-check spinner (`AniRotate`), pipe transitions, plug in/out animations, and error-text animations.
- [ ] Run `pnpm test` / Playwright suite.

https://claude.ai/code/session_0188CiRzfYT1Ez928a1qAGXo

---
_Generated by [Claude Code](https://claude.ai/code/session_0188CiRzfYT1Ez928a1qAGXo)_