### PR TITLE
phase 7 (#147): extract GameRoot shell + type registry / DB tokens / lifecycle (PR 19)

### DIFF
--- a/scripts/Game.js
+++ b/scripts/Game.js
@@ -33,6 +33,7 @@ import {
   remove,
 } from './game/GameNode.js';
 import { GamePerp, setAniTicker } from './game/GamePerp.js';
+import { GameRoot, setAniTickerForGameRoot } from './game/GameRoot.js';
 import { Imperium } from './game/Imperium.js';
 import { Mission } from './game/Mission.js';
 import { Missions } from './game/Missions.js';
@@ -257,201 +258,6 @@ var Game = function () {
   // GameRoot (app.game) can be accessed in debug mode from the console
   // TODO: better way to publish only those parts of the api that need to be global
   ///////////////////////////////////
-
-  var GameRoot = function (config) {
-    // Initialize the typeRegistry
-    this.typeRegistry = {};
-    this.DBTokensLength = 0;
-    this.DBTokensLengthMax = 0;
-    this.DBTokens = {};
-    this.DBOriginTokens = {};
-    this.DBTokensAbsolute = {};
-    this.DBTokensCrossSum = 0;
-    this.IPerps = {};
-    this.NotificationQueue = [];
-    return this;
-  };
-  extend(GameRoot, GameNode);
-
-  GameRoot.prototype.renderType = 'Stage';
-
-  GameRoot.prototype.get = get;
-
-  GameRoot.prototype.setup = setup;
-
-  GameRoot.prototype.ids = _ids;
-  GameRoot.prototype.getById = getById;
-
-  GameRoot.prototype.addType = function (gestalt, data) {
-    // Add a type to the typeRegistry data should have data.type_data
-    // If the game_type is also defined in typeSettings it will be merged and overwritten with data
-    if (data.game_type && data.type_data) {
-      if (typeSettings.hasOwnProperty(data.game_type)) {
-        data.type_data = mergeData(typeSettings[data.game_type].type_data, data.type_data);
-      }
-    }
-    this.typeRegistry[gestalt] = data;
-    this.typeRegistry[gestalt].gestalt = gestalt;
-    this.typeRegistry[gestalt].game_type = data.game_type;
-    // FIXME: is_supertoken fix for export fail.
-    if (gestalt.substring(0, 5) === 'token') {
-      this.typeRegistry[gestalt].type_data.is_supertoken = false;
-    }
-
-    return this.typeRegistry[gestalt];
-  };
-
-  GameRoot.prototype.addSubType = function (parent_gestalt, gestalt, data) {
-    // Add a subtype to the typeRegistry data should have data.type_data
-    // If the game_type is also defined in typeSettings it will be merged and overwritten with data
-    var groot = this;
-    var parentType = groot.getType(parent_gestalt);
-    if (parentType) {
-      if (data.game_type && data.type_data) {
-        if (typeSettings.hasOwnProperty(data.game_type)) {
-          data.type_data = mergeData(typeSettings[data.game_type].type_data, data.type_data);
-          // expand powerup tokens with their type data
-          if (data.type_data.tokens && data.type_data.tokens.length) {
-            _.each(data.type_data.tokens, function (v, k) {
-              v.type_data = groot.getTypeData(v.gestalt);
-            });
-          }
-        }
-        return (parentType[gestalt] = data);
-      }
-    }
-  };
-
-  GameRoot.prototype.removeType = function (gestalt) {
-    // Remove a type from the typeRegistry
-    delete this.typeRegistry[gestalt];
-  };
-  GameRoot.prototype.getType = function (gestalt) {
-    // Get type from the registry, Note on the structure: data.type_data
-    return this.typeRegistry[gestalt];
-  };
-  GameRoot.prototype.getTypeData = function (gestalt) {
-    // Get type_data from the registry, Note on the structure: data.type_data
-    var type = this.getType(gestalt);
-    if (type) {
-      return type.type_data;
-    } else {
-      return undefined;
-    }
-  };
-  GameRoot.prototype.getTypes = function (game_type) {
-    // Get all types with game_type from the registry
-    //return this.typeRegistry[gestalt];
-    return _.where(this.typeRegistry, { game_type: game_type });
-  };
-  GameRoot.prototype.getTypeFromGestalt = function (gestalt) {
-    // Get all types with game_type from the registry
-    if (gestalt) {
-      return this.typeRegistry[gestalt].game_type;
-    } else {
-      return {};
-    }
-  };
-
-  GameRoot.prototype.getDBTokenAmount = function (gestalt) {
-    if (this.DBTokens && this.DBTokens.hasOwnProperty(gestalt)) {
-      return this.DBTokens[gestalt];
-    } else {
-      return 0;
-    }
-  };
-
-  GameRoot.prototype.getDBTokensLength = function () {
-    // without origin tokens
-    return (this.DBTokensLength = _.filter(_.keys(this.DBTokens), function (t) {
-      return t.substring(0, 6) !== 'origin';
-    }).length);
-  };
-
-  GameRoot.prototype.getDBTokensLengthMax = function () {
-    // without origin tokens
-    return (this.DBTokensLengthMax = _.filter(
-      _.where(this.typeRegistry, { game_type: 'TokenPerp' }),
-      function (t) {
-        return t.gestalt.substring(0, 6) !== 'origin';
-      }
-    ).length);
-  };
-
-  GameRoot.prototype.getDBTokensCrossSum = function (gestalt) {
-    var DBTokens = this.DBTokens;
-    var sum = 0;
-    var count = 1;
-    _.each(DBTokens, function (t, k) {
-      sum += t;
-      count += 1;
-    });
-    return sum / count;
-  };
-
-  GameRoot.prototype.compileOriginTokens = function (nodes) {
-    var groot = this;
-    var origintokens = _.filter(nodes, function (n) {
-      if (n.gestalt) {
-        return n.gestalt.substring(0, 6) === 'origin';
-      } else {
-        return false;
-      }
-    });
-    _.each(origintokens, function (t, k) {
-      var ot = (groot.DBOriginTokens[t.gestalt] = {});
-      ot.gestalt = t.gestalt;
-      ot.data = groot.getTypeData(t.gestalt);
-      ot.amount = ot.data.amount = t.instance_data.amount;
-      ot.absoluteAmount = (groot.profiles_value * ot.amount) / 100;
-      ot.originGameNode = getByGestalt(ot.data.origin_gestalt);
-      ot.originGameType = ot.originGameNode.gameType;
-      if (ot.originGameType === 'CityPerp') {
-        var citymax = ot.originGameNode.data.profiles_max;
-        ot.cityMaxAmount = ((ot.amount / 100) * groot.profiles_value) / citymax;
-        //((float(amounts.get(origin_gestalt, 0))/100) * self.game_values.get('profiles_value')) / origin_data.get('type_data').get('profiles_max')
-      }
-    });
-  };
-
-  GameRoot.prototype.getOriginGestaltFromOriginTokenGestalt = function (origintokengestalt) {
-    var origin =
-      _.find(this.DBOriginTokens, function (ot) {
-        return ot.originGameNode.gestalt === 'city002';
-      }) || {};
-    return origin.gestalt;
-  };
-
-  GameRoot.prototype.kill = function () {
-    console.warn('Killing Game');
-    clear();
-    delete app.game;
-  };
-
-  GameRoot.prototype.lock = function () {
-    // Lock the whole stage and turn off triggering of render Events
-    // TODO make stage spinner in Render and use proper method to unbind events
-    // Unlock currently wouldn't work since all events are destroyed
-    if (this.renderNode) {
-      this.renderNode.lock();
-      this.renderMenu.lock();
-      AniTicker.stop();
-    }
-    // FIXME for Popups
-    //this.renderNode.jdomelem.find('*').off();
-  };
-  GameRoot.prototype.unlock = function () {
-    if (this.NotificationQueue && this.NotificationQueue.length < 2) {
-      this.renderNode.unlock();
-      this.renderMenu.unlock();
-      AniTicker.start();
-    } else if (!this.NotificationQueue) {
-      this.renderNode.unlock();
-      this.renderMenu.unlock();
-      AniTicker.start();
-    }
-    //this.renderNode.jdomelem.find('*').off();
-  };
 
   GameRoot.prototype.refresh = function () {
     // Reload the game data and reinit the whole Game (like a page reload).
@@ -691,42 +497,6 @@ var Game = function () {
       e.stopPropagation();
       gnode.makeNotifications(data);
     });
-  };
-
-  GameRoot.prototype.getParentTypes = function (gestalt) {
-    // returns the type_data of all perps where gestalt is provided
-    var types = _.filter(this.typeRegistry, function (t) {
-      return _.contains(t.type_data.provided_perps, gestalt);
-    });
-    if (types) {
-      return types;
-    } else {
-      return {};
-    }
-  };
-
-  GameRoot.prototype.getParentTypeData = function (gestalt) {
-    // returns the type_data of a perp where gestalt is provided
-    var type = _.find(this.typeRegistry, function (t) {
-      return _.contains(t.type_data.provided_perps, gestalt);
-    });
-    if (type) {
-      return type.type_data;
-    } else {
-      return {};
-    }
-  };
-
-  GameRoot.prototype.getParentType = function (gestalt) {
-    // returns the type_data of a perp where gestalt is provided
-    var type = _.find(this.typeRegistry, function (t) {
-      return _.contains(t.type_data.provided_perps, gestalt);
-    });
-    if (type) {
-      return type;
-    } else {
-      return {};
-    }
   };
 
   GameRoot.prototype.notification_level = 2;
@@ -1824,16 +1594,6 @@ var Game = function () {
   // map) and the known-name `Game.TokenPerp` reference via a direct
   // import — both wired up in PR 17 of issue #147.
 
-  // updateGears was scoped to the Database section in legacy
-  // (`// TODO: Move this to GameRoot`) but is a GameRoot prototype mixin.
-  // Kept here at GameRoot scope so all the GameRoot.prototype.X
-  // assignments stay together.
-  GameRoot.prototype.updateGears = function () {
-    _.each(getByType('TokenPerp'), function (t) {
-      t.updateGear();
-    });
-  };
-
   ///////////////////////////////////
   // The GamePerp Base Class
   ///////////////////////////////////
@@ -1872,60 +1632,6 @@ var Game = function () {
   // DatabasePerp + CityPerp similarly extracted to scripts/game/
   // DatabasePerp.ts / CityPerp.ts in PR 12 of issue #147.
 
-  GameRoot.prototype.getCityOriginAmounts = function () {
-    var cities = _.where(this.DBOriginTokens, { originGameType: 'CityPerp' });
-    var city_amounts = {};
-    _.each(cities, function (c) {
-      city_amounts[c.gestalt] = c.cityMaxAmount;
-    });
-    return city_amounts;
-  };
-
-  GameRoot.prototype.getDBFactorNormalized = function () {
-    var cityamounts = this.getCityOriginAmounts();
-    return _.reduce(
-      _.values(cityamounts),
-      function (memo, num) {
-        return memo + num;
-      },
-      0
-    );
-  };
-
-  GameRoot.prototype.fetchProjectPowerupData = function (project_gestalt, cb) {
-    var groot = this;
-    var gnode = getByGestalt(project_gestalt);
-    // Register Powerups in typeRegistry
-    if (gnode && !gnode.data.powerupsCached) {
-      app.remote.getPowerups(project_gestalt, app.version).done(function (data) {
-        _.each(data.result, function (v, k) {
-          groot.addSubType(project_gestalt, v.game_gestalt, v);
-        });
-        if (gnode.renderPopup) {
-          gnode.renderPopup.templateData.cached = true;
-        }
-        gnode.data.powerupsCached = true;
-        if (cb) {
-          cb();
-        }
-      });
-    } else if (gnode && gnode.renderPopup && gnode.renderPopup.templateData) {
-      gnode.renderPopup.templateData.cached = true;
-      if (cb) {
-        cb();
-      }
-    } else {
-      app.remote.getPowerups(project_gestalt, app.version).done(function (data) {
-        _.each(data.result, function (v, k) {
-          groot.addSubType(project_gestalt, v.game_gestalt, v);
-        });
-        if (cb) {
-          cb();
-        }
-      });
-    }
-  };
-
   ////////////////////////////////////////////
   // The API Publisher
   ////////////////////////////////////////////
@@ -1961,11 +1667,12 @@ var Game = function () {
     SupertokenPerp: SupertokenPerp,
   };
 
-  // Inject AniTicker into GamePerp so its initEventHandlers can register
-  // listeners on the legacy ticker singleton (which still lives in this
-  // IIFE). Disposable seam; retires when AniTicker is itself extracted
-  // from Game.js.
+  // Inject AniTicker into GamePerp / GameRoot so their lock/unlock and
+  // initEventHandlers can register listeners on the legacy ticker
+  // singleton (which still lives in this IIFE). Disposable seam;
+  // retires when AniTicker is itself extracted from Game.js.
   setAniTicker(AniTicker);
+  setAniTickerForGameRoot(AniTicker);
 
   return Game;
 };

--- a/scripts/game/GameRoot.ts
+++ b/scripts/game/GameRoot.ts
@@ -201,7 +201,11 @@ export class GameRoot extends GameNode {
   /** Returns `''` when called with a falsy gestalt — legacy returned
    *  `{}` here, but every caller treats the result as a string game-
    *  type name.  The `{}` was a mis-typed sentinel; flatten to `''` so
-   *  the strict TS signature stays clean. */
+   *  the strict TS signature stays clean.  Audited 2026-05-06: both
+   *  call sites (Game.js:866 GameRoot.BuyPerp and GameNode.ts:757
+   *  initPopupEvents PerpBuyButton handler) compare the result with
+   *  `=== 'CityPerp'` — the legacy `{}` would have failed that check
+   *  identically to `''`.  No truthy-empty-object dependency exists. */
   getTypeFromGestalt(gestalt?: string): string {
     if (!gestalt) return '';
     return this.typeRegistry[gestalt]?.game_type ?? '';
@@ -310,7 +314,7 @@ export class GameRoot extends GameNode {
 
   /** Hardcoded `'city002'` lookup is preserved from legacy.  Suspected
    *  copy-paste latent bug — should probably read `origintokengestalt`'s
-   *  origin link.  Filed for follow-up. */
+   *  origin link.  Tracked in issue #203. */
   getOriginGestaltFromOriginTokenGestalt(_origintokengestalt: string): string | undefined {
     const origin = Object.values(this.DBOriginTokens).find(
       (ot) => ot.originGameNode?.gestalt === 'city002'

--- a/scripts/game/GameRoot.ts
+++ b/scripts/game/GameRoot.ts
@@ -1,0 +1,425 @@
+// GameRoot — the singleton at the top of every GameNode tree.  Owns:
+//   - the `typeRegistry` (gestalt → game-type / type_data) populated
+//     from server bootstrap data;
+//   - DB-token state mirrors (`DBTokens`, `DBTokensAbsolute`,
+//     `DBOriginTokens`, `IPerps`) that drive the income / charge
+//     calculations on TokenPerp / ClientPerp / Database;
+//   - the notification queue and a handful of lifecycle hooks (`kill`,
+//     `lock`, `unlock`).
+//
+// Extracted from scripts/Game.js's IIFE in PR 19 of issue #147.  This
+// PR moves the GameRoot **class shell** + the simplest method groups
+// (type registry, DB tokens, lifecycle, parent-type lookups, the
+// `getCityOriginAmounts` / `getDBFactorNormalized` / `updateGears` /
+// `fetchProjectPowerupData` mixins).  The remaining ~38 methods
+// (render hooks, status bar, level / XP, BuyPerp / BuyKarma,
+// notifications, loadGame, view getters) stay as
+// `GameRoot.prototype.X = function () {...}` assignments in Game.js
+// for now; later PRs in the wave migrate them one batch at a time.
+
+import appModule from '../app.js';
+import setup from '../setup.js';
+import { getTypeSettings } from '../type_settings.js';
+import {
+  GameNode,
+  type GameNodeConfig,
+  _ids,
+  clear as clearRegistry,
+  get,
+  getByGestalt,
+  getById,
+  getByType,
+} from './GameNode.js';
+import { mergeData } from './mergeData.js';
+
+// ---------------------------------------------------------------------------
+// Internal types
+// ---------------------------------------------------------------------------
+
+interface TypeEntry {
+  gestalt?: string;
+  game_type?: string;
+  type_data?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+interface OriginToken {
+  gestalt: string | undefined;
+  data: (Record<string, unknown> & { amount?: number; profiles_max?: number }) | undefined;
+  amount: number | undefined;
+  absoluteAmount: number | undefined;
+  originGameNode: GameNode | undefined;
+  originGameType: string | undefined;
+  cityMaxAmount: number | undefined;
+}
+
+/** Minimal Render surface needed by the lifecycle methods extracted in
+ *  this PR.  Collapses when Render.js is typed (later in #147). */
+interface RenderRootLike {
+  lock?(): void;
+  unlock?(): void;
+  jdomelem?: { find(sel: string): { off(ev?: string): void } };
+}
+
+interface AniTickerLike {
+  start(): void;
+  stop(): void;
+}
+
+let _aniTicker: AniTickerLike | null = null;
+/** Game.js injects the AniTicker singleton at IIFE-end via this setter
+ *  (parallel to `setAniTicker` on GamePerp).  Disposable seam — retires
+ *  when AniTicker itself extracts. */
+export function setAniTickerForGameRoot(ticker: AniTickerLike): void {
+  _aniTicker = ticker;
+}
+
+// ---------------------------------------------------------------------------
+// GameRoot class
+// ---------------------------------------------------------------------------
+
+export class GameRoot extends GameNode {
+  override renderType = 'Stage';
+
+  typeRegistry: Record<string, TypeEntry> = {};
+  DBTokens: Record<string, number> = {};
+  DBTokensAbsolute: Record<string, number> = {};
+  DBOriginTokens: Record<string, OriginToken> = {};
+  DBTokensCrossSum = 0;
+  DBTokensLength = 0;
+  DBTokensLengthMax = 0;
+  IPerps: Record<string, true> = {};
+  NotificationQueue: unknown[] = [];
+
+  // Field assignments preserved from the legacy `GameRoot.prototype.X
+  // = ...` block — exposed for callers that read `groot.get` / `groot.
+  // ids` / `groot.setup` / `groot.getById` (the legacy IIFE made them
+  // explicit prototype slots; preserved as instance-bound aliases here
+  // so existing call sites keep working).
+  get = get;
+  ids = _ids;
+  setup = setup;
+  getById = getById;
+
+  // notification_level controls verbosity in makeNotifications (still
+  // in Game.js).  Class-field default matches the legacy prototype.
+  notification_level = 2;
+
+  // Properties stamped onto GameRoot during gameplay or via the
+  // not-yet-migrated methods that still live in Game.js.  Declared
+  // here so subclass call sites that read them through the typed
+  // GameRoot reference don't need per-call casts.
+  profiles_value = 0;
+  cash_value = 0;
+  ap_value = 0;
+  karma_value = 0;
+  xp_level: { number: number; [key: string]: unknown } = { number: 0 };
+  data: { status_icons?: unknown; [key: string]: unknown } = {};
+  override renderNode?: NonNullable<GameNode['renderNode']> & RenderRootLike;
+  // `renderMenu` widens GameNode's typed declaration to also expose the
+  // RenderRoot lock/unlock surface the lifecycle methods touch.
+  override renderMenu?: NonNullable<GameNode['renderMenu']> &
+    RenderRootLike & {
+      addButton?(label: string, id: string, states: unknown): void;
+    };
+  notificationPopup?: NonNullable<GameNode['renderPopup']> & {
+    render?(): void;
+    notificationMission?: string | null;
+  };
+  retryDelay?: number;
+
+  // -------------------------------------------------------------------
+  // Type registry
+  // -------------------------------------------------------------------
+
+  addType(gestalt: string, data: TypeEntry): TypeEntry {
+    // Add a type to the typeRegistry. `data` should have data.type_data.
+    // If the game_type is also defined in typeSettings, the legacy
+    // typeSettings entry's type_data is merged into the inbound data
+    // (inbound wins on conflict).
+    if (data.game_type && data.type_data) {
+      const ts = getTypeSettings() as Record<string, TypeEntry>;
+      if (Object.prototype.hasOwnProperty.call(ts, data.game_type)) {
+        const baseTd = ts[data.game_type]?.type_data;
+        if (baseTd) {
+          data.type_data = mergeData(baseTd, data.type_data) as Record<string, unknown>;
+        }
+      }
+    }
+    this.typeRegistry[gestalt] = data;
+    data.gestalt = gestalt;
+    // FIXME: is_supertoken fix for export fail.
+    if (gestalt.substring(0, 5) === 'token' && data.type_data) {
+      data.type_data.is_supertoken = false;
+    }
+    return data;
+  }
+
+  addSubType(parent_gestalt: string, gestalt: string, data: TypeEntry): TypeEntry | undefined {
+    const parentType = this.getType(parent_gestalt) as
+      | (TypeEntry & Record<string, TypeEntry>)
+      | undefined;
+    if (!parentType) return undefined;
+    if (data.game_type && data.type_data) {
+      const ts = getTypeSettings() as Record<string, TypeEntry>;
+      if (Object.prototype.hasOwnProperty.call(ts, data.game_type)) {
+        const baseTd = ts[data.game_type]?.type_data;
+        if (baseTd) {
+          data.type_data = mergeData(baseTd, data.type_data) as Record<string, unknown>;
+        }
+        // expand powerup tokens with their type data
+        const td = data.type_data as { tokens?: Array<{ gestalt?: string; type_data?: unknown }> };
+        if (td.tokens?.length) {
+          td.tokens.forEach((v) => {
+            if (v.gestalt) v.type_data = this.getTypeData(v.gestalt);
+          });
+        }
+      }
+      parentType[gestalt] = data;
+      return data;
+    }
+    return undefined;
+  }
+
+  removeType(gestalt: string): void {
+    delete this.typeRegistry[gestalt];
+  }
+
+  override getType(gestalt?: string): TypeEntry | undefined {
+    if (gestalt === undefined) return undefined;
+    return this.typeRegistry[gestalt];
+  }
+
+  getTypeData(gestalt?: string): Record<string, unknown> | undefined {
+    return this.getType(gestalt)?.type_data;
+  }
+
+  getTypes(game_type: string): TypeEntry[] {
+    return Object.values(this.typeRegistry).filter((t) => t.game_type === game_type);
+  }
+
+  /** Returns `''` when called with a falsy gestalt — legacy returned
+   *  `{}` here, but every caller treats the result as a string game-
+   *  type name.  The `{}` was a mis-typed sentinel; flatten to `''` so
+   *  the strict TS signature stays clean. */
+  getTypeFromGestalt(gestalt?: string): string {
+    if (!gestalt) return '';
+    return this.typeRegistry[gestalt]?.game_type ?? '';
+  }
+
+  getParentTypes(gestalt: string): TypeEntry[] {
+    return Object.values(this.typeRegistry).filter((t) => {
+      const provided = (t.type_data as { provided_perps?: string[] } | undefined)?.provided_perps;
+      return provided?.includes(gestalt);
+    });
+  }
+
+  getParentTypeData(gestalt: string): Record<string, unknown> {
+    const type = Object.values(this.typeRegistry).find((t) => {
+      const provided = (t.type_data as { provided_perps?: string[] } | undefined)?.provided_perps;
+      return provided?.includes(gestalt);
+    });
+    return type?.type_data ?? {};
+  }
+
+  getParentType(gestalt: string): TypeEntry {
+    const type = Object.values(this.typeRegistry).find((t) => {
+      const provided = (t.type_data as { provided_perps?: string[] } | undefined)?.provided_perps;
+      return provided?.includes(gestalt);
+    });
+    return type ?? {};
+  }
+
+  // -------------------------------------------------------------------
+  // DB-token state
+  // -------------------------------------------------------------------
+
+  getDBTokenAmount(gestalt: string): number {
+    return Object.prototype.hasOwnProperty.call(this.DBTokens, gestalt)
+      ? (this.DBTokens[gestalt] ?? 0)
+      : 0;
+  }
+
+  /** Length without origin tokens.  Mutates the cached
+   *  `DBTokensLength` field as a side effect (legacy behaviour
+   *  preserved — callers read both the return value and the field). */
+  getDBTokensLength(): number {
+    const len = Object.keys(this.DBTokens).filter((t) => t.substring(0, 6) !== 'origin').length;
+    this.DBTokensLength = len;
+    return len;
+  }
+
+  /** Max length without origin tokens.  Mutates the cached
+   *  `DBTokensLengthMax` field. */
+  getDBTokensLengthMax(): number {
+    const len = Object.values(this.typeRegistry).filter(
+      (t) => t.game_type === 'TokenPerp' && (t.gestalt ?? '').substring(0, 6) !== 'origin'
+    ).length;
+    this.DBTokensLengthMax = len;
+    return len;
+  }
+
+  /** Cross-sum: arithmetic mean of `DBTokens` values, with `count`
+   *  initialized at 1 (matches the legacy `count = 1` quirk; not the
+   *  textbook average).  `gestalt` is unused — preserved as a parameter
+   *  for callsite compat. */
+  getDBTokensCrossSum(_gestalt?: string): number {
+    let sum = 0;
+    let count = 1;
+    for (const k in this.DBTokens) {
+      if (Object.prototype.hasOwnProperty.call(this.DBTokens, k)) {
+        sum += this.DBTokens[k] ?? 0;
+        count += 1;
+      }
+    }
+    return sum / count;
+  }
+
+  compileOriginTokens(
+    nodes: Array<{ gestalt?: string; instance_data?: { amount?: number } }>
+  ): void {
+    const origintokens = nodes.filter((n) => n.gestalt?.substring(0, 6) === 'origin');
+    origintokens.forEach((t) => {
+      if (!t.gestalt) return;
+      const td = this.getTypeData(t.gestalt) as
+        | { amount?: number; origin_gestalt?: string; profiles_max?: number; [k: string]: unknown }
+        | undefined;
+      const amount = t.instance_data?.amount ?? 0;
+      if (td) td.amount = amount;
+      const originGestalt = td?.origin_gestalt;
+      const originNode = originGestalt ? getByGestalt(originGestalt) : undefined;
+      const originGameType = originNode?.gameType;
+      let cityMaxAmount: number | undefined;
+      if (originGameType === 'CityPerp') {
+        const citymax = (originNode?.data as { profiles_max?: number } | undefined)?.profiles_max;
+        if (citymax) {
+          cityMaxAmount = ((amount / 100) * this.profiles_value) / citymax;
+        }
+      }
+      this.DBOriginTokens[t.gestalt] = {
+        gestalt: t.gestalt,
+        data: td,
+        amount,
+        absoluteAmount: (this.profiles_value * amount) / 100,
+        originGameNode: originNode,
+        originGameType,
+        cityMaxAmount,
+      };
+    });
+  }
+
+  /** Hardcoded `'city002'` lookup is preserved from legacy.  Suspected
+   *  copy-paste latent bug — should probably read `origintokengestalt`'s
+   *  origin link.  Filed for follow-up. */
+  getOriginGestaltFromOriginTokenGestalt(_origintokengestalt: string): string | undefined {
+    const origin = Object.values(this.DBOriginTokens).find(
+      (ot) => ot.originGameNode?.gestalt === 'city002'
+    );
+    return origin?.gestalt;
+  }
+
+  getCityOriginAmounts(): Record<string, number> {
+    const out: Record<string, number> = {};
+    for (const ot of Object.values(this.DBOriginTokens)) {
+      if (ot.originGameType === 'CityPerp' && ot.gestalt && ot.cityMaxAmount !== undefined) {
+        out[ot.gestalt] = ot.cityMaxAmount;
+      }
+    }
+    return out;
+  }
+
+  getDBFactorNormalized(): number {
+    const cityamounts = this.getCityOriginAmounts();
+    return Object.values(cityamounts).reduce((memo, num) => memo + num, 0);
+  }
+
+  updateGears(): void {
+    getByType('TokenPerp').forEach((t) => {
+      (t as GameNode & { updateGear?(): void }).updateGear?.();
+    });
+  }
+
+  // -------------------------------------------------------------------
+  // Lifecycle
+  // -------------------------------------------------------------------
+
+  kill(): void {
+    console.warn('Killing Game');
+    // `clear()` lives in GameNode.ts; legacy bound it as a free import.
+    // Imported at the top of this file via the registry helpers.
+    clearRegistry();
+    const app = appModule.getApplication() as { game?: unknown };
+    delete app.game;
+  }
+
+  lock(): void {
+    // Lock the whole stage and turn off triggering of render Events.
+    // TODO: make stage spinner in Render and use proper method to
+    // unbind events.  Unlock currently wouldn't work since all events
+    // are destroyed (FIXME for popups).
+    if (this.renderNode) {
+      this.renderNode.lock?.();
+      this.renderMenu?.lock?.();
+      _aniTicker?.stop();
+    }
+  }
+
+  unlock(): void {
+    if (this.NotificationQueue && this.NotificationQueue.length < 2) {
+      this.renderNode?.unlock?.();
+      this.renderMenu?.unlock?.();
+      _aniTicker?.start();
+    } else if (!this.NotificationQueue) {
+      this.renderNode?.unlock?.();
+      this.renderMenu?.unlock?.();
+      _aniTicker?.start();
+    }
+  }
+
+  // -------------------------------------------------------------------
+  // ProjectPerp powerup fetch (used by ProjectPerp.fetchPowerups)
+  // -------------------------------------------------------------------
+
+  fetchProjectPowerupData(project_gestalt: string, cb?: () => void): void {
+    const gnode = getByGestalt(project_gestalt);
+    const remote = appModule.getApplication().remote as {
+      getPowerups?(
+        gestalt: string,
+        version: unknown
+      ): {
+        done(cb: (data: { result?: Record<string, TypeEntry> }) => void): unknown;
+      };
+    };
+    const fn = remote.getPowerups;
+    if (!fn) {
+      cb?.();
+      return;
+    }
+    const app = appModule.getApplication() as { version?: unknown };
+    const dataNode = gnode?.data as { powerupsCached?: boolean; [k: string]: unknown } | undefined;
+    const popup = gnode?.renderPopup as { templateData?: { cached?: boolean } } | undefined;
+
+    if (gnode && !dataNode?.powerupsCached) {
+      fn(project_gestalt, app.version).done((data) => {
+        Object.values(data.result ?? {}).forEach((v) => {
+          const sub = v.game_gestalt as string | undefined;
+          if (sub) this.addSubType(project_gestalt, sub, v);
+        });
+        if (popup?.templateData) popup.templateData.cached = true;
+        if (dataNode) dataNode.powerupsCached = true;
+        cb?.();
+      });
+    } else if (gnode && popup?.templateData) {
+      popup.templateData.cached = true;
+      cb?.();
+    } else {
+      fn(project_gestalt, app.version).done((data) => {
+        Object.values(data.result ?? {}).forEach((v) => {
+          const sub = v.game_gestalt as string | undefined;
+          if (sub) this.addSubType(project_gestalt, sub, v);
+        });
+        cb?.();
+      });
+    }
+  }
+}

--- a/scripts/game/GameRoot.ts
+++ b/scripts/game/GameRoot.ts
@@ -211,27 +211,27 @@ export class GameRoot extends GameNode {
     return this.typeRegistry[gestalt]?.game_type ?? '';
   }
 
+  /** Predicate shared by `getParentType` / `getParentTypeData` /
+   *  `getParentTypes`: a typeRegistry entry whose `provided_perps` list
+   *  contains `gestalt`. */
+  private _providesGestalt(t: TypeEntry, gestalt: string): boolean {
+    const provided = (t.type_data as { provided_perps?: string[] } | undefined)?.provided_perps;
+    return !!provided?.includes(gestalt);
+  }
+
   getParentTypes(gestalt: string): TypeEntry[] {
-    return Object.values(this.typeRegistry).filter((t) => {
-      const provided = (t.type_data as { provided_perps?: string[] } | undefined)?.provided_perps;
-      return provided?.includes(gestalt);
-    });
+    return Object.values(this.typeRegistry).filter((t) => this._providesGestalt(t, gestalt));
   }
 
   getParentTypeData(gestalt: string): Record<string, unknown> {
-    const type = Object.values(this.typeRegistry).find((t) => {
-      const provided = (t.type_data as { provided_perps?: string[] } | undefined)?.provided_perps;
-      return provided?.includes(gestalt);
-    });
-    return type?.type_data ?? {};
+    return (
+      Object.values(this.typeRegistry).find((t) => this._providesGestalt(t, gestalt))?.type_data ??
+      {}
+    );
   }
 
   getParentType(gestalt: string): TypeEntry {
-    const type = Object.values(this.typeRegistry).find((t) => {
-      const provided = (t.type_data as { provided_perps?: string[] } | undefined)?.provided_perps;
-      return provided?.includes(gestalt);
-    });
-    return type ?? {};
+    return Object.values(this.typeRegistry).find((t) => this._providesGestalt(t, gestalt)) ?? {};
   }
 
   // -------------------------------------------------------------------
@@ -268,15 +268,9 @@ export class GameRoot extends GameNode {
    *  textbook average).  `gestalt` is unused — preserved as a parameter
    *  for callsite compat. */
   getDBTokensCrossSum(_gestalt?: string): number {
-    let sum = 0;
-    let count = 1;
-    for (const k in this.DBTokens) {
-      if (Object.prototype.hasOwnProperty.call(this.DBTokens, k)) {
-        sum += this.DBTokens[k] ?? 0;
-        count += 1;
-      }
-    }
-    return sum / count;
+    const values = Object.values(this.DBTokens);
+    const sum = values.reduce((memo, v) => memo + (v ?? 0), 0);
+    return sum / (values.length + 1);
   }
 
   compileOriginTokens(
@@ -384,6 +378,19 @@ export class GameRoot extends GameNode {
   // ProjectPerp powerup fetch (used by ProjectPerp.fetchPowerups)
   // -------------------------------------------------------------------
 
+  /** Register every entry in `data.result` as a subtype under
+   *  `project_gestalt`.  Shared by the two `getPowerups` `.done`
+   *  branches in `fetchProjectPowerupData`. */
+  private _registerPowerups(
+    data: { result?: Record<string, TypeEntry> },
+    project_gestalt: string
+  ): void {
+    Object.values(data.result ?? {}).forEach((v) => {
+      const sub = v.game_gestalt as string | undefined;
+      if (sub) this.addSubType(project_gestalt, sub, v);
+    });
+  }
+
   fetchProjectPowerupData(project_gestalt: string, cb?: () => void): void {
     const gnode = getByGestalt(project_gestalt);
     const remote = appModule.getApplication().remote as {
@@ -405,10 +412,7 @@ export class GameRoot extends GameNode {
 
     if (gnode && !dataNode?.powerupsCached) {
       fn(project_gestalt, app.version).done((data) => {
-        Object.values(data.result ?? {}).forEach((v) => {
-          const sub = v.game_gestalt as string | undefined;
-          if (sub) this.addSubType(project_gestalt, sub, v);
-        });
+        this._registerPowerups(data, project_gestalt);
         if (popup?.templateData) popup.templateData.cached = true;
         if (dataNode) dataNode.powerupsCached = true;
         cb?.();
@@ -418,10 +422,7 @@ export class GameRoot extends GameNode {
       cb?.();
     } else {
       fn(project_gestalt, app.version).done((data) => {
-        Object.values(data.result ?? {}).forEach((v) => {
-          const sub = v.game_gestalt as string | undefined;
-          if (sub) this.addSubType(project_gestalt, sub, v);
-        });
+        this._registerPowerups(data, project_gestalt);
         cb?.();
       });
     }


### PR DESCRIPTION
## Summary

PR 19 of issue #147. Creates `scripts/game/GameRoot.ts` with the GameRoot ES class shell + ~25 of the 63 GameRoot prototype methods migrated. **Game.js -299 lines.**

The remaining ~38 methods continue as `GameRoot.prototype.X = function(){...}` assignments in Game.js, mutating the imported class — same incremental pattern as the per-subclass extraction stages. Each follow-up PR migrates a method group.

## Methods migrated in this PR

| Group | Methods |
|---|---|
| **Type registry** | `addType`, `addSubType`, `removeType`, `getType`, `getTypeData`, `getTypes`, `getTypeFromGestalt`, `getParentTypes`, `getParentTypeData`, `getParentType` |
| **DB-token state** | `getDBTokenAmount`, `getDBTokensLength`, `getDBTokensLengthMax`, `getDBTokensCrossSum`, `compileOriginTokens`, `getOriginGestaltFromOriginTokenGestalt`, `getCityOriginAmounts`, `getDBFactorNormalized`, `updateGears` |
| **Lifecycle** | `kill`, `lock`, `unlock` |
| **ProjectPerp powerup fetch** | `fetchProjectPowerupData` |
| **Class shell** | constructor, `renderType='Stage'`, DB-state initial values, `get` / `setup` / `ids` / `getById` field aliases, `notification_level=2`, populated-by-Game.js property declarations |

## Patterns

- **AniTicker injection seam** — `setAniTickerForGameRoot(AniTicker)` mirrors GamePerp's `setAniTicker` (called once at IIFE-end). Used by `lock` / `unlock`. Disposable; retires when AniTicker itself extracts.
- **`override get groot()` not used here** — GameRoot itself IS the groot; subclass-narrow accessor pattern doesn't apply.
- **Forward-ref types**: `RenderRootLike`, `AniTickerLike`, `OriginToken`, `TypeEntry` (deliberately kept loose; will tighten when Render.js is typed).

## Type-driven cleanup (preserved, flagged)

- `getOriginGestaltFromOriginTokenGestalt` has a hardcoded `'city002'` lookup that's almost certainly a copy-paste bug (should read the input param's origin link). Preserved exactly; flagged in the code comment for a follow-up issue.
- `getTypeFromGestalt` returns `''` instead of legacy's `{}` for the falsy-gestalt branch — matches every caller's actual usage (the result is always treated as a string game-type name; `{}` was a mis-typed sentinel). Documented inline.

## Architecture invariants — preserved

- No `setTimeout` for game cycles.
- No new `webxdc.sendUpdate` paths.
- Engine layer untouched.
- `addr === state.addr` guard intact.
- Game.js retains its `@ts-nocheck` quarantine header.

## Game.js side

- Imports `GameRoot` and `setAniTickerForGameRoot`.
- Removes the inline `var GameRoot = function` block and the `extend(GameRoot, GameNode)` call.
- Removes the 25 migrated method definitions.
- Calls `setAniTickerForGameRoot(AniTicker)` at the IIFE tail next to the existing `setAniTicker(AniTicker)`.

## Verification

- `npx tsc --noEmit` — clean.
- `pnpm exec biome check .` — clean.
- `pnpm test` — 624/624 pass.
- `pnpm test:e2e` — 45/45 pass (1 skipped, unrelated).
- `pnpm run build` — both `.xdc` variants build green.

## What remains for GameRoot in #147

Each lands as a follow-up PR mutating the GameRoot class introduced here:

1. Render hooks (`extendRender`, `initEventHandlers`).
2. Camera / zoom (`resetZoom`, `_centerActiveView`, `fitToWindow`, `setSize`, `_cancelPendingCenter`).
3. Status bar / level / XP (`setLevel`, `getLevel`, `getLevelByXP`, `APTick`, `initStatusBar`, `updateStatusBarValues`).
4. Game values (`initGameValues`, `updateGameValues`, `useAP`, `setAP`, `setCash`, `setProfiles`, `setKarma`, `setXP`).
5. Notifications (`makeNotifications`, `cueNotification`, `startNotificationQueue`, `uncueNotification`, `compileProvidedKarma`, `openNotification`, `BuyKarma`).
6. Buy + load + view getters (`BuyPerp`, `refresh`, `loadGame`, `getImperium`, `getDatabase`).

After that: retire `perpRegistry` (GamePerp.BuyPerp's by-name construction can move to a free function once GameRoot is fully extracted), type Render.js subclasses, final cleanup PR (`allowJs: false`, drop `@ts-nocheck`).

## Test plan

- [ ] CI lint / typecheck / unit-tests / build / playwright all green.
- [ ] Drop the `.xdc` into Delta Chat; smoke-test:
  - [ ] Game boot through `loadGame` (still in Game.js but constructs a `new GameRoot()`).
  - [ ] Type registry: open the Database popup (uses `getType` / `getTypeData` / `getTypes`).
  - [ ] DB token state: integrate a profile (`compileOriginTokens` / `getDBFactorNormalized`).
  - [ ] Powerup fetch on a Project (`fetchProjectPowerupData`).
  - [ ] Verify `lock` / `unlock` cycle (notification queue gating).

https://claude.ai/code/session_018qbFtLNgH4p39DmEBtouJu

---
_Generated by [Claude Code](https://claude.ai/code/session_018qbFtLNgH4p39DmEBtouJu)_