### PR TITLE
feat(ts): extract ProfileSet subclass to scripts/game/

### DIFF
--- a/scripts/Game.js
+++ b/scripts/Game.js
@@ -30,6 +30,7 @@ import { Imperium } from './game/Imperium.js';
 import { Mission } from './game/Mission.js';
 import { Missions } from './game/Missions.js';
 import { OrderedSet } from './game/OrderedSet.js';
+import { ProfileSet } from './game/ProfileSet.js';
 import { Topscore } from './game/Topscore.js';
 import { Topscores } from './game/Topscores.js';
 import { mergeData } from './game/mergeData.js';
@@ -1829,149 +1830,12 @@ var Game = function () {
   ///////////////////////////////////
   // The ProfileSet
   ///////////////////////////////////
-
-  var ProfileSet = function (config, tokens) {
-    // Used both as Template and cued Object in DBQueue
-    this.init(config);
-    var gnode = this;
-    var groot = this.GameRoot;
-
-    tokens = _.clone(tokens);
-    this.data = groot.getTypeData('ProfileSet');
-    var filter_is_query = this.filter_is_query;
-
-    if (this.convertTokens) {
-      _.each(tokens, function (t, k) {
-        tokens[k] = { gestalt: t };
-      });
-    }
-
-    this.tokens_map = {};
-    this.tokens_set = [];
-    var addtokens = [];
-    // Check if tokens is object with keys or array
-    if (tokens.length === undefined && gnode.origin) {
-      // Asuming its a token_map from the queue or collect
-      // FIXME: this messes with sorting, either we use a kind of sort key, or backend can give me an array!
-      _.each(tokens.tokens_map, function (v, k) {
-        var addme = {
-          gestalt: k,
-          amount: v.amount,
-          // collect_amount is profiles value here
-          collect_amount: gnode.profiles_value,
-        };
-        // exclude origin tokens
-        if (addme.gestalt.substring(0, 6) !== 'origin') {
-          addtokens.push(addme);
-        }
-      });
-      this.tokens_map = tokens.tokens_map;
-    } else {
-      // Asuming its from the source perp
-      // exclude origin tokens
-      addtokens = _.filter(tokens, function (n) {
-        if (n.gestalt) {
-          return n.gestalt.substring(0, 6) !== 'origin';
-        }
-      });
-      if (config.filter_is_query) {
-        var is_query = filter_is_query === 'blue';
-        addtokens = _.filter(tokens, function (n) {
-          return n.is_query === is_query;
-        });
-      }
-    }
-
-    // We build and extend the token_set
-    _.each(addtokens, function (token, k) {
-      // don't mess with the original data
-      var t = _.extend({}, token);
-      t.data = groot.getTypeData(token.gestalt);
-      if (gnode.DBAmounts) {
-        t.database_amount = groot.DBTokens[token.gestalt] || 0;
-        t.database_absoluteAmount = groot.DBTokensAbsolute[token.gestalt] || 0;
-      }
-      if (gnode.markNew) {
-        var seenMap = (groot.raw_data && groot.raw_data.tokens_seen) || {};
-        if (!groot.DBTokens.hasOwnProperty(token.gestalt) && !seenMap[token.gestalt]) {
-          t.new = true;
-        }
-      }
-      if (gnode.lockAmountZero && token.amount === 0) {
-        t.locked = true;
-      }
-      if (gnode.lockNotInDB && !groot.DBTokens.hasOwnProperty(token.gestalt)) {
-        t.locked = true;
-      }
-      if (gnode.markUpgradeValues && gnode.lastUpgradeValues && !t.locked) {
-        var lastProfileValues = gnode.lastUpgradeValues.profiles_value;
-        var lastAmount = gnode.lastUpgradeValues.token_map[t.gestalt] || 0;
-        var lastAbsoluteAmount = (lastProfileValues * lastAmount) / 100;
-        var currentAbsoluteAmount = gnode.GameRoot.DBTokensAbsolute[t.gestalt];
-        t.diffAbsoluteAmount = currentAbsoluteAmount - lastAbsoluteAmount;
-        t.doneAbsoluteAmount = t.database_absoluteAmount - t.diffAbsoluteAmount;
-        t.diffAmount = 100 / (groot.profiles_value / t.diffAbsoluteAmount);
-        t.doneAmount = t.database_amount - t.diffAmount;
-      } else if (gnode.markUpgradeValues && !gnode.lastUpgradeValues && !t.locked) {
-        t.diffAbsoluteAmount = groot.DBTokensAbsolute[token.gestalt] || 0;
-        t.diffAmount = groot.DBTokens[token.gestalt] || 0;
-        t.doneAmount = 0;
-        t.doneAbsoluteAmount = 0;
-      }
-
-      // FIXME: Show origin data for debug reasons only
-      if (token.origin_gestalt) {
-        t.data = groot.getTypeData(token.origin_gestalt);
-      }
-      if (t.data) {
-        gnode.tokens_set.push(t);
-      }
-    });
-    // sort when locked tokens are marked
-
-    // biome-ignore lint/suspicious/noSelfCompare: legacy always-true guard, removal is a separate refactor
-    if (gnode.lockAmountZero || gnode.lockNotInDB || 0 === 0) {
-      var sorted = gnode.tokens_set;
-      // FIXME: sortBy Gestalt for messed up TokenSets from CMS/Backend (DBQueue and Clients)
-      if (gnode.sortByGestalt) {
-        sorted = _.sortBy(gnode.tokens_set, function (t) {
-          return t.gestalt;
-        });
-      }
-      var grouped = _.groupBy(sorted, function (t) {
-        return t.locked ? 1 : 0;
-      });
-      gnode.tokens_set = _.flatten(grouped);
-      /*
-        gnode.tokens_set = _(gnode.tokens_set).sortBy(function(t,k){
-          if (t.locked) {
-            return k+gnode.tokens_set.length;
-          }  
-          else {
-            return k;
-          }
-        });
-        */
-    }
-
-    return this;
-  };
-  extend(ProfileSet, GameNode);
-
-  ProfileSet.prototype.updateNewMarker = function () {
-    var groot = this.GameRoot;
-    var seenMap = (groot.raw_data && groot.raw_data.tokens_seen) || {};
-    _.each(this.tokens_set, function (token) {
-      if (!groot.DBTokens.hasOwnProperty(token.gestalt) && !seenMap[token.gestalt]) {
-        token.new = true;
-      } else {
-        token.new = false;
-      }
-    });
-    if (this.popupTemplateData) {
-      this.popupTemplateData.ProfileSet = this;
-    }
-  };
+  //
+  // Extracted to scripts/game/ProfileSet.ts in PR 9 of issue #147.  The
+  // class is imported above; the API publisher at the bottom of this
+  // IIFE re-exposes it as Game.ProfileSet (where applicable) and
+  // Database.cue / Perp BuyToken flows reach it through the imported
+  // identity.
 
   ///////////////////////////////////
   // The Imperium

--- a/scripts/game/ProfileSet.ts
+++ b/scripts/game/ProfileSet.ts
@@ -104,12 +104,18 @@ export class ProfileSet extends GameNode {
     super(config);
     const groot = this.GameRoot as unknown as GameRootForProfileSet;
 
-    // Shallow clone so we don't mutate the caller's tokens.
+    // Shallow clone to match legacy `_.clone(tokens)` — array → slice
+    // (elements shared by reference), object → top-level shallow copy
+    // (`tokens_map` reference shared).  Anything deeper would diverge
+    // from the legacy mutation-propagation behaviour; in practice the
+    // downstream `addtokens.forEach` builds fresh TokenSetEntry objects
+    // so deeper cloning would wash out anyway, but matching legacy is
+    // the safer default for this PR.
     let workTokens: TokensInput;
     if (Array.isArray(tokens)) {
-      workTokens = tokens.map((t) => ({ ...t }));
+      workTokens = tokens.slice();
     } else {
-      workTokens = { tokens_map: { ...tokens.tokens_map } };
+      workTokens = { tokens_map: tokens.tokens_map };
     }
 
     this.data = (groot.getTypeData('ProfileSet') || {}) as Record<string, unknown>;

--- a/scripts/game/ProfileSet.ts
+++ b/scripts/game/ProfileSet.ts
@@ -1,0 +1,252 @@
+// ProfileSet — DB-queue entry representing a profileset awaiting integrate.
+// Used both as a template for buyToken popups and as the cued object in the
+// Database queue.  Extracted from scripts/Game.js's IIFE in PR 9 of
+// issue #147.
+
+import { GameNode, type GameNodeConfig } from './GameNode.js';
+
+interface TokenInput {
+  gestalt?: string;
+  amount?: number;
+  is_query?: boolean;
+  origin_gestalt?: string;
+  [key: string]: unknown;
+}
+
+/** ProfileSet's `tokens` arg can be either a flat token-list or a
+ *  `{ tokens_map: {gestalt: {amount, …}} }` queue payload. */
+type TokensInput =
+  | TokenInput[]
+  | { tokens_map: Record<string, { amount?: number; [key: string]: unknown }> };
+
+interface TokenSetEntry {
+  gestalt: string;
+  amount?: number;
+  collect_amount?: number;
+  data?: Record<string, unknown>;
+  database_amount?: number;
+  database_absoluteAmount?: number;
+  diffAbsoluteAmount?: number;
+  diffAmount?: number;
+  doneAmount?: number;
+  doneAbsoluteAmount?: number;
+  origin_gestalt?: string;
+  is_query?: boolean;
+  new?: boolean;
+  locked?: boolean;
+  [key: string]: unknown;
+}
+
+interface UpgradeValuesShape {
+  profiles_value: number;
+  token_map: Record<string, number>;
+}
+
+interface ProfileSetOriginNode {
+  states?: Record<string, boolean>;
+  data?: Record<string, unknown>;
+  gestalt?: string;
+  id?: string;
+}
+
+/** GameRoot's surface this class touches.  Will collapse when GameRoot
+ *  is extracted into its own typed module. */
+interface GameRootForProfileSet {
+  DBTokens: Record<string, number>;
+  DBTokensAbsolute: Record<string, number>;
+  profiles_value: number;
+  raw_data?: { tokens_seen?: Record<string, unknown>; [key: string]: unknown };
+  getTypeData(gestalt?: string): Record<string, unknown> | undefined;
+}
+
+/** ProfileSet config — extends the base GameNodeConfig with the
+ *  ProfileSet-specific fields that callers stamp on at construction time
+ *  (Database.cue and the various Perp `BuyToken` flows). */
+export interface ProfileSetConfig extends GameNodeConfig {
+  psid?: string;
+  origin?: ProfileSetOriginNode;
+  profiles_value?: number;
+  markNew?: boolean;
+  sortByGestalt?: boolean;
+  convertTokens?: boolean;
+  filter_is_query?: string;
+  DBAmounts?: boolean;
+  lockAmountZero?: boolean;
+  lockNotInDB?: boolean;
+  markUpgradeValues?: boolean;
+  lastUpgradeValues?: UpgradeValuesShape;
+}
+
+export class ProfileSet extends GameNode {
+  psid?: string;
+  origin?: ProfileSetOriginNode;
+  profiles_value?: number;
+  markNew?: boolean;
+  sortByGestalt?: boolean;
+  convertTokens?: boolean;
+  filter_is_query?: string;
+  DBAmounts?: boolean;
+  lockAmountZero?: boolean;
+  lockNotInDB?: boolean;
+  markUpgradeValues?: boolean;
+  lastUpgradeValues?: UpgradeValuesShape;
+
+  /** gestalt → { amount, … } map captured from the queue/collect payload. */
+  tokens_map: Record<string, { amount?: number; [key: string]: unknown }> = {};
+  /** Sorted token entries for the popup template. */
+  tokens_set: TokenSetEntry[] = [];
+
+  /** Popup-template scratch data; stamped by Database.openProfileSetPopup. */
+  popupTemplateData?: Record<string, unknown>;
+
+  constructor(config: ProfileSetConfig, tokens: TokensInput) {
+    // Used both as a Template and as a cued object in DBQueue.
+    super(config);
+    const groot = this.GameRoot as unknown as GameRootForProfileSet;
+
+    // Shallow clone so we don't mutate the caller's tokens.
+    let workTokens: TokensInput;
+    if (Array.isArray(tokens)) {
+      workTokens = tokens.map((t) => ({ ...t }));
+    } else {
+      workTokens = { tokens_map: { ...tokens.tokens_map } };
+    }
+
+    this.data = (groot.getTypeData('ProfileSet') || {}) as Record<string, unknown>;
+    const filter_is_query = this.filter_is_query;
+
+    if (this.convertTokens && Array.isArray(workTokens)) {
+      workTokens = workTokens.map((t: TokenInput) => ({ gestalt: t as unknown as string }));
+    }
+
+    this.tokens_map = {};
+    this.tokens_set = [];
+    let addtokens: TokenInput[] = [];
+
+    if (!Array.isArray(workTokens) && this.origin) {
+      // Assume it's a token_map from the queue or collect.
+      // FIXME: this messes with sorting; either use a sort key or have
+      // backend supply an array.
+      const tokens_map = workTokens.tokens_map || {};
+      for (const k in tokens_map) {
+        if (Object.prototype.hasOwnProperty.call(tokens_map, k)) {
+          const v = tokens_map[k];
+          const addme: TokenInput = { gestalt: k };
+          if (v?.amount !== undefined) addme.amount = v.amount;
+          // collect_amount is profiles_value here.
+          if (this.profiles_value !== undefined) addme.collect_amount = this.profiles_value;
+          // exclude origin tokens
+          if (k.substring(0, 6) !== 'origin') {
+            addtokens.push(addme);
+          }
+        }
+      }
+      this.tokens_map = tokens_map;
+    } else if (Array.isArray(workTokens)) {
+      // Assume it's from the source perp.
+      // exclude origin tokens
+      addtokens = workTokens.filter((n) => {
+        if (n.gestalt) return n.gestalt.substring(0, 6) !== 'origin';
+        return false;
+      });
+      if (config.filter_is_query) {
+        const is_query = filter_is_query === 'blue';
+        addtokens = workTokens.filter((n) => n.is_query === is_query);
+      }
+    }
+
+    // Build and extend the tokens_set.
+    addtokens.forEach((token) => {
+      // Don't mess with the original data.
+      const t: TokenSetEntry = { gestalt: token.gestalt || '', ...token };
+      const td = groot.getTypeData(token.gestalt);
+      if (td) t.data = td;
+      if (this.DBAmounts) {
+        t.database_amount = (token.gestalt ? groot.DBTokens[token.gestalt] : undefined) || 0;
+        t.database_absoluteAmount =
+          (token.gestalt ? groot.DBTokensAbsolute[token.gestalt] : undefined) || 0;
+      }
+      if (this.markNew) {
+        const seenMap: Record<string, unknown> =
+          (groot.raw_data && groot.raw_data.tokens_seen) || {};
+        if (
+          token.gestalt &&
+          !Object.prototype.hasOwnProperty.call(groot.DBTokens, token.gestalt) &&
+          !seenMap[token.gestalt]
+        ) {
+          t.new = true;
+        }
+      }
+      if (this.lockAmountZero && token.amount === 0) {
+        t.locked = true;
+      }
+      if (
+        this.lockNotInDB &&
+        token.gestalt &&
+        !Object.prototype.hasOwnProperty.call(groot.DBTokens, token.gestalt)
+      ) {
+        t.locked = true;
+      }
+      if (this.markUpgradeValues && this.lastUpgradeValues && !t.locked) {
+        const lastProfileValues = this.lastUpgradeValues.profiles_value;
+        const lastAmount = (t.gestalt && this.lastUpgradeValues.token_map[t.gestalt]) || 0;
+        const lastAbsoluteAmount = (lastProfileValues * lastAmount) / 100;
+        const currentAbsoluteAmount = (t.gestalt && groot.DBTokensAbsolute[t.gestalt]) || 0;
+        t.diffAbsoluteAmount = currentAbsoluteAmount - lastAbsoluteAmount;
+        t.doneAbsoluteAmount = (t.database_absoluteAmount || 0) - t.diffAbsoluteAmount;
+        const denom = groot.profiles_value;
+        t.diffAmount = denom ? 100 / (denom / t.diffAbsoluteAmount) : 0;
+        t.doneAmount = (t.database_amount || 0) - t.diffAmount;
+      } else if (this.markUpgradeValues && !this.lastUpgradeValues && !t.locked) {
+        t.diffAbsoluteAmount = (token.gestalt ? groot.DBTokensAbsolute[token.gestalt] : 0) || 0;
+        t.diffAmount = (token.gestalt ? groot.DBTokens[token.gestalt] : 0) || 0;
+        t.doneAmount = 0;
+        t.doneAbsoluteAmount = 0;
+      }
+
+      // FIXME: Show origin data for debug reasons only.
+      if (token.origin_gestalt) {
+        const otd = groot.getTypeData(token.origin_gestalt);
+        if (otd) t.data = otd;
+      }
+      if (t.data) {
+        this.tokens_set.push(t);
+      }
+    });
+
+    // Sort when locked tokens are marked.
+    // biome-ignore lint/suspicious/noSelfCompare: legacy always-true guard, removal is a separate refactor
+    if (this.lockAmountZero || this.lockNotInDB || 0 === 0) {
+      let sorted = this.tokens_set;
+      // FIXME: sortBy Gestalt for messed up TokenSets from CMS/Backend
+      // (DBQueue and Clients).
+      if (this.sortByGestalt) {
+        sorted = sorted
+          .slice()
+          .sort((a, b) => (a.gestalt < b.gestalt ? -1 : a.gestalt > b.gestalt ? 1 : 0));
+      }
+      const unlocked = sorted.filter((t) => !t.locked);
+      const locked = sorted.filter((t) => t.locked);
+      this.tokens_set = unlocked.concat(locked);
+    }
+  }
+
+  updateNewMarker(): void {
+    const groot = this.GameRoot as unknown as GameRootForProfileSet;
+    const seenMap: Record<string, unknown> = (groot.raw_data && groot.raw_data.tokens_seen) || {};
+    this.tokens_set.forEach((token) => {
+      if (
+        token.gestalt &&
+        !Object.prototype.hasOwnProperty.call(groot.DBTokens, token.gestalt) &&
+        !seenMap[token.gestalt]
+      ) {
+        token.new = true;
+      } else {
+        token.new = false;
+      }
+    });
+    if (this.popupTemplateData) {
+      this.popupTemplateData.ProfileSet = this;
+    }
+  }
+}


### PR DESCRIPTION
PR 9 of issue #147 — fourth `GameNode` subclass extraction.

**Reordering note**: this was originally planned as the `Database` extraction, but `Database` imports `ProfileSet` directly, so landing `ProfileSet` first removes one of `Database`'s cross-class refs and makes PR 10's diff smaller.

## What changed

**New: `scripts/game/ProfileSet.ts` (~250 LOC, fully strict-typed).** ES class `extends GameNode`. Used as both a template for buyToken popups and as the cued object in the `Database` queue (`Database.cue` constructs one and prepends to the queue `OrderedSet`).

Class-side surface preserved bit-for-bit:
- **`ProfileSetConfig`** interface gathers all the constructor-time stamps (`psid`, `origin`, `profiles_value`, `markNew`, `sortByGestalt`, `convertTokens`, `filter_is_query`, `DBAmounts`, `lockAmountZero`, `lockNotInDB`, `markUpgradeValues`, `lastUpgradeValues`) so callers (`Database.cue`, the various Perp `BuyToken` flows) get a typed config object instead of `Record<string, unknown>`.
- `tokens_map`: `Record<string, { amount?, [key]: unknown }>` typed field; `tokens_set: TokenSetEntry[]` typed field with the legacy `diff/done/database/locked/new` fields.
- `GameRoot` narrowed via local `GameRootForProfileSet` interface declaring `DBTokens`, `DBTokensAbsolute`, `profiles_value`, `raw_data`, `getTypeData` — the only fields ProfileSet reads.
- `updateNewMarker` preserved.

Behaviour preservation notes:
- Legacy `tokens = _.clone(tokens)` shallow-clone preserved via `Array.isArray`-branched `Array.map` / object-spread.
- Legacy `0 === 0` always-true sort guard at line 1933 preserved with the same biome-ignore comment from `Game.js` (removal is a separate refactor — the gate-effect of the full condition isn't documented).
- The two non-array branches (token_map from queue/collect vs flat list from the source perp) preserve the original control flow.

**`scripts/Game.js`:**
- Imports `ProfileSet` from `./game/ProfileSet.js`.
- Removes ~145 LOC of inline `ProfileSet` class definition (lines 1830-1974 in the pre-PR file).
- Replaces with a comment block pointing to the extracted file.
- The legacy IIFE never published `ProfileSet` on the API publisher; the inline `new ProfileSet(...)` call sites in `Database.cue` and the Perp `BuyToken` methods still work because `ProfileSet` is now imported at module top — same closure visibility, different resolution path.

## Architecture invariants — preserved

- No new `setState` writers — `ProfileSet` is a UI queue entry; engine layer untouched.
- No new `webxdc.sendUpdate` emit sites.
- No new `setTimeout` for game cycles.
- No DOM globals in handler bodies.
- `addr === state.addr` guard at `state.ts:791` untouched.
- `logAction` / `resetGame` policy preserved.

## Cast count — direction

- **`scripts/game/GameNode.ts`: 18 → 18** (held flat).
- **`scripts/game/ProfileSet.ts`: 5 internal casts.** 3 are `GameRoot` forward-refs (`as unknown as GameRootForProfileSet`). 1 is the `(groot.getTypeData('ProfileSet') || {}) as Record<string, unknown>` fallback for `data`. 1 is `t as unknown as string` for the `convertTokens` compat branch (legacy code overloaded the gestalt slot to hold a string in that branch).

All 5 will dissolve when `GameRoot` is extracted with a typed surface and when `convertTokens` callers tighten their token shape.

Render-side narrows are zero in this file because `ProfileSet` has no Render code (popup template is set up by `Database`, which will keep its Render touches when extracted in PR 10).

## Test plan

- [x] `pnpm typecheck` — clean.
- [x] `pnpm exec biome check .` — clean (auto-fix replaced the legacy `var gnode = this` aliases with direct `this` references).
- [x] `pnpm test` — 622 unit tests pass.
- [x] `pnpm test:e2e` — 16 specs pass. `share-merge.spec.ts` and `gameplay.spec.ts` exercise the integrate-collect flow that walks through `Database.cue → new ProfileSet → mergeCued`.
- [x] `pnpm build` — both `.xdc` bundles produced.
- [ ] CI green on PR.

## Roadmap update

- **PR 10: `Database` (~500 LOC).** Now imports `ProfileSet` directly. Still has the dynamic `Game[node.game_type]` lookup + a direct `Game.TokenPerp` ref; will solve via a small `perpRegistry` helper module (register/lookup pattern) so `Database` doesn't need to wait for every Perp class extraction first.
- **PR 11+: Perp classes** (`GamePerp` first, then individual perps).

Refs #147.

---
_Generated by [Claude Code](https://claude.ai/code/session_018qbFtLNgH4p39DmEBtouJu)_