### PR TITLE
feat(ts): extract Set collection helper to scripts/game/OrderedSet.ts

### DIFF
--- a/scripts/Game.js
+++ b/scripts/Game.js
@@ -5,6 +5,7 @@ import { getRender } from './Render.js';
 // alongside scripts that run before vendor `<script>` tags execute.
 import appModule from './app.js';
 import * as bootMod from './boot.js';
+import { OrderedSet } from './game/OrderedSet.js';
 import i18n from './i18n.js';
 import setup from './setup.js';
 import { getTypeSettings } from './type_settings.js';
@@ -20,6 +21,12 @@ var Game = function () {
   var extend = utilDefault.extend;
   var Render = getRender();
   var typeSettings = getTypeSettings();
+
+  // Legacy in-IIFE alias for the extracted ordered-collection class.
+  // See scripts/game/OrderedSet.ts for the full contract; the rest of
+  // this file calls `new Set()` to retain the historical name.
+  // biome-ignore lint/suspicious/noShadowRestrictedNames: legacy collection class predates ES6 Set
+  var Set = OrderedSet;
 
   //////////////////////////////////////////
   //
@@ -73,49 +80,6 @@ var Game = function () {
     app.game = new GameRoot();
     app.game.loadGame(data);
     return app.game;
-  };
-
-  ////////////////////////////////
-  // The Set
-  ////////////////////////////////
-
-  // biome-ignore lint/suspicious/noShadowRestrictedNames: legacy collection class predates ES6 Set
-  var Set = function (set) {
-    if (!set) {
-      set = [];
-    }
-    this.set = set;
-    this.length = this.set.length;
-    return this;
-  };
-
-  Set.prototype.add = function (node) {
-    this.set.push(node);
-    this.length = this.set.length;
-  };
-
-  Set.prototype.prepend = function (node) {
-    this.set.unshift(node);
-    this.length = this.set.length;
-  };
-
-  Set.prototype.remove = function (node) {
-    var index = this.set.indexOf(node);
-    if (index !== -1) {
-      this.set.splice(index, 1);
-    }
-    this.length = this.set.length;
-  };
-
-  Set.prototype.each = function (func) {
-    if (!func) {
-      return;
-    }
-    for (var n = 0; n < this.set.length; n++) {
-      var node = this.set[n];
-      func(node);
-    }
-    this.length = this.set.length;
   };
 
   //////////////////////////////////////////

--- a/scripts/game/OrderedSet.ts
+++ b/scripts/game/OrderedSet.ts
@@ -5,8 +5,8 @@
 // `length` field, single `each` walker).
 //
 // Extracted from scripts/Game.js's IIFE in the issue #147 / Phase 7
-// migration.  Game.ts re-exports this as `Set` to keep the in-IIFE call
-// sites unchanged while the rest of Game.ts is still under `@ts-nocheck`.
+// migration.  Game.js re-exports this as `Set` to keep the in-IIFE call
+// sites unchanged while the rest of Game.js is still under `@ts-nocheck`.
 //
 // Behaviour preserved from the legacy class:
 //   - `set` and `length` are public.  AniTicker.listeners.set is reassigned
@@ -55,8 +55,7 @@ export class OrderedSet<T> {
 
   each(func: (node: T) => void): void {
     if (!func) return;
-    for (let n = 0; n < this.set.length; n++) {
-      const node = this.set[n] as T;
+    for (const node of this.set) {
       func(node);
     }
     this.length = this.set.length;

--- a/scripts/game/OrderedSet.ts
+++ b/scripts/game/OrderedSet.ts
@@ -1,0 +1,64 @@
+// Ordered insertion-set used by GameRoot's child collections, the legacy
+// AniTicker / APTicker listener queues, and the Database / Topscores /
+// Missions queue trackers.  Predates ES `Set` and exposes a slightly
+// different surface (insertion-ordered, public `set` array, mirrored
+// `length` field, single `each` walker).
+//
+// Extracted from scripts/Game.js's IIFE in the issue #147 / Phase 7
+// migration.  Game.ts re-exports this as `Set` to keep the in-IIFE call
+// sites unchanged while the rest of Game.ts is still under `@ts-nocheck`.
+//
+// Behaviour preserved from the legacy class:
+//   - `set` and `length` are public.  AniTicker.listeners.set is reassigned
+//     via `_.shuffle(...)` at scripts/Game.js:329,348 — i.e. callers may
+//     swap the underlying array out from under us.  Length tracking is
+//     therefore a snapshot at the last add/prepend/remove/each call, not
+//     a live mirror of `set.length`.
+//   - `each(undefined)` is a no-op (legacy guard); `each` does not return
+//     the result of the callback and skips nothing.
+
+export class OrderedSet<T> {
+  /**
+   * Public underlying array.  Some legacy call sites mutate it directly
+   * (e.g. `_.shuffle(this.set)`); see the class docstring.
+   */
+  set: T[];
+
+  /**
+   * Snapshot of `set.length` at the last add/prepend/remove/each call.
+   * Public for compatibility with legacy reads (`children.length`).
+   */
+  length: number;
+
+  constructor(initial?: T[]) {
+    this.set = initial ?? [];
+    this.length = this.set.length;
+  }
+
+  add(node: T): void {
+    this.set.push(node);
+    this.length = this.set.length;
+  }
+
+  prepend(node: T): void {
+    this.set.unshift(node);
+    this.length = this.set.length;
+  }
+
+  remove(node: T): void {
+    const index = this.set.indexOf(node);
+    if (index !== -1) {
+      this.set.splice(index, 1);
+    }
+    this.length = this.set.length;
+  }
+
+  each(func: (node: T) => void): void {
+    if (!func) return;
+    for (let n = 0; n < this.set.length; n++) {
+      const node = this.set[n] as T;
+      func(node);
+    }
+    this.length = this.set.length;
+  }
+}


### PR DESCRIPTION
PR 4 of issue #147 — first sub-class extraction from `scripts/Game.js`.

## Why a foundation PR before `Game.<SubClass>` typings

`Game.js` is 6088 LOC in one IIFE with 22 class constructors that share helpers (`extend`, `getById`, `getFirstId`, `getByGestalt`, `mergeData`, …) and a common `GameNode` base. The brief's "split sub-class by sub-class" plan needs an established import pattern before subclass extractions can proceed; this PR establishes that pattern with the smallest, most decoupled helper class — `Set` (a pre-ES2015 ordered collection).

TypeScript has no block-level `@ts-nocheck`, so "remove `// @ts-nocheck` from the converted sub-class scope" works only by moving the sub-class to its own file. PR 5 will do the same for `GameNode` (the foundational base class — needed before any subclass extraction). PR 6+ moves out individual subclasses (`Topscores`/`Topscore` first, per the brief's "smallest classes first" rule).

## What changed

**New file: `scripts/game/OrderedSet.ts` (62 LOC, fully strict-typed).**

`OrderedSet<T>` matches the legacy contract:
- `set: T[]` — public underlying array. Legacy `AniTicker.listeners.set` is reassigned via `_.shuffle(...)` at `scripts/Game.js:329,348`, so the underlying array is swappable from outside. Documented in the class docstring.
- `length: number` mirrors `set.length`, snapshotted at the last `add`/`prepend`/`remove`/`each` call. Matches the legacy "stale-friendly" behaviour where `length` doesn't auto-track external `set` mutations (the AniTicker shuffle pattern relies on this).
- `add` / `prepend` / `remove` / `each(func)` with the original signatures. `each(undefined)` is a no-op (legacy guard preserved).

**`scripts/Game.js`:**
- Add `import { OrderedSet } from './game/OrderedSet.js';` at the top.
- Inside the `var Game = function () { … }` factory: single alias `var Set = OrderedSet;` (with the existing `biome-ignore lint/suspicious/noShadowRestrictedNames` carried over to the alias).
- Remove the 38-line inline `var Set = function(set) { … }` + 4 prototype methods.
- All 6 `new Set()` call sites and the `.set` / `.length` reads keep working unchanged.

## Discipline

- **Zero behavioural change.** Same constructor identity, same prototype methods, same arity, same `length` semantics.
- **`Game.js` keeps `@ts-nocheck`.** The new module is strict-typed on its own; the rest of `Game.js` stays quarantined until later PRs.
- **No `as Foo` casts**, no `!` non-null assertions, no `any`.
- No new `setState` / `webxdc.sendUpdate` sites — pure helper extraction.
- No DOM, no clock, no engine touches.

## Test plan

- [x] `pnpm typecheck` — clean.
- [x] `pnpm exec biome check .` — clean (only the gitignored `test-results/.last-run.json` local artifact flags, never present in CI).
- [x] `pnpm test` — 622 unit tests pass.
- [x] `pnpm test:e2e` — 16 specs pass, 1 skipped, 0 failures (`Set` is on the hot path for `GameRoot`'s `children`, `Database.queue`, `Topscores.queue`, `APTicker.listeners`, `AniTicker.listeners`; the e2e suite exercises all of those).
- [x] `pnpm build` — both `.xdc` bundles produced.
- [ ] CI green on PR.

## Roadmap visibility

- PR 5 (next): extract `GameNode` base class and the shared helpers it captures (`extend`, `_ids`, `getById`, `add`, `get`, `remove`, `clear`) into `scripts/game/GameNode.ts`. This is the foundational refactor — every subclass extends `GameNode`, so it has to be importable before any subclass can move.
- PR 6+: `Topscores` + `Topscore` (~135 LOC, smallest extends-`GameNode` pair, per the brief's preferred ordering), then `Missions` + `Mission`, then `Imperium`, then `Database`, then individual `Perp` classes.

Refs #147.

---
_Generated by [Claude Code](https://claude.ai/code/session_018qbFtLNgH4p39DmEBtouJu)_