### PR TITLE
Recover stuck mission goals on load and on Missions tab open

### DIFF
--- a/scripts/Game.js
+++ b/scripts/Game.js
@@ -3348,30 +3348,18 @@ var Game = function() {
     Missions.prototype.extendEventHandlers = function() {
       var mroot = this;
       var groot = this.GameRoot;
-      // Recover any mission goals that filled to 100% but never flipped to
-      // complete (e.g. integrate_profiles goals where current_amount caught
-      // DBTokensAbsolute via UI math but the delta never marked complete).
-      // Runs each time the player opens the Missions tab so the checkmark
-      // and reward catch up without re-triggering the original action.
       mroot.on('states_active', function(e, params) {
-        if (!params) { return; }
-        if (!app.remote || !app.remote.recheckMissions) { return; }
+        if (!params || !app.remote || !app.remote.recheckMissions) { return; }
         app.remote.recheckMissions().done(function(data) {
-          if (!data || !data.result) { return; }
-          var r = data.result;
-          if (!r.missions) { return; }
-          var hasCompletions = r.missions.complete_missions
-            && r.missions.complete_missions.length;
-          if (!hasCompletions) {
-            // No mission flipped to complete — just refresh the goal rows so
-            // the checkmark on a now-complete goal renders without the
-            // reward/levelup popup machinery.
-            mroot.updateMissionGoals(
-              r.missions.mission_data && r.missions.mission_data.mission_goals
-            );
-            return;
+          var r = data && data.result;
+          if (!r || !r.repaired) { return; }
+          if (r.missions.complete_missions && r.missions.complete_missions.length) {
+            groot.updateGameValues(r.game_values, r.levelup, r.missions, true);
+          } else {
+            // Goal flipped without finishing the mission — refresh rows only,
+            // skipping the reward/levelup popup machinery.
+            mroot.updateMissionGoals(r.missions.mission_data.mission_goals);
           }
-          groot.updateGameValues(r.game_values, r.levelup, r.missions, true);
         });
       });
     };

--- a/scripts/Game.js
+++ b/scripts/Game.js
@@ -3345,6 +3345,37 @@ var Game = function() {
       this.GameRoot.renderMenu.addButton(_._('Missions'), this.id,this.states);
     };
 
+    Missions.prototype.extendEventHandlers = function() {
+      var mroot = this;
+      var groot = this.GameRoot;
+      // Recover any mission goals that filled to 100% but never flipped to
+      // complete (e.g. integrate_profiles goals where current_amount caught
+      // DBTokensAbsolute via UI math but the delta never marked complete).
+      // Runs each time the player opens the Missions tab so the checkmark
+      // and reward catch up without re-triggering the original action.
+      mroot.on('states_active', function(e, params) {
+        if (!params) { return; }
+        if (!app.remote || !app.remote.recheckMissions) { return; }
+        app.remote.recheckMissions().done(function(data) {
+          if (!data || !data.result) { return; }
+          var r = data.result;
+          if (!r.missions) { return; }
+          var hasCompletions = r.missions.complete_missions
+            && r.missions.complete_missions.length;
+          if (!hasCompletions) {
+            // No mission flipped to complete — just refresh the goal rows so
+            // the checkmark on a now-complete goal renders without the
+            // reward/levelup popup machinery.
+            mroot.updateMissionGoals(
+              r.missions.mission_data && r.missions.mission_data.mission_goals
+            );
+            return;
+          }
+          groot.updateGameValues(r.game_values, r.levelup, r.missions, true);
+        });
+      });
+    };
+
     Missions.prototype.getMission = function(gestalt) {
       return this.Missions[gestalt] || {};
     };

--- a/scripts/LocalEngine.ts
+++ b/scripts/LocalEngine.ts
@@ -495,26 +495,14 @@ export function loadGame(): Promise<{ result: ReturnType<typeof _buildLoadGameRe
   var seededState = _seedMissionGoals(mat.state);
   setState(seededState);
 
-  // Recover any stuck mission goals (current_amount >= amount but
-  // complete=false) before building the load response. Persisting as a
-  // recheckMissions delta makes the recovery part of the durable history,
-  // so rewards are not re-applied on subsequent loads.
+  // Persist as a recheckMissions delta so the repair lands in durable
+  // history; otherwise rewards would be reapplied every materialize pass.
   var startupRepair = _repairStuckMissionGoals(seededState);
-  if (startupRepair.changed) {
-    var startupGv = startupRepair.rewards
-      ? _applyRewardsToGv(seededState.game_values || {}, startupRepair.rewards)
-      : (seededState.game_values || {});
-    var startupMissions: MissionUpdate = startupRepair.missions || {
-      complete_missions: [],
-      updated_missions: [],
-      mission_data: {
-        active_missions: startupRepair.active_missions,
-        mission_goals: startupRepair.mission_goals,
-      },
-    };
+  if (startupRepair && startupRepair.missions) {
+    var startupGv = _applyRewardsToGv(seededState.game_values || {}, startupRepair.rewards);
     _persistDelta(_mkDelta(seededState.addr, 'recheckMissions', [], {
       game_values: startupGv,
-      missions: startupMissions,
+      missions: startupRepair.missions,
     }));
     seededState = getState();
   }
@@ -1713,55 +1701,30 @@ function _completeMissionsIfReady(
   };
 }
 
-// Recovers mission goals whose current_amount has reached the required amount
-// but whose `complete` flag never flipped (e.g. a prior progression handler
-// updated current_amount without setting complete, or a buggy code path
-// stored partial progress). Run on every load and on mission-tab activation
-// so the UI checkmark and mission completion catch up without forcing the
-// player to re-trigger the original action.
-interface RepairResult {
-  changed: boolean;
-  missions: MissionUpdate | null;
-  rewards: RewardSet | undefined;
-  mission_goals: MissionGoal[];
-  active_missions: string[];
-}
-
-function _repairStuckMissionGoals(state: LocalState): RepairResult {
+// Flips goals where current_amount >= amount but complete=false (caused by
+// progression handlers that updated current_amount without setting complete).
+// Returns null when nothing needed repair so callers can skip persistence.
+function _repairStuckMissionGoals(state: LocalState): MissionAdvanceResult | null {
   var goals = state.mission_goals || [];
   var activeMissions = state.active_missions || [];
-  var unchanged: RepairResult = {
-    changed: false,
-    missions: null,
-    rewards: undefined,
-    mission_goals: goals,
-    active_missions: activeMissions,
-  };
-  if (!goals.length || !activeMissions.length) return unchanged;
+  if (!goals.length || !activeMissions.length) return null;
+
+  var activeSet: Record<string, true> = {};
+  activeMissions.forEach(function (m) { activeSet[m] = true; });
 
   var changed = false;
   var updatedGoals = goals.map(function (goal) {
-    if (goal.complete) return goal;
-    if (activeMissions.indexOf(goal.mission) === -1) return goal;
+    if (goal.complete || !activeSet[goal.mission]) return goal;
     var amount = goal.amount || 0;
-    var current = goal.current_amount || 0;
-    if (amount > 0 && current >= amount) {
+    if (amount > 0 && (goal.current_amount || 0) >= amount) {
       changed = true;
       return Object.assign({}, goal, { complete: true, current_amount: amount });
     }
     return goal;
   });
 
-  if (!changed) return unchanged;
-
-  var advance = _completeMissionsIfReady(updatedGoals, activeMissions);
-  return {
-    changed: true,
-    missions: advance.missions,
-    rewards: advance.rewards,
-    mission_goals: advance.mission_goals,
-    active_missions: advance.active_missions,
-  };
+  if (!changed) return null;
+  return _completeMissionsIfReady(updatedGoals, activeMissions);
 }
 
 // Sums up cash / xp / karma rewards across the just-completed missions so
@@ -2681,43 +2644,26 @@ export function dismissMissionBriefing(gestalt: unknown): Promise<{ result: { er
   return Promise.resolve({ result: { ok: true } });
 }
 
-// ---------------------------------------------------------------------------
-// recheckMissions() — sweep mission goals for current_amount >= amount but
-// complete=false and flip them, then complete any missions whose goals are
-// all done. Called when the player opens the missions tab so a stuck
-// mission catches up without requiring another progression action.
-// Returns the same shape as collectPerp/integrateCollected so the caller
-// can route through GameRoot.updateGameValues unchanged.
-// ---------------------------------------------------------------------------
+// On-demand counterpart of the loadGame repair. Called when the player
+// opens the Missions tab. Returns { repaired: false } when nothing was
+// stuck so the caller can skip rerendering.
 export function recheckMissions(): Promise<{
-  result: {
-    missions: MissionUpdate;
-    game_values: GameValues;
-    levelup: false;
-  };
+  result:
+    | { repaired: false }
+    | { repaired: true; missions: MissionUpdate; game_values: GameValues; levelup: false };
 }> {
   var state = getState();
   var repair = _repairStuckMissionGoals(state);
-  var newGv = state.game_values || {};
-  if (repair.changed && repair.rewards) {
-    newGv = _applyRewardsToGv(newGv, repair.rewards);
+  if (!repair || !repair.missions) {
+    return Promise.resolve({ result: { repaired: false } });
   }
-  var missionUpdate: MissionUpdate = repair.missions || {
-    complete_missions: [],
-    updated_missions: [],
-    mission_data: {
-      active_missions: repair.active_missions,
-      mission_goals: repair.mission_goals,
-    },
-  };
-  if (repair.changed) {
-    _persistDelta(_mkDelta(state.addr, 'recheckMissions', [], {
-      game_values: newGv,
-      missions: missionUpdate,
-    }));
-  }
+  var newGv = _applyRewardsToGv(state.game_values || {}, repair.rewards);
+  _persistDelta(_mkDelta(state.addr, 'recheckMissions', [], {
+    game_values: newGv,
+    missions: repair.missions,
+  }));
   return Promise.resolve({
-    result: { missions: missionUpdate, game_values: newGv, levelup: false },
+    result: { repaired: true, missions: repair.missions, game_values: newGv, levelup: false },
   });
 }
 

--- a/scripts/LocalEngine.ts
+++ b/scripts/LocalEngine.ts
@@ -495,6 +495,30 @@ export function loadGame(): Promise<{ result: ReturnType<typeof _buildLoadGameRe
   var seededState = _seedMissionGoals(mat.state);
   setState(seededState);
 
+  // Recover any stuck mission goals (current_amount >= amount but
+  // complete=false) before building the load response. Persisting as a
+  // recheckMissions delta makes the recovery part of the durable history,
+  // so rewards are not re-applied on subsequent loads.
+  var startupRepair = _repairStuckMissionGoals(seededState);
+  if (startupRepair.changed) {
+    var startupGv = startupRepair.rewards
+      ? _applyRewardsToGv(seededState.game_values || {}, startupRepair.rewards)
+      : (seededState.game_values || {});
+    var startupMissions: MissionUpdate = startupRepair.missions || {
+      complete_missions: [],
+      updated_missions: [],
+      mission_data: {
+        active_missions: startupRepair.active_missions,
+        mission_goals: startupRepair.mission_goals,
+      },
+    };
+    _persistDelta(_mkDelta(seededState.addr, 'recheckMissions', [], {
+      game_values: startupGv,
+      missions: startupMissions,
+    }));
+    seededState = getState();
+  }
+
   // Re-arm one-shot materializers for any charges still in flight. Clear
   // any prior handles first so calling loadGame twice doesn't queue
   // duplicate node_ready emissions for the same charge.
@@ -1689,6 +1713,57 @@ function _completeMissionsIfReady(
   };
 }
 
+// Recovers mission goals whose current_amount has reached the required amount
+// but whose `complete` flag never flipped (e.g. a prior progression handler
+// updated current_amount without setting complete, or a buggy code path
+// stored partial progress). Run on every load and on mission-tab activation
+// so the UI checkmark and mission completion catch up without forcing the
+// player to re-trigger the original action.
+interface RepairResult {
+  changed: boolean;
+  missions: MissionUpdate | null;
+  rewards: RewardSet | undefined;
+  mission_goals: MissionGoal[];
+  active_missions: string[];
+}
+
+function _repairStuckMissionGoals(state: LocalState): RepairResult {
+  var goals = state.mission_goals || [];
+  var activeMissions = state.active_missions || [];
+  var unchanged: RepairResult = {
+    changed: false,
+    missions: null,
+    rewards: undefined,
+    mission_goals: goals,
+    active_missions: activeMissions,
+  };
+  if (!goals.length || !activeMissions.length) return unchanged;
+
+  var changed = false;
+  var updatedGoals = goals.map(function (goal) {
+    if (goal.complete) return goal;
+    if (activeMissions.indexOf(goal.mission) === -1) return goal;
+    var amount = goal.amount || 0;
+    var current = goal.current_amount || 0;
+    if (amount > 0 && current >= amount) {
+      changed = true;
+      return Object.assign({}, goal, { complete: true, current_amount: amount });
+    }
+    return goal;
+  });
+
+  if (!changed) return unchanged;
+
+  var advance = _completeMissionsIfReady(updatedGoals, activeMissions);
+  return {
+    changed: true,
+    missions: advance.missions,
+    rewards: advance.rewards,
+    mission_goals: advance.mission_goals,
+    active_missions: advance.active_missions,
+  };
+}
+
 // Sums up cash / xp / karma rewards across the just-completed missions so
 // the caller can fold them into the new game_values. Without this, mission
 // completion notifications fire but the player never sees the payout.
@@ -2607,6 +2682,46 @@ export function dismissMissionBriefing(gestalt: unknown): Promise<{ result: { er
 }
 
 // ---------------------------------------------------------------------------
+// recheckMissions() — sweep mission goals for current_amount >= amount but
+// complete=false and flip them, then complete any missions whose goals are
+// all done. Called when the player opens the missions tab so a stuck
+// mission catches up without requiring another progression action.
+// Returns the same shape as collectPerp/integrateCollected so the caller
+// can route through GameRoot.updateGameValues unchanged.
+// ---------------------------------------------------------------------------
+export function recheckMissions(): Promise<{
+  result: {
+    missions: MissionUpdate;
+    game_values: GameValues;
+    levelup: false;
+  };
+}> {
+  var state = getState();
+  var repair = _repairStuckMissionGoals(state);
+  var newGv = state.game_values || {};
+  if (repair.changed && repair.rewards) {
+    newGv = _applyRewardsToGv(newGv, repair.rewards);
+  }
+  var missionUpdate: MissionUpdate = repair.missions || {
+    complete_missions: [],
+    updated_missions: [],
+    mission_data: {
+      active_missions: repair.active_missions,
+      mission_goals: repair.mission_goals,
+    },
+  };
+  if (repair.changed) {
+    _persistDelta(_mkDelta(state.addr, 'recheckMissions', [], {
+      game_values: newGv,
+      missions: missionUpdate,
+    }));
+  }
+  return Promise.resolve({
+    result: { missions: missionUpdate, game_values: newGv, levelup: false },
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Stub handlers — Wave 4+ issues fill these in.
 // ---------------------------------------------------------------------------
 var _STUBS = [
@@ -2651,6 +2766,7 @@ var LocalEngine = Object.assign({
   integrateCollected: integrateCollected,
   dismissMissionBriefing: dismissMissionBriefing,
   markTokenSeen:      markTokenSeen,
+  recheckMissions:    recheckMissions,
   setEmitter:           setEmitter,
   setSendDelta:         setSendDelta,
   setSendAchievement:   setSendAchievement,

--- a/scripts/state.ts
+++ b/scripts/state.ts
@@ -204,6 +204,7 @@ var OP_NAMES = [
   'setLocale',
   'dismissMissionBriefing',
   'markTokenSeen',
+  'recheckMissions',
 ];
 
 // ---------------------------------------------------------------------------
@@ -629,6 +630,24 @@ reducers.integrateCollected = function integrateCollectedReducer(state, delta) {
     nodes:          newNodes,
     mission_goals: mp.mission_goals,
     active_missions: mp.active_missions
+  });
+};
+
+// recheckMissions: applies the mission/game_values fix-up baked into the
+// delta so a stuck-goal recovery (set in LocalEngine.recheckMissions) is
+// durable across reloads instead of being reapplied (and rewards re-added)
+// every materialize pass.
+reducers.recheckMissions = function recheckMissionsReducer(state, delta) {
+  if (!delta || !delta.result) return state;
+  var r = delta.result;
+  var newGv = r.game_values
+    ? Object.assign({}, state.game_values, r.game_values)
+    : state.game_values;
+  var mp = _missionDataFromResult(state, r);
+  return Object.assign({}, state, {
+    game_values: newGv,
+    mission_goals: mp.mission_goals,
+    active_missions: mp.active_missions,
   });
 };
 

--- a/scripts/state.ts
+++ b/scripts/state.ts
@@ -633,10 +633,8 @@ reducers.integrateCollected = function integrateCollectedReducer(state, delta) {
   });
 };
 
-// recheckMissions: applies the mission/game_values fix-up baked into the
-// delta so a stuck-goal recovery (set in LocalEngine.recheckMissions) is
-// durable across reloads instead of being reapplied (and rewards re-added)
-// every materialize pass.
+// Bakes the stuck-goal repair into history so rewards aren't reapplied
+// each materialize pass.
 reducers.recheckMissions = function recheckMissionsReducer(state, delta) {
   if (!delta || !delta.result) return state;
   var r = delta.result;

--- a/tests/handlers/handlers.test.js
+++ b/tests/handlers/handlers.test.js
@@ -1212,6 +1212,7 @@ describe('recheckMissions — recovers stuck goals (current_amount >= amount)', 
 
     const { result } = await recheckMissions();
 
+    expect(result.repaired).toBe(true);
     expect(result.missions.complete_missions).toContain('mission007');
     const stuck = getState().mission_goals.find(
       (g) => g.mission === 'mission007' && g.workflow === 'integrate_profiles'
@@ -1229,7 +1230,7 @@ describe('recheckMissions — recovers stuck goals (current_amount >= amount)', 
     }));
 
     const { result } = await recheckMissions();
-    expect(result.missions.complete_missions).toEqual([]);
+    expect(result.repaired).toBe(false);
     expect(getState().active_missions).toContain('mission007');
   });
 

--- a/tests/handlers/handlers.test.js
+++ b/tests/handlers/handlers.test.js
@@ -4,7 +4,7 @@ import {
   getToken, ping, getSessionLocale, setLocale, loadGame, getRanking, setEmitter,
   setDisplayName, setPerpCoordinates, buyKarma,
   buyPowerup, sellPowerup, buySlots, buyPerp,
-  dismissMissionBriefing, markTokenSeen
+  dismissMissionBriefing, markTokenSeen, recheckMissions
 } from '../../scripts/LocalEngine.js';
 import { getState, setState } from '../../scripts/boot.js';
 import { freshState, applyDelta } from '../../scripts/state.js';
@@ -1196,6 +1196,79 @@ describe('buyPerp — loadGame repairs stuck buy_perp goal', () => {
     );
     expect(goal).toBeDefined();
     expect(goal.complete).toBe(false);
+  });
+});
+
+describe('recheckMissions — recovers stuck goals (current_amount >= amount)', () => {
+  it('flips a stuck integrate_profiles goal to complete and finishes the mission', async () => {
+    setState(Object.assign(mkBuyPerpState(), {
+      active_missions: ['mission007'],
+      mission_goals: [
+        { mission: 'mission007', workflow: 'buy_perp',           target: 'contact001', amount: null, position: 1, current_amount: 1,    complete: true  },
+        { mission: 'mission007', workflow: 'collect_profiles',   target: 'contact001', amount: 3000, position: 2, current_amount: 3000, complete: true  },
+        { mission: 'mission007', workflow: 'integrate_profiles', target: 'token017',   amount: 3000, position: 3, current_amount: 3000, complete: false },
+      ],
+    }));
+
+    const { result } = await recheckMissions();
+
+    expect(result.missions.complete_missions).toContain('mission007');
+    const stuck = getState().mission_goals.find(
+      (g) => g.mission === 'mission007' && g.workflow === 'integrate_profiles'
+    );
+    expect(stuck.complete).toBe(true);
+    expect(getState().active_missions).not.toContain('mission007');
+  });
+
+  it('is a no-op when no goal is stuck', async () => {
+    setState(Object.assign(mkBuyPerpState(), {
+      active_missions: ['mission007'],
+      mission_goals: [
+        { mission: 'mission007', workflow: 'collect_profiles',   target: 'contact001', amount: 3000, position: 2, current_amount: 1500, complete: false },
+      ],
+    }));
+
+    const { result } = await recheckMissions();
+    expect(result.missions.complete_missions).toEqual([]);
+    expect(getState().active_missions).toContain('mission007');
+  });
+
+  it('replaying the recheckMissions delta does not double-apply rewards', async () => {
+    setState(Object.assign(mkBuyPerpState(), {
+      active_missions: ['mission007'],
+      mission_goals: [
+        { mission: 'mission007', workflow: 'buy_perp',           target: 'contact001', amount: null, position: 1, current_amount: 1,    complete: true  },
+        { mission: 'mission007', workflow: 'collect_profiles',   target: 'contact001', amount: 3000, position: 2, current_amount: 3000, complete: true  },
+        { mission: 'mission007', workflow: 'integrate_profiles', target: 'token017',   amount: 3000, position: 3, current_amount: 3000, complete: false },
+      ],
+    }));
+
+    await recheckMissions();
+    const xpAfterFirst = getState().game_values.xp_value;
+    // Second recheck after the first persisted: nothing left to repair.
+    await recheckMissions();
+    expect(getState().game_values.xp_value).toBe(xpAfterFirst);
+  });
+});
+
+describe('loadGame — repairs stuck integrate_profiles goal at startup', () => {
+  it('marks goal complete and removes mission from active_missions on load', async () => {
+    setState(Object.assign(mkBuyPerpState(), {
+      active_missions: ['mission007'],
+      mission_goals: [
+        { mission: 'mission007', workflow: 'buy_perp',           target: 'contact001', amount: null, position: 1, current_amount: 1,    complete: true  },
+        { mission: 'mission007', workflow: 'collect_profiles',   target: 'contact001', amount: 3000, position: 2, current_amount: 3000, complete: true  },
+        { mission: 'mission007', workflow: 'integrate_profiles', target: 'token017',   amount: 3000, position: 3, current_amount: 3000, complete: false },
+      ],
+    }));
+
+    await loadGame();
+
+    const stuck = getState().mission_goals.find(
+      (g) => g.mission === 'mission007' && g.workflow === 'integrate_profiles'
+    );
+    expect(stuck.complete).toBe(true);
+    expect(getState().active_missions).not.toContain('mission007');
   });
 });
 


### PR DESCRIPTION
## Summary

Mission goals can fill to their required `amount` without their `complete` flag flipping (e.g. `integrate_profiles` goals where the UI recomputes `current_amount` from `DBTokensAbsolute` but the persisted goal stays at `complete: false`). The mission then sits in `active_missions` forever — the player sees `3,000 / 3,000` next to an unchecked box and never gets the reward.

- New `_repairStuckMissionGoals` (LocalEngine.ts) flips any goal where `current_amount >= amount && !complete`, then runs `_completeMissionsIfReady` so missions whose every goal is now done transition out of active.
- The repair runs once during `loadGame`, persisted as a `recheckMissions` delta so rewards become part of durable history (and aren't reapplied on every reload).
- A new `recheckMissions` handler runs the same repair on demand. `Missions.prototype.extendEventHandlers` (Game.js) wires it to the tab's `states_active` event, returning `{ repaired: false }` to short-circuit when nothing was stuck.
- New reducer in state.ts applies the baked-in `game_values` + `mission_data`.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 619 tests pass, including 4 new tests covering the on-demand repair, the no-op path, idempotent replay (no double rewards), and the loadGame startup repair
- [ ] Manual: load a save with a known stuck mission, verify the third goal flips to checked and the reward lands

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZ4EbQpwgPFoaA8ZgqaRxD)_