### PR TITLE
ci: split Tests workflow into lint / typecheck / unit-tests / build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,11 +8,9 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
-    name: Unit tests
+  lint:
+    name: Lint (Biome)
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
@@ -32,14 +30,46 @@ jobs:
       - name: Lint + format check (Biome)
         run: pnpm exec biome check .
 
+  typecheck:
+    name: Type-check (tsc)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
       - name: Type-check (tsc --noEmit)
         run: pnpm typecheck
 
-      - name: Build both variants (HQ + casual)
-        # Casual variant assets are pre-quantized in img-casual/ and
-        # icon-casual.png; CI does not need pngquant/oxipng installed.
-        # See README.md "Bundle variants" and `pnpm quantize-assets`.
-        run: pnpm build:all
+  unit-tests:
+    name: Unit tests (vitest)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
 
       - name: Run tests with coverage
         run: pnpm test:coverage
@@ -51,6 +81,33 @@ jobs:
           name: coverage-report
           path: coverage/
           retention-days: 30
+
+  build:
+    name: Build .xdc bundles
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build both variants (HQ + casual)
+        # Casual variant assets are pre-quantized in img-casual/ and
+        # icon-casual.png; CI does not need pngquant/oxipng installed.
+        # See README.md "Bundle variants" and `pnpm quantize-assets`.
+        run: pnpm build:all
 
       - name: Get .xdc bundle info
         if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
@@ -159,7 +216,7 @@ jobs:
 
   release:
     name: Attach .xdc to GitHub Release
-    needs: [test]
+    needs: [build]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

The Tests workflow had a single `test` job named "Unit tests" that ran biome + tsc + build + vitest serially. That made failure attribution misleading — a biome formatting error showed up in the PR status row as "Unit tests fail".

Split the monolithic job into four parallel jobs so the GitHub PR status row reflects what actually broke:

- **Lint (Biome)** — `pnpm exec biome check .`
- **Type-check (tsc)** — `pnpm typecheck`
- **Unit tests (vitest)** — `pnpm test:coverage` + coverage upload
- **Build .xdc bundles** — `pnpm build:all` + `.xdc` artifact upload + sticky PR comment

`release` now depends on `build` (was `test`). `playwright` is unchanged.

## Trade-offs

The four new jobs each repeat `pnpm install`, but the `actions/setup-node` pnpm cache makes the warm-cache install fast (~5–10s). Wall-clock total drops from `sum(steps)` to `max(lint, typecheck, unit-tests, build, playwright)`, so PRs typically come back faster.

## Test plan

- [ ] All four new jobs run on this PR
- [ ] All four pass green
- [ ] Sticky `.xdc` PR comment still posts (now from the `build` job)

https://claude.ai/code/session_018qbFtLNgH4p39DmEBtouJu

---
_Generated by [Claude Code](https://claude.ai/code/session_018qbFtLNgH4p39DmEBtouJu)_