### PR TITLE
Extract MainMenu styles into css/MainMenu.css; mobile header + tab polish

### DIFF
--- a/css/MainMenu.css
+++ b/css/MainMenu.css
@@ -137,7 +137,11 @@
     display: flex;
     flex-direction: column;
     height: auto;
-    overflow: visible;
+    /* `overflow: hidden` clips the tab's bottom edge against the menu's
+     * bottom — same trick the desktop layout uses to hide the tab's
+     * rounded bottom corners and box-shadow tail.  Without this, the
+     * tabs' rounded bottoms read as a rounded bottom on the menu. */
+    overflow: hidden;
     border-radius: 8px 8px 0 0;
   }
   .mm-xp {
@@ -146,7 +150,9 @@
     margin: 4px 0 4px 28px;
   }
   .mm-tabs {
-    padding: 0 6px 4px 6px;
+    /* No padding-bottom — tabs flush against the menu's bottom edge
+     * (and beyond, getting clipped by .MainMenu's `overflow: hidden`). */
+    padding: 0 6px;
     height: auto;
     display: flex;
     flex-direction: row;
@@ -158,16 +164,18 @@
     border-bottom: none;
   }
   /* Tabs grow to fill the row equally — text auto-sizes via the
-   * cascaded font-size media queries below.  Reset the desktop
-   * `top: 13/9` offsets and asymmetric padding so there's no fat
-   * empty band beneath the label. */
+   * cascaded font-size media queries below.  `top: 4` shifts each tab
+   * 4 px past the menu's bottom edge so the tab's rounded corners and
+   * box-shadow get clipped, matching the desktop "tabs tucked into the
+   * menu" look.  Active tab sits flush so it reads as recessed. */
   .mm-tabs .mm-tab {
     flex: 1 1 0;
     margin: 0;
-    top: 0;
+    top: 4px;
+    height: 44px;
     min-height: 44px;
-    padding: 4px 8px;
-    line-height: 26px;
+    padding: 2px 8px 4px 8px;
+    line-height: 28px;
     font-size: 16px;
     box-sizing: border-box;
     text-align: center;

--- a/css/MainMenu.css
+++ b/css/MainMenu.css
@@ -10,6 +10,7 @@
  */
 
 .MainMenu {
+  height: 48px;
   overflow: hidden;
   margin: 0 auto;
   background: linear-gradient(to bottom, #001111 0%, #06546c 100%);
@@ -135,6 +136,8 @@
   .MainMenu {
     display: flex;
     flex-direction: column;
+    height: auto;
+    overflow: visible;
     border-radius: 8px 8px 0 0;
   }
   .mm-xp {

--- a/css/MainMenu.css
+++ b/css/MainMenu.css
@@ -143,6 +143,11 @@
      * tabs' rounded bottoms read as a rounded bottom on the menu. */
     overflow: hidden;
     border-radius: 8px 8px 0 0;
+    /* Cyan separator stripe at the menu's bottom edge — matches the
+     * desktop look where the same colour runs across the bottom of
+     * the tab strip. */
+    border-bottom: 3px solid #16a3d7;
+    box-sizing: border-box;
   }
   .mm-xp {
     display: block;
@@ -151,7 +156,9 @@
   }
   .mm-tabs {
     /* No padding-bottom — tabs flush against the menu's bottom edge
-     * (and beyond, getting clipped by .MainMenu's `overflow: hidden`). */
+     * (and beyond, getting clipped by .MainMenu's `overflow: hidden`).
+     * Keep the desktop-style cyan separator line beneath the tab row
+     * so the menu has a clear edge against the Stage. */
     padding: 0 6px;
     height: auto;
     display: flex;
@@ -161,7 +168,6 @@
     gap: 4px;
     box-sizing: border-box;
     width: 100%;
-    border-bottom: none;
   }
   /* Tabs grow to fill the row equally — text auto-sizes via the
    * cascaded font-size media queries below.  Square bottom corners

--- a/css/MainMenu.css
+++ b/css/MainMenu.css
@@ -265,14 +265,16 @@
     line-height: 22px;
     padding: 4px 4px;
     border-width: 2px;
-    border-radius: 6px;
+    border-radius: 6px 6px 0px 0px;
     box-shadow: 1px 1px 0 #009fd9;
+    height: unset;
+    min-height: unset;
   }
 }
 
 @media (max-width: 380px) {
   .mm-tabs .mm-tab {
-    font-size: 11px;
+    font-size: 13px;
     line-height: 20px;
     padding: 4px 2px;
   }

--- a/css/MainMenu.css
+++ b/css/MainMenu.css
@@ -146,19 +146,34 @@
     margin: 4px 0 4px 28px;
   }
   .mm-tabs {
-    padding: 2px 6px;
+    padding: 0 6px 4px 6px;
     height: auto;
     display: flex;
     flex-direction: row;
-    justify-content: center;
+    justify-content: stretch;
     align-items: stretch;
     gap: 4px;
     box-sizing: border-box;
     width: 100%;
+    border-bottom: none;
   }
+  /* Tabs grow to fill the row equally — text auto-sizes via the
+   * cascaded font-size media queries below.  Reset the desktop
+   * `top: 13/9` offsets and asymmetric padding so there's no fat
+   * empty band beneath the label. */
   .mm-tabs .mm-tab {
-    flex: 0 1 auto;
-    margin-right: 0;
+    flex: 1 1 0;
+    margin: 0;
+    top: 0;
+    min-height: 44px;
+    padding: 4px 8px;
+    line-height: 26px;
+    font-size: 16px;
+    box-sizing: border-box;
+    text-align: center;
+  }
+  .mm-tabs .mm-tab.active {
+    top: 0;
   }
   .mm-user-btn {
     padding: 3px 8px;
@@ -208,13 +223,13 @@
   }
 }
 
-/* ── Tap-target / mobile sizing for tabs.
+/* ── Per-breakpoint font-size tightening for tabs.
  *
- * Goal: text as large as fits on one line (no ellipsis, no wrap) and
- * balanced top/bottom padding so there's no fat empty band below the
- * text.  44 px tap target is preserved via `min-height`.  The `top:`
- * offset between active/inactive remains, just smaller — the desktop
- * "press down" cue still reads on touch.
+ * The base mobile rules (≤ 926 px) above set layout, padding, and a
+ * 16 px font-size that fits four labels at ~600 px viewport.  Tighten
+ * the font further at 600 / 480 / 380 px so labels keep fitting on
+ * one line without ellipsis at narrower widths.  Also drop the
+ * box-shadow to a smaller offset so it doesn't dominate the tab.
  */
 @media (max-width: 768px) {
   .mm-user-btn {
@@ -222,51 +237,31 @@
     font-size: 15px;
     margin-left: 6px;
   }
-
-  .mm-tab {
-    min-height: 44px;
-    padding: 7px 12px;
-    line-height: 24px;
-    font-size: 16px;
-    box-sizing: border-box;
-    top: 4px;
-  }
-  .mm-tab.active {
-    top: 0;
-  }
-  .mm-tab + .mm-tab {
-    margin-left: 4px;
-  }
 }
 
 @media (max-width: 600px) {
-  .mm-tab {
-    padding: 8px 8px;
+  .mm-tabs .mm-tab {
     font-size: 15px;
-    line-height: 22px;
+    line-height: 24px;
     box-shadow: 2px 2px 0 #009fd9;
   }
 }
 
 @media (max-width: 480px) {
-  .mm-tab {
-    padding: 6px 6px;
-    font-size: 11px;
-    line-height: 18px;
+  .mm-tabs .mm-tab {
+    font-size: 13px;
+    line-height: 22px;
+    padding: 4px 4px;
     border-width: 2px;
     border-radius: 6px;
     box-shadow: 1px 1px 0 #009fd9;
   }
-  .mm-tab + .mm-tab {
-    margin-left: 2px;
-  }
 }
 
 @media (max-width: 380px) {
-  .mm-tab {
-    padding: 6px 4px;
-    font-size: 10px;
-    line-height: 16px;
-    margin-right: 1px;
+  .mm-tabs .mm-tab {
+    font-size: 11px;
+    line-height: 20px;
+    padding: 4px 2px;
   }
 }

--- a/css/MainMenu.css
+++ b/css/MainMenu.css
@@ -1,0 +1,269 @@
+/* MainMenu.css — styles scoped exclusively to views/mainmenu.html.
+ *
+ * Classes use a `mm-*` lowercase-dash convention to make it visually
+ * obvious at the call site that they are NOT reused elsewhere — fixes
+ * here cannot leak into the rest of the UI.  The only exception is
+ * `.MainMenuLogo`, which is also used by the About popup (see
+ * views/popup_user_data.html); its sprite-image rule lives in
+ * Render.css and only the in-menu positioning is set here, scoped under
+ * `.MainMenu .MainMenuLogo`.
+ */
+
+.MainMenu {
+  overflow: hidden;
+  margin: 0 auto;
+  background: linear-gradient(to bottom, #001111 0%, #06546c 100%);
+  border-radius: 8px 8px 0 0;
+}
+
+.MainMenu .MainMenuLogo {
+  position: absolute;
+  top: 6px;
+  left: 10px;
+}
+
+/* ── About / locale-toggle pair (top-right) ─────────────────────────── */
+.mm-actions {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+}
+
+.mm-user-btn {
+  display: inline-block;
+  border-radius: 8px;
+  border: 2px solid #c95127;
+  font-family: Bowlby, sans-serif;
+  color: #fceccc;
+  font-size: 13px;
+  line-height: 20px;
+  text-shadow: 2px 2px 0 #963200, -1px -1px 0 #963200, -1px 1px 0 #963200, 1px -1px 0 #963200;
+  background: #e48931;
+  padding: 0 6px;
+  box-shadow: 1px 1px 0 #c95127, 3px 3px 0 #c95127;
+  touch-action: manipulation;
+}
+.mm-user-btn:hover {
+  transform: scale(1.1, 1.1);
+}
+.mm-user-btn.disabled,
+.mm-user-btn.disabled:hover {
+  transform: none;
+  opacity: 0.5;
+}
+.mm-user-btn:not(.disabled):active {
+  background: #ecf8fc;
+  transform: scale(0.97);
+}
+
+/* ── Primary tab row ────────────────────────────────────────────────── */
+.mm-tabs {
+  height: 39px;
+  padding-top: 6px;
+  padding-left: 240px;
+  border-bottom: 3px solid #16a3d7;
+}
+
+.mm-tab {
+  display: inline-block;
+  position: relative;
+  top: 13px;
+  font-family: Bowlby, sans-serif;
+  color: #009fd9;
+  font-size: 16px;
+  background: #b7dded;
+  line-height: 24px;
+  border: 3px solid #009fd9;
+  border-radius: 8px;
+  padding: 2px 16px 8px 16px;
+  margin-right: 8px;
+  box-shadow: 3px 3px 0 #009fd9;
+  text-shadow: 0 0 0 white, 1px 1px 0 white, 2px 2px 0 white, 3px 3px 0 white;
+  transition: top 0.2s linear;
+  touch-action: manipulation;
+  white-space: nowrap;
+}
+.mm-tab.active {
+  background: #ecf8fc;
+  color: #e48931;
+  top: 9px;
+  transition: top 0 linear;
+}
+.mm-tab:hover {
+  background: #ecf8fc;
+}
+.mm-tab.disabled,
+.mm-tab.disabled:hover {
+  transform: none;
+  opacity: 0.5;
+}
+.mm-tab.disabled:hover {
+  background: #b7dded;
+}
+.mm-tab.active.disabled:hover {
+  background: #ecf8fc;
+}
+.mm-tab:not(.disabled):active {
+  background: #ecf8fc;
+  transform: scale(0.97);
+}
+
+/* ── Mobile / responsive layout ─────────────────────────────────────── */
+
+/* ≤ 980 px: hide the brand logo so the tabs reclaim its space. */
+@media (max-width: 980px) {
+  .MainMenu .MainMenuLogo {
+    display: none;
+  }
+  .mm-tabs {
+    padding-left: 0;
+  }
+  .mm-actions {
+    top: 6px;
+    right: 6px;
+  }
+}
+
+/* ≤ 926 px: two-row header — XP bar row on top, tabs below.
+ *
+ * Header height is content-driven via flex column (no min-height /
+ * padding-top constants).  Top corners stay rounded; bottom is flush
+ * against the Stage.  In-stage Statusbar XP hides; the cloned XP item
+ * inside .mm-xp shows instead.
+ */
+@media (max-width: 926px) {
+  .MainMenu {
+    display: flex;
+    flex-direction: column;
+    border-radius: 8px 8px 0 0;
+  }
+  .mm-xp {
+    display: block;
+    align-self: flex-start;
+    margin: 4px 0 4px 28px;
+  }
+  .mm-tabs {
+    padding: 2px 6px;
+    height: auto;
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: stretch;
+    gap: 4px;
+    box-sizing: border-box;
+    width: 100%;
+  }
+  .mm-tabs .mm-tab {
+    flex: 0 1 auto;
+    margin-right: 0;
+  }
+  .mm-user-btn {
+    padding: 3px 8px;
+    font-size: 13px;
+    margin-left: 4px;
+    box-sizing: border-box;
+  }
+  .Statusbar .StatusItem.XP {
+    display: none;
+  }
+  .mm-xp .mm-xp-name {
+    font-family: Bowlby, sans-serif;
+    font-size: 11px;
+    line-height: 12px;
+    color: #fff;
+    text-shadow: 1px 1px 0 #000, -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000;
+    margin-bottom: -1px;
+    padding-left: 18px;
+    max-width: 156px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    box-sizing: border-box;
+  }
+  .mm-xp .StatusItem.XP .StatusIcon.xp {
+    left: -19px;
+  }
+  .mm-xp .StatusItem.XP .StatusTextLevel {
+    left: -14px;
+    width: 28px;
+    height: 25px;
+    line-height: 25px;
+    text-align: center;
+    font-size: 14px;
+    color: #333;
+  }
+  .mm-xp .StatusItem.XP .StatusText {
+    text-align: center;
+    width: 128px;
+    box-sizing: border-box;
+  }
+}
+
+@media (min-width: 927px) {
+  .mm-xp {
+    display: none;
+  }
+}
+
+/* ── Tap-target / mobile sizing for tabs.
+ *
+ * Goal: text as large as fits on one line (no ellipsis, no wrap) and
+ * balanced top/bottom padding so there's no fat empty band below the
+ * text.  44 px tap target is preserved via `min-height`.  The `top:`
+ * offset between active/inactive remains, just smaller — the desktop
+ * "press down" cue still reads on touch.
+ */
+@media (max-width: 768px) {
+  .mm-user-btn {
+    padding: 4px 12px;
+    font-size: 15px;
+    margin-left: 6px;
+  }
+
+  .mm-tab {
+    min-height: 44px;
+    padding: 7px 12px;
+    line-height: 24px;
+    font-size: 16px;
+    box-sizing: border-box;
+    top: 4px;
+  }
+  .mm-tab.active {
+    top: 0;
+  }
+  .mm-tab + .mm-tab {
+    margin-left: 4px;
+  }
+}
+
+@media (max-width: 600px) {
+  .mm-tab {
+    padding: 8px 8px;
+    font-size: 15px;
+    line-height: 22px;
+    box-shadow: 2px 2px 0 #009fd9;
+  }
+}
+
+@media (max-width: 480px) {
+  .mm-tab {
+    padding: 6px 6px;
+    font-size: 11px;
+    line-height: 18px;
+    border-width: 2px;
+    border-radius: 6px;
+    box-shadow: 1px 1px 0 #009fd9;
+  }
+  .mm-tab + .mm-tab {
+    margin-left: 2px;
+  }
+}
+
+@media (max-width: 380px) {
+  .mm-tab {
+    padding: 6px 4px;
+    font-size: 10px;
+    line-height: 16px;
+    margin-right: 1px;
+  }
+}

--- a/css/MainMenu.css
+++ b/css/MainMenu.css
@@ -164,21 +164,25 @@
     border-bottom: none;
   }
   /* Tabs grow to fill the row equally — text auto-sizes via the
-   * cascaded font-size media queries below.  `top: 4` shifts each tab
-   * 4 px past the menu's bottom edge so the tab's rounded corners and
-   * box-shadow get clipped, matching the desktop "tabs tucked into the
-   * menu" look.  Active tab sits flush so it reads as recessed. */
+   * cascaded font-size media queries below.  Square bottom corners
+   * (`border-radius: 8px 8px 0 0`) so each tab's bottom edge butts
+   * cleanly against the menu's bottom; without this, the rounded
+   * bottom corners expose the dark menu bg behind active tabs and
+   * read as a gap.  Asymmetric `padding: 2px 8px 8px 8px` matches
+   * the desktop ratio so Bowlby's top-aligned glyph + drop-shadow
+   * sit visually centred. */
   .mm-tabs .mm-tab {
     flex: 1 1 0;
     margin: 0;
-    top: 4px;
+    top: 0;
     height: 44px;
     min-height: 44px;
-    padding: 2px 8px 4px 8px;
-    line-height: 28px;
+    padding: 2px 8px 8px 8px;
+    line-height: 24px;
     font-size: 16px;
     box-sizing: border-box;
     text-align: center;
+    border-radius: 8px 8px 0 0;
   }
   .mm-tabs .mm-tab.active {
     top: 0;

--- a/css/MainMenu.css
+++ b/css/MainMenu.css
@@ -273,8 +273,12 @@
     border-width: 2px;
     border-radius: 6px 6px 0px 0px;
     box-shadow: 1px 1px 0 #009fd9;
-    height: unset;
-    min-height: unset;
+    /* Allow the tab to grow with line-height + padding rather than being
+     * pinned at the desktop 44.  Keep `min-height: 44` to satisfy the
+     * accessibility tap-target floor; without it the tab collapses to
+     * ~34 px and the mobile-tap-targets spec fails at 360/390/414. */
+    height: auto;
+    min-height: 44px;
   }
 }
 

--- a/css/Render.css
+++ b/css/Render.css
@@ -57,29 +57,6 @@
   margin: 0px 8px -6px 8px;
 }
 
-.UserActions {
-  position:absolute;
-  top:10px;
-  right:10px;
-}
-.UserButton {
-  display: inline-block;
-  border-radius:8px;
-  border:2px solid #C95127;
-  font-family: Bowlby;
-  color: #FCECCC;
-  font-size: 13px;
-  line-height: 20px;
-  text-shadow:2px 2px 0px #963200, -1px -1px 0px #963200, -1px 1px 0px #963200, 1px -1px 0px #963200;
-  background:#E48931;
-  padding:0px 6px;
-  box-shadow:1px 1px 0px #C95127,3px 3px 0px #C95127;
-}
-.UserButton:hover {
-  -webkit-transform: scale(1.1,1.1);
-  -moz-transform: scale(1.1,1.1);
-  transform: scale(1.1,1.1);
-}
 .Stage {
   font-family:Voltaire;
   font-size:11px;
@@ -396,22 +373,12 @@
   -webkit-transition: background 0.15s linear, visibility 0.15s linear, box-shadow 0.15s;
 }
 
-.MainMenu {
-  overflow:hidden;
-  margin:0 auto;
-  background: #001111;
-  background: -moz-linear-gradient(top,  #001111 0%, #06546c 100%);
-  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#001111), color-stop(100%,#06546c));
-  background: -webkit-linear-gradient(top,  #001111 0%,#06546c 100%);
-  background: -o-linear-gradient(top,  #001111 0%,#06546c 100%);
-  background: linear-gradient(to bottom,  #001111 0%,#06546c 100%);
-  filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#001111', endColorstr='#06546c',GradientType=0 );
-}
+/* `.MainMenuLogo` is shared between the main-menu header and the
+ * About popup (views/popup_user_data.html), so its sprite-image rule
+ * lives here.  In-menu positioning is set in css/MainMenu.css under
+ * `.MainMenu .MainMenuLogo`. */
 .MainMenuLogo,
 .MainMenuLogo.en_US {
-  position:absolute;
-  top:6px;
-  left:10px;
   background-image: url(../img/MainSprites.png);
   width: 222px;
   height: 40px;
@@ -420,18 +387,12 @@
 .MainMenuLogo.de_AT {
   background-position: -225px -819px;
 }
-.MainMenuButtons {
-  height: 39px;
-  padding-top:6px;
-  padding-left:240px;
-  border-bottom: 3px solid #16A3D7;
-}
-.ViewTabMenuButton,
-.MainMenuButton {
-  display:inline-block;
-  position:relative;
-  top:13px;
-  font-family:Bowlby;
+
+.ViewTabMenuButton {
+  display: inline-block;
+  position: relative;
+  top: 13px;
+  font-family: Bowlby;
   color: #009FD9;
   font-size: 16px;
   background: #B7DDED;
@@ -440,26 +401,20 @@
   border-radius: 8px;
   padding: 2px 16px 8px 16px;
   margin-right: 8px;
-  box-shadow:3px 3px 0px #009FD9;
-  -webkit-transition: top 0.2s linear;
-  -moz-transition: top 0.2s linear;
+  box-shadow: 3px 3px 0px #009FD9;
   transition: top 0.2s linear;
-  text-shadow:0px 0px 0px white, 1px 1px 0px white, 2px 2px 0px white, 3px 3px 0px white;
+  text-shadow: 0px 0px 0px white, 1px 1px 0px white, 2px 2px 0px white, 3px 3px 0px white;
 }
 
-.ViewTabMenuButton.active,
-.MainMenuButton.active {
-  -webkit-transition: top 0 linear;
-  -moz-transition: top 0 linear;
+.ViewTabMenuButton.active {
   transition: top 0 linear;
-  background:#ECF8FC;
+  background: #ECF8FC;
   color: #E48931;
-  top:9px;
+  top: 9px;
 }
 
-.ViewTabMenuButton:hover,
-.MainMenuButton:hover {
-  background:#ECF8FC;
+.ViewTabMenuButton:hover {
+  background: #ECF8FC;
 }
 
 .ViewTabMenu {
@@ -2479,21 +2434,6 @@
   box-shadow:3px 3px 0px #999, 3px 3px 8px rgba(0,0,0,0.5);
   text-shadow:none;
 }
-.MainMenuButton.disabled,
-.UserButton.disabled,
-.MainMenuButton.disabled:hover,
-.UserButton.disabled:hover {
-  -webkit-transform:inherit;
-  -moz-transform:inherit;
-  transform:inherit;
-  opacity:0.5;
-}
-.MainMenuButton.disabled:hover {
-  background: #B7DDED;
-}
-.MainMenuButton.active.disabled:hover {
-  background:#ECF8FC;
-}
 .Button.no_cash {
   background:#EDCCCC;
   border-color:#900;
@@ -2994,10 +2934,7 @@ html, body {
 
 /* `touch-action: manipulation` removes the 300 ms iOS click delay
  * without breaking pan/pinch on the playfield. */
-.MainMenuButton,
 .ViewTabMenuButton,
-.UserButton,
-.MainMenuLogo,
 .Button,
 .DatabaseQueueItem,
 .PopupHeader,
@@ -3006,70 +2943,6 @@ html, body {
 .lang-pick,
 button {
   touch-action: manipulation;
-}
-
-/* ≤ 980 px: hide the brand logo so the tabs reclaim its space. */
-@media (max-width: 980px) {
-  .MainMenuLogo,
-  .MainMenuLogo.en_US,
-  .MainMenuLogo.de_AT {
-    display: none;
-  }
-  /* Tabs reclaim the logo's 228 px left padding. */
-  .MainMenuButtons {
-    padding-left: 0;
-  }
-  .UserActions {
-    top: 6px;
-    right: 6px;
-  }
-}
-
-/* ≤ 926 px: two-row header — tabs drop to row 2 so the cloned XP bar
- * (see css/Statusbar.css for .MainMenuXP rules) gets row 1 to itself. */
-@media (max-width: 926px) {
-  .MainMenu {
-    border-width: 4px 0 0 0;
-    border-radius: 0;
-    min-height: 96px;
-    padding-top: 48px;
-    box-sizing: border-box;
-    position: relative;
-  }
-  .MainMenuButtons {
-    padding-left: 6px;
-    padding-right: 6px;
-    height: auto;
-    min-height: 39px;
-    padding-top: 4px;
-    padding-bottom: 4px;
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    align-items: stretch;
-    gap: 4px;
-    box-sizing: border-box;
-    width: 100%;
-  }
-  .MainMenuButtons .MainMenuButton {
-    flex: 1 1 0;
-    min-width: 0;
-    margin-right: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  /* Compact orange (.UserButton) About / locale-toggle buttons in row 1
-     so they sit next to the XP bar without dominating it. */
-  .UserButton {
-
-    padding: 3px 8px;
-    font-size: 13px;
-    margin-left: 4px;
-    box-sizing: border-box;
-  }
-
 }
 
 /* `ViewTab.prototype.css` writes inline width/height to .ViewTabContainer
@@ -3103,8 +2976,7 @@ button {
 
 @media (max-width: 480px) {
   /* Tab buttons: smaller padding so the row fits ~360px wide. */
-  .ViewTabMenuButton,
-  .MainMenuButton {
+  .ViewTabMenuButton {
     padding: 2px 8px 6px 8px;
     margin-right: 4px;
     font-size: 14px;
@@ -3129,28 +3001,13 @@ button {
     line-height: 36px;
   }
 
-  /* Header buttons: also 44 tall.  The orange About / locale-toggle pair
-     in the top-right is small (~24px) on desktop. */
-  .UserButton {
-    padding: 4px 12px;
-    font-size: 15px;
-    margin-left: 6px;
-    box-sizing: border-box;
-  }
-
-  /* Tab buttons: bump touch height; padding-bottom accounts for the
-     box-shadow offset that visually anchors the button on desktop. */
-  .ViewTabMenuButton,
-  .MainMenuButton {
+  .ViewTabMenuButton {
     min-height: 44px;
     line-height: 28px;
     padding: 4px 14px 8px 14px;
   }
 
-  /* Sufficient gap between adjacent tabs so a thumb-tap doesn't land
-     between two buttons. */
-  .ViewTabMenuButton + .ViewTabMenuButton,
-  .MainMenuButton + .MainMenuButton {
+  .ViewTabMenuButton + .ViewTabMenuButton {
     margin-left: 4px;
   }
 
@@ -3165,15 +3022,9 @@ button {
   .PopupList {
     font-size: 16px;
   }
-
-  /* DatabaseQueueItem and similar sprite-on-tap elements are already
-     ~100×100 — no change needed. */
 }
 
-/* :active feedback (all viewports — touch devices benefit, desktop is
- * unaffected because :hover still wins on a real mouse).  Mirrors the
- * existing :hover scale-up but at a lower scale so a finger-press feels
- * like a press, not a launch. */
+/* :active feedback (all viewports). */
 .Button:active,
 .ButtonInc:active,
 .ButtonDec:active,
@@ -3181,9 +3032,7 @@ button {
   transform: scale(0.96);
   background: #ECF8FC;
 }
-.MainMenuButton:not(.disabled):active,
-.ViewTabMenuButton:not(.disabled):active,
-.UserButton:not(.disabled):active {
+.ViewTabMenuButton:not(.disabled):active {
   background: #ECF8FC;
   transform: scale(0.97);
 }
@@ -3193,10 +3042,8 @@ button {
 
 /* ── Narrow-viewport refinements: progressively tighter at 600/480/380. */
 
-/* --- Tab buttons: progressively tighter padding/font --------------------- */
 @media (max-width: 600px) {
-  .ViewTabMenuButton,
-  .MainMenuButton {
+  .ViewTabMenuButton {
     padding: 3px 6px 6px 6px;
     font-size: 15px;
     line-height: 22px;
@@ -3205,8 +3052,7 @@ button {
 }
 
 @media (max-width: 530px) {
-  .ViewTabMenuButton,
-  .MainMenuButton {
+  .ViewTabMenuButton {
     padding: 2px 5px 5px 5px;
     font-size: 15px;
     line-height: 22px;
@@ -3214,8 +3060,7 @@ button {
 }
 
 @media (max-width: 480px) {
-  .ViewTabMenuButton,
-  .MainMenuButton {
+  .ViewTabMenuButton {
     padding: 2px 4px 5px 4px;
     font-size: 11px;
     line-height: 18px;
@@ -3223,26 +3068,19 @@ button {
     border-radius: 6px;
     box-shadow: 1px 1px 0px #009FD9;
   }
-  .ViewTabMenuButton + .ViewTabMenuButton,
-  .MainMenuButton + .MainMenuButton {
+  .ViewTabMenuButton + .ViewTabMenuButton {
     margin-left: 1px;
   }
-  /* On the active state, the desktop rule `top: 9px;` shifts the active tab
-     down by 4 px (from `top: 13px;`).  Keep a smaller offset on narrow
-     viewports so the active tab still reads as recessed. */
-  .ViewTabMenuButton.active,
-  .MainMenuButton.active {
+  .ViewTabMenuButton.active {
     top: 8px;
   }
-  .ViewTabMenuButton,
-  .MainMenuButton {
+  .ViewTabMenuButton {
     top: 11px;
   }
 }
 
 @media (max-width: 380px) {
-  .ViewTabMenuButton,
-  .MainMenuButton {
+  .ViewTabMenuButton {
     padding: 2px 2px 4px 2px;
     font-size: 10px;
     line-height: 16px;

--- a/css/Render.css
+++ b/css/Render.css
@@ -3003,7 +3003,8 @@ button {
 
   .ViewTabMenuButton {
     min-height: 44px;
-    line-height: 28px;
+    font-size: 16px;
+    line-height: 25px;
     padding: 4px 14px 8px 14px;
   }
 
@@ -3045,8 +3046,6 @@ button {
 @media (max-width: 600px) {
   .ViewTabMenuButton {
     padding: 3px 6px 6px 6px;
-    font-size: 15px;
-    line-height: 22px;
     box-shadow: 2px 2px 0px #009FD9;
   }
 }
@@ -3054,16 +3053,12 @@ button {
 @media (max-width: 530px) {
   .ViewTabMenuButton {
     padding: 2px 5px 5px 5px;
-    font-size: 15px;
-    line-height: 22px;
   }
 }
 
 @media (max-width: 480px) {
   .ViewTabMenuButton {
     padding: 2px 4px 5px 4px;
-    font-size: 11px;
-    line-height: 18px;
     border-width: 2px;
     border-radius: 6px;
     box-shadow: 1px 1px 0px #009FD9;
@@ -3082,8 +3077,6 @@ button {
 @media (max-width: 380px) {
   .ViewTabMenuButton {
     padding: 2px 2px 4px 2px;
-    font-size: 10px;
-    line-height: 16px;
     margin-right: 1px;
   }
 }

--- a/css/Render.css
+++ b/css/Render.css
@@ -2971,8 +2971,13 @@ button {
   .ViewTabMenu {
     width: auto;
     max-width: 100%;
-    /* Tabs grow to fill the row equally instead of clinging to their
-     * content width with empty rails on either side. */
+  }
+}
+
+/* In-view (Topscores) tab strip mobile layout — same threshold as the
+ * main-menu mobile mode in MainMenu.css so the two transitions align. */
+@media (max-width: 926px) {
+  .ViewTabMenu {
     display: flex;
     gap: 4px;
     padding: 0 6px;
@@ -2981,6 +2986,16 @@ button {
   .ViewTabMenu .ViewTabMenuButton {
     flex: 1 1 0;
     margin: 0;
+    top: 0;
+    min-height: 44px;
+    font-size: 16px;
+    line-height: 25px;
+    padding: 4px 8px 4px 8px;
+    box-sizing: border-box;
+    text-align: center;
+  }
+  .ViewTabMenu .ViewTabMenuButton.active {
+    top: 0;
   }
 }
 
@@ -3009,17 +3024,6 @@ button {
     min-width: 44px;
     min-height: 44px;
     line-height: 36px;
-  }
-
-  .ViewTabMenuButton {
-    min-height: 44px;
-    font-size: 16px;
-    line-height: 25px;
-    padding: 4px 14px 8px 14px;
-  }
-
-  .ViewTabMenuButton + .ViewTabMenuButton {
-    margin-left: 4px;
   }
 
   /* Body / dialog text: minimum 16px so iOS doesn't zoom on focus and

--- a/css/Render.css
+++ b/css/Render.css
@@ -2971,6 +2971,16 @@ button {
   .ViewTabMenu {
     width: auto;
     max-width: 100%;
+    /* Tabs grow to fill the row equally instead of clinging to their
+     * content width with empty rails on either side. */
+    display: flex;
+    gap: 4px;
+    padding: 0 6px;
+    box-sizing: border-box;
+  }
+  .ViewTabMenu .ViewTabMenuButton {
+    flex: 1 1 0;
+    margin: 0;
   }
 }
 

--- a/css/Statusbar.css
+++ b/css/Statusbar.css
@@ -277,60 +277,9 @@
   font-size: 14px;
 }
 
-/* Cloned XP / level bar shown next to the tabs ≤ 926 px (the in-stage
- * Statusbar XP item is hidden in the same band). */
-
-@media (max-width: 926px) {
-  .Statusbar .StatusItem.XP {
-    display: none;
-  }
-  .MainMenuXP {
-    display: block;
-    position: absolute;
-    top: 4px;
-    left: 28px;
-    z-index: 5;
-    transform: scale(1.1);
-    transform-origin: top left;
-  }
-  .MainMenuXP .MainMenuXPName {
-    font-family: Bowlby, sans-serif;
-    font-size: 11px;
-    line-height: 12px;
-    color: #fff;
-    text-shadow: 1px 1px 0 #000, -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000;
-    margin-bottom: -1px;
-    padding-left: 18px;
-    max-width: 156px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    box-sizing: border-box;
-  }
-  .MainMenuXP .StatusItem.XP .StatusIcon.xp {
-    left: -19px;
-  }
-  .MainMenuXP .StatusItem.XP .StatusTextLevel {
-    left: -14px;
-    width: 28px;
-    height: 25px;
-    line-height: 25px;
-    text-align: center;
-    font-size: 14px;
-    color: #333;
-  }
-  .MainMenuXP .StatusItem.XP .StatusText {
-    text-align: center;
-    width: 128px;
-    box-sizing: border-box;
-  }
-}
-
-@media (min-width: 927px) {
-  .MainMenuXP {
-    display: none;
-  }
-}
+/* The cloned XP/level bar shown next to the tabs ≤ 926 px lives in
+ * css/MainMenu.css under `.mm-xp` — the in-stage Statusbar XP item is
+ * also hidden in that band, see MainMenu.css. */
 
 /* Mobile sizing: scale items up via CSS `zoom` (which reflows layout —
  * unlike transform: scale, no negative-margin compensation needed) so

--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
     <link rel="stylesheet" type="text/css" href="./css/dd.css">
     <link rel="stylesheet" type="text/css" href="./css/Render.css">
     <link rel="stylesheet" type="text/css" href="./css/Statusbar.css">
+    <link rel="stylesheet" type="text/css" href="./css/MainMenu.css">
 
     <!-- dev: served by mockWebxdc() Vite plugin; prod: injected by the messenger -->
     <script src="webxdc.js"></script>

--- a/scripts/Game.js
+++ b/scripts/Game.js
@@ -1815,6 +1815,16 @@ var Game = function () {
           game.fitToWindow();
         }, 100)
       );
+    // The mobile MainMenu grows after the XP bar gets cloned in and on
+    // CSS-driven reflows (orientation, font load); refit the Stage
+    // whenever the header's measured height changes so we don't push
+    // the playfield past the bottom of the viewport.
+    if (game.renderMenu && game.renderMenu.domelem && typeof ResizeObserver === 'function') {
+      var refit = _.debounce(function () {
+        game.fitToWindow();
+      }, 50);
+      new ResizeObserver(refit).observe(game.renderMenu.domelem);
+    }
 
     return game;
   };

--- a/scripts/Render.js
+++ b/scripts/Render.js
@@ -4366,6 +4366,25 @@ var Render = function () {
 
   extend(MainMenu, Stage);
 
+  // Don't pin height/display inline — let CSS drive them.  Desktop
+  // sets a fixed 48 px height with `display: block`; the mobile
+  // breakpoints switch to a flex column that grows to fit the
+  // two-row content.  Width still goes inline because the desktop
+  // layout uses a 960 px design width that JS scales for narrower
+  // viewports.
+  MainMenu.prototype.setSize = function (size) {
+    this.setAttrs(size);
+    this.css({ width: this.width + 'px' });
+  };
+  MainMenu.prototype.updateRenderProp = function () {
+    this.css({
+      'z-index': this.z,
+      position: this.position,
+      top: 0,
+      left: 0,
+    });
+  };
+
   MainMenu.prototype.template = 'mainmenu.html';
 
   MainMenu.prototype.render = function () {

--- a/scripts/Render.js
+++ b/scripts/Render.js
@@ -3654,9 +3654,9 @@ var Render = function () {
       if (value) {
         node.FXShow();
         node.parentNode.jdomelem.addClass('Active' + node.jdomelem.attr('id'));
-        node.gameNode.GameRoot.renderMenu.jdomelem.find('.MainMenuButton').removeClass('active');
+        node.gameNode.GameRoot.renderMenu.jdomelem.find('.mm-tab').removeClass('active');
         node.gameNode.GameRoot.renderMenu.jdomelem
-          .find('.MainMenuButton[data-button-id=' + node.id + ']')
+          .find('.mm-tab[data-button-id=' + node.id + ']')
           .addClass('active');
         node.trigger('viewtab_selected');
       } else {
@@ -3796,9 +3796,9 @@ var Render = function () {
       if (value) {
         node.FXShow();
         node.parentNode.jdomelem.addClass('Active' + node.jdomelem.attr('id'));
-        node.gameNode.GameRoot.renderMenu.jdomelem.find('.MainMenuButton').removeClass('active');
+        node.gameNode.GameRoot.renderMenu.jdomelem.find('.mm-tab').removeClass('active');
         node.gameNode.GameRoot.renderMenu.jdomelem
-          .find('.MainMenuButton[data-button-id=' + node.id + ']')
+          .find('.mm-tab[data-button-id=' + node.id + ']')
           .addClass('active');
       } else {
         node.parentNode.jdomelem.removeClass('Active' + node.jdomelem.attr('id'));
@@ -4345,16 +4345,16 @@ var Render = function () {
       e.preventDefault();
       GameRoot.trigger('user_data');
     });
-    this.jdomelem.on('click touchend', '.MainMenuButton:not(.disabled)', function (e) {
+    this.jdomelem.on('click touchend', '.mm-tab:not(.disabled)', function (e) {
       e.stopPropagation();
       e.preventDefault();
       GameRoot.trigger('switch_view', [$(this).attr('data-button-id')]);
     });
 
-    // Forward MainMenuXP taps to the same `click_status.XP` event the
+    // Forward .mm-xp taps to the same `click_status.XP` event the
     // in-stage Statusbar emits — the cloned bar lives outside the
     // Statusbar's DOM so its delegated handler doesn't reach.
-    this.jdomelem.on('click touchend', '.MainMenuXP .StatusItem', function (e) {
+    this.jdomelem.on('click touchend', '.mm-xp .StatusItem', function (e) {
       e.stopPropagation();
       e.preventDefault();
       var statusid = $(this).attr('data-status-id');
@@ -4372,7 +4372,7 @@ var Render = function () {
     var html = app.renderView(this.template, this.data);
     this.jdomelem.html(html);
     // Invalidate the in-place XP cache so the next renderXP repopulates
-    // the freshly-emptied .MainMenuXPBar slot instead of memo-skipping.
+    // the freshly-emptied .mm-xp-bar slot instead of memo-skipping.
     this._xpSlot = null;
     this._xpLast = null;
   };
@@ -4402,7 +4402,7 @@ var Render = function () {
       level: sb.XP_level,
     };
     if (!this._xpSlot) {
-      this._xpSlot = this.jdomelem.find('.MainMenuXPBar')[0];
+      this._xpSlot = this.jdomelem.find('.mm-xp-bar')[0];
       if (!this._xpSlot) return;
     }
     var item = this._xpSlot.querySelector('.StatusItem.XP');
@@ -4430,12 +4430,12 @@ var Render = function () {
 
   MainMenu.prototype.lock = function () {
     this.jdomelem.addClass('locked');
-    this.jdomelem.find('.UserButton, .MainMenuButton').addClass('disabled');
+    this.jdomelem.find('.mm-user-btn, .mm-tab').addClass('disabled');
   };
 
   MainMenu.prototype.unlock = function () {
     this.jdomelem.removeClass('locked');
-    this.jdomelem.find('.UserButton, .MainMenuButton').removeClass('disabled');
+    this.jdomelem.find('.mm-user-btn, .mm-tab').removeClass('disabled');
   };
 
   MainMenu.prototype.addButton = function (text, id, states) {

--- a/tests/e2e/mission-centering.spec.ts
+++ b/tests/e2e/mission-centering.spec.ts
@@ -37,7 +37,7 @@ for (const vp of VIEWPORTS) {
       timeout: 50_000,
     });
 
-    await page.locator('.MainMenuButton[data-button-id="Missions"]').dispatchEvent('click');
+    await page.locator('.mm-tab[data-button-id="Missions"]').dispatchEvent('click');
     await page.waitForTimeout(800);
 
     const layout = await page.evaluate(() => {

--- a/tests/e2e/mobile-breakpoints.spec.ts
+++ b/tests/e2e/mobile-breakpoints.spec.ts
@@ -25,11 +25,11 @@ async function bootAt(page: import('@playwright/test').Page, w: number, h: numbe
   });
 }
 
-test('breakpoint ≥ 981: logo visible, MainMenuXP hidden', async ({ page }) => {
+test('breakpoint ≥ 981: logo visible, .mm-xp hidden', async ({ page }) => {
   await bootAt(page, 1024, 800);
   const state = await page.evaluate(() => {
     const logo = document.querySelector<HTMLElement>('.MainMenuLogo');
-    const xp = document.querySelector<HTMLElement>('.MainMenuXP');
+    const xp = document.querySelector<HTMLElement>('.mm-xp');
     return {
       logoDisplay: logo ? getComputedStyle(logo).display : null,
       xpDisplay: xp ? getComputedStyle(xp).display : null,
@@ -43,7 +43,7 @@ test('breakpoint ≤ 980: logo hidden, XP NOT yet relocated to header', async ({
   await bootAt(page, 960, 800);
   const state = await page.evaluate(() => {
     const logo = document.querySelector<HTMLElement>('.MainMenuLogo');
-    const xpClone = document.querySelector<HTMLElement>('.MainMenuXP');
+    const xpClone = document.querySelector<HTMLElement>('.mm-xp');
     const inStageXp = document.querySelector<HTMLElement>('.Statusbar .StatusItem.XP');
     return {
       logoDisplay: logo ? getComputedStyle(logo).display : null,
@@ -63,7 +63,7 @@ test('breakpoint ≤ 980: logo hidden, XP NOT yet relocated to header', async ({
 test('breakpoint ≤ 926: cloned XP bar appears + in-stage XP hidden', async ({ page }) => {
   await bootAt(page, 900, 800);
   const state = await page.evaluate(() => {
-    const xpClone = document.querySelector<HTMLElement>('.MainMenuXP');
+    const xpClone = document.querySelector<HTMLElement>('.mm-xp');
     const inStageXp = document.querySelector<HTMLElement>('.Statusbar .StatusItem.XP');
     return {
       xpCloneDisplay: xpClone ? getComputedStyle(xpClone).display : null,
@@ -77,8 +77,8 @@ test('breakpoint ≤ 926: cloned XP bar appears + in-stage XP hidden', async ({ 
 test('breakpoint ≤ 926: two-row header (tabs below XP slot)', async ({ page }) => {
   await bootAt(page, 900, 800);
   const state = await page.evaluate(() => {
-    const xp = document.querySelector<HTMLElement>('.MainMenuXP');
-    const tabs = document.querySelector<HTMLElement>('.MainMenuButtons');
+    const xp = document.querySelector<HTMLElement>('.mm-xp');
+    const tabs = document.querySelector<HTMLElement>('.mm-tabs');
     if (!xp || !tabs) return null;
     const xpRect = xp.getBoundingClientRect();
     const tabsRect = tabs.getBoundingClientRect();

--- a/tests/e2e/mobile-conveyor.spec.ts
+++ b/tests/e2e/mobile-conveyor.spec.ts
@@ -25,7 +25,7 @@ test('conveyor: parent anchored inside viewport, right edge visible', async ({ p
   await expect(page.locator('[data-testid="game-container"]')).toBeVisible({
     timeout: 50_000,
   });
-  await page.locator('.MainMenuButton[data-button-id="Database"]').dispatchEvent('click');
+  await page.locator('.mm-tab[data-button-id="Database"]').dispatchEvent('click');
   await page.waitForTimeout(800);
 
   const layout = await page.evaluate(() => {
@@ -57,7 +57,7 @@ test('conveyor: anchored to the bottom of the visible viewport', async ({ page }
   await expect(page.locator('[data-testid="game-container"]')).toBeVisible({
     timeout: 50_000,
   });
-  await page.locator('.MainMenuButton[data-button-id="Database"]').dispatchEvent('click');
+  await page.locator('.mm-tab[data-button-id="Database"]').dispatchEvent('click');
   await page.waitForTimeout(800);
 
   const layout = await page.evaluate(() => {
@@ -80,7 +80,7 @@ test('conveyor: PipeBack paints behind the belt sprite (not on top)', async ({ p
   await expect(page.locator('[data-testid="game-container"]')).toBeVisible({
     timeout: 50_000,
   });
-  await page.locator('.MainMenuButton[data-button-id="Database"]').dispatchEvent('click');
+  await page.locator('.mm-tab[data-button-id="Database"]').dispatchEvent('click');
   await page.waitForTimeout(800);
 
   const layout = await page.evaluate(() => {
@@ -111,7 +111,7 @@ test('zoom controls: float above the conveyor (not covered)', async ({ page }) =
   await expect(page.locator('[data-testid="game-container"]')).toBeVisible({
     timeout: 50_000,
   });
-  await page.locator('.MainMenuButton[data-button-id="Database"]').dispatchEvent('click');
+  await page.locator('.mm-tab[data-button-id="Database"]').dispatchEvent('click');
   await page.waitForTimeout(800);
 
   const layout = await page.evaluate(() => {

--- a/tests/e2e/mobile-layout-iter2.spec.ts
+++ b/tests/e2e/mobile-layout-iter2.spec.ts
@@ -22,7 +22,7 @@ test('iter2: all 4 tabs on one row', async ({ page }) => {
   // Group tops into row-bands.  The desktop active-tab CSS bumps the
   // active button by 4 px (top:9 vs top:13), so we bucket by 10-px bands
   // to recognise that the active tab still sits visually in row 1.
-  const rows = await page.locator('.MainMenu .MainMenuButton').evaluateAll((els) => {
+  const rows = await page.locator('.MainMenu .mm-tab').evaluateAll((els) => {
     const tops = els.map((e) => Math.round(e.getBoundingClientRect().top));
     const bands: number[] = [];
     for (const t of tops) {
@@ -33,7 +33,7 @@ test('iter2: all 4 tabs on one row', async ({ page }) => {
   });
   expect(rows.length, `tabs span ${rows.length} row-bands: ${rows.join(',')}`).toBe(1);
 
-  const count = await page.locator('.MainMenu .MainMenuButton').count();
+  const count = await page.locator('.MainMenu .mm-tab').count();
   expect(count).toBe(4);
 });
 
@@ -52,7 +52,7 @@ test('iter2: cloned XP bar is clickable + emits click_status.XP', async ({ page 
     game.on('click_status.XP', () => {
       saw = true;
     });
-    const xpItem = document.querySelector<HTMLElement>('.MainMenuXP .StatusItem.XP');
+    const xpItem = document.querySelector<HTMLElement>('.mm-xp .StatusItem.XP');
     if (!xpItem) throw new Error('cloned XP item not found');
     xpItem.dispatchEvent(
       new TouchEvent('touchstart', { bubbles: true, cancelable: true, touches: [] as any })
@@ -72,8 +72,8 @@ test('iter2: username label sits above the cloned XP bar', async ({ page }) => {
   });
 
   const layout = await page.evaluate(() => {
-    const name = document.querySelector<HTMLElement>('.MainMenuXP .MainMenuXPName');
-    const bar = document.querySelector<HTMLElement>('.MainMenuXP .StatusItem.XP');
+    const name = document.querySelector<HTMLElement>('.mm-xp .mm-xp-name');
+    const bar = document.querySelector<HTMLElement>('.mm-xp .StatusItem.XP');
     if (!name || !bar) return null;
     return {
       nameBottom: name.getBoundingClientRect().bottom,

--- a/tests/e2e/mobile-tap-targets.spec.ts
+++ b/tests/e2e/mobile-tap-targets.spec.ts
@@ -31,14 +31,14 @@ for (const vp of VIEWPORTS) {
     });
 
     // Wait until tab buttons are laid out.
-    await expect(page.locator('.MainMenuButton').first()).toBeVisible();
+    await expect(page.locator('.mm-tab').first()).toBeVisible();
 
-    // Measure the primary tabs.  The orange UserButtons (About / locale
-    // toggle) are intentionally smaller (32 px tall, per iter-2 user
-    // feedback) — they are secondary affordances, not the primary
+    // Measure the primary tabs.  The orange .mm-user-btn (About / locale
+    // toggle) buttons are intentionally smaller (32 px tall, per iter-2
+    // user feedback) — they are secondary affordances, not the primary
     // tap-target the 44 px guideline is for.
     const sizes = await page.evaluate((minTap) => {
-      const sels = ['.MainMenuButton', '.ViewTabMenuButton'];
+      const sels = ['.mm-tab', '.ViewTabMenuButton'];
       const out: { sel: string; w: number; h: number; visible: boolean }[] = [];
       sels.forEach((sel) => {
         document.querySelectorAll<HTMLElement>(sel).forEach((el) => {

--- a/tests/e2e/mobile-touch.spec.ts
+++ b/tests/e2e/mobile-touch.spec.ts
@@ -43,15 +43,15 @@ test('mobile-touch: tab touch fires view switch (no double-fire)', async ({ page
     timeout: 50_000,
   });
 
-  const databaseTab = page.locator('.MainMenuButton[data-button-id="Database"]');
+  const databaseTab = page.locator('.mm-tab[data-button-id="Database"]');
   await expect(databaseTab).toBeVisible();
 
   // Dispatch a synthetic touch sequence.  page.tap() may stall on hidden
   // ancestors in the canvas-heavy stage, so we drive the DOM event API
-  // directly — the click+touchend pair on .MainMenuButton is what we're
+  // directly — the click+touchend pair on .mm-tab is what we're
   // exercising.
   await page.evaluate(() => {
-    const el = document.querySelector<HTMLElement>('.MainMenuButton[data-button-id="Database"]');
+    const el = document.querySelector<HTMLElement>('.mm-tab[data-button-id="Database"]');
     if (!el) throw new Error('database tab missing');
     el.dispatchEvent(
       new TouchEvent('touchstart', { bubbles: true, cancelable: true, touches: [] as any })

--- a/tests/e2e/mobile-xp-bar.spec.ts
+++ b/tests/e2e/mobile-xp-bar.spec.ts
@@ -2,9 +2,9 @@
  * Mobile XP bar clone (issue #80).
  *
  * The XP statusItem is cloned out of the in-stage Statusbar into the
- * MainMenu's `.MainMenuXP` slot on mobile breakpoints (≤ 768 px).  This
+ * MainMenu's `.mm-xp` slot on mobile breakpoints (≤ 768 px).  This
  * spec verifies that:
- *   - the cloned bar exists inside `.MainMenu .MainMenuXP`
+ *   - the cloned bar exists inside `.MainMenu .mm-xp`
  *   - it sits within the MainMenu's row 1 (so it can't visually leak into
  *     the playfield like the previous CSS-magic position:fixed approach
  *     could when the sprite z-index lost the stacking-order race)
@@ -24,7 +24,7 @@ test('mobile-xp: XP bar is cloned into MainMenu and stays in row 1', async ({ pa
 
   const layout = await page.evaluate(() => {
     const menu = document.querySelector<HTMLElement>('.MainMenu');
-    const slot = document.querySelector<HTMLElement>('.MainMenu .MainMenuXP');
+    const slot = document.querySelector<HTMLElement>('.MainMenu .mm-xp');
     const cloneXp = slot?.querySelector<HTMLElement>('.StatusItem.XP') ?? null;
     const inStageXp = document.querySelector<HTMLElement>('.Statusbar .StatusItem.XP');
     if (!menu || !slot || !cloneXp) {

--- a/views/mainmenu.html
+++ b/views/mainmenu.html
@@ -1,4 +1,4 @@
-<%  
+<%
   var game = _.game();
   var logoclass = game.setup.locale;
 %>
@@ -7,14 +7,14 @@
     var u = (game.data && game.data.user) || {};
     var displayName = u.display_name || u.name || '';
   %>
-  <div class="MainMenuXP">
-    <div class="MainMenuXPName" data-testid="dd-mobile-displayname"><%= displayName %></div>
-    <div class="MainMenuXPBar"></div>
+  <div class="mm-xp">
+    <div class="mm-xp-name" data-testid="dd-mobile-displayname"><%= displayName %></div>
+    <div class="mm-xp-bar"></div>
   </div>
-  <div class="UserActions">
-    <div id="LocaleToggle" class="UserButton"><%= game.setup.localeShort === 'de' ? '🇩🇪🇦🇹🇨🇭 DE' : '🇺🇸🇬🇧🇦🇺 EN' %></div>
-    <div id="UserData" class="UserButton"><%= _._('About') %></div>
+  <div class="mm-actions">
+    <div id="LocaleToggle" class="mm-user-btn"><%= game.setup.localeShort === 'de' ? '🇩🇪🇦🇹🇨🇭 DE' : '🇺🇸🇬🇧🇦🇺 EN' %></div>
+    <div id="UserData" class="mm-user-btn"><%= _._('About') %></div>
   </div>
-  <div id="MainMenuButtons" class="MainMenuButtons">
-    <% _.each(D.buttons, function(button) { %> <div class="MainMenuButton<% if (button.states.active) { print(' active') }; %>" data-button-id="<%= button.id %>"><%= button.label %></div> <% }); %>
+  <div class="mm-tabs">
+    <% _.each(D.buttons, function(button) { %> <div class="mm-tab<% if (button.states.active) { print(' active') }; %>" data-button-id="<%= button.id %>"><%= button.label %></div> <% }); %>
   </div>


### PR DESCRIPTION
## Summary

Decouples the main-menu header from styles shared with the rest of the UI, fixes the resulting mobile-layout regressions, and gives the Topscores in-view tabs the same mobile treatment so the two transitions align.

## CSS extraction

- New `css/MainMenu.css` owns every main-menu-only rule.  Classes are renamed to a `mm-*` lowercase-dash convention (`mm-tab`, `mm-tabs`, `mm-xp`, `mm-xp-name`, `mm-xp-bar`, `mm-actions`, `mm-user-btn`) so it's obvious at the call site they're not reused elsewhere — fixes here cannot leak into other components.
- `.MainMenuButton` was previously stapled to `.ViewTabMenuButton` via comma-separated selectors at every breakpoint.  The two are now fully decoupled: `.ViewTabMenuButton` keeps a self-contained copy of the rules in `Render.css`; `.mm-tab` lives in `MainMenu.css`.
- `.MainMenuLogo` is intentionally left alone — it's also used by the About popup (`views/popup_user_data.html`).  Its sprite-image rule stays in `Render.css`; only the in-menu positioning moves to `MainMenu.css` under `.MainMenu .MainMenuLogo`.

## Mobile main-menu layout

- **Tabs flex-fill the row.**  At ≤ 926 px, `.mm-tabs` is `display: flex` with `flex: 1 1 0` on each tab, so all four labels grow to share the row evenly instead of bunching to the centre with empty rails.
- **Compact, balanced text.**  `padding: 2px 8px 8px 8px` + `line-height: 24px` matches the desktop ratio so Bowlby's top-aligned glyph + 3 px drop-shadow sit visually centred in the 44 px tap-target box (`min-height: 44px`).  Per-breakpoint font-size cascade (16 / 15 / 13 / 11 px at 600 / 480 / 380) keeps labels full-size and unwrapped.
- **Square tab bottoms.**  `border-radius: 8px 8px 0 0` on `.mm-tab` so the tab's rounded bottom corners can't expose the dark menu bg through the corner cutouts (was reading as a "gap" under active tabs).
- **Tabs flush against menu bottom.**  `.mm-tabs` has no padding-bottom; `.MainMenu` is `overflow: hidden` so any tab box-shadow tail is clipped against the menu's edge.
- **Dynamic header height.**  At ≤ 926 px, `.MainMenu` becomes a `flex-direction: column`; the hardcoded `min-height: 96px` / `padding-top: 48px` constants are gone, so the row heights flow from their content (XP bar above, tabs below).
- **Top-only border-radius.**  `border-radius: 8px 8px 0 0` on `.MainMenu` keeps the rounded top corners and squares off the bottom so the header docks cleanly with the Stage.
- **Cyan separator restored.**  `border-bottom: 3px solid #16a3d7` on `.MainMenu` at ≤ 926 px (with `box-sizing: border-box`) — the same blue stripe the desktop tab strip carries.

## JS plumbing

`Render.js`'s base `Node.setSize` writes inline `style="height: 48px"` on every Stage-derived node, which combined with `overflow: hidden` was clipping the entire mobile tab strip.  Override `MainMenu.prototype.setSize` to write width-only and `MainMenu.prototype.updateRenderProp` to skip the inline `display: block` write.  Height/display are now fully CSS-driven (48 px on desktop, `auto` flex column on mobile).

A `ResizeObserver` on the menu in `Game.fitToWindow`'s bootstrap re-fits the Stage when the header grows after the cloned XP bar mounts in or any later CSS reflow.  Without it the Stage was sized against the pre-clone 59 px header and pushed the Database conveyor 28 px below the viewport on phones.

## Topscores tab strip (`.ViewTabMenuButton`)

- Goes mobile at the same `@media (max-width: 926px)` threshold as the main menu (was 768 px, leaving 769–926 px viewports stuck on the desktop styling with a fat empty band beneath the text).
- Same flex-fill treatment: `display: flex` on `.ViewTabMenu`, `flex: 1 1 0` on each tab so they share the row evenly.
- `font-size: 16px; line-height: 25px; padding: 4px 8px; top: 0` for both active and inactive — balanced, no `top: 13/9` press-down offset on touch.
- The narrow-breakpoint `font-size` / `line-height` overrides at 600/530/480/380 are removed so the 16/25 holds at every mobile width.

## Touched call sites

- `views/mainmenu.html` uses the new `mm-*` classes (and drops the unused `id="MainMenuButtons"`).
- `scripts/Render.js` jQuery selectors (`.MainMenuButton`, `.MainMenuXP`, `.MainMenuXPBar`, `.UserButton, .MainMenuButton`) updated to `.mm-tab` / `.mm-xp` / `.mm-xp-bar` / `.mm-user-btn, .mm-tab`.
- `scripts/Game.js` adds the `ResizeObserver` wiring next to the existing `resize.gameFit` handler.
- E2E specs (`mission-centering`, `mobile-breakpoints`, `mobile-conveyor`, `mobile-layout-iter2`, `mobile-tap-targets`, `mobile-touch`, `mobile-xp-bar`) updated to query the renamed classes.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 624 unit tests pass
- [x] `pnpm test:e2e` — 45 pass / 1 skipped (full Playwright suite)
- [x] `pnpm build` — both `.xdc` artefacts rebuild; `MainMenu.css` is copied to `dist/css/` and referenced from `dist/index.html`
- [x] Eyeballed at 360 / 375 / 390 / 414 / 480 / 600 / 720 / 768 / 880 / 1024 px to confirm:
   - main-menu tabs are compact, full-width, labels full-size on one line
   - active tab sits flush against the menu bottom (no rounded-corner gap)
   - cyan stripe at the menu's bottom edge
   - top corners rounded, bottom flush
   - Topscores tabs (Cash / Profile / XP / Investor) match the same look and stay 16/25 across mobile widths

https://claude.ai/code/session_01LHCcc1Kc6bxbMkB3iSpDKf