### PR TITLE
Fix shrinking energy refill on level-up by also raising ap_max

### DIFF
--- a/scripts/LocalEngine.ts
+++ b/scripts/LocalEngine.ts
@@ -906,7 +906,7 @@ export function buyKarma(
     xp_level: newLevel.number,
   });
 
-  if (levelup) newGv.ap_snapshot = newLevel.ap_max;
+  if (levelup) newGv = _applyLevelUp(newGv, newLevel.number);
 
   _persistDelta(_mkDelta(state.addr, 'buyKarma', [karmalauterGestalt], { game_values: newGv }));
 
@@ -1034,6 +1034,26 @@ function _getLevelByXP(xp: number): number {
 
 function _checkLevelup(currentLevel: number, newXp: number): boolean {
   return _getLevelByXP(newXp) > currentLevel;
+}
+
+// Refill AP and raise ap_max/regen rates to the new level's values.
+// Centralised because previously every level-up site (chargePerp,
+// collectPerp, integrateCollected, buyKarma) open-coded a partial copy
+// that forgot to advance ap_max — so the very next materialize() pass
+// clamped ap_snapshot back to the old ceiling and the player visibly
+// lost the energy refill they just earned.
+function _applyLevelUp(gv: GameValues, newLevelNum: number): GameValues {
+  var levels = _getRuleset().levels;
+  var info = levels[newLevelNum - 1] || levels[levels.length - 1];
+  if (!info) return Object.assign({}, gv, { xp_level: newLevelNum });
+  var iv = info as LevelEntry & { ap_inc_value?: number; ap_inc_interval?: number };
+  return Object.assign({}, gv, {
+    xp_level: newLevelNum,
+    ap_inc_value: iv.ap_inc_value !== undefined ? iv.ap_inc_value : gv.ap_inc_value,
+    ap_inc_interval: iv.ap_inc_interval !== undefined ? iv.ap_inc_interval : gv.ap_inc_interval,
+    ap_max: info.ap_max,
+    ap_snapshot: info.ap_max,
+  });
 }
 
 // All delta-emitting handlers funnel through _persistDelta (above). The legacy
@@ -1460,24 +1480,7 @@ export function buyPerp(
   var oldLevel = gv.xp_level || 1;
   var newLevel = _getLevelByXP(newGv.xp_value || 0);
   var levelup = newLevel > oldLevel;
-  if (levelup) {
-    newGv = Object.assign({}, newGv, { xp_level: newLevel });
-    var levelInfo = ruleset.levels[newLevel - 1] as
-      | (LevelEntry & { ap_inc_value?: number; ap_inc_interval?: number })
-      | undefined;
-    if (levelInfo) {
-      newGv = Object.assign({}, newGv, {
-        ap_inc_value: levelInfo.ap_inc_value,
-        ap_inc_interval: levelInfo.ap_inc_interval,
-        ap_max: levelInfo.ap_max,
-        // Refill AP on levelup so the player gets a fresh batch of actions —
-        // matches buyKarma/chargePerp behaviour. Without this, ap_snapshot
-        // stayed at the previous level's value while ap_max grew, so the AP
-        // bar visibly under-filled after a buyPerp-triggered level.
-        ap_snapshot: levelInfo.ap_max,
-      });
-    }
-  }
+  if (levelup) newGv = _applyLevelUp(newGv, newLevel);
 
   var missionResult = _advanceBuyPerpMissions(state, gestalt);
   newGv = _applyRewardsToGv(newGv, missionResult.rewards);
@@ -2093,16 +2096,7 @@ export function chargePerp(
   var oldLevelNum = gv.xp_level || 1;
   var newLevelNum = _getLevelByXP(newGv.xp_value || 0);
   var levelup = newLevelNum > oldLevelNum;
-  if (levelup) {
-    var levels = _getRuleset().levels;
-    var newLevelInfo = levels[newLevelNum - 1] || levels[levels.length - 1];
-    if (newLevelInfo) {
-      newGv = Object.assign({}, newGv, {
-        xp_level: newLevelNum,
-        ap_snapshot: newLevelInfo.ap_max,
-      });
-    }
-  }
+  if (levelup) newGv = _applyLevelUp(newGv, newLevelNum);
 
   var preMissionStateCharge = Object.assign({}, state, {
     nodes: newNodes,
@@ -2405,16 +2399,7 @@ export function collectPerp(
   var oldLevel = (ms.game_values && ms.game_values.xp_level) || 1;
   var newLevel = _getLevelByXP(newGv.xp_value || 0);
   var levelup = newLevel > oldLevel;
-  if (levelup) {
-    var collectLevels = _getRuleset().levels;
-    var collectLevelInfo = collectLevels[newLevel - 1] || collectLevels[collectLevels.length - 1];
-    if (collectLevelInfo) {
-      newGv = Object.assign({}, newGv, {
-        xp_level: newLevel,
-        ap_snapshot: collectLevelInfo.ap_max,
-      });
-    }
-  }
+  if (levelup) newGv = _applyLevelUp(newGv, newLevel);
 
   var preMissionState = Object.assign({}, ms, {
     nodes: newNodes,
@@ -2654,17 +2639,7 @@ export function integrateCollected(
   var oldLevel = (state.game_values && state.game_values.xp_level) || 1;
   var newLevel = _getLevelByXP(newGv.xp_value || 0);
   var levelup = newLevel > oldLevel;
-  if (levelup) {
-    var integrateLevels = _getRuleset().levels;
-    var integrateLevelInfo =
-      integrateLevels[newLevel - 1] || integrateLevels[integrateLevels.length - 1];
-    if (integrateLevelInfo) {
-      newGv = Object.assign({}, newGv, {
-        xp_level: newLevel,
-        ap_snapshot: integrateLevelInfo.ap_max,
-      });
-    }
-  }
+  if (levelup) newGv = _applyLevelUp(newGv, newLevel);
 
   var preMissionState = Object.assign({}, state, {
     db_queue: newQueue,

--- a/tests/handlers/chargePerp.test.js
+++ b/tests/handlers/chargePerp.test.js
@@ -410,6 +410,18 @@ describe('chargePerp — level-up refills AP and advances xp_level', () => {
     const { result } = await chargePerp(NODE_PATH);
     expect(result.game_values.ap_snapshot).toBe(8);
   });
+
+  // Regression: without raising ap_max in game_values too, the next
+  // materialize() pass clamps ap_snapshot back down to the previous
+  // level's ceiling — so the player visibly loses the energy they were
+  // just awarded for levelling up.
+  it("raises ap_max to the new level's ceiling so the refill survives materialize", async () => {
+    const { result } = await chargePerp(NODE_PATH);
+    expect(result.game_values.ap_max).toBe(8);
+
+    var mat = materialize(getState(), FIXED_NOW + 1);
+    expect(mat.state.game_values.ap_snapshot).toBe(8);
+  });
 });
 
 describe('chargePerp — no level-up keeps xp_level and decrements ap_snapshot', () => {

--- a/tests/handlers/handlers.test.js
+++ b/tests/handlers/handlers.test.js
@@ -21,6 +21,7 @@ import {
 } from '../../scripts/LocalEngine.js';
 import { getState, setState } from '../../scripts/boot.js';
 import { clearOverride, setOverride } from '../../scripts/clock.js';
+import { materialize } from '../../scripts/materializer.js';
 import { applyDelta, freshState } from '../../scripts/state.js';
 import { FIXED_NOW, mkState } from './_fixtures.js';
 
@@ -431,6 +432,50 @@ describe('buyKarma — failure: insufficient cash', () => {
     const before = getState().game_values.cash_value;
     await buyKarma(KARMA_GESTALT);
     expect(getState().game_values.cash_value).toBe(before);
+  });
+});
+
+// karma001 awards 5 karma_points (also +5 XP). Starting at xp=6/level 1
+// (xp_max=10) crosses to xp=11/level 2 (xp_min=11, ap_max=8) on a single
+// buy — exercising the level-up path that previously refilled
+// ap_snapshot but forgot to raise ap_max, so the very next materialize()
+// pass clamped the player back to the old ceiling.
+describe('buyKarma — level-up raises ap_max so the refill survives materialize', () => {
+  beforeEach(() => {
+    setOverride(FIXED_NOW);
+    setState(
+      mkState({
+        game_values: {
+          xp_value: 6,
+          xp_level: 1,
+          cash_value: 1000,
+          cash_spent: 0,
+          karma_value: 50,
+          ap_snapshot: 2,
+          ap_max: 6,
+          ap_update: FIXED_NOW,
+          ap_inc_value: 1,
+          ap_inc_interval: 120000,
+        },
+      })
+    );
+  });
+
+  afterEach(() => clearOverride());
+
+  it('returns levelup=true and refills ap_snapshot to the new ap_max', async () => {
+    const { result } = await buyKarma(KARMA_GESTALT);
+    expect(result.levelup).toBe(true);
+    expect(result.game_values.xp_level).toBe(2);
+    expect(result.game_values.ap_snapshot).toBe(8);
+    expect(result.game_values.ap_max).toBe(8);
+  });
+
+  it('keeps the refill across a subsequent materialize() pass', async () => {
+    await buyKarma(KARMA_GESTALT);
+    var mat = materialize(getState(), FIXED_NOW + 1);
+    expect(mat.state.game_values.ap_snapshot).toBe(8);
+    expect(mat.state.game_values.ap_max).toBe(8);
   });
 });
 


### PR DESCRIPTION
## Summary

Players who levelled up via `chargePerp`, `collectPerp`, `integrateCollected`, or `buyKarma` did not get their full energy back. The next `materialize()` pass clamped them straight back down to the previous level's ceiling.

## Root cause

Each of those four handlers set `gv.ap_snapshot` to the new level's `ap_max` on level-up but left `gv.ap_max` itself at the previous level's value. The materializer's AP-regen rule (`scripts/materializer.ts:157`) then capped `ap_snapshot` against the stale `gv.ap_max`:

```ts
ap_snapshot: Math.min(gv.ap_max, gv.ap_snapshot + ticks * gv.ap_inc_value),
```

So a player at level 1 (`ap_max=6`) who crossed into level 2 (`ap_max=8`) saw their AP refill to 8, then immediately get clamped back to 6 on the next read. Only `buyPerp` had the correct full update.

## Fix

Centralise the level-up bookkeeping in `_applyLevelUp(gv, newLevelNum)` and call it from all five level-up sites. The helper updates `xp_level`, `ap_max`, `ap_snapshot`, and per-level `ap_inc_value` / `ap_inc_interval` so the regen rate also tracks the new level.

The three shop-action handlers (`buyPowerup`, `sellPowerup`, `buySlots`) are intentionally left unchanged — they already only bumped `xp_level` and have never refilled AP on level-up; that is a separate behavior choice and out of scope.

## Test plan

- [x] New regression test in `tests/handlers/chargePerp.test.js` runs `materialize()` after the level-up and asserts `ap_snapshot` survives at the new `ap_max=8`.
- [x] New regression test in `tests/handlers/handlers.test.js` covers the same flow for `buyKarma`.
- [x] Both new tests fail on master (`expected 6 to be 8`) and pass on this branch.
- [x] Full suite still green: `npx vitest run` → 622 / 622.
- [x] `npx tsc --noEmit` clean.
- [x] `npx biome check` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RmVk72dhssQoSGDkXHGsZC)_