### PR TITLE
Simplify level-up notification UI and remove button

### DIFF
--- a/views/levelup.html
+++ b/views/levelup.html
@@ -1,5 +1,4 @@
 <%
-  var data = D.data || {};
   var game = _.game();
   var says = _._('Mark sagt:');
   var text = _.sprintf(_._("levelup level %s! %s XP to level %s. %s energy"),

--- a/views/levelup.html
+++ b/views/levelup.html
@@ -1,9 +1,8 @@
 <%
   var data = D.data || {};
   var game = _.game();
-  var button = _._('levelup button');
   var says = _._('Mark sagt:');
-  var text = _.sprintf(_._("levelup level %s! %s XP to level %s. %s energy"), 
+  var text = _.sprintf(_._("levelup level %s! %s XP to level %s. %s energy"),
     _.toKSNum(game.xp_level.number),
     _.toKSNum(game.xp_level.xp_max - game.xp_value),
     _.toKSNum(game.xp_level.number + 1),
@@ -18,9 +17,7 @@
       <div class="NotificationText">
         <%= text  %>
       </div>
-    </div>
-    <div class="PopupButtons TutorialButtons">
-      <div class="Button" data-button-id="MainButton"><%= button %></div>
+      <div class="TutorialTapHint">tap anywhere to continue</div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
Refactored the level-up notification popup to simplify the user interface by removing the explicit button element and replacing it with a tap-to-continue hint.

## Key Changes
- Removed the `button` variable declaration and its associated translation lookup
- Replaced the dedicated button UI structure with a simpler `TutorialTapHint` div containing "tap anywhere to continue" text
- Consolidated the popup structure by removing the separate `PopupButtons` container div
- Fixed trailing whitespace in the sprintf call

## Implementation Details
The change shifts from an explicit clickable button to an implicit tap-anywhere interaction pattern, which is more consistent with tutorial/notification UX patterns. The notification now uses a hint text to guide users rather than a labeled button, reducing visual complexity while maintaining the same functionality.

https://claude.ai/code/session_01PGfSpXHgRNx2krxtdRq72g