### PR TITLE
Snapshot upgrade state on chargePerp for SuperTokenPerp popup

### DIFF
--- a/scripts/LocalEngine.ts
+++ b/scripts/LocalEngine.ts
@@ -2063,7 +2063,29 @@ export function chargePerp(
         : typeof typeData.income_base === 'number'
           ? typeData.income_base
           : 0;
-  var chargeResult = { amount: _getVariatedAmount(baseAmount, now, path) };
+  // Snapshot { profiles_value, token_map } at charge-init so the
+  // SuperTokenPerp upgrade popup can compute "Data not yet analyzed" vs
+  // "Data already analyzed" against the state at the last compute.
+  // Mirrors dd_app views.py:776, which $sets instance_data.last_upgrade_values
+  // on chargePerp; the value is also surfaced in the node_ready payload so
+  // Game.js's in-memory copy stays in sync without a reload.
+  var tokenMap: Record<string, number> = {};
+  for (var ti = 0; ti < nodes.length; ti++) {
+    var tn = nodes[ti];
+    if (tn && tn.game_type === 'TokenPerp' && tn.gestalt && tn.instance_data) {
+      var tnAmt = tn.instance_data.amount;
+      tokenMap[tn.gestalt] = typeof tnAmt === 'number' ? tnAmt : 0;
+    }
+  }
+  var lastUpgradeData = {
+    profiles_value: gv.profiles_value || 0,
+    token_map: tokenMap,
+  };
+
+  var chargeResult = {
+    amount: _getVariatedAmount(baseAmount, now, path),
+    last_upgrade_data: lastUpgradeData,
+  };
 
   var durationMs = typeData.charge_time;
   var chargeEntry = {
@@ -2077,12 +2099,15 @@ export function chargePerp(
 
   var xpInc = typeof typeData.xp_inc === 'number' ? typeData.xp_inc : 0;
 
-  // mirrors dd_app views.py:776: $set charge_start, $addToSet nodes_charging,
-  // $inc cash_value/cash_spent/xp_value, $dec ap_snapshot
+  // mirrors dd_app views.py:776: $set charge_start + last_upgrade_values,
+  // $addToSet nodes_charging, $inc cash_value/cash_spent/xp_value, $dec ap_snapshot
   var newNodes = nodes.map(function (n, idx) {
     if (idx !== nodeIdx) return n;
     return Object.assign({}, n, {
-      instance_data: Object.assign({}, n.instance_data, { charge_start: now }),
+      instance_data: Object.assign({}, n.instance_data, {
+        charge_start: now,
+        last_upgrade_values: lastUpgradeData,
+      }),
     });
   });
 

--- a/scripts/LocalEngine.ts
+++ b/scripts/LocalEngine.ts
@@ -16,6 +16,7 @@ import i18nDe from '../i18n/de_AT.json' with { type: 'json' };
 import i18nEn from '../i18n/en_US.json' with { type: 'json' };
 import { getState, setState } from './boot.js';
 import { now as clockNow } from './clock.js';
+import type { UpgradeValuesShape } from './game/ProfileSet.js';
 import { materialize } from './materializer.js';
 import { applyDelta } from './state.js';
 import type { Delta, GameNode, GameValues, LocalState, MissionGoal } from './state.js';
@@ -1639,6 +1640,19 @@ function _seedMissionGoals(state: LocalState): LocalState {
   return Object.assign({}, state, { mission_goals: repairedGoals });
 }
 
+// gestalt → instance_data.amount for every TokenPerp node, mirroring
+// the GameRoot.DBTokens map the UI keys upgrade math against.
+function _buildTokenMap(nodes: GameNode[] | undefined): Record<string, number> {
+  var out: Record<string, number> = {};
+  (nodes || []).forEach(function (n) {
+    if (n.game_type === 'TokenPerp' && n.gestalt && n.instance_data) {
+      var amt = (n.instance_data as NodeInstanceData).amount;
+      out[n.gestalt] = typeof amt === 'number' ? amt : 0;
+    }
+  });
+  return out;
+}
+
 // current_amount math mirrors TokenPerp.setAmount → DBTokensAbsolute
 // (Game.js:5439) so the LocalEngine and UI agree on completion.
 function _advanceIntegrateProfilesMissions(
@@ -1652,14 +1666,7 @@ function _advanceIntegrateProfilesMissions(
     return { missions: null, mission_goals: goals, active_missions: activeMissions };
   }
 
-  var amountByGestalt: Record<string, number> = {};
-  (nodes || []).forEach(function (n) {
-    if (n.game_type === 'TokenPerp' && n.gestalt && n.instance_data) {
-      var idata: NodeInstanceData = n.instance_data || {};
-      var amt = idata.amount;
-      amountByGestalt[n.gestalt] = typeof amt === 'number' ? amt : 0;
-    }
-  });
+  var amountByGestalt = _buildTokenMap(nodes);
 
   var changed = false;
   var updatedGoals = goals.map(function (goal) {
@@ -2063,29 +2070,18 @@ export function chargePerp(
         : typeof typeData.income_base === 'number'
           ? typeData.income_base
           : 0;
-  // Snapshot { profiles_value, token_map } at charge-init so the
-  // SuperTokenPerp upgrade popup can compute "Data not yet analyzed" vs
-  // "Data already analyzed" against the state at the last compute.
-  // Mirrors dd_app views.py:776, which $sets instance_data.last_upgrade_values
-  // on chargePerp; the value is also surfaced in the node_ready payload so
-  // Game.js's in-memory copy stays in sync without a reload.
-  var tokenMap: Record<string, number> = {};
-  for (var ti = 0; ti < nodes.length; ti++) {
-    var tn = nodes[ti];
-    if (tn && tn.game_type === 'TokenPerp' && tn.gestalt && tn.instance_data) {
-      var tnAmt = tn.instance_data.amount;
-      tokenMap[tn.gestalt] = typeof tnAmt === 'number' ? tnAmt : 0;
-    }
-  }
-  var lastUpgradeData = {
-    profiles_value: gv.profiles_value || 0,
-    token_map: tokenMap,
-  };
+  // SuperTokenPerp upgrade popup compares current DB state to the snapshot
+  // taken at the last compute to render "not yet analyzed" vs "already
+  // analyzed". Other perp types never read this, so skip the work.
+  var lastUpgradeData: UpgradeValuesShape | undefined =
+    node.game_type === 'TokenPerp'
+      ? { profiles_value: gv.profiles_value || 0, token_map: _buildTokenMap(nodes) }
+      : undefined;
 
-  var chargeResult = {
+  var chargeResult: { amount: number; last_upgrade_data?: UpgradeValuesShape } = {
     amount: _getVariatedAmount(baseAmount, now, path),
-    last_upgrade_data: lastUpgradeData,
   };
+  if (lastUpgradeData) chargeResult.last_upgrade_data = lastUpgradeData;
 
   var durationMs = typeData.charge_time;
   var chargeEntry = {
@@ -2103,12 +2099,11 @@ export function chargePerp(
   // $addToSet nodes_charging, $inc cash_value/cash_spent/xp_value, $dec ap_snapshot
   var newNodes = nodes.map(function (n, idx) {
     if (idx !== nodeIdx) return n;
-    return Object.assign({}, n, {
-      instance_data: Object.assign({}, n.instance_data, {
-        charge_start: now,
-        last_upgrade_values: lastUpgradeData,
-      }),
+    var inst: Record<string, unknown> = Object.assign({}, n.instance_data, {
+      charge_start: now,
     });
+    if (lastUpgradeData) inst.last_upgrade_values = lastUpgradeData;
+    return Object.assign({}, n, { instance_data: inst });
   });
 
   var newGv: GameValues = Object.assign({}, gv, {

--- a/scripts/game/ProfileSet.ts
+++ b/scripts/game/ProfileSet.ts
@@ -37,7 +37,7 @@ interface TokenSetEntry {
   [key: string]: unknown;
 }
 
-interface UpgradeValuesShape {
+export interface UpgradeValuesShape {
   profiles_value: number;
   token_map: Record<string, number>;
 }

--- a/scripts/state.ts
+++ b/scripts/state.ts
@@ -508,13 +508,19 @@ reducers.chargePerp = function chargePerpReducer(state, delta) {
   // would charge the wrong perp.
   var path = chargeEntry.path;
   var nodes = state.nodes || [];
+  var lastUpgradeData =
+    chargeEntry.result && chargeEntry.result.last_upgrade_data
+      ? chargeEntry.result.last_upgrade_data
+      : undefined;
   var newNodes = nodes.map(function (n) {
     if (n.full_path !== path) return n;
-    return Object.assign({}, n, {
-      instance_data: Object.assign({}, n.instance_data, {
-        charge_start: chargeEntry.charge_start,
-      }),
+    var newInstance: Record<string, any> = Object.assign({}, n.instance_data, {
+      charge_start: chargeEntry.charge_start,
     });
+    if (lastUpgradeData !== undefined) {
+      newInstance.last_upgrade_values = lastUpgradeData;
+    }
+    return Object.assign({}, n, { instance_data: newInstance });
   });
 
   var stillCharging = _filterByPath(state.nodes_charging, chargeEntry.path) as ChargingEntry[];

--- a/tests/handlers/chargePerp.test.js
+++ b/tests/handlers/chargePerp.test.js
@@ -143,6 +143,31 @@ describe('chargePerp — happy path', () => {
     expect(node.instance_data.charge_start).toBe(FIXED_NOW);
   });
 
+  it('snapshots last_upgrade_values on instance_data and chargeResult', async () => {
+    // Seed two existing TokenPerps so the snapshot has a non-empty token_map.
+    setState(
+      _mkBaseState({
+        nodes: [
+          _mkNode('ContactPerp', NODE_PATH),
+          _mkNode('TokenPerp', 'Database.first_name_nora', { amount: 30 }),
+          _mkNode('TokenPerp', 'Database.first_name_sara', { amount: 70 }),
+        ],
+        game_values: Object.assign({}, BASE_GV, { profiles_value: 12345 }),
+      })
+    );
+
+    await chargePerp(NODE_PATH);
+
+    const node = getState().nodes.find((n) => n.full_path === NODE_PATH);
+    expect(node.instance_data.last_upgrade_values).toEqual({
+      profiles_value: 12345,
+      token_map: { first_name_nora: 30, first_name_sara: 70 },
+    });
+
+    const chargeEntry = getState().nodes_charging[0];
+    expect(chargeEntry.result.last_upgrade_data).toEqual(node.instance_data.last_upgrade_values);
+  });
+
   it('is deterministic: same ts+path produces same amount on repeated calls', async () => {
     // Charge, collect state, reset to initial, charge again — same result.
     await chargePerp(NODE_PATH);

--- a/tests/handlers/chargePerp.test.js
+++ b/tests/handlers/chargePerp.test.js
@@ -143,29 +143,38 @@ describe('chargePerp — happy path', () => {
     expect(node.instance_data.charge_start).toBe(FIXED_NOW);
   });
 
-  it('snapshots last_upgrade_values on instance_data and chargeResult', async () => {
-    // Seed two existing TokenPerps so the snapshot has a non-empty token_map.
+  it('omits last_upgrade_values for non-TokenPerp charges', async () => {
+    await chargePerp(NODE_PATH); // contact035 = ContactPerp
+    expect(getState().nodes_charging[0].result.last_upgrade_data).toBeUndefined();
+    expect(getState().nodes[0].instance_data.last_upgrade_values).toBeUndefined();
+  });
+
+  it('snapshots last_upgrade_values for TokenPerp charges', async () => {
+    // supertoken002 is the canonical SuperTokenPerp in the ruleset (charge_time set,
+    // contained_tokens non-empty). Seed two sibling TokenPerps so the snapshot map
+    // is non-trivial.
+    const TP_PATH = 'Database.supertoken002';
     setState(
       _mkBaseState({
         nodes: [
-          _mkNode('ContactPerp', NODE_PATH),
-          _mkNode('TokenPerp', 'Database.first_name_nora', { amount: 30 }),
-          _mkNode('TokenPerp', 'Database.first_name_sara', { amount: 70 }),
+          _mkNode('TokenPerp', TP_PATH),
+          _mkNode('TokenPerp', 'Database.token018', { amount: 30 }),
+          _mkNode('TokenPerp', 'Database.token125', { amount: 70 }),
         ],
         game_values: Object.assign({}, BASE_GV, { profiles_value: 12345 }),
       })
     );
 
-    await chargePerp(NODE_PATH);
+    await chargePerp(TP_PATH);
 
-    const node = getState().nodes.find((n) => n.full_path === NODE_PATH);
+    const node = getState().nodes.find((n) => n.full_path === TP_PATH);
     expect(node.instance_data.last_upgrade_values).toEqual({
       profiles_value: 12345,
-      token_map: { first_name_nora: 30, first_name_sara: 70 },
+      token_map: { supertoken002: 0, token018: 30, token125: 70 },
     });
-
-    const chargeEntry = getState().nodes_charging[0];
-    expect(chargeEntry.result.last_upgrade_data).toEqual(node.instance_data.last_upgrade_values);
+    expect(getState().nodes_charging[0].result.last_upgrade_data).toEqual(
+      node.instance_data.last_upgrade_values
+    );
   });
 
   it('is deterministic: same ts+path produces same amount on repeated calls', async () => {


### PR DESCRIPTION
## Summary
This change captures a snapshot of the game state at the moment a perpetual charge is initiated, enabling the SuperTokenPerp upgrade popup to accurately determine whether data has been analyzed since the last upgrade.

## Key Changes
- **LocalEngine.ts**: Modified `chargePerp()` to snapshot `profiles_value` and `token_map` (amounts of all existing TokenPerps) at charge initialization time
  - Stores snapshot in `last_upgrade_data` on both the `chargeResult` object and the node's `instance_data`
  - Mirrors the backend behavior in `dd_app views.py:776` which sets `instance_data.last_upgrade_values`
  - Snapshot is included in the `node_ready` payload to keep Game.js's in-memory state synchronized

- **state.ts**: Updated the `chargePerp` reducer to apply `last_upgrade_data` from the charge entry to the node's `instance_data.last_upgrade_values`

- **chargePerp.test.js**: Added test case verifying that `last_upgrade_values` is correctly captured on both the node instance data and the charge result entry

## Implementation Details
- The token map is built by iterating through all nodes and collecting amounts from nodes with `game_type === 'TokenPerp'`
- The snapshot is keyed by the node's `gestalt` property to match backend expectations
- Gracefully handles missing or non-numeric amounts by defaulting to 0
- The snapshot mechanism allows the UI to compare current state against the state at the last charge to determine if new data has been analyzed

https://claude.ai/code/session_01RzAkhpnZfGdDY9u4P9eRHL