### PR TITLE
Fix camera animation conflicts by canceling debounced recentering

### DIFF
--- a/scripts/Game.js
+++ b/scripts/Game.js
@@ -995,14 +995,16 @@ var Game = function () {
       gnode.activeView = getById(view_id);
       gnode.activeView.setState('active', true);
       // Refresh the new view's scroller dimensions against the current
-      // stage (it may have been resized while a different tab was active),
-      // then recentre on its content. Without this, switching to Database
-      // leaves the camera wherever the previous view was scrolled.
+      // stage (it may have been resized while a different tab was active).
+      // Auto-recentering used to live here, but it raced with tutorial
+      // scripted events that scrollTo a perp right after switch_view —
+      // the debounced re-center fired ~50ms later and overwrote the
+      // perp focus. Tab switches now keep their last scroll position;
+      // the fullscreen/reset-zoom button is the explicit way to recentre.
       var vm = gnode.activeView && gnode.activeView.renderNode;
       if (vm && typeof vm.updateScroller === 'function') {
         vm.updateScroller();
       }
-      gnode._centerActiveView(true);
     });
 
     gnode.on('toggle_locale', function (e) {

--- a/scripts/Game.js
+++ b/scripts/Game.js
@@ -994,13 +994,9 @@ var Game = function () {
       });
       gnode.activeView = getById(view_id);
       gnode.activeView.setState('active', true);
-      // Refresh the new view's scroller dimensions against the current
-      // stage (it may have been resized while a different tab was active).
-      // Auto-recentering used to live here, but it raced with tutorial
-      // scripted events that scrollTo a perp right after switch_view —
-      // the debounced re-center fired ~50ms later and overwrote the
-      // perp focus. Tab switches now keep their last scroll position;
-      // the fullscreen/reset-zoom button is the explicit way to recentre.
+      // Refresh scroller dimensions in case the stage was resized while
+      // this tab was inactive. Tab switches preserve scroll position;
+      // the reset-zoom button is the explicit way to recentre.
       var vm = gnode.activeView && gnode.activeView.renderNode;
       if (vm && typeof vm.updateScroller === 'function') {
         vm.updateScroller();
@@ -1666,43 +1662,40 @@ var Game = function () {
     return popup;
   };
 
-  // The fullscreen button now resets zoom AND re-centers on the ViewMap's
+  // Cancel any debounced _centerActiveView so an explicit camera move
+  // (reset-zoom, tutorial scrollTo) isn't clobbered ~50ms later.
+  GameRoot.prototype._cancelPendingCenter = function () {
+    clearTimeout(this._centerActiveViewTimer);
+    this._centerActiveViewTimer = null;
+  };
+
+  // The fullscreen button resets zoom AND re-centers on the ViewMap's
   // design home point — for Imperium that's where the seed places the
-  // Database (≈1024,800).  Falls back to a no-op if no ViewMap is active.
+  // Database (≈1024,800). No-op if no ViewMap is active.
   GameRoot.prototype.resetZoom = function () {
-    // activeView is only set after the first switch_view; on initial
-    // boot we need the same Imperium fallback as _centerActiveView.
     var view = this.activeView || (this.getImperium && this.getImperium());
     var vm = view && view.renderNode;
     if (!vm || !vm.scroller || typeof vm.scroller.scrollTo !== 'function') return;
     if (typeof vm.updateScroller === 'function') vm.updateScroller();
     var vp = vm.parentNode;
     if (!vp) return;
-    // Cancel any debounced re-center so it can't interrupt this animation
-    // 50ms in, which used to freeze zoom mid-tween (zoomTo+scrollTo issue
-    // a single __publish each, and the second one cancels the first).
-    clearTimeout(this._centerActiveViewTimer);
-    // scrollTo with an explicit zoom multiplies left/top by zoom internally
-    // and combines both into one __publish, so we get a single tween from
-    // (current zoom, current scroll) to (1.0, centered) instead of two
-    // animations fighting each other.
+    this._cancelPendingCenter();
+    // Combined zoom+scroll in one __publish so the tween goes
+    // (current zoom, current scroll) → (1.0, centered) instead of
+    // two animations fighting each other.
     var sx = Math.max(0, vm.width / 2 - vp.width / 2);
     var sy = Math.max(0, vm.height / 2 - vp.height / 2);
     vm.scroller.scrollTo(sx, sy, true, 1);
   };
 
-  // Re-centers the active ViewMap so the design home point sits in the
-  // middle of the visible viewport — used both at startup and from the
-  // reset-zoom button so the player isn't staring at empty space when
-  // the window is wider than the legacy 960×600 frame.
-  // Debounced: rapid callers during initial mount (fitToWindow → render
-  // after_render → tutorial switch_view) collapse into one scroll.
+  // Re-centers the active ViewMap on its design home point. Debounced
+  // so rapid callers during initial mount (fitToWindow → after_render
+  // → tutorial switch_view) collapse into one scroll.
   GameRoot.prototype._centerActiveView = function (animate) {
     var self = this;
-    clearTimeout(self._centerActiveViewTimer);
+    self._cancelPendingCenter();
     self._centerActiveViewTimer = setTimeout(function () {
       self._centerActiveViewTimer = null;
-      // activeView is set only after a switch_view; fall back to Imperium.
       var view = self.activeView || (self.getImperium && self.getImperium());
       var vm = view && view.renderNode;
       if (!vm || !vm.scroller || !vm.parentNode) return;

--- a/scripts/Render.js
+++ b/scripts/Render.js
@@ -4181,15 +4181,9 @@ var Render = function () {
   ViewMap.prototype.scrollTo = function (pos, dur) {
     var vpCenter = this.parentNode.getCenterPosition();
     dur = dur !== undefined ? dur : 300;
-    // An explicit scrollTo wins over any pending generic re-center —
-    // otherwise the debounced GameRoot._centerActiveView fires ~50ms
-    // later and snaps the camera back to the design home point, which
-    // used to clobber tutorial perp focus.
+    // Explicit scrollTo beats any debounced generic recenter still pending.
     var groot = this.gameNode && this.gameNode.GameRoot;
-    if (groot && groot._centerActiveViewTimer) {
-      clearTimeout(groot._centerActiveViewTimer);
-      groot._centerActiveViewTimer = null;
-    }
+    if (groot) groot._cancelPendingCenter();
     this.scroller.options.animating = dur > 0;
     this.scroller.options.animationDuration = dur;
     this.scroller.scrollTo(pos.x - vpCenter.x, pos.y - vpCenter.y, true);

--- a/scripts/Render.js
+++ b/scripts/Render.js
@@ -4181,6 +4181,15 @@ var Render = function () {
   ViewMap.prototype.scrollTo = function (pos, dur) {
     var vpCenter = this.parentNode.getCenterPosition();
     dur = dur !== undefined ? dur : 300;
+    // An explicit scrollTo wins over any pending generic re-center —
+    // otherwise the debounced GameRoot._centerActiveView fires ~50ms
+    // later and snaps the camera back to the design home point, which
+    // used to clobber tutorial perp focus.
+    var groot = this.gameNode && this.gameNode.GameRoot;
+    if (groot && groot._centerActiveViewTimer) {
+      clearTimeout(groot._centerActiveViewTimer);
+      groot._centerActiveViewTimer = null;
+    }
     this.scroller.options.animating = dur > 0;
     this.scroller.options.animationDuration = dur;
     this.scroller.scrollTo(pos.x - vpCenter.x, pos.y - vpCenter.y, true);


### PR DESCRIPTION
## Summary
This PR fixes camera animation conflicts that occurred when explicit camera movements (reset-zoom, tutorial scrollTo) were interrupted by debounced generic recentering logic. The changes ensure that intentional camera animations complete without being clobbered by pending automatic recentering.

## Key Changes
- **Extracted `_cancelPendingCenter()` method**: Created a dedicated method to cancel any pending debounced `_centerActiveView` calls, improving code clarity and reusability
- **Updated `resetZoom()` behavior**: Removed automatic recentering from tab switches; reset-zoom now explicitly cancels pending recentering before performing its zoom+scroll animation
- **Added cancellation in `ViewMap.scrollTo()`**: Tutorial and other explicit scroll-to operations now cancel pending generic recentering to prevent animation conflicts
- **Removed auto-center from tab switches**: Tabs no longer automatically recenter when activated; only `resetZoom()` and explicit `scrollTo()` calls trigger recentering
- **Simplified comments**: Updated documentation to reflect the new behavior and clarify the purpose of debouncing

## Implementation Details
The core issue was that rapid camera movements could trigger multiple competing animations:
- `resetZoom()` would call `scrollTo()` with zoom
- A debounced `_centerActiveView()` would fire ~50ms later with a conflicting scroll
- These would issue separate `__publish` events, causing the second to cancel the first

The fix ensures that explicit camera operations (`resetZoom`, tutorial `scrollTo`) cancel any pending generic recentering before executing, so both zoom and scroll happen in a single coordinated animation.

https://claude.ai/code/session_01Vw9ySzGupmKqBNN6cyQQuR