### PR TITLE
phase 7 (#147): migrate GameRoot status bar / level / XP methods (PR 21)

### DIFF
--- a/scripts/Game.js
+++ b/scripts/Game.js
@@ -33,7 +33,7 @@ import {
   remove,
 } from './game/GameNode.js';
 import { GamePerp, setAniTicker } from './game/GamePerp.js';
-import { GameRoot, setAniTickerForGameRoot } from './game/GameRoot.js';
+import { GameRoot, setAPTickerForGameRoot, setAniTickerForGameRoot } from './game/GameRoot.js';
 import { Imperium } from './game/Imperium.js';
 import { Mission } from './game/Mission.js';
 import { Missions } from './game/Missions.js';
@@ -976,66 +976,6 @@ var Game = function () {
     return popup;
   };
 
-  GameRoot.prototype.initStatusBar = function () {
-    this.data.status_bar.gameNode = this;
-    this.updateStatusBarValues();
-  };
-
-  GameRoot.prototype.setLevel = function (levelnum, nolevelup) {
-    var lvl;
-    if (levelnum) {
-      lvl = this.getLevel(levelnum);
-    } else {
-      lvl = this.getLevel();
-    }
-    if (lvl !== this.getLevelByXP(this.xp_value)) {
-      this.xp_value = lvl.xp_min;
-    }
-    this.xp_level = lvl;
-    APTicker.interval = lvl.ap_inc_interval;
-    if (!nolevelup) {
-      APTicker.reset();
-    }
-    this.setAP();
-    this.setXP();
-    return this.xp_level;
-  };
-
-  GameRoot.prototype.getLevel = function (level) {
-    if (level) {
-      return this.data.levels[level - 1];
-    } else {
-      return this.data.levels[this.data.game_values.xp_level - 1];
-    }
-  };
-  GameRoot.prototype.getLevelByXP = function (xp) {
-    if (!xp) {
-      return {};
-    }
-    var level = _.find(this.data.levels, function (lvl) {
-      return xp >= lvl.xp_min && xp <= lvl.xp_max;
-    });
-    return level;
-  };
-
-  GameRoot.prototype.APTick = function () {
-    if (this.xp_level.ap_max > this.ap_value) {
-      this.ap_value += this.xp_level.ap_inc_value;
-      this.setAP();
-      // Remove No-AP decorators
-      this.renderNode.jdomelem.find('.Popup .no_AP').removeClass('no_AP disabled active');
-    }
-  };
-
-  GameRoot.prototype.updateStatusBarValues = function () {
-    // Map and evantually crunch game_values to statusbar values, without rendering
-    this.setProfiles();
-    this.setCash();
-    this.setAP();
-    this.setKarma();
-    this.setXP();
-  };
-
   GameRoot.prototype.initGameValues = function () {
     var gv = this.data.game_values; // FIXME: Added var; check for side-effects
     this.ap_value = gv.ap_initial;
@@ -1569,6 +1509,10 @@ var Game = function () {
   // retires when AniTicker is itself extracted from Game.js.
   setAniTicker(AniTicker);
   setAniTickerForGameRoot(AniTicker);
+  // APTicker (level-derived AP regen interval) is consumed by
+  // GameRoot.setLevel and GameRoot.APTick; injected the same way as
+  // AniTicker until APTicker itself is extracted from this IIFE.
+  setAPTickerForGameRoot(APTicker);
 
   return Game;
 };

--- a/scripts/game/GameRoot.ts
+++ b/scripts/game/GameRoot.ts
@@ -62,7 +62,10 @@ interface RenderRootLike {
   width?: number;
   height?: number;
   jdomelem?: {
-    find?(sel: string): { off(ev?: string): void };
+    find?(sel: string): {
+      off?(ev?: string): void;
+      removeClass?(cls: string): void;
+    };
     outerHeight?(): number;
   };
   setSize?(opts: { width?: number; height?: number }): void;
@@ -88,9 +91,29 @@ interface ViewLike {
   renderNode?: ViewMapRenderLike;
 }
 
+/** Per-level config from `data.levels`.  AP regeneration interval +
+ *  cap, XP range, and the level number (1-indexed). */
+interface Level {
+  number: number;
+  xp_min: number;
+  xp_max: number;
+  ap_max: number;
+  ap_inc_value: number;
+  ap_inc_interval: number;
+  [key: string]: unknown;
+}
+
 interface AniTickerLike {
   start(): void;
   stop(): void;
+}
+
+/** APTicker singleton interface — increments AP at level-derived
+ *  intervals.  Game.js owns the implementation; injected via
+ *  `setAPTickerForGameRoot`. */
+interface APTickerLike {
+  interval: number;
+  reset(): void;
 }
 
 let _aniTicker: AniTickerLike | null = null;
@@ -99,6 +122,14 @@ let _aniTicker: AniTickerLike | null = null;
  *  when AniTicker itself extracts. */
 export function setAniTickerForGameRoot(ticker: AniTickerLike): void {
   _aniTicker = ticker;
+}
+
+let _apTicker: APTickerLike | null = null;
+/** Game.js injects the APTicker singleton at IIFE-end (parallel to
+ *  `setAniTickerForGameRoot`).  Used by `setLevel` / `APTick`.
+ *  Disposable seam — retires when APTicker itself extracts. */
+export function setAPTickerForGameRoot(ticker: APTickerLike): void {
+  _apTicker = ticker;
 }
 
 // ---------------------------------------------------------------------------
@@ -140,12 +171,22 @@ export class GameRoot extends GameNode {
   cash_value = 0;
   ap_value = 0;
   karma_value = 0;
-  xp_level: { number: number; [key: string]: unknown } = { number: 0 };
+  xp_value = 0;
+  xp_level: Level = {
+    number: 0,
+    xp_min: 0,
+    xp_max: 0,
+    ap_max: 0,
+    ap_inc_value: 0,
+    ap_inc_interval: 0,
+  };
   data: {
     status_icons?: unknown;
     status_bar?: { gameNode?: GameNode; [key: string]: unknown };
     width?: number;
     height?: number;
+    levels?: Level[];
+    game_values?: { xp_level?: number; [key: string]: unknown };
     [key: string]: unknown;
   } = {};
   override renderNode?: NonNullable<GameNode['renderNode']> & RenderRootLike;
@@ -168,6 +209,15 @@ export class GameRoot extends GameNode {
   // call them through the typed GameRoot reference.
   getImperium?(): ViewLike | undefined;
   getDatabase?(): GameNode & { renderDBQueue?: { render?(): void } };
+
+  // Game-values setters still live in Game.js.  Declared optional so
+  // `setLevel` / `updateStatusBarValues` can call them through the
+  // typed GameRoot reference (the next PR in this wave migrates them).
+  setAP?(num?: number, silent?: boolean): void;
+  setCash?(num?: number, silent?: boolean): void;
+  setProfiles?(num?: number, silent?: boolean): void;
+  setKarma?(num?: number, silent?: boolean): void;
+  setXP?(num?: number, silent?: boolean): void;
   notificationPopup?: NonNullable<GameNode['renderPopup']> & {
     render?(): void;
     notificationMission?: string | null;
@@ -547,6 +597,81 @@ export class GameRoot extends GameNode {
     const dbQueue = (this.getDatabase?.() as { renderDBQueue?: { render?(): void } } | undefined)
       ?.renderDBQueue;
     dbQueue?.render?.();
+  }
+
+  // -------------------------------------------------------------------
+  // Status bar / level / XP (extracted in PR 21 of issue #147)
+  // -------------------------------------------------------------------
+
+  initStatusBar(): void {
+    if (this.data.status_bar) this.data.status_bar.gameNode = this;
+    this.updateStatusBarValues();
+  }
+
+  setLevel(levelnum?: number, nolevelup?: boolean): Level {
+    const lvl = levelnum ? this.getLevel(levelnum) : this.getLevel();
+    if (lvl !== this.getLevelByXP(this.xp_value)) {
+      this.xp_value = lvl.xp_min;
+    }
+    this.xp_level = lvl;
+    if (_apTicker) {
+      _apTicker.interval = lvl.ap_inc_interval;
+      if (!nolevelup) _apTicker.reset();
+    }
+    this.setAP?.();
+    this.setXP?.();
+    return this.xp_level;
+  }
+
+  getLevel(level?: number): Level {
+    const levels = this.data.levels ?? [];
+    const idx = level ? level - 1 : (this.data.game_values?.xp_level ?? 1) - 1;
+    return (
+      levels[idx] ?? {
+        number: 0,
+        xp_min: 0,
+        xp_max: 0,
+        ap_max: 0,
+        ap_inc_value: 0,
+        ap_inc_interval: 0,
+      }
+    );
+  }
+
+  /** Returns the Level whose `xp_min..xp_max` window contains `xp`,
+   *  or an empty Level-shape when `xp` is falsy.  Legacy returned
+   *  `{}` for the falsy branch — flattened to a Level-shaped sentinel
+   *  to keep the strict-TS signature clean (callers pass it to
+   *  `setLevel`'s identity check, never read fields off it). */
+  getLevelByXP(xp?: number): Level {
+    if (!xp) {
+      return { number: 0, xp_min: 0, xp_max: 0, ap_max: 0, ap_inc_value: 0, ap_inc_interval: 0 };
+    }
+    const found = (this.data.levels ?? []).find((lvl) => xp >= lvl.xp_min && xp <= lvl.xp_max);
+    return (
+      found ?? { number: 0, xp_min: 0, xp_max: 0, ap_max: 0, ap_inc_value: 0, ap_inc_interval: 0 }
+    );
+  }
+
+  override APTick(): void {
+    if (this.xp_level.ap_max > this.ap_value) {
+      this.ap_value += this.xp_level.ap_inc_value;
+      this.setAP?.();
+      // Remove No-AP decorators
+      const popups = this.renderNode?.jdomelem?.find?.('.Popup .no_AP');
+      popups?.removeClass?.('no_AP disabled active');
+    }
+  }
+
+  /** Map (and eventually crunch) game_values onto status-bar values
+   *  without rendering — the per-setter methods own the render
+   *  trigger.  All five setters still live in Game.js (next PR). */
+  updateStatusBarValues(): void {
+    this.setProfiles?.();
+    this.setCash?.();
+    this.setAP?.();
+    this.setKarma?.();
+    this.setXP?.();
   }
 
   // -------------------------------------------------------------------

--- a/scripts/game/GameRoot.ts
+++ b/scripts/game/GameRoot.ts
@@ -623,6 +623,15 @@ export class GameRoot extends GameNode {
     return this.xp_level;
   }
 
+  /** Looks up `data.levels[level - 1]` (legacy 1-indexed); falls back
+   *  to the current `data.game_values.xp_level`.  The zero-Level
+   *  fallback covers two cases:
+   *    - `data.levels` unset (server bootstrap not yet run);
+   *    - `level` index out of bounds.
+   *  Both are dead paths in production (loadGame populates `levels`
+   *  before any `setLevel` caller runs), but the strict-TS shape
+   *  silently no-ops rather than throwing the legacy `TypeError` on
+   *  `undefined.xp_min`. */
   getLevel(level?: number): Level {
     const levels = this.data.levels ?? [];
     const idx = level ? level - 1 : (this.data.game_values?.xp_level ?? 1) - 1;


### PR DESCRIPTION
## Summary

PR 21 of issue #147. Migrates 6 status-bar / level / XP methods from `GameRoot.prototype.X = function () {...}` assignments in Game.js into typed methods on the `GameRoot` ES class. **Game.js -64 lines.**

## Methods migrated

- **`initStatusBar()`** — wires the status-bar gameNode backref and pushes initial values via `updateStatusBarValues`.
- **`setLevel(levelnum?, nolevelup?)`** — sets the active Level (by number or current `xp_level`), realigns `xp_value` if it falls outside the new level's window, updates `APTicker.interval`, re-renders AP/XP via the per-setter game-values methods.
- **`getLevel(level?)`** — looks up `data.levels[level - 1]` (1-indexed array); falls back to the current `data.game_values.xp_level`.
- **`getLevelByXP(xp?)`** — finds the Level whose `xp_min..xp_max` window contains `xp`. Falsy-xp branch returns a zero-Level sentinel (legacy `{}` flattened to a Level-shape — no caller reads fields off it; only used in the `setLevel` identity check).
- **`APTick()`** — per-tick AP regen up to `xp_level.ap_max`, with the jQuery-based `no_AP`-decorator removal preserved.
- **`updateStatusBarValues()`** — pumps profiles/cash/AP/karma/XP into the status bar via the per-setter methods.

## New types in `GameRoot.ts`

- **`Level`** interface — `{ number, xp_min, xp_max, ap_max, ap_inc_value, ap_inc_interval }`. Replaces the legacy untyped `{}` and `data.levels[i]` reads.
- **`APTickerLike`** forward-ref + **`setAPTickerForGameRoot(ticker)`** injection seam. Game.js calls it at IIFE-end alongside `setAniTickerForGameRoot(AniTicker)`. Disposable; retires when APTicker itself extracts.

## Class fields added

- `xp_value` — the current XP count (was previously stamped on by `loadGame`; declared explicitly now).
- `xp_level` re-typed `Level` (was loose `{number, [key]: unknown}`).
- `data` extended with `levels?: Level[]`, `game_values?: { xp_level?: number }`.
- `RenderRootLike.jdomelem.find(...)` extended with `removeClass` — used by `APTick` to clear no_AP popup state.

## Forward-ref optional methods on the class

The five game-values setters (`setAP`, `setCash`, `setProfiles`, `setKarma`, `setXP`) still live in Game.js — declared as optional methods on the class so `setLevel` and `updateStatusBarValues` can call them through the typed reference. **Migrated in the next PR (PR 22, game values).**

## Architecture invariants — preserved

- No `setTimeout` for game cycles (the APTicker's tick is already in Game.js, untouched).
- No new `webxdc.sendUpdate` paths.
- Engine layer untouched.
- Game.js retains its `@ts-nocheck` quarantine header.

## Subtle preserved behavior

- The legacy `getLevelByXP(xp)` returned `{}` for falsy `xp` and the only caller (`setLevel`) compared the result with strict `!==`. The new `Level`-shaped sentinel preserves that behavior — both `{}` and the zero-Level shape fail the identity check identically.
- Off-by-one in `getLevel(levelnum)`: legacy did `levels[levelnum - 1]`. Preserved exactly.

## Verification

- `npx tsc --noEmit` — clean.
- `pnpm exec biome check .` — clean.
- `pnpm test` — 624/624 pass.
- `pnpm test:e2e` — 45/45 pass (1 skipped, unrelated).
- `pnpm run build` — both `.xdc` variants build green.

## Test plan

- [ ] CI lint / typecheck / unit-tests / build / playwright all green.
- [ ] Drop the `.xdc` into Delta Chat; smoke-test:
  - [ ] Game boot reaches a populated status bar (`initStatusBar` → `updateStatusBarValues`).
  - [ ] Level-up flow (`setLevel` → APTicker.reset, AP/XP rerender).
  - [ ] AP regen tick (`APTick` clears `no_AP` popup styling).
  - [ ] Existing `tests/e2e/ap-bar.spec.ts` and `tests/e2e/sweepstakes-upgrade.spec.ts` already passing in unit run.

## What remains for GameRoot in #147

Three method-group PRs to follow:
1. **Game values** — `initGameValues`, `updateGameValues`, `useAP`, `setAP`, `setCash`, `setProfiles`, `setKarma`, `setXP`.
2. **Notifications** — `makeNotifications`, `cueNotification`, `startNotificationQueue`, `uncueNotification`, `compileProvidedKarma`, `openNotification`, `BuyKarma`.
3. **Buy + load + view getters + render hooks** — `BuyPerp`, `refresh`, `loadGame`, `getImperium`, `getDatabase`, `extendRender`, `initEventHandlers`.

Then: retire `perpRegistry`, type Render.js subclasses, final cleanup PR.

https://claude.ai/code/session_018qbFtLNgH4p39DmEBtouJu

---
_Generated by [Claude Code](https://claude.ai/code/session_018qbFtLNgH4p39DmEBtouJu)_