### PR TITLE
phase 7 (#147): retire perpRegistry from Database / DatabasePerp / Game.js

### DIFF
--- a/scripts/Game.js
+++ b/scripts/Game.js
@@ -46,7 +46,7 @@ import { TokenPerp } from './game/TokenPerp.js';
 import { Topscore } from './game/Topscore.js';
 import { Topscores } from './game/Topscores.js';
 import { mergeData } from './game/mergeData.js';
-import { setPerpClasses } from './game/perpRegistry.js';
+import './game/perpCtors.js';
 import i18n from './i18n.js';
 import setup from './setup.js';
 import { getTypeSettings } from './type_settings.js';
@@ -1854,11 +1854,10 @@ var Game = function () {
   //
   // Extracted to scripts/game/Database.ts in PR 10 of issue #147.  The
   // class is imported above; the API publisher at the bottom of this
-  // IIFE re-exposes it as Game.Database.  Database's dynamic
-  // `Game[node.game_type]` and `Game.TokenPerp` lookups are routed
-  // through scripts/game/perpRegistry.ts; setPerpClasses(Game) is
-  // called at the bottom of this IIFE so the registry is populated
-  // before any Database method runs.
+  // IIFE re-exposes it as Game.Database.  Database resolves the
+  // `Game[node.game_type]` lookup via `perpCtors[name]` (typed direct
+  // map) and the known-name `Game.TokenPerp` reference via a direct
+  // import — both wired up in PR 17 of issue #147.
 
   // updateGears was scoped to the Database section in legacy
   // (`// TODO: Move this to GameRoot`) but is a GameRoot prototype mixin.
@@ -1878,9 +1877,11 @@ var Game = function () {
   // class is imported above; the API publisher at the bottom of this
   // IIFE re-exposes it as Game.GamePerp.  The dynamic
   // `Game[node.game_type]` lookup in BuyPerp is routed through
-  // scripts/game/perpRegistry.ts (registered via setPerpClasses(Game)
-  // at the IIFE's tail).  AniTicker is injected via setAniTicker(AniTicker)
-  // at the same spot so GamePerp can subscribe to charge-running animations.
+  // scripts/game/perpRegistry.ts (seeded as a side effect of
+  // perpCtors.ts; the import on line 49 of this file kicks the
+  // registration before any BuyPerp flow runs).  AniTicker is injected
+  // via setAniTicker(AniTicker) at the IIFE's tail so GamePerp can
+  // subscribe to charge-running animations.
 
   GameNode.prototype.initPopupEvents = function (popup) {
     var gnode = this;
@@ -2178,16 +2179,10 @@ var Game = function () {
     SupertokenPerp: SupertokenPerp,
   };
 
-  // Register every published class with the perpRegistry so
-  // scripts/game/Database.ts (and future-extracted subclasses) can
-  // resolve dynamic `Game[node.game_type]` lookups + direct
-  // `Game.TokenPerp` references without an IIFE-closure roundtrip.
-  // Disposable seam — retired with the IIFE in the final PR (#147).
-  setPerpClasses(Game);
   // Inject AniTicker into GamePerp so its initEventHandlers can register
   // listeners on the legacy ticker singleton (which still lives in this
-  // IIFE). Disposable seam alongside setPerpClasses; retires when AniTicker
-  // is itself extracted from Game.js.
+  // IIFE). Disposable seam; retires when AniTicker is itself extracted
+  // from Game.js.
   setAniTicker(AniTicker);
 
   return Game;

--- a/scripts/game/Database.ts
+++ b/scripts/game/Database.ts
@@ -2,11 +2,10 @@
 // (pending profilesets to integrate) and the integrated TokenPerps.
 // Extracted from scripts/Game.js's IIFE in PR 10 of issue #147.
 //
-// The biggest UI subclass extracted so far (~500 LOC).  GameRoot's surface
-// is narrowed via a local `GameRootForDatabase` interface; the dynamic
-// `Game[node.game_type]` and direct `Game.TokenPerp` lookups are routed
-// through ./perpRegistry.ts so Database can land before every Perp class
-// is extracted in PR 11+.
+// GameRoot's surface is narrowed via a local `GameRootForDatabase`
+// interface.  The dynamic `Game[node.game_type]` lookup is resolved via
+// `perpCtors[name]` (typed direct map, PR 17 of issue #147); the
+// known-name `Game.TokenPerp` reference uses a direct import.
 
 import { getRender } from '../Render.js';
 import appModule from '../app.js';
@@ -23,8 +22,9 @@ import {
 } from './GameNode.js';
 import { OrderedSet } from './OrderedSet.js';
 import { ProfileSet } from './ProfileSet.js';
+import { TokenPerp } from './TokenPerp.js';
 import { mergeData } from './mergeData.js';
-import { lookupPerpClass } from './perpRegistry.js';
+import { perpCtors } from './perpCtors.js';
 
 // ---------------------------------------------------------------------------
 // Local types
@@ -379,7 +379,7 @@ export class Database extends GameNode {
         const node = r.node;
         const nodeGameType = node.game_type;
         if (!nodeGameType) return;
-        const Ctor = lookupPerpClass(nodeGameType);
+        const Ctor = perpCtors[nodeGameType];
         if (!Ctor) return;
         const node_data = groot.getTypeData(bgestalt);
         const perp = new Ctor({
@@ -582,7 +582,6 @@ export class Database extends GameNode {
       });
 
       const triggerQueue: GameNode[] = [];
-      const TokenPerpCtor = lookupPerpClass('TokenPerp');
       // Precompute gestalt-keyed lookup maps so the inner loop is O(M)
       // instead of O(M*N) — a profileset with M tokens against a Database
       // with N children would otherwise scan children.set + all_tokens
@@ -600,13 +599,13 @@ export class Database extends GameNode {
         if (token) {
           // collect update tokens
           update_tokens.push(token);
-        } else if (TokenPerpCtor) {
+        } else {
           // create new tokens
           const type = groot.getType(gestalt);
           if (type && type.game_type === 'TokenPerp') {
             const token_instance = allTokensByGestalt.get(gestalt);
             if (token_instance) {
-              const newToken = new TokenPerpCtor({
+              const newToken = new TokenPerp({
                 id: token_instance.game_id,
                 gestalt: gestalt,
                 path: token_instance.full_path,
@@ -614,7 +613,7 @@ export class Database extends GameNode {
                 renderNodeParent: getFirstId('Database'),
                 ViewMap: getByFirstId('Database'),
                 gameType: type.game_type,
-              }) as TokenPerpLike;
+              } as ConstructorParameters<typeof TokenPerp>[0]) as TokenPerpLike;
               gnode.addChild(newToken);
               triggerQueue.push(newToken);
               new_tokens.push(newToken);

--- a/scripts/game/DatabasePerp.ts
+++ b/scripts/game/DatabasePerp.ts
@@ -20,7 +20,7 @@ import {
   type RenderPopupLike,
 } from './GamePerp.js';
 import { mergeData } from './mergeData.js';
-import { lookupPerpClass } from './perpRegistry.js';
+import { perpCtors } from './perpCtors.js';
 
 /** Database BuyPerp returns one extra field (`profile_set`) that the
  *  generic perp BuyPerp doesn't — the Database queues it after the
@@ -90,7 +90,7 @@ export class DatabasePerp extends GamePerp {
       const node = r.node;
       const nodeGameType = node.game_type;
       if (!nodeGameType) return;
-      const Ctor = lookupPerpClass(nodeGameType);
+      const Ctor = perpCtors[nodeGameType];
       if (!Ctor) return;
       const node_data = groot.getTypeData(bgestalt);
       const perp = new Ctor({

--- a/scripts/game/GamePerp.ts
+++ b/scripts/game/GamePerp.ts
@@ -3,10 +3,12 @@
 // ProjectPerp, TokenPerp, SupertokenPerp).  Extracted from
 // scripts/Game.js's IIFE in PR 11 of issue #147.
 //
-// The dynamic `Game[node.game_type]` lookup in BuyPerp is routed through
-// scripts/game/perpRegistry.ts so GamePerp can land before the individual
-// perp subclasses; PR 12+ extracts each subclass and migrates the
-// registry consumers to direct imports.
+// The dynamic `Game[node.game_type]` lookup in BuyPerp is routed
+// through scripts/game/perpRegistry.ts because GamePerp.ts can't
+// import its own subclasses directly without a load-time cycle (each
+// subclass extends GamePerp).  Database / DatabasePerp resolved
+// their own dynamic lookups against `perpCtors[name]` directly in
+// PR 17 of issue #147; this seam stays only for GamePerp's case.
 
 import { getRender } from '../Render.js';
 import appModule from '../app.js';
@@ -127,9 +129,8 @@ export interface ProvidedPerpRow {
 }
 
 // AniTicker is captured at GamePerp-class scope and injected by Game.js
-// via `setAniTicker` (called once at IIFE-end, alongside setPerpClasses).
-// Keeps GamePerp.ts free of the legacy AniTicker singleton's Game.js-side
-// implementation.
+// via `setAniTicker` (called once at IIFE-end).  Keeps GamePerp.ts free
+// of the legacy AniTicker singleton's Game.js-side implementation.
 let _aniTicker: AniTickerLike | null = null;
 export function setAniTicker(ticker: AniTickerLike): void {
   _aniTicker = ticker;

--- a/scripts/game/perpCtors.ts
+++ b/scripts/game/perpCtors.ts
@@ -1,0 +1,45 @@
+// Direct-import map of perp constructors keyed by `gameType`.
+//
+// Replaces the IIFE-end `setPerpClasses(Game)` call in scripts/Game.js
+// (PR 17 of issue #147).  Importing this module both:
+//   - exposes `perpCtors[name]` for typed direct lookups in Database
+//     and DatabasePerp (the only callers that need a runtime
+//     by-name resolution and don't have a cycle problem); and
+//   - seeds `perpRegistry` as a side effect, so `GamePerp.BuyPerp`'s
+//     `lookupPerpClass(name)` keeps working without GamePerp.ts
+//     having to import the perp subclasses directly (which would
+//     create a cycle: GamePerp ↔ AgentPerp / CityPerp / …).
+//
+// The `perpRegistry` indirection retires fully when GamePerp.BuyPerp
+// no longer needs a dynamic by-name construction — likely once
+// GameRoot extracts and the buy-flow can be a free function.
+
+import { AgentPerp } from './AgentPerp.js';
+import { CityPerp } from './CityPerp.js';
+import { ClientPerp } from './ClientPerp.js';
+import { ContactPerp } from './ContactPerp.js';
+import { DatabasePerp } from './DatabasePerp.js';
+import { ProjectPerp } from './ProjectPerp.js';
+import { ProxyPerp } from './ProxyPerp.js';
+import { PusherPerp } from './PusherPerp.js';
+import { SupertokenPerp } from './SupertokenPerp.js';
+import { TokenPerp } from './TokenPerp.js';
+import { type PerpCtor, setPerpClasses } from './perpRegistry.js';
+
+// The `as PerpCtor` casts widen each subclass's declared
+// constructor parameter (`GameNodeConfig`) to the registry's
+// `unknown`-input shape — see perpRegistry.ts for the rationale.
+export const perpCtors: Record<string, PerpCtor> = {
+  AgentPerp: AgentPerp as unknown as PerpCtor,
+  CityPerp: CityPerp as unknown as PerpCtor,
+  ClientPerp: ClientPerp as unknown as PerpCtor,
+  ContactPerp: ContactPerp as unknown as PerpCtor,
+  DatabasePerp: DatabasePerp as unknown as PerpCtor,
+  ProjectPerp: ProjectPerp as unknown as PerpCtor,
+  ProxyPerp: ProxyPerp as unknown as PerpCtor,
+  PusherPerp: PusherPerp as unknown as PerpCtor,
+  SupertokenPerp: SupertokenPerp as unknown as PerpCtor,
+  TokenPerp: TokenPerp as unknown as PerpCtor,
+};
+
+setPerpClasses(perpCtors);

--- a/scripts/game/perpRegistry.ts
+++ b/scripts/game/perpRegistry.ts
@@ -1,30 +1,34 @@
 // Cross-class constructor registry for the Perp class hierarchy.
 //
-// Background: scripts/Game.js's IIFE used to expose every subclass on a
-// shared `Game` object so that `Game[node.game_type]` lookups could
-// resolve to the right class.  As subclasses migrate to scripts/game/*.ts,
-// the dynamic lookup needs a way to keep working without each subclass
-// having to know about every other.  This module is that hub:
+// Used by `GamePerp.BuyPerp` to resolve `Game[node.game_type]` lookups
+// without GamePerp.ts having to import its own subclasses (each of
+// which extends GamePerp — direct imports would be a load-time cycle).
 //
-//   - Game.js calls `setPerpClasses(Game)` after the IIFE assembles the
-//     public API object — this registers every class identity (extracted
-//     and still-in-IIFE alike) under their game-type name.
-//   - Database / future-extracted classes call `lookupPerpClass(name)` to
-//     get a constructor by name.  Returns `undefined` if the class hasn't
-//     been registered yet (caller decides how to handle that).
+// Population: `scripts/game/perpCtors.ts` calls `setPerpClasses` as a
+// side effect at module load.  `perpCtors.ts` is imported by
+// `Game.js` (and by `Database.ts` / `DatabasePerp.ts` via their
+// per-call lookups), so the registry is seeded before any BuyPerp
+// flow runs.
 //
-// Disposable seam: when every Perp class is extracted to its own .ts file
-// in PR 11+, callers can switch to direct imports and the registry is
-// retired with the IIFE.
+// Direct callers (Database, DatabasePerp) prefer `perpCtors[name]`
+// from the perpCtors module — this registry exists only for
+// GamePerp's cycle-bound case.  Retires fully when GamePerp's
+// dynamic-by-name construction can be turned into a free function
+// (likely after GameRoot extracts).
 
 import type { GameNode } from './GameNode.js';
 
+// Constructor parameter is `unknown` (not `GameNodeConfig`) because
+// callers (Database / GamePerp.BuyPerp) build config objects from
+// server-response shapes whose individual fields are `string |
+// undefined` rather than absent — `exactOptionalPropertyTypes: true`
+// would reject the assignment under a tighter type without
+// per-call-site narrowing.  The Perp constructors themselves accept
+// `GameNodeConfig` and validate at the seam.
 export type PerpCtor = new (config: unknown) => GameNode;
 
 let _classes: Record<string, PerpCtor> = {};
 
-/** Replaces the registry.  Called once by Game.js after the IIFE
- *  assembles the API object. */
 export function setPerpClasses(classes: Record<string, PerpCtor>): void {
   _classes = classes;
 }


### PR DESCRIPTION
## Summary

PR 17 of issue #147. Retires the `setPerpClasses(Game)` IIFE-end registration call in `Game.js` and migrates Database / DatabasePerp from the dynamic registry to typed direct-map / direct-import lookups.

The seam doesn't fully retire — `GamePerp.BuyPerp` still calls `lookupPerpClass(name)` because GamePerp.ts can't directly import its own subclasses (each one extends GamePerp; direct imports would be a load-time cycle). The registry stays alive only for that one caller, seeded transparently by the new `perpCtors` module.

## What changes

**New module:** `scripts/game/perpCtors.ts` (~50 LOC)
- Imports all 10 perp classes directly.
- Exports a `Record<string, PerpCtor>` keyed by `gameType`.
- Calls `setPerpClasses(perpCtors)` as a module-load side effect.

**Game.js:**
- Drops `import { setPerpClasses }` and the `setPerpClasses(Game)` call at the IIFE tail.
- Replaces with a side-effect `import './game/perpCtors.js'`.
- Updates two block comments to reflect the new wiring.

**`Database.ts`:**
- Drops `lookupPerpClass` import; adds `perpCtors` and direct `TokenPerp` imports.
- Line 382's `lookupPerpClass(nodeGameType)` → `perpCtors[nodeGameType]`.
- Line 585's known-name `lookupPerpClass('TokenPerp')` → direct `TokenPerp` reference; the now-redundant `if (TokenPerpCtor)` guard collapses to an unconditional `else`.
- The `new TokenPerp(...)` instantiation needs a per-call-site `as ConstructorParameters<typeof TokenPerp>[0]` cast because the legacy config-object shape has `id: string | undefined` fields that violate `exactOptionalPropertyTypes`.

**`DatabasePerp.ts`:** same swap as `Database.ts:382`.

**`GamePerp.ts`:** comment-only updates (header + AniTicker note). Still uses the registry — that's intentional.

**`perpRegistry.ts`:** no API changes. Updated header to document the new wiring; added a comment explaining why `PerpCtor`'s parameter stays `unknown` rather than `GameNodeConfig` (caller-side narrows).

## Architecture invariants — preserved

- No `setTimeout` for game cycles.
- No new `webxdc.sendUpdate` paths.
- No DOM globals in handler bodies.
- Engine layer untouched (`state.ts`, `materializer.ts`, `LocalEngine.ts`, etc.).
- `addr === state.addr` guard intact.

## Why the registry can't fully go away yet

`GamePerp.ts` is loaded before any of its subclasses (each subclass's `extends GamePerp` requires GamePerp to be defined). If GamePerp.ts directly imports `perpCtors.ts`, the import chain becomes:

```
GamePerp.ts → perpCtors.ts → AgentPerp.ts → GamePerp.ts (mid-load)
```

At step 4, `GamePerp` is undefined and `class AgentPerp extends GamePerp` crashes at module load. The registry's late-binding sidesteps this — `lookupPerpClass(name)` is called at runtime (well after all modules have evaluated), so the registry is fully populated by then.

The seam can fully retire once `GamePerp.BuyPerp`'s dynamic by-name construction moves to a free function in a non-GamePerp module — likely after GameRoot extracts.

## Verification

- `npx tsc --noEmit` — clean.
- `pnpm exec biome check .` — clean.
- `pnpm test` — 624/624 pass.
- `pnpm test:e2e` — 45/45 pass (1 skipped, unrelated).
- `pnpm run build` — both `.xdc` variants build green.

## Test plan

- [ ] CI lint / typecheck / unit-tests / build / playwright all green.
- [ ] Drop the `.xdc` into Delta Chat; smoke-test buy → charge → collect → integrate (Database / Token / Project flows exercise the new lookups).

https://claude.ai/code/session_018qbFtLNgH4p39DmEBtouJu

---
_Generated by [Claude Code](https://claude.ai/code/session_018qbFtLNgH4p39DmEBtouJu)_