### PR TITLE
Default Imperium and Database views to mid zoom

### DIFF
--- a/scripts/type_settings.js
+++ b/scripts/type_settings.js
@@ -354,7 +354,7 @@ var typeSettings = function () {
         height: 1600,
         x: -544,
         y: -500,
-        zoom_scale: 1,
+        zoom_scale: 0.75,
       },
     },
     UpgradePowerup: {
@@ -482,7 +482,7 @@ var typeSettings = function () {
         height: 1600,
         x: -544,
         y: -500,
-        zoom_scale: 1,
+        zoom_scale: 0.75,
       },
     },
     AgentPerp: {


### PR DESCRIPTION
## Summary
- Sets `zoom_scale` to `0.75` for the Imperium map and Database views in `scripts/type_settings.js`
- Zoom range is `0.5` (min) to `1.0` (max) with `0.25` steps, so `0.75` is the mid level
- Both views previously opened fully zoomed in (`1.0`); they now open at mid zoom

## Test plan
- [ ] Open the Imperium view and confirm it loads at the mid zoom level
- [ ] Open the Database view and confirm it loads at the mid zoom level
- [ ] Verify zoom in / zoom out controls still reach `0.5` min and `1.0` max
- [ ] Verify the reset/fullscreen button behavior is unaffected

https://claude.ai/code/session_01682RT95xwbmd5azDCZbbay

---
_Generated by [Claude Code](https://claude.ai/code/session_01682RT95xwbmd5azDCZbbay)_