### PR TITLE
Clamp bling text x position to prevent off-screen rendering

### DIFF
--- a/scripts/Render.js
+++ b/scripts/Render.js
@@ -2037,17 +2037,10 @@ var Render = function () {
     config = config || {};
     var node = this.gameNode.GameRoot.renderNode;
     var nodePos = this.gameNode.GameRoot.renderStatusbar.getTopLeftPosition();
-    // Statusbar.getTopLeftPosition() returns stage.width/2 - 360 because
-    // the statusbar's logical design width is 720. On viewports narrower
-    // than 720 the value is negative, which would render the bling text
-    // off the left edge of the stage. Statusbar.css already forces the
-    // bar to left:0/width:100%, so clamp x into the visible stage with a
-    // small inset that matches the statusbar's CSS padding-inline.
-    var stageWidth = node.getSize().width;
-    var minX = 8;
-    var maxX = Math.max(minX, stageWidth - 8);
-    if (nodePos.x < minX) nodePos.x = minX;
-    if (nodePos.x > maxX) nodePos.x = maxX;
+    // Statusbar.css pins the bar to left:0/width:100%, but
+    // getTopLeftPosition() still returns stage.width/2 - 360 from the
+    // 720 px design — negative on narrower viewports.
+    nodePos.x = Math.max(8, nodePos.x);
     config.wait = config.wait || 0;
     if (!node.renderBlings) {
       node.renderBlings = {};

--- a/scripts/Render.js
+++ b/scripts/Render.js
@@ -2037,6 +2037,17 @@ var Render = function () {
     config = config || {};
     var node = this.gameNode.GameRoot.renderNode;
     var nodePos = this.gameNode.GameRoot.renderStatusbar.getTopLeftPosition();
+    // Statusbar.getTopLeftPosition() returns stage.width/2 - 360 because
+    // the statusbar's logical design width is 720. On viewports narrower
+    // than 720 the value is negative, which would render the bling text
+    // off the left edge of the stage. Statusbar.css already forces the
+    // bar to left:0/width:100%, so clamp x into the visible stage with a
+    // small inset that matches the statusbar's CSS padding-inline.
+    var stageWidth = node.getSize().width;
+    var minX = 8;
+    var maxX = Math.max(minX, stageWidth - 8);
+    if (nodePos.x < minX) nodePos.x = minX;
+    if (nodePos.x > maxX) nodePos.x = maxX;
     config.wait = config.wait || 0;
     if (!node.renderBlings) {
       node.renderBlings = {};


### PR DESCRIPTION
## Summary
Fixed an issue where bling text could render off the left edge of the stage on narrow viewports by clamping the x position to the visible stage bounds.

## Key Changes
- Added bounds checking for the bling text x position based on stage width
- Clamp x position between a minimum of 8 pixels and a maximum of (stageWidth - 8) pixels
- The inset of 8 pixels matches the statusbar's CSS padding-inline for visual consistency

## Implementation Details
The statusbar's `getTopLeftPosition()` method returns `stage.width/2 - 360` (since the statusbar has a logical design width of 720). On viewports narrower than 720 pixels, this calculation produces negative x values, causing the bling text to render outside the visible stage area.

Since the statusbar is already constrained to `left:0/width:100%` via CSS, the bling text position is now clamped to ensure it stays within the visible stage bounds with a small inset that matches the statusbar's padding.

https://claude.ai/code/session_01FhRiQtLDD4oXnHGKexjafi