### PR TITLE
fix(perps): restore prototype defaults so legacy subclasses inherit them

### DIFF
--- a/scripts/game/GamePerp.ts
+++ b/scripts/game/GamePerp.ts
@@ -594,3 +594,17 @@ export class GamePerp extends GameNode {
     dataRec.providedPerps = unlocked.concat(locked);
   }
 }
+
+// Prototype-default shim — TS class field initializers (`sticky = true`,
+// `cableType = 'in'`, `popupTemplate = 'popup.html'`) compile to
+// constructor assignments under target ES2020.  The 10 perp subclasses
+// in scripts/Game.js extend this class via the legacy `extend(SubClass,
+// GamePerp)` helper from scripts/util.js, whose `function (config) {
+// this.init(config); }` constructors never reach `super()` — so the
+// field assignments never run and `instance.sticky` etc. resolve to
+// `undefined`.  Restoring the defaults on the prototype reinstates the
+// pre-#178 inherit-through-the-prototype-chain behaviour.  Retires when
+// the legacy subclasses are migrated to proper TS classes (issue #187).
+GamePerp.prototype.cableType = 'in';
+GamePerp.prototype.sticky = true;
+GamePerp.prototype.popupTemplate = 'popup.html';


### PR DESCRIPTION
Fixes the dragging-parent-doesn't-drag-children regression introduced by #178.

## Root cause

#178 extracted `GamePerp` to `scripts/game/GamePerp.ts` as a real TS class. Defaults that previously lived on the prototype:

```js
GamePerp.prototype.cableType     = 'in';
GamePerp.prototype.sticky        = true;
GamePerp.prototype.popupTemplate = 'popup.html';
```

are now declared as TS class fields:

```ts
cableType: CableType = 'in';
sticky = true;
popupTemplate = 'popup.html';
```

With `tsconfig.json` targeting ES2020, those fields compile to **constructor assignments** (`this.sticky = true`), not prototype properties.

The 10 perp subclasses in `scripts/Game.js` still wire up via the legacy `extend(SubClass, GamePerp)` helper from `scripts/util.js:7-13`, whose `function (config) { this.init(config); }` constructors never call `super()`. The class-field assignments therefore never run on those instances, and `instance.sticky` / `instance.cableType` / `instance.popupTemplate` resolve to `undefined`.

## Visible symptom

Dragging a sticky parent perp no longer pulls its non-sticky cable-connected children along. `GamePerp.extendRender` writes `node.sticky = this.sticky` → `undefined`, and Render.js:2381's `else if (perp.sticky)` dragalong branch is dead:

```js
} else if (perp.sticky) {
  perp.cables.each(function (cable) {
    var othernode = cable.perpFrom === perp ? cable.perpTo : cable.perpFrom;
    if (othernode.sticky) { ... }
    else {
      othernode.dragalong = true;
      othernode.useDragHandler.addListener(othernode);   // never reached
    }
  });
}
```

Latent regressions cascade through `cableType` (cable-mode default for `DatabasePerp` / `TokenPerp` / `SupertokenPerp` — initial cable rendered with `mode: undefined`, BuyPerp animation `if/else` falls through) and `popupTemplate` (`SupertokenPerp` popup renders with `template: undefined`).

## Fix

Stamp the three defaults back onto `GamePerp.prototype` after the class definition. Restores the inherit-through-the-prototype-chain behaviour the legacy subclasses rely on. Three lines + a comment explaining why and pointing at the proper-fix tracking issue.

This is the **short-term shim** flagged in #187. The proper fix — migrating all 10 subclasses to real TS classes that call `super()` and dropping the `extend()` helper — is the body of that issue and will retire this shim.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 624/624 pass
- [ ] CI `pnpm test:e2e` — should pass (no e2e env locally)
- [ ] Manual smoke: drag a `PusherPerp` and confirm its connected `ContactPerp` children move along
- [ ] Manual smoke: click a `SupertokenPerp` and confirm popup opens with `popup.html`
- [ ] Manual smoke: buy a child under `DatabasePerp` / `TokenPerp` / `SupertokenPerp` and confirm the parent→child cable renders and the post-buy bounce hits the `cableType === 'in'` branch (only the bought child bounces)

Refs #187 (does not close — that issue tracks the proper TS-class migration).
Regression introduced by #178.

https://claude.ai/code/session_01C3DNdegHp9JMjyEJZR5BGB

---
_Generated by [Claude Code](https://claude.ai/code/session_01C3DNdegHp9JMjyEJZR5BGB)_