### PR TITLE
phase 7 (#147): convert devtools.js / vendor-install.js to TS (PR 27)

### DIFF
--- a/scripts/devtools.ts
+++ b/scripts/devtools.ts
@@ -1,8 +1,7 @@
-// @ts-nocheck — strict-TS quarantine; remove when this file is migrated to TS (issue #147)
 // Browser-only devtools surface for the injectable clock.
 //
 // Loaded only when the page URL contains ?devtools=1.
-// In production (no flag) this module is a no-op and window.__dd is never
+// In production (no flag) this module is a no-op and `window.__dd` is never
 // defined, so there is zero debug surface exposed to end users.
 //
 // Usage from a browser console or Playwright test:
@@ -11,8 +10,46 @@
 //   window.__dd.clearNowOverride();                // revert to real wall clock
 //   window.__dd.getZoom();                          // current zoom of active ViewMap
 //   window.__dd.setZoom(0.6);                       // jump zoom (no animation)
+//
+// File converted from devtools.js in PR 27 of issue #147; `@ts-nocheck`
+// quarantine dropped.
 
 import { advance, clearOverride, setOverride } from './clock.js';
+
+interface ZyngaScrollerLike {
+  __zoomLevel?: number;
+  zoomTo?(level: number, animate?: boolean): void;
+}
+
+interface ViewMapRenderNodeLike {
+  scroller?: ZyngaScrollerLike;
+}
+
+interface ViewLike {
+  renderNode?: ViewMapRenderNodeLike;
+}
+
+interface GameLike {
+  activeView?: ViewLike;
+  getImperium?(): ViewLike | undefined;
+}
+
+interface DevToolsHooks {
+  setNow: typeof setOverride;
+  advanceNow: typeof advance;
+  clearNowOverride: typeof clearOverride;
+  getZoom(): number | null;
+  setZoom(level: number): void;
+  /** Set by `app.ts` once `Application.start()` finishes — exposes the
+   *  GameRoot instance to the dev-time hooks. */
+  _app?: { game?: GameLike };
+}
+
+declare global {
+  interface Window {
+    __dd?: DevToolsHooks;
+  }
+}
 
 if (
   typeof window !== 'undefined' &&
@@ -21,27 +58,26 @@ if (
 ) {
   // app.js populates window.__dd._app once Application.start finishes, so
   // the active ViewMap may not be reachable until after the boot sequence.
-  const activeViewMap = () => {
-    const game = window.__dd._app && window.__dd._app.game;
+  const activeViewMap = (): ViewMapRenderNodeLike | null => {
+    const game = window.__dd?._app?.game;
     if (!game) return null;
-    const view = game.activeView || (game.getImperium && game.getImperium());
-    return (view && view.renderNode) || null;
+    const view = game.activeView ?? game.getImperium?.();
+    return view?.renderNode ?? null;
   };
+
   window.__dd = {
     setNow: setOverride,
     advanceNow: advance,
     clearNowOverride: clearOverride,
     // Test hooks for the zoom-controls e2e spec — read from / write to the
     // active ViewMap's scroller without exposing the whole app surface.
-    getZoom: () => {
+    getZoom: (): number | null => {
       const vm = activeViewMap();
-      return vm && vm.scroller ? vm.scroller.__zoomLevel : null;
+      return vm?.scroller?.__zoomLevel ?? null;
     },
-    setZoom: (level) => {
+    setZoom: (level: number): void => {
       const vm = activeViewMap();
-      if (vm && vm.scroller && typeof vm.scroller.zoomTo === 'function') {
-        vm.scroller.zoomTo(level, false);
-      }
+      if (vm?.scroller?.zoomTo) vm.scroller.zoomTo(level, false);
     },
   };
 }

--- a/scripts/vendor-install.ts
+++ b/scripts/vendor-install.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
-// @ts-nocheck — strict-TS quarantine; remove when this file is migrated to TS (issue #147)
 // Regenerates vendor/ from npm packages. Run after a fresh clone if the vendor/
 // directory is ever deleted, or to upgrade a pinned lib.
 //
-// Usage: node scripts/vendor-install.js
+// Usage: node scripts/vendor-install.js (or, post-build, the .ts file is run
+// through tsx or compiled by tsc — see package.json)
 //
 // Version notes (divergences from original bower.json pins):
 //   jquery        bower: 2.0.3      npm: latest (4.x) — API-compatible for boot path
@@ -25,10 +25,12 @@
 //   zynga-animate: https://raw.githubusercontent.com/zynga/scroller/7d460ea/src/Animate.js
 //   zynga-scroller:https://raw.githubusercontent.com/zynga/scroller/dadd850/src/Scroller.js
 //   sprintf:       https://raw.githubusercontent.com/alexei/sprintf.js/192bc60/src/sprintf.js
+//
+// File converted from vendor-install.js in PR 27 of issue #147; `@ts-nocheck`
+// quarantine dropped.
 
 import { execSync } from 'node:child_process';
-import { copyFileSync, existsSync, mkdirSync, readdirSync } from 'node:fs';
-import { mkdtempSync } from 'node:fs';
+import { copyFileSync, existsSync, mkdirSync, mkdtempSync, readdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -39,11 +41,11 @@ mkdirSync(vendorDir, { recursive: true });
 
 const tmp = mkdtempSync(join(tmpdir(), 'dd-vendor-'));
 
-function run(cmd) {
+function run(cmd: string): void {
   execSync(cmd, { stdio: 'inherit', cwd: tmp });
 }
 
-function cp(src, dest) {
+function cp(src: string, dest: string): void {
   const full = join(tmp, 'node_modules', src);
   if (!existsSync(full)) {
     console.warn(`  WARN: ${src} not found — skipping`);
@@ -85,4 +87,6 @@ console.log('Vendored verbatim in repo: zynga-animate.js, zynga-scroller.js');
 console.log('\nFiles in vendor/:');
 readdirSync(vendorDir)
   .sort()
-  .forEach((f) => console.log('  ' + f));
+  .forEach((f) => {
+    console.log(`  ${f}`);
+  });


### PR DESCRIPTION
## Summary

PR 27 of issue #147. Two more small files converted to strict TypeScript; **two `@ts-nocheck` quarantine markers retired**.

## Conversions

| Before | After | Notes |
|---|---|---|
| `scripts/devtools.js` (47 LOC) | `scripts/devtools.ts` | Browser-only devtools hooks loaded behind `?devtools=1`. |
| `scripts/vendor-install.js` (88 LOC) | `scripts/vendor-install.ts` | Pure Node script — npm-based vendor population. |

## `devtools.ts` typing

- Forward-refs for the ZyngaScroller (`__zoomLevel` / `zoomTo`), the ViewMap renderNode shape, and the GameLike facade (`activeView` / `getImperium()`).
- `window.__dd` declared via `declare global { interface Window { __dd?: DevToolsHooks } }` so the mutation site is type-checked end-to-end.
- Replaces legacy `&&` chains with `?.` optional-chain and `??` nullish-fallback for cleaner narrows.

## `vendor-install.ts` typing

- Pure Node script — strict-typed against `@types/node`.
- `run(cmd: string): void` and `cp(src: string, dest: string): void` get explicit signatures.
- `readdirSync().sort().forEach` log loop wrapped in a block to satisfy biome.

## Quarantine state

| Before | After |
|---:|---:|
| 4 markers | 2 markers |

Remaining `@ts-nocheck`'d files:
- **`scripts/Render.js`** (~5,680 LOC — the largest remaining piece).
- **`scripts/type_settings.js`** (992 LOC of literal game-data).

## Architecture invariants — preserved

- No `setTimeout` for game cycles.
- No `webxdc.sendUpdate` paths.
- Engine layer untouched.
- `window.__dd` only exposed when `?devtools=1` (production zero-surface preserved).

## Verification

- `npx tsc --noEmit` — clean.
- `pnpm exec biome check .` — clean.
- `pnpm test` — 624/624 pass.
- `pnpm test:e2e` — 45/45 pass (1 skipped, unrelated).
- `pnpm run build` — both `.xdc` variants build green.

## Test plan

- [ ] CI lint / typecheck / unit-tests / build / playwright all green.
- [ ] Drop the `.xdc` into Delta Chat with `?devtools=1`; smoke-test:
  - [ ] `window.__dd.setZoom(0.6)` and `window.__dd.getZoom()` round-trip.
  - [ ] `window.__dd.setNow(...)` / `advanceNow(...)` / `clearNowOverride()` work (already covered by `tests/e2e/zoom-controls.spec.ts`).
- [ ] `node scripts/vendor-install.ts` (or `npx tsx scripts/vendor-install.ts`) successfully populates `vendor/` from npm. (Optional — only run when refreshing vendor pins.)

## What remains for #147

- **Render.js subclass extractions** (~6 PRs).
- **type_settings.js** conversion (992 LOC).
- **Final cleanup PR** — `allowJs: false`, drop the remaining `@ts-nocheck` markers, close #147.

https://claude.ai/code/session_018qbFtLNgH4p39DmEBtouJu

---
_Generated by [Claude Code](https://claude.ai/code/session_018qbFtLNgH4p39DmEBtouJu)_