### PR TITLE
phase 7 (#147): extract entire Perp class hierarchy from Game.js IIFE — PR 11–16

### DIFF
--- a/scripts/Game.js
+++ b/scripts/Game.js
@@ -27,6 +27,7 @@ import {
   getParentId,
   remove,
 } from './game/GameNode.js';
+import { GamePerp, setAniTicker } from './game/GamePerp.js';
 import { Imperium } from './game/Imperium.js';
 import { Mission } from './game/Mission.js';
 import { Missions } from './game/Missions.js';
@@ -1873,151 +1874,14 @@ var Game = function () {
   ///////////////////////////////////
   // The GamePerp Base Class
   ///////////////////////////////////
-
-  var GamePerp = function (config) {
-    this.init(config);
-
-    return this;
-  };
-
-  extend(GamePerp, GameNode);
-
-  GamePerp.prototype.cableType = 'in';
-  GamePerp.prototype.labelClass = undefined;
-  GamePerp.prototype.sticky = true;
-  GamePerp.prototype.popupTemplate = 'popup.html';
-
-  GamePerp.prototype.extendRender = function () {
-    var render = this.renderData || {};
-    var node = this.renderNode;
-    node.sticky = this.sticky;
-
-    // TODO: Some mixed Renderer rules, review/rewrite and split up to subclasses when we know how to better handle this
-    if (
-      !this.noConnect &&
-      this.renderType === 'Perp' &&
-      this.parentNode &&
-      this.parentNode.renderType === 'Perp'
-    ) {
-      this.parentNode.renderNode.cableTo(node, { mode: this.cableType });
-    }
-    if (render.config.label) {
-      node.addDecorator(
-        new Render.DecoratorLabel({ text: render.config.label, extendClass: this.labelClass })
-      );
-    }
-    if (this._loadReady) {
-      this.markReady();
-      this._loadReady = undefined;
-    } else if (this._loadTimer) {
-      this.markTimer(this._loadTimer);
-      this._loadTimer = undefined;
-    }
-  };
-
-  GamePerp.prototype.markTimer = function (conf) {
-    if (!conf) {
-      return false;
-    }
-    this.setState('idle', false);
-    this.setState('chargeRunning', true);
-    this.renderTimer = this.renderNode.addDecorator(
-      new Render.DecoratorTimer({
-        duration: conf.duration,
-        serverTime: conf.serverTime,
-        serverStartTime: conf.serverStart,
-      })
-    );
-    this.renderTimer.FXSproing();
-  };
-
-  GamePerp.prototype.initEventHandlers = function () {
-    var gnode = this;
-    var groot = this.GameRoot;
-    gnode.on('dragend', function (e) {
-      e.stopPropagation();
-      // FIXME: Testing Save Coords...
-      gnode.GameRoot.trigger('saveCoordsQueue', [gnode.path, gnode.renderNode.getPosition()]);
-    });
-    gnode.on('vclick', function (e) {
-      e.stopPropagation();
-    });
-    gnode.on('vdblclick', function (e) {
-      e.stopPropagation();
-    });
-
-    gnode.on('after_buy after_create', function (e) {
-      e.stopPropagation();
-      if (gnode.data.story) {
-        groot.makeNotifications({ story: gnode.data.story, storyPerp: gnode });
-      }
-    });
-
-    if (gnode.AniTick) {
-      gnode.on('states_chargeRunning', function (e, state) {
-        e.stopPropagation();
-        if (state) {
-          AniTicker.addListener(gnode);
-        } else {
-          AniTicker.removeListener(gnode);
-        }
-      });
-    }
-
-    if (this.extendEventHandlers) {
-      this.extendEventHandlers();
-    }
-  };
-
-  ///////////////////////////////////
-  // GamePerp open a Popup
-  ///////////////////////////////////
-
-  GamePerp.prototype.updateTemplateData = function () {
-    var groot = this.GameRoot;
-    // Popup instantiated for the first time
-    if (!this.popupTemplateData) {
-      this.popupTemplateData = {};
-      this.popupTemplateData.states = this.states;
-      this.popupTemplateData.status_icons = this.GameRoot.data.status_icons;
-      this.popupTemplateData.data = {};
-      this.popupTemplateData.data.gestalt = this.gestalt;
-      this.popupTemplateData.data.id = this.id;
-      this.popupTemplateData.loading = true;
-      this.popupTemplateData.groot = groot;
-    }
-    // highlight Tabs in popups
-    this.popupTemplateData.highlightTabs = this.highlightTabs || [];
-    _.extend(this.popupTemplateData.data, this.data);
-    // FIXME: make this get game values method on groot
-    this.popupTemplateData.game_values = {
-      xp_level: groot.xp_level,
-    };
-  };
-
-  GamePerp.prototype.openPopup = function () {
-    var groot = this.GameRoot;
-    //gnode.renderNode.setFrame('active');
-
-    // Update TemplateData with current gnode data
-    this.updateTemplateData();
-
-    var popupConfig = {
-      // Fixme: gameNode only used for debug info on logo click
-      gameNode: this,
-      template: this.popupTemplate,
-      templateData: this.popupTemplateData,
-      popupContainer: this.ViewMap,
-    };
-
-    var popup = (this.renderPopup = new Render.Popup(popupConfig));
-
-    this.ViewMap.renderNode.addPopup(popup);
-
-    this.initPopupEvents();
-
-    return popup;
-  };
+  //
+  // Extracted to scripts/game/GamePerp.ts in PR 11 of issue #147.  The
+  // class is imported above; the API publisher at the bottom of this
+  // IIFE re-exposes it as Game.GamePerp.  The dynamic
+  // `Game[node.game_type]` lookup in BuyPerp is routed through
+  // scripts/game/perpRegistry.ts (registered via setPerpClasses(Game)
+  // at the IIFE's tail).  AniTicker is injected via setAniTicker(AniTicker)
+  // at the same spot so GamePerp can subscribe to charge-running animations.
 
   GameNode.prototype.initPopupEvents = function (popup) {
     var gnode = this;
@@ -2142,155 +2006,6 @@ var Game = function () {
     popup.on('button_click.RefreshButton', function (e) {
       e.stopPropagation();
       gnode.GameRoot.refresh();
-    });
-  };
-
-  GamePerp.prototype.updatePopup = function () {
-    if (this.popupTemplateData) {
-      //gnode.popupTemplateData.loading = false;
-    }
-
-    // Update data with current gnode data
-    //_.extend(this.popupTemplateData.data,gnode.data);
-    this.updateTemplateData();
-
-    var popupConfig = {
-      gameNode: this,
-      template: this.popupTemplate,
-      templateData: this.popupTemplateData,
-      popupContainer: this.ViewMap,
-    };
-
-    if (this.renderPopup) {
-      this.renderPopup.remove();
-    }
-    var popup = (this.renderPopup = new Render.Popup(popupConfig));
-
-    this.ViewMap.renderNode.addPopup(popup);
-
-    this.initPopupEvents();
-
-    return popup;
-  };
-
-  GamePerp.prototype.BuyPerp = function (bgestalt, placePos) {
-    var gnode = this;
-    var groot = this.GameRoot;
-    // TODO: backendcall and do purchase...
-    app.remote.buyPerp(gnode.path, bgestalt).done(function (data) {
-      if (data.result) {
-        if (data.result.error !== undefined) {
-          // Probably no cash
-          if (gnode.renderPopup && gnode.renderPopup.open) {
-            if (data.result.error === 2 || data.result === 2) {
-              gnode.renderPopup.trigger('no_cash');
-            } else if (gnode.gameType === 'ProxyPerp' && data.result.error === 3) {
-              gnode.renderPopup.trigger('error');
-              groot.makeNotifications({
-                simplemessage: { text: _._('projectbuy_proxyslotsfull') },
-              });
-            } else {
-              gnode.renderPopup.trigger('error');
-            }
-          } else {
-            gnode.renderNode.FXNoCash();
-          }
-          return;
-        }
-        if (gnode.renderPopup) {
-          gnode.renderPopup.trigger('popup_close');
-        }
-        if (data.result.node) {
-          groot.updateGameValues(
-            data.result.game_values,
-            data.result.levelup,
-            data.result.missions
-          );
-          var node = data.result.node;
-          var node_data = groot.getTypeData(bgestalt);
-          var perp = new Game[node.game_type]({
-            id: node.game_id,
-            gestalt: bgestalt,
-            path: node.full_path,
-            noConnect: true,
-            data: mergeData(node_data, node.instance_data),
-            // Render perps to first item in path (Imperium or Database)
-            renderNodeParent: getFirstId('Imperium'),
-            ViewMap: getByFirstId('Imperium'),
-            gameType: node.game_type,
-          });
-          gnode.addChild(perp);
-          // FIXME: fishy but works?
-          var perpNode = gnode.renderNode;
-          var vector = gnode.parentNode.renderNode.getVectorTo(gnode.renderNode);
-          // golden ratio:
-          if (placePos) {
-          } else {
-            placePos = gnode.renderNode.getVectorPos(vector, 0.61803398875);
-            perp.renderData.config.placeRandom = placePos;
-            perp.renderData.config.placeParentRadius = 320;
-          }
-
-          perp.renderData.config.placeRandom = placePos;
-          perp.renderData.config.placeParentRadius = 0;
-          perp.renderData.config.hidden = true;
-
-          perp.render();
-          groot.trigger('saveCoords', [perp.path, perp.renderNode.getPosition()]);
-          perp.renderNode.addDecorator(
-            new Render.DecoratorNew({ text: _._('New!'), extendClass: 'NewPerp' })
-          );
-          perp.renderNode.hide();
-          perp.renderNode.parentNode.scrollTo(perp.renderNode.getPosition());
-          //perp.renderNode.hide();
-          window.setTimeout(function () {
-            perp.renderNode.FXArise(function () {
-              gnode.renderNode.cableAnimatedTo(
-                perp.renderNode,
-                { mode: perp.cableType },
-                function () {
-                  if (perp.cableType === 'in') {
-                    perp.renderNode.FXBounce();
-                  } else if (perp.cableType === 'out') {
-                    gnode.renderNode.FXBounce();
-                  } else {
-                    gnode.renderNode.FXBounce();
-                    perp.renderNode.FXBounce();
-                  }
-                  if (perp.data.provided_perps && perp.data.provided_perps.length) {
-                    var n = {};
-                    if (perp.gameType === 'PusherPerp') {
-                      n.perps = perp.getProvidedByRequiredPerps();
-                    } else {
-                      n.perps = perp.getProvidedByLevel();
-                    }
-                    var thefirst = getAllByGestalt(perp.gestalt).length <= 1;
-                    if (thefirst) {
-                      groot.makeNotifications(n);
-                    } else {
-                      perp.markNewItems();
-                    }
-                  }
-                }
-              );
-            });
-          }, 300);
-          // save coords to backend
-          perp.trigger('after_buy');
-          return perp;
-        }
-      } else {
-        // Server Error
-        gnode.Error('The computer says NOOOO', data);
-      }
-    });
-  };
-
-  // FIXME DEBUG: testpopup for each gameperp (gets overwritten)
-  GamePerp.prototype.extendEventHandlers = function () {
-    this.on('vclick', function (e, renderNode) {
-      e.stopPropagation();
-      var popup = this.openPopup();
     });
   };
 
@@ -2638,134 +2353,6 @@ var Game = function () {
       });
       var popup = this.openPopup();
     });
-  };
-
-  // FIXME: move this to the GamePerp section
-
-  GamePerp.prototype.markNewItems = function () {
-    /* FIXME? no decorator when max_slots is full?
-      if (this.data && this.data.max_slots) {
-        if (this.children.length >= this.data.max_slots) {
-          return;
-        }
-      }
-      */
-    var text = this.textNewItems || _._('New Items!');
-    this.renderNode.addDecorator(new Render.DecoratorNew({ text: text, arrow: true }));
-  };
-
-  GamePerp.prototype.checkProvidedByRequiredPerps = function () {
-    // checks for provided perps by required providers
-    var gnode = this;
-    var groot = this.GameRoot;
-    _.each(gnode.data.provided_perps, function (gestalt, key) {
-      var type = groot.getType(gestalt);
-      if (type.type_data.required_providers && !groot.IPerps.hasOwnProperty(gestalt)) {
-        _.each(type.type_data.required_providers, function (provided) {
-          if (groot.IPerps.hasOwnProperty(provided)) {
-            gnode.markNewItems();
-          }
-        });
-      }
-    });
-  };
-
-  GamePerp.prototype.getProvidedByRequiredPerps = function () {
-    var groot = this.GameRoot;
-    var perps = [];
-    _.each(this.data.provided_perps, function (gestalt, key) {
-      var type = groot.getType(gestalt);
-      if (type.type_data.required_providers && !groot.IPerps.hasOwnProperty(gestalt)) {
-        _.each(type.type_data.required_providers, function (provided) {
-          if (groot.IPerps.hasOwnProperty(provided)) {
-            perps.push(gestalt);
-          }
-        });
-      }
-    });
-    return perps;
-  };
-
-  GamePerp.prototype.checkProvidedByLevel = function () {
-    // checks for same level
-    var gnode = this;
-    var groot = this.GameRoot;
-    _.each(gnode.data.provided_perps, function (gestalt, key) {
-      var type = groot.getType(gestalt);
-      if (
-        type.type_data.required_level === groot.xp_level.number &&
-        !groot.IPerps.hasOwnProperty(gestalt)
-      ) {
-        gnode.markNewItems();
-      }
-    });
-  };
-
-  GamePerp.prototype.getProvidedByLevel = function () {
-    var groot = this.GameRoot;
-    var perps = [];
-    _.each(this.data.provided_perps, function (gestalt, key) {
-      var type = groot.getType(gestalt);
-      if (
-        type.type_data.required_level <= groot.xp_level.number &&
-        !groot.IPerps.hasOwnProperty(gestalt)
-      ) {
-        perps.push(gestalt);
-      }
-    });
-    return perps;
-  };
-
-  GamePerp.prototype.compileProvided = function () {
-    var gnode = this;
-    var groot = this.GameRoot;
-    gnode.data.providedPerps = [];
-    if (gnode.data.buyablePerps === undefined) {
-      return;
-    }
-    _.each(gnode.data.provided_perps, function (p, key) {
-      var perp = {};
-      var type_data = groot.getTypeData(p);
-      perp.data = type_data;
-      perp.gestalt = p;
-      // Already-owned perps shouldn't appear in the buy dialog at all —
-      // backend `provided_perps` is a static list per-provider, so the
-      // UI is the only place that knows about ownership.
-      if (groot.IPerps.hasOwnProperty(perp.gestalt)) {
-        return;
-      }
-      perp.locked =
-        _.find(gnode.data.buyablePerps, function (v) {
-          return perp.gestalt === v;
-        }) === undefined;
-      if (
-        perp.locked &&
-        perp.data.required_level &&
-        !perp.data.required_providers &&
-        perp.data.required_level <= groot.xp_level.number
-      ) {
-        perp.locked = false;
-      }
-      if (perp.locked) {
-        if (perp.data.required_providers && perp.data.required_providers.length) {
-          perp.data.requiredProviders = [];
-          _.each(perp.data.required_providers, function (v, k) {
-            var tdata = groot.getTypeData(v);
-            if (tdata && tdata.title) {
-              perp.data.requiredProviders.push(tdata.title);
-            }
-          });
-        }
-      }
-      gnode.data.providedPerps.push(perp);
-    });
-    var sorted = _.sortBy(gnode.data.providedPerps, function (v) {
-      return v.data.required_level;
-    });
-    var grouped = _.groupBy(sorted, function (v) {
-      return v.locked ? 1 : 0;
-    });
-    gnode.data.providedPerps = _.flatten(grouped);
   };
 
   ///////////////////////////////////
@@ -4526,6 +4113,11 @@ class CollectableClient(CollectablePerpBase):
   // `Game.TokenPerp` references without an IIFE-closure roundtrip.
   // Disposable seam — retired with the IIFE in the final PR (#147).
   setPerpClasses(Game);
+  // Inject AniTicker into GamePerp so its initEventHandlers can register
+  // listeners on the legacy ticker singleton (which still lives in this
+  // IIFE). Disposable seam alongside setPerpClasses; retires when AniTicker
+  // is itself extracted from Game.js.
+  setAniTicker(AniTicker);
 
   return Game;
 };

--- a/scripts/game/GameNode.ts
+++ b/scripts/game/GameNode.ts
@@ -272,6 +272,11 @@ export class GameNode {
   extendRender?(): void;
   APTick?(): void;
   AniTick?(): void;
+  markReady?(): void;
+
+  /** Set by Imperium / Database / Topscores / Missions in their
+   *  constructors so descendant nodes can resolve a popup container. */
+  ViewMap?: GameNode;
 
   // Legacy GameNode prototype mixins still attached from scripts/Game.js
   // (`GameNode.prototype.openGenericPopup` at Game.js:1199, `Error` /

--- a/scripts/game/GamePerp.ts
+++ b/scripts/game/GamePerp.ts
@@ -1,0 +1,654 @@
+// GamePerp — shared base for the 10 perp subclasses (DatabasePerp,
+// CityPerp, AgentPerp, ContactPerp, PusherPerp, ClientPerp, ProxyPerp,
+// ProjectPerp, TokenPerp, SupertokenPerp).  Extracted from
+// scripts/Game.js's IIFE in PR 11 of issue #147.
+//
+// The dynamic `Game[node.game_type]` lookup in BuyPerp is routed through
+// scripts/game/perpRegistry.ts so GamePerp can land before the individual
+// perp subclasses; PR 12+ extracts each subclass and migrates the
+// registry consumers to direct imports.
+
+import { getRender } from '../Render.js';
+import appModule from '../app.js';
+import {
+  GameNode,
+  type GameNodeConfig,
+  getAllByGestalt,
+  getByFirstId,
+  getFirstId,
+} from './GameNode.js';
+import { mergeData } from './mergeData.js';
+import { lookupPerpClass } from './perpRegistry.js';
+
+// ---------------------------------------------------------------------------
+// Local types
+// ---------------------------------------------------------------------------
+
+type CableType = 'in' | 'out' | 'inout';
+
+interface RenderNodeLike {
+  sticky?: boolean;
+  cableTo?(target: unknown, opts: { mode: CableType }): void;
+  cableAnimatedTo?(target: unknown, opts: { mode: CableType }, cb?: () => void): void;
+  addDecorator?(deco: unknown): unknown;
+  addPopup?(popup: unknown): void;
+  hide?(): void;
+  show?(): void;
+  remove?(): void;
+  getPosition?(): { x: number; y: number };
+  getVectorTo?(target: unknown): unknown;
+  getVectorPos?(vector: unknown, ratio: number): { x: number; y: number };
+  parentNode?: { scrollTo?(pos: { x: number; y: number }): void };
+  jdomelem?: unknown;
+  FXSproing?(): void;
+  FXNoCash?(): void;
+  FXArise?(cb?: () => void): void;
+  FXBounce?(): void;
+  DecoratorNew?: { remove?(): void };
+}
+
+interface RenderPopupLike {
+  open?: boolean;
+  trigger(ev: string, args?: unknown[]): void;
+  close(): void;
+  remove?(): void;
+}
+
+interface TimerConf {
+  duration: number;
+  serverTime?: number;
+  serverStart?: number;
+}
+
+interface GameRootForPerp {
+  data: { status_icons?: unknown; [key: string]: unknown };
+  IPerps: Record<string, true>;
+  xp_level: { number: number; [key: string]: unknown };
+  trigger(ev: string, args?: unknown[]): void;
+  makeNotifications(data: Record<string, unknown>): void;
+  updateGameValues(
+    gv: Record<string, unknown>,
+    levelup?: boolean,
+    missions?: unknown,
+    quiet?: boolean
+  ): void;
+  getType(
+    gestalt?: string
+  ):
+    | { type_data?: Record<string, unknown>; game_type?: string; [key: string]: unknown }
+    | undefined;
+  getTypeData(gestalt?: string): Record<string, unknown> | undefined;
+}
+
+interface BuyPerpResult {
+  game_values?: Record<string, unknown>;
+  levelup?: boolean;
+  missions?: unknown;
+  node?: {
+    game_id?: string;
+    game_type?: string;
+    full_path?: string;
+    instance_data?: Record<string, unknown>;
+  };
+  error?: number;
+}
+
+interface DoneFailChain<T> {
+  done(cb: (data: { result?: T }) => void): DoneFailChain<T>;
+  fail(cb: (data: unknown) => void): DoneFailChain<T>;
+}
+
+/** Animation-singleton interface from Game.js's AniTicker. */
+interface AniTickerLike {
+  addListener(node: GamePerp): void;
+  removeListener(node: GamePerp): void;
+}
+
+/** ProvidedPerp UI-row shape for the buy dialog (compileProvided). */
+interface ProvidedPerpRow {
+  gestalt: string;
+  locked: boolean;
+  data: Record<string, unknown> & {
+    required_level?: number;
+    required_providers?: string[];
+    requiredProviders?: string[];
+    [key: string]: unknown;
+  };
+}
+
+// AniTicker is captured at GamePerp-class scope and injected by Game.js
+// via `setAniTicker` (called once at IIFE-end, alongside setPerpClasses).
+// Keeps GamePerp.ts free of the legacy AniTicker singleton's Game.js-side
+// implementation.
+let _aniTicker: AniTickerLike | null = null;
+export function setAniTicker(ticker: AniTickerLike): void {
+  _aniTicker = ticker;
+}
+
+// ---------------------------------------------------------------------------
+// GamePerp class
+// ---------------------------------------------------------------------------
+
+export class GamePerp extends GameNode {
+  cableType: CableType = 'in';
+  labelClass?: string;
+  sticky = true;
+  popupTemplate = 'popup.html';
+  textNewItems?: string;
+
+  // Init flags carried across renders (legacy fields).
+  _loadReady?: boolean;
+  _loadTimer?: TimerConf;
+  renderTimer?: { FXSproing?(): void } | undefined;
+
+  // Subclass-stamped fields read by GamePerp methods.
+  path?: string;
+  noConnect?: boolean;
+  popupTemplateData?: Record<string, unknown>;
+  highlightTabs?: string[];
+
+  // -------------------------------------------------------------------
+  // Typed accessors (consolidated cast seam, per PR #177 review)
+  // -------------------------------------------------------------------
+
+  private get groot(): GameRootForPerp {
+    return this.GameRoot as unknown as GameRootForPerp;
+  }
+
+  private get renderApi(): RenderNodeLike | undefined {
+    return this.renderNode as RenderNodeLike | undefined;
+  }
+
+  private getRenderModule(): {
+    Popup: new (cfg: unknown) => RenderPopupLike;
+    DecoratorLabel: new (cfg: unknown) => unknown;
+    DecoratorNew: new (cfg: unknown) => unknown;
+    DecoratorTimer: new (cfg: unknown) => { FXSproing?(): void };
+  } {
+    return getRender() as unknown as {
+      Popup: new (cfg: unknown) => RenderPopupLike;
+      DecoratorLabel: new (cfg: unknown) => unknown;
+      DecoratorNew: new (cfg: unknown) => unknown;
+      DecoratorTimer: new (cfg: unknown) => { FXSproing?(): void };
+    };
+  }
+
+  // -------------------------------------------------------------------
+  // Render hooks
+  // -------------------------------------------------------------------
+
+  override extendRender(): void {
+    const Render = this.getRenderModule();
+    const render = this.renderData || {};
+    const node = this.renderApi;
+    if (!node) return;
+    node.sticky = this.sticky;
+
+    // TODO: Some mixed Renderer rules — review/rewrite and split up to
+    // subclasses when we know how to better handle this.
+    if (
+      !this.noConnect &&
+      this.renderType === 'Perp' &&
+      this.parentNode &&
+      this.parentNode.renderType === 'Perp'
+    ) {
+      const parentNode = this.parentNode.renderNode as RenderNodeLike | undefined;
+      parentNode?.cableTo?.(node, { mode: this.cableType });
+    }
+    if (render.config?.label) {
+      node.addDecorator?.(
+        new Render.DecoratorLabel({
+          text: render.config.label,
+          extendClass: this.labelClass,
+        })
+      );
+    }
+    if (this._loadReady) {
+      const markReady = (this as unknown as { markReady?: () => void }).markReady;
+      if (markReady) markReady.call(this);
+      delete this._loadReady;
+    } else if (this._loadTimer) {
+      this.markTimer(this._loadTimer);
+      delete this._loadTimer;
+    }
+  }
+
+  markTimer(conf: TimerConf | undefined): boolean {
+    if (!conf) return false;
+    const Render = this.getRenderModule();
+    this.setState('idle', false);
+    this.setState('chargeRunning', true);
+    this.renderTimer = this.renderApi?.addDecorator?.(
+      new Render.DecoratorTimer({
+        duration: conf.duration,
+        serverTime: conf.serverTime,
+        serverStartTime: conf.serverStart,
+      })
+    ) as { FXSproing?(): void } | undefined;
+    this.renderTimer?.FXSproing?.();
+    return true;
+  }
+
+  override initEventHandlers(): void {
+    const gnode = this;
+    const groot = this.groot;
+
+    gnode.on('dragend', function (e: unknown) {
+      if (e && typeof (e as { stopPropagation?: () => void }).stopPropagation === 'function') {
+        (e as { stopPropagation: () => void }).stopPropagation();
+      }
+      // FIXME: Testing Save Coords.
+      const pos = (gnode.renderNode as RenderNodeLike | undefined)?.getPosition?.();
+      if (gnode.path && pos) {
+        groot.trigger('saveCoordsQueue', [gnode.path, pos]);
+      }
+    });
+    gnode.on('vclick', function (e: unknown) {
+      if (e && typeof (e as { stopPropagation?: () => void }).stopPropagation === 'function') {
+        (e as { stopPropagation: () => void }).stopPropagation();
+      }
+    });
+    gnode.on('vdblclick', function (e: unknown) {
+      if (e && typeof (e as { stopPropagation?: () => void }).stopPropagation === 'function') {
+        (e as { stopPropagation: () => void }).stopPropagation();
+      }
+    });
+
+    gnode.on('after_buy after_create', function (e: unknown) {
+      if (e && typeof (e as { stopPropagation?: () => void }).stopPropagation === 'function') {
+        (e as { stopPropagation: () => void }).stopPropagation();
+      }
+      const story = gnode.data && (gnode.data as { story?: unknown }).story;
+      if (story) {
+        groot.makeNotifications({ story: story, storyPerp: gnode });
+      }
+    });
+
+    if (gnode.AniTick) {
+      gnode.on('states_chargeRunning', function (e: unknown, state: unknown) {
+        if (e && typeof (e as { stopPropagation?: () => void }).stopPropagation === 'function') {
+          (e as { stopPropagation: () => void }).stopPropagation();
+        }
+        if (state) {
+          _aniTicker?.addListener(gnode);
+        } else {
+          _aniTicker?.removeListener(gnode);
+        }
+      });
+    }
+
+    if (this.extendEventHandlers) {
+      this.extendEventHandlers();
+    }
+  }
+
+  // -------------------------------------------------------------------
+  // Popup helpers
+  // -------------------------------------------------------------------
+
+  updateTemplateData(): void {
+    const groot = this.groot;
+    // Popup instantiated for the first time
+    if (!this.popupTemplateData) {
+      const ptd: Record<string, unknown> = {};
+      ptd.states = this.states;
+      ptd.status_icons = groot.data.status_icons;
+      const pd: Record<string, unknown> = {};
+      if (this.gestalt !== undefined) pd.gestalt = this.gestalt;
+      pd.id = this.id;
+      ptd.data = pd;
+      ptd.loading = true;
+      ptd.groot = groot;
+      this.popupTemplateData = ptd;
+    }
+    // Highlight tabs in popups.
+    this.popupTemplateData.highlightTabs = this.highlightTabs || [];
+    Object.assign(this.popupTemplateData.data as Record<string, unknown>, this.data || {});
+    // FIXME: make this a getGameValues method on groot.
+    this.popupTemplateData.game_values = {
+      xp_level: groot.xp_level,
+    };
+  }
+
+  openPopup(): RenderPopupLike {
+    const Render = this.getRenderModule();
+    this.updateTemplateData();
+
+    const popupConfig = {
+      // FIXME: gameNode only used for debug info on logo click.
+      gameNode: this,
+      template: this.popupTemplate,
+      templateData: this.popupTemplateData,
+      popupContainer: (this as unknown as { ViewMap?: GameNode }).ViewMap,
+    };
+
+    const popup = new Render.Popup(popupConfig);
+    this.renderPopup = popup;
+
+    const viewMap = (this as unknown as { ViewMap?: GameNode }).ViewMap;
+    const viewMapNode = viewMap?.renderNode as RenderNodeLike | undefined;
+    viewMapNode?.addPopup?.(popup);
+
+    if (this.initPopupEvents) this.initPopupEvents();
+
+    return popup;
+  }
+
+  updatePopup(): RenderPopupLike {
+    const Render = this.getRenderModule();
+    this.updateTemplateData();
+
+    const popupConfig = {
+      gameNode: this,
+      template: this.popupTemplate,
+      templateData: this.popupTemplateData,
+      popupContainer: (this as unknown as { ViewMap?: GameNode }).ViewMap,
+    };
+
+    if (this.renderPopup) {
+      (this.renderPopup as RenderPopupLike).remove?.();
+    }
+    const popup = new Render.Popup(popupConfig);
+    this.renderPopup = popup;
+
+    const viewMap = (this as unknown as { ViewMap?: GameNode }).ViewMap;
+    const viewMapNode = viewMap?.renderNode as RenderNodeLike | undefined;
+    viewMapNode?.addPopup?.(popup);
+
+    if (this.initPopupEvents) this.initPopupEvents();
+
+    return popup;
+  }
+
+  // -------------------------------------------------------------------
+  // BuyPerp — server round-trip + new-perp creation
+  // -------------------------------------------------------------------
+
+  BuyPerp(bgestalt: string, placePos?: { x: number; y: number }): void {
+    const gnode = this;
+    const groot = this.groot;
+    const Render = this.getRenderModule();
+    const remote = appModule.getApplication().remote;
+    const buyPerpFn = remote.buyPerp;
+    if (!buyPerpFn) return;
+    const path = gnode.path || '';
+    const call = buyPerpFn(path, bgestalt) as unknown as DoneFailChain<BuyPerpResult>;
+    call.done(function (data) {
+      if (!data.result) {
+        // Server Error
+        gnode.Error?.('The computer says NOOOO', data);
+        return;
+      }
+      const r = data.result;
+      if (r.error !== undefined) {
+        // Probably no cash (or proxy slots full).
+        if (gnode.renderPopup && (gnode.renderPopup as RenderPopupLike).open) {
+          if (r.error === 2) {
+            gnode.renderPopup.trigger('no_cash');
+          } else if (gnode.gameType === 'ProxyPerp' && r.error === 3) {
+            gnode.renderPopup.trigger('error');
+            groot.makeNotifications({
+              simplemessage: { text: i18nProxySlotsFull() },
+            });
+          } else {
+            gnode.renderPopup.trigger('error');
+          }
+        } else {
+          (gnode.renderNode as RenderNodeLike | undefined)?.FXNoCash?.();
+        }
+        return;
+      }
+      if (gnode.renderPopup) {
+        gnode.renderPopup.trigger('popup_close');
+      }
+      if (!r.node) return;
+      groot.updateGameValues(r.game_values || {}, r.levelup === true, r.missions);
+      const node = r.node;
+      const nodeGameType = node.game_type;
+      if (!nodeGameType) return;
+      const Ctor = lookupPerpClass(nodeGameType);
+      if (!Ctor) return;
+      const node_data = groot.getTypeData(bgestalt);
+      const perp = new Ctor({
+        id: node.game_id,
+        gestalt: bgestalt,
+        path: node.full_path,
+        noConnect: true,
+        data: mergeData(node_data, node.instance_data),
+        // Render perps to first item in path (Imperium or Database).
+        renderNodeParent: getFirstId('Imperium'),
+        ViewMap: getByFirstId('Imperium'),
+        gameType: nodeGameType,
+      }) as GamePerp & {
+        renderData: {
+          config: {
+            placeRandom?: { x: number; y: number };
+            placeParentRadius?: number;
+            hidden?: boolean;
+          };
+        };
+        data: { contained_tokens?: unknown[]; provided_perps?: string[]; [key: string]: unknown };
+      };
+      gnode.addChild(perp);
+      // FIXME: fishy but works?
+      const gnodeRn = gnode.renderNode as RenderNodeLike | undefined;
+      const parentRn = gnode.parentNode?.renderNode as RenderNodeLike | undefined;
+      if (gnodeRn && parentRn) {
+        const vector = parentRn.getVectorTo?.(gnodeRn);
+        // Golden ratio.
+        if (!placePos && vector) {
+          const calced = gnodeRn.getVectorPos?.(vector, 0.61803398875);
+          if (calced) {
+            placePos = calced;
+            perp.renderData.config.placeRandom = placePos;
+            perp.renderData.config.placeParentRadius = 320;
+          }
+        }
+      }
+
+      if (placePos) perp.renderData.config.placeRandom = placePos;
+      perp.renderData.config.placeParentRadius = 0;
+      perp.renderData.config.hidden = true;
+
+      perp.render();
+      const perpRn = perp.renderNode as RenderNodeLike | undefined;
+      const perpPos = perpRn?.getPosition?.();
+      if (perp.path && perpPos) {
+        groot.trigger('saveCoords', [perp.path, perpPos]);
+      }
+      perpRn?.addDecorator?.(new Render.DecoratorNew({ text: i18nNew(), extendClass: 'NewPerp' }));
+      perpRn?.hide?.();
+      if (perpPos) perpRn?.parentNode?.scrollTo?.(perpPos);
+
+      window.setTimeout(function () {
+        perpRn?.FXArise?.(function () {
+          gnodeRn?.cableAnimatedTo?.(perpRn, { mode: perp.cableType }, function () {
+            if (perp.cableType === 'in') {
+              perpRn?.FXBounce?.();
+            } else if (perp.cableType === 'out') {
+              gnodeRn?.FXBounce?.();
+            } else {
+              gnodeRn?.FXBounce?.();
+              perpRn?.FXBounce?.();
+            }
+            if (perp.data.provided_perps && perp.data.provided_perps.length) {
+              const n: { perps?: string[] } = {};
+              if (perp.gameType === 'PusherPerp') {
+                n.perps = perp.getProvidedByRequiredPerps();
+              } else {
+                n.perps = perp.getProvidedByLevel();
+              }
+              const thefirst = (perp.gestalt ? getAllByGestalt(perp.gestalt).length : 0) <= 1;
+              if (thefirst) {
+                groot.makeNotifications(n as Record<string, unknown>);
+              } else {
+                perp.markNewItems();
+              }
+            }
+          });
+        });
+      }, 300);
+      perp.trigger('after_buy');
+    });
+  }
+
+  // FIXME DEBUG: testpopup for each gameperp (gets overwritten).
+  override extendEventHandlers(): void {
+    const gnode = this;
+    this.on('vclick', function (e: unknown) {
+      if (e && typeof (e as { stopPropagation?: () => void }).stopPropagation === 'function') {
+        (e as { stopPropagation: () => void }).stopPropagation();
+      }
+      gnode.openPopup();
+    });
+  }
+
+  // -------------------------------------------------------------------
+  // Provided-perps helpers (UI compile + new-item marking)
+  // -------------------------------------------------------------------
+
+  markNewItems(): void {
+    /* FIXME? no decorator when max_slots is full?
+       if (this.data && this.data.max_slots) {
+         if (this.children.length >= this.data.max_slots) return;
+       }
+    */
+    const Render = this.getRenderModule();
+    const text = this.textNewItems || i18nNewItems();
+    this.renderApi?.addDecorator?.(new Render.DecoratorNew({ text: text, arrow: true }));
+  }
+
+  checkProvidedByRequiredPerps(): void {
+    // Checks for provided perps by required providers.
+    const groot = this.groot;
+    const provided = (this.data as { provided_perps?: string[] } | undefined)?.provided_perps || [];
+    provided.forEach((gestalt) => {
+      const type = groot.getType(gestalt);
+      const td = type?.type_data as { required_providers?: string[] } | undefined;
+      if (td?.required_providers && !Object.prototype.hasOwnProperty.call(groot.IPerps, gestalt)) {
+        td.required_providers.forEach((p) => {
+          if (Object.prototype.hasOwnProperty.call(groot.IPerps, p)) {
+            this.markNewItems();
+          }
+        });
+      }
+    });
+  }
+
+  getProvidedByRequiredPerps(): string[] {
+    const groot = this.groot;
+    const perps: string[] = [];
+    const provided = (this.data as { provided_perps?: string[] } | undefined)?.provided_perps || [];
+    provided.forEach((gestalt) => {
+      const type = groot.getType(gestalt);
+      const td = type?.type_data as { required_providers?: string[] } | undefined;
+      if (td?.required_providers && !Object.prototype.hasOwnProperty.call(groot.IPerps, gestalt)) {
+        td.required_providers.forEach((p) => {
+          if (Object.prototype.hasOwnProperty.call(groot.IPerps, p)) {
+            perps.push(gestalt);
+          }
+        });
+      }
+    });
+    return perps;
+  }
+
+  checkProvidedByLevel(): void {
+    // Checks for same level.
+    const groot = this.groot;
+    const provided = (this.data as { provided_perps?: string[] } | undefined)?.provided_perps || [];
+    provided.forEach((gestalt) => {
+      const type = groot.getType(gestalt);
+      const td = type?.type_data as { required_level?: number } | undefined;
+      if (
+        td?.required_level === groot.xp_level.number &&
+        !Object.prototype.hasOwnProperty.call(groot.IPerps, gestalt)
+      ) {
+        this.markNewItems();
+      }
+    });
+  }
+
+  getProvidedByLevel(): string[] {
+    const groot = this.groot;
+    const perps: string[] = [];
+    const provided = (this.data as { provided_perps?: string[] } | undefined)?.provided_perps || [];
+    provided.forEach((gestalt) => {
+      const type = groot.getType(gestalt);
+      const td = type?.type_data as { required_level?: number } | undefined;
+      if (
+        typeof td?.required_level === 'number' &&
+        td.required_level <= groot.xp_level.number &&
+        !Object.prototype.hasOwnProperty.call(groot.IPerps, gestalt)
+      ) {
+        perps.push(gestalt);
+      }
+    });
+    return perps;
+  }
+
+  compileProvided(): void {
+    const groot = this.groot;
+    const dataRec = this.data as {
+      provided_perps?: string[];
+      buyablePerps?: string[];
+      providedPerps?: ProvidedPerpRow[];
+    };
+    dataRec.providedPerps = [];
+    if (dataRec.buyablePerps === undefined) return;
+    const provided = dataRec.provided_perps || [];
+    provided.forEach((p) => {
+      // Already-owned perps shouldn't appear in the buy dialog at all —
+      // backend `provided_perps` is a static list per-provider, so the
+      // UI is the only place that knows about ownership.
+      if (Object.prototype.hasOwnProperty.call(groot.IPerps, p)) return;
+      const type_data = (groot.getTypeData(p) || {}) as ProvidedPerpRow['data'];
+      const perp: ProvidedPerpRow = {
+        gestalt: p,
+        data: type_data,
+        locked: dataRec.buyablePerps?.find((v) => p === v) === undefined,
+      };
+      if (
+        perp.locked &&
+        perp.data.required_level &&
+        !perp.data.required_providers &&
+        perp.data.required_level <= groot.xp_level.number
+      ) {
+        perp.locked = false;
+      }
+      if (perp.locked && perp.data.required_providers && perp.data.required_providers.length) {
+        perp.data.requiredProviders = [];
+        perp.data.required_providers.forEach((v) => {
+          const tdata = groot.getTypeData(v);
+          if (tdata && typeof tdata.title === 'string') {
+            perp.data.requiredProviders?.push(tdata.title);
+          }
+        });
+      }
+      dataRec.providedPerps?.push(perp);
+    });
+    // Sort by required_level then partition unlocked/locked.
+    const sorted = (dataRec.providedPerps || []).slice().sort((a, b) => {
+      const ra = a.data.required_level ?? 0;
+      const rb = b.data.required_level ?? 0;
+      return ra - rb;
+    });
+    const unlocked = sorted.filter((v) => !v.locked);
+    const locked = sorted.filter((v) => v.locked);
+    dataRec.providedPerps = unlocked.concat(locked);
+  }
+}
+
+// Lazy i18n string fetches — `_._` reads the i18n.gettext mixin off the
+// underscore global registered by app.ts.  Pulled into helpers because
+// the strings are used at multiple sites inside long callbacks where
+// inlining the global access wouldn't read clean.
+function i18nNew(): string {
+  return (globalThis._ as unknown as { _(s: string): string })._('New!');
+}
+function i18nNewItems(): string {
+  return (globalThis._ as unknown as { _(s: string): string })._('New Items!');
+}
+function i18nProxySlotsFull(): string {
+  return (globalThis._ as unknown as { _(s: string): string })._('projectbuy_proxyslotsfull');
+}

--- a/scripts/game/GamePerp.ts
+++ b/scripts/game/GamePerp.ts
@@ -10,9 +10,9 @@
 
 import { getRender } from '../Render.js';
 import appModule from '../app.js';
+import i18n from '../i18n.js';
 import {
   GameNode,
-  type GameNodeConfig,
   getAllByGestalt,
   getByFirstId,
   getFirstId,
@@ -204,8 +204,7 @@ export class GamePerp extends GameNode {
       );
     }
     if (this._loadReady) {
-      const markReady = (this as unknown as { markReady?: () => void }).markReady;
-      if (markReady) markReady.call(this);
+      this.markReady?.();
       delete this._loadReady;
     } else if (this._loadTimer) {
       this.markTimer(this._loadTimer);
@@ -229,35 +228,28 @@ export class GamePerp extends GameNode {
     return true;
   }
 
+  private static _stopProp(e: unknown): void {
+    const fn = (e as { stopPropagation?: () => void } | null | undefined)?.stopPropagation;
+    if (typeof fn === 'function') fn.call(e);
+  }
+
   override initEventHandlers(): void {
     const gnode = this;
     const groot = this.groot;
 
     gnode.on('dragend', function (e: unknown) {
-      if (e && typeof (e as { stopPropagation?: () => void }).stopPropagation === 'function') {
-        (e as { stopPropagation: () => void }).stopPropagation();
-      }
+      GamePerp._stopProp(e);
       // FIXME: Testing Save Coords.
       const pos = (gnode.renderNode as RenderNodeLike | undefined)?.getPosition?.();
       if (gnode.path && pos) {
         groot.trigger('saveCoordsQueue', [gnode.path, pos]);
       }
     });
-    gnode.on('vclick', function (e: unknown) {
-      if (e && typeof (e as { stopPropagation?: () => void }).stopPropagation === 'function') {
-        (e as { stopPropagation: () => void }).stopPropagation();
-      }
-    });
-    gnode.on('vdblclick', function (e: unknown) {
-      if (e && typeof (e as { stopPropagation?: () => void }).stopPropagation === 'function') {
-        (e as { stopPropagation: () => void }).stopPropagation();
-      }
-    });
+    gnode.on('vclick', GamePerp._stopProp);
+    gnode.on('vdblclick', GamePerp._stopProp);
 
     gnode.on('after_buy after_create', function (e: unknown) {
-      if (e && typeof (e as { stopPropagation?: () => void }).stopPropagation === 'function') {
-        (e as { stopPropagation: () => void }).stopPropagation();
-      }
+      GamePerp._stopProp(e);
       const story = gnode.data && (gnode.data as { story?: unknown }).story;
       if (story) {
         groot.makeNotifications({ story: story, storyPerp: gnode });
@@ -266,9 +258,7 @@ export class GamePerp extends GameNode {
 
     if (gnode.AniTick) {
       gnode.on('states_chargeRunning', function (e: unknown, state: unknown) {
-        if (e && typeof (e as { stopPropagation?: () => void }).stopPropagation === 'function') {
-          (e as { stopPropagation: () => void }).stopPropagation();
-        }
+        GamePerp._stopProp(e);
         if (state) {
           _aniTicker?.addListener(gnode);
         } else {
@@ -310,23 +300,24 @@ export class GamePerp extends GameNode {
     };
   }
 
-  openPopup(): RenderPopupLike {
+  private _buildPopup(replaceExisting: boolean): RenderPopupLike {
     const Render = this.getRenderModule();
     this.updateTemplateData();
 
-    const popupConfig = {
+    const popup = new Render.Popup({
       // FIXME: gameNode only used for debug info on logo click.
       gameNode: this,
       template: this.popupTemplate,
       templateData: this.popupTemplateData,
-      popupContainer: (this as unknown as { ViewMap?: GameNode }).ViewMap,
-    };
+      popupContainer: this.ViewMap,
+    });
 
-    const popup = new Render.Popup(popupConfig);
+    if (replaceExisting && this.renderPopup) {
+      (this.renderPopup as RenderPopupLike).remove?.();
+    }
     this.renderPopup = popup;
 
-    const viewMap = (this as unknown as { ViewMap?: GameNode }).ViewMap;
-    const viewMapNode = viewMap?.renderNode as RenderNodeLike | undefined;
+    const viewMapNode = this.ViewMap?.renderNode as RenderNodeLike | undefined;
     viewMapNode?.addPopup?.(popup);
 
     if (this.initPopupEvents) this.initPopupEvents();
@@ -334,30 +325,12 @@ export class GamePerp extends GameNode {
     return popup;
   }
 
+  openPopup(): RenderPopupLike {
+    return this._buildPopup(false);
+  }
+
   updatePopup(): RenderPopupLike {
-    const Render = this.getRenderModule();
-    this.updateTemplateData();
-
-    const popupConfig = {
-      gameNode: this,
-      template: this.popupTemplate,
-      templateData: this.popupTemplateData,
-      popupContainer: (this as unknown as { ViewMap?: GameNode }).ViewMap,
-    };
-
-    if (this.renderPopup) {
-      (this.renderPopup as RenderPopupLike).remove?.();
-    }
-    const popup = new Render.Popup(popupConfig);
-    this.renderPopup = popup;
-
-    const viewMap = (this as unknown as { ViewMap?: GameNode }).ViewMap;
-    const viewMapNode = viewMap?.renderNode as RenderNodeLike | undefined;
-    viewMapNode?.addPopup?.(popup);
-
-    if (this.initPopupEvents) this.initPopupEvents();
-
-    return popup;
+    return this._buildPopup(true);
   }
 
   // -------------------------------------------------------------------
@@ -388,7 +361,7 @@ export class GamePerp extends GameNode {
           } else if (gnode.gameType === 'ProxyPerp' && r.error === 3) {
             gnode.renderPopup.trigger('error');
             groot.makeNotifications({
-              simplemessage: { text: i18nProxySlotsFull() },
+              simplemessage: { text: i18n.gettext('projectbuy_proxyslotsfull') },
             });
           } else {
             gnode.renderPopup.trigger('error');
@@ -456,7 +429,9 @@ export class GamePerp extends GameNode {
       if (perp.path && perpPos) {
         groot.trigger('saveCoords', [perp.path, perpPos]);
       }
-      perpRn?.addDecorator?.(new Render.DecoratorNew({ text: i18nNew(), extendClass: 'NewPerp' }));
+      perpRn?.addDecorator?.(
+        new Render.DecoratorNew({ text: i18n.gettext('New!'), extendClass: 'NewPerp' })
+      );
       perpRn?.hide?.();
       if (perpPos) perpRn?.parentNode?.scrollTo?.(perpPos);
 
@@ -496,9 +471,7 @@ export class GamePerp extends GameNode {
   override extendEventHandlers(): void {
     const gnode = this;
     this.on('vclick', function (e: unknown) {
-      if (e && typeof (e as { stopPropagation?: () => void }).stopPropagation === 'function') {
-        (e as { stopPropagation: () => void }).stopPropagation();
-      }
+      GamePerp._stopProp(e);
       gnode.openPopup();
     });
   }
@@ -514,76 +487,63 @@ export class GamePerp extends GameNode {
        }
     */
     const Render = this.getRenderModule();
-    const text = this.textNewItems || i18nNewItems();
+    const text = this.textNewItems || i18n.gettext('New Items!');
     this.renderApi?.addDecorator?.(new Render.DecoratorNew({ text: text, arrow: true }));
   }
 
-  checkProvidedByRequiredPerps(): void {
-    // Checks for provided perps by required providers.
+  /** Walks `data.provided_perps`, skipping already-owned ones, and calls
+   *  `match` on each gestalt whose `type_data` satisfies `predicate`. */
+  private _walkProvided(
+    predicate: (
+      td: { required_providers?: string[]; required_level?: number } | undefined,
+      groot: GameRootForPerp
+    ) => boolean,
+    match: (gestalt: string) => void
+  ): void {
     const groot = this.groot;
     const provided = (this.data as { provided_perps?: string[] } | undefined)?.provided_perps || [];
     provided.forEach((gestalt) => {
-      const type = groot.getType(gestalt);
-      const td = type?.type_data as { required_providers?: string[] } | undefined;
-      if (td?.required_providers && !Object.prototype.hasOwnProperty.call(groot.IPerps, gestalt)) {
-        td.required_providers.forEach((p) => {
-          if (Object.prototype.hasOwnProperty.call(groot.IPerps, p)) {
-            this.markNewItems();
-          }
-        });
-      }
+      if (Object.prototype.hasOwnProperty.call(groot.IPerps, gestalt)) return;
+      const td = groot.getType(gestalt)?.type_data as
+        | { required_providers?: string[]; required_level?: number }
+        | undefined;
+      if (predicate(td, groot)) match(gestalt);
     });
   }
 
+  private static _hasOwnedRequiredProvider(
+    td: { required_providers?: string[] } | undefined,
+    groot: GameRootForPerp
+  ): boolean {
+    return !!td?.required_providers?.some((p) =>
+      Object.prototype.hasOwnProperty.call(groot.IPerps, p)
+    );
+  }
+
+  checkProvidedByRequiredPerps(): void {
+    this._walkProvided(GamePerp._hasOwnedRequiredProvider, () => this.markNewItems());
+  }
+
   getProvidedByRequiredPerps(): string[] {
-    const groot = this.groot;
     const perps: string[] = [];
-    const provided = (this.data as { provided_perps?: string[] } | undefined)?.provided_perps || [];
-    provided.forEach((gestalt) => {
-      const type = groot.getType(gestalt);
-      const td = type?.type_data as { required_providers?: string[] } | undefined;
-      if (td?.required_providers && !Object.prototype.hasOwnProperty.call(groot.IPerps, gestalt)) {
-        td.required_providers.forEach((p) => {
-          if (Object.prototype.hasOwnProperty.call(groot.IPerps, p)) {
-            perps.push(gestalt);
-          }
-        });
-      }
-    });
+    this._walkProvided(GamePerp._hasOwnedRequiredProvider, (g) => perps.push(g));
     return perps;
   }
 
   checkProvidedByLevel(): void {
-    // Checks for same level.
-    const groot = this.groot;
-    const provided = (this.data as { provided_perps?: string[] } | undefined)?.provided_perps || [];
-    provided.forEach((gestalt) => {
-      const type = groot.getType(gestalt);
-      const td = type?.type_data as { required_level?: number } | undefined;
-      if (
-        td?.required_level === groot.xp_level.number &&
-        !Object.prototype.hasOwnProperty.call(groot.IPerps, gestalt)
-      ) {
-        this.markNewItems();
-      }
-    });
+    this._walkProvided(
+      (td, groot) => td?.required_level === groot.xp_level.number,
+      () => this.markNewItems()
+    );
   }
 
   getProvidedByLevel(): string[] {
-    const groot = this.groot;
     const perps: string[] = [];
-    const provided = (this.data as { provided_perps?: string[] } | undefined)?.provided_perps || [];
-    provided.forEach((gestalt) => {
-      const type = groot.getType(gestalt);
-      const td = type?.type_data as { required_level?: number } | undefined;
-      if (
-        typeof td?.required_level === 'number' &&
-        td.required_level <= groot.xp_level.number &&
-        !Object.prototype.hasOwnProperty.call(groot.IPerps, gestalt)
-      ) {
-        perps.push(gestalt);
-      }
-    });
+    this._walkProvided(
+      (td, groot) =>
+        typeof td?.required_level === 'number' && td.required_level <= groot.xp_level.number,
+      (g) => perps.push(g)
+    );
     return perps;
   }
 
@@ -596,6 +556,7 @@ export class GamePerp extends GameNode {
     };
     dataRec.providedPerps = [];
     if (dataRec.buyablePerps === undefined) return;
+    const buyable = new Set(dataRec.buyablePerps);
     const provided = dataRec.provided_perps || [];
     provided.forEach((p) => {
       // Already-owned perps shouldn't appear in the buy dialog at all —
@@ -606,7 +567,7 @@ export class GamePerp extends GameNode {
       const perp: ProvidedPerpRow = {
         gestalt: p,
         data: type_data,
-        locked: dataRec.buyablePerps?.find((v) => p === v) === undefined,
+        locked: !buyable.has(p),
       };
       if (
         perp.locked &&
@@ -639,16 +600,3 @@ export class GamePerp extends GameNode {
   }
 }
 
-// Lazy i18n string fetches — `_._` reads the i18n.gettext mixin off the
-// underscore global registered by app.ts.  Pulled into helpers because
-// the strings are used at multiple sites inside long callbacks where
-// inlining the global access wouldn't read clean.
-function i18nNew(): string {
-  return (globalThis._ as unknown as { _(s: string): string })._('New!');
-}
-function i18nNewItems(): string {
-  return (globalThis._ as unknown as { _(s: string): string })._('New Items!');
-}
-function i18nProxySlotsFull(): string {
-  return (globalThis._ as unknown as { _(s: string): string })._('projectbuy_proxyslotsfull');
-}

--- a/scripts/game/GamePerp.ts
+++ b/scripts/game/GamePerp.ts
@@ -11,12 +11,7 @@
 import { getRender } from '../Render.js';
 import appModule from '../app.js';
 import i18n from '../i18n.js';
-import {
-  GameNode,
-  getAllByGestalt,
-  getByFirstId,
-  getFirstId,
-} from './GameNode.js';
+import { GameNode, getAllByGestalt, getByFirstId, getFirstId } from './GameNode.js';
 import { mergeData } from './mergeData.js';
 import { lookupPerpClass } from './perpRegistry.js';
 
@@ -599,4 +594,3 @@ export class GamePerp extends GameNode {
     dataRec.providedPerps = unlocked.concat(locked);
   }
 }
-


### PR DESCRIPTION
## Summary

Stacked extraction of the entire Perp class hierarchy from `scripts/Game.js`'s IIFE into `scripts/game/*.ts` modules under strict TypeScript. Previously this PR was scoped to just PR 11 (GamePerp); the branch now carries PR 11–16, which extracts **all 10 Perp subclasses**.

## Stack

| PR | Class(es) | LOC removed from Game.js |
|---|---|---:|
| 11 | `GamePerp` (shared base for all 10 perp subclasses) + `perpRegistry` seam refresh + `setAniTicker` injection | ~640 |
| 12 | `DatabasePerp` + `CityPerp` | ~264 |
| 13 | `AgentPerp` + `ProxyPerp` | ~95 |
| 14 | `ContactPerp` + `PusherPerp` | ~248 |
| 15 | `ClientPerp` + `ProjectPerp` + `powerupTypes.ts` helper | ~973 |
| 16 | `TokenPerp` + `SupertokenPerp` | ~381 |

**Total Game.js reduction: ~2,600 lines.** All 10 Perp subclasses extracted (Database / City / Agent / Proxy / Contact / Pusher / Client / Project / Token / Supertoken). The `perpRegistry` seam can retire next.

## Key patterns established

**Cast-consolidation (per PR #177 review):**
- `protected get groot()` accessor returning a per-subclass narrow that `extends GameRootForPerp`. Drops 4+ inline casts per subclass.
- Shared types exported from `GamePerp.ts`: `RenderNodeLike`, `RenderPopupLike`, `BuyPerpResult`, `ChargeResult`, `DoneFailChain`, `ProvidedPerpRow`, `GameRootForPerp`. Subclasses import instead of redeclaring.
- `protected static _stopProp(e: unknown)` helper on `GamePerp`; subclasses call it instead of hand-rolled stopPropagation guards.
- `protected _serverError(data)` helper for the 16+ literal `gnode.Error?.('The computer says NOOOO', data)` sites.

**Class-field overrides** (per PR #175 review pattern): `override renderType = 'Perp'`, `override popupTemplate = '...'`, `override cableType = 'inout' as const` etc. on every subclass. No prototype assignment.

**Disposable seams** (retired with the IIFE in the final PR):
- `perpRegistry` (`setPerpClasses(Game)` / `lookupPerpClass(name)`) for cross-class dynamic lookups (`Game[node.game_type]`).
- `setAniTicker(AniTicker)` injection from Game.js.

## Architecture invariants — preserved

- No `setTimeout` for game cycles (300ms `FXArise` is animation choreography, not a cycle driver).
- State source-of-truth is `webxdc.sendUpdate` history; no new emit paths.
- No DOM globals in handler bodies (jQuery wrappers for the GameNode event bus only).
- Pure functions in the engine layer untouched.
- `addr === state.addr` guard on per-self reducers preserved.
- `logAction` policy = drop; `resetGame` removed.

## GameRoot / GameNode mixins preserved in Game.js

Mixins embedded *between* extracted Perp blocks were preserved in place — they're not perp methods:
- `GameNode.prototype.{Error, NoCash, NoAP, fetchProvided, initPopupEvents, openGenericPopup}`
- `GameRoot.prototype.{getCityOriginAmounts, getDBFactorNormalized, fetchProjectPowerupData}`

These migrate later when GameRoot itself extracts.

## Latent bug preserved (flagged for separate issue)

PR 16 surfaces a runtime quirk: legacy Game.js had `TokenPerp.prototype.cableType = 'inout'` typo'd in the *Supertoken* prototype-defaults block, overriding the `'in'` set in the Token block. At runtime, TokenPerp.cableType is `'inout'` and SupertokenPerp's is the GamePerp default `'in'`. Preserved exactly in `TokenPerp.ts:95-99` with a code comment; flagged for the issue tracker.

## Cumulative simplify findings applied across the stack

- N+1 fixes: `compileProvided` `.find` → `Set.has`; `compilePowerups` lookup table; `getIncome` extracted `getIncomeBase()` to avoid double token-reduction on popup-open.
- Helpers added on `GamePerp`: `_stopProp`, `_serverError`.
- Multi-pass filter → single-pass categorize in `CityPerp.compileProvided`.
- 4 walker methods unified to `_walkProvided(predicate, match)` in `GamePerp` (PR 12 fixup).
- `_buildPopup(replaceExisting)` consolidates `openPopup` / `updatePopup`.
- Per-instance `i18n.gettext` instead of class-load-time `_._('...')`.
- `Math.trunc` instead of `Number.parseInt(String(...))` for integer truncation.
- Dropped duplicated forward-ref interfaces — single source of truth in GamePerp.ts.
- ProjectPerp.Charge.done nested if/else flattened with ternary chargeDetail.

## Verification

- `npx tsc --noEmit` — clean.
- `pnpm exec biome check .` — clean.
- `pnpm test` — 622/622 pass.
- `pnpm test:e2e` — 16/16 pass (1 skipped, unrelated).
- `pnpm run build` — both `.xdc` variants build green.

## Commit log on this branch

```
a5bef52 PR 16: extract TokenPerp + SupertokenPerp from Game.js IIFE
eb73a63 ClientPerp + ProjectPerp + ContactPerp + DatabasePerp: simplify findings
a880361 PR 15: extract ClientPerp + ProjectPerp from Game.js IIFE
6f625b2 PR 14: extract ContactPerp + PusherPerp from Game.js IIFE
77a5460 PR 13: extract AgentPerp + ProxyPerp from Game.js IIFE
e66aa57 PR 12 simplify findings: groot getter promotion, _stopProp protected, walker consolidation
25b6012 PR 12: extract DatabasePerp + CityPerp from Game.js IIFE
68e9e5e PR 11: biome format fix
0b44d57 PR 11 review/simplify fixup
bc711622 PR 11: extract GamePerp shared base
```

## What remains for issue #147 (after this PR lands)

1. Retire `perpRegistry` / `setPerpClasses` seam — replace with direct imports.
2. Extract `GameNode.prototype.*` mixins into `GameNode.ts`.
3. Extract `GameRoot` from Game.js.
4. Type `Render.js` subclasses one PR at a time.
5. Final PR: drop `allowJs`, remove all `// @ts-nocheck`, close #147.

## Test plan

- [ ] CI lint / typecheck / unit-tests / build / playwright all green.
- [ ] Drop the .xdc into Delta Chat; smoke-test buy → charge → collect → integrate cycles for at least one of each perp type.
- [ ] Verify Token charge animation (cable-in stagger 300+150ms per contained token) and collect FXSpinner display.
- [ ] Verify Project popup buy/sell flows and powerup-slot updates (most complex updatePopupGracefully path).

https://claude.ai/code/session_018qbFtLNgH4p39DmEBtouJu