### PR TITLE
Hide irrelevant Statusbar items per tab on mobile

### DIFF
--- a/css/Statusbar.css
+++ b/css/Statusbar.css
@@ -339,3 +339,21 @@
     order: 4;
   }
 }
+
+/* Mobile per-tab Statusbar trimming (≤ 926 px — same band that splits
+ * the header into two rows and moves the XP/level into `.mm-xp`).
+ *
+ * - Topscores / Missions: hide all in-stage stat items; level stays
+ *   visible via the cloned `.mm-xp` bar in the menu header.
+ * - Database: hide Cash and Karma only — Profiles and AP remain. */
+@media (max-width: 926px) {
+  .Stage.ActiveTopscores .Statusbar .StatusItem,
+  .Stage.ActiveMissions .Statusbar .StatusItem {
+    display: none;
+  }
+
+  .Stage.ActiveDatabase .Statusbar .StatusItem.Cash,
+  .Stage.ActiveDatabase .Statusbar .StatusItem.Karma {
+    display: none;
+  }
+}

--- a/css/Statusbar.css
+++ b/css/Statusbar.css
@@ -343,13 +343,21 @@
 /* Mobile per-tab Statusbar trimming (≤ 926 px — same band that splits
  * the header into two rows and moves the XP/level into `.mm-xp`).
  *
- * - Topscores / Missions: hide all in-stage stat items; level stays
- *   visible via the cloned `.mm-xp` bar in the menu header.
- * - Database: hide Cash and Karma only — Profiles and AP remain. */
+ * - Topscores / Missions: hide the entire in-stage Statusbar and reclaim
+ *   the 50 px top reservation `.ViewTab` carves out for it (otherwise
+ *   the tab content opens with an empty band).  Level stays visible via
+ *   the cloned `.mm-xp` bar in the menu header.
+ * - Database (a ViewMap, not a ViewTab — no padding to reclaim): hide
+ *   Cash and Karma only; Profiles and AP remain. */
 @media (max-width: 926px) {
-  .Stage.ActiveTopscores .Statusbar .StatusItem,
-  .Stage.ActiveMissions .Statusbar .StatusItem {
-    display: none;
+  .Stage.ActiveTopscores .Statusbar,
+  .Stage.ActiveMissions .Statusbar {
+    display: none !important;
+  }
+
+  .Stage.ActiveTopscores .ViewTab,
+  .Stage.ActiveMissions .ViewTab {
+    padding-top: 0;
   }
 
   .Stage.ActiveDatabase .Statusbar .StatusItem.Cash,


### PR DESCRIPTION
## Summary
On mobile (≤ 926 px — the existing breakpoint that splits the header into two rows and moves XP/level into `.mm-xp`), trim the in-stage Statusbar items per active tab:

- **Topscores / Missions**: hide Profiles, Cash, AP, Karma. Level remains visible via the cloned `.mm-xp` bar in the menu header.
- **Database**: hide Cash and Karma; Profiles and AP remain (the resources spent here).

Implemented purely in CSS via the existing `.Stage.Active{Topscores,Missions,Database}` classes that the renderer already toggles on the Stage when a view becomes active.

## Test plan
- [ ] Resize viewport ≤ 926 px and switch to **Topscores** — Profiles/Cash/AP/Karma items hidden in Statusbar; level still visible in the menu's XP row.
- [ ] Same on **Missions** — same items hidden.
- [ ] Switch to **Database** — only Cash and Karma hidden; Profiles and AP visible.
- [ ] Resize back ≥ 927 px on each tab — full Statusbar restored.
- [ ] Imperium tab unchanged — full Statusbar still shown on mobile.

https://claude.ai/code/session_01RA7EzdV8RdGGgkoqHhSfSa

---
_Generated by [Claude Code](https://claude.ai/code/session_01RA7EzdV8RdGGgkoqHhSfSa)_