### PR TITLE
phase 7 (#147): extract Render's Set class to scripts/render/RenderSet.ts (PR 29)

### DIFF
--- a/scripts/Render.js
+++ b/scripts/Render.js
@@ -4,6 +4,7 @@
 // so this module is safe to bundle alongside code that runs before
 // the vendor `<script>` tags execute.
 import appModule from './app.js';
+import { RenderSet } from './render/RenderSet.js';
 import setup from './setup.js';
 import utilDefault from './util.js';
 
@@ -409,80 +410,15 @@ var Render = function () {
 
   ///////////////////////////////////////////
   // The Set
-  // An array of Nodes with some shortcuts
   ///////////////////////////////////////////
-
+  //
+  // Extracted to scripts/render/RenderSet.ts in PR 29 of issue #147.
+  // Imported as `RenderSet`, aliased back to `Set` here so the
+  // existing `new Set()` call sites inside this IIFE keep working
+  // unchanged.  RenderSet extends scripts/game/OrderedSet.ts so the
+  // common collection surface is no longer duplicated.
   // biome-ignore lint/suspicious/noShadowRestrictedNames: legacy collection class predates ES6 Set
-  var Set = function (set) {
-    if (!set) {
-      set = [];
-    }
-    //this._id = _instances.length;
-    //addSet(this);
-    this.set = set;
-    this.length = this.set.length;
-    return this;
-  };
-
-  Set.prototype.add = function (node) {
-    this.set.push(node);
-    this.length = this.set.length;
-  };
-
-  Set.prototype.remove = function (node) {
-    var index = this.set.indexOf(node);
-    if (index !== -1) {
-      this.set.splice(index, 1);
-    }
-    this.length = this.set.length;
-  };
-
-  Set.prototype.each = function (func) {
-    if (!func) {
-      return;
-    }
-    for (var n = 0; n < this.set.length; n++) {
-      var node = this.set[n];
-      func(node);
-    }
-    this.length = this.set.length;
-  };
-
-  Set.prototype.hide = function () {
-    this.each(function (node) {
-      node.hide();
-    });
-  };
-
-  Set.prototype.show = function () {
-    this.each(function (node) {
-      node.show();
-    });
-  };
-
-  Set.prototype.fade = function (opa) {
-    this.each(function (node) {
-      node.setOpacity(opa);
-    });
-  };
-
-  Set.prototype.draw = function () {
-    this.each(function (node) {
-      node.draw();
-    });
-  };
-
-  Set.prototype.removeAll = function () {
-    while (this.set.length > 0) {
-      var node = this.set[0];
-      this.remove(node);
-      node.remove();
-    }
-  };
-
-  Set.prototype.clear = function () {
-    this.set.length = 0;
-  };
+  var Set = RenderSet;
 
   /////////////////////////////////////////////
   // The SlowTicker

--- a/scripts/render/RenderSet.ts
+++ b/scripts/render/RenderSet.ts
@@ -1,0 +1,52 @@
+// Render-side `Set` collection — extends the engine-side OrderedSet
+// (scripts/game/OrderedSet.ts) with the bulk-action methods the
+// renderer's children / decorators / cables collections need
+// (`hide` / `show` / `fade` / `draw` / `removeAll`).
+//
+// Extracted from scripts/Render.js's IIFE in PR 29 of issue #147.
+// First seam in the Render.js wave — establishes the
+// scripts/render/ directory and the OrderedSet-share pattern.
+
+import { OrderedSet } from '../game/OrderedSet.js';
+
+interface RenderNodeLike {
+  hide?(): void;
+  show?(): void;
+  setOpacity?(opa: number): void;
+  draw?(): void;
+  remove?(): void;
+}
+
+export class RenderSet<T extends RenderNodeLike> extends OrderedSet<T> {
+  hide(): void {
+    this.each((node) => node.hide?.());
+  }
+
+  show(): void {
+    this.each((node) => node.show?.());
+  }
+
+  fade(opa: number): void {
+    this.each((node) => node.setOpacity?.(opa));
+  }
+
+  draw(): void {
+    this.each((node) => node.draw?.());
+  }
+
+  removeAll(): void {
+    while (this.set.length > 0) {
+      const node = this.set[0];
+      if (!node) break;
+      this.remove(node);
+      node.remove?.();
+    }
+  }
+
+  /** Empty the set without invoking each item's `remove()`.  Distinct
+   *  from `removeAll`. */
+  clear(): void {
+    this.set.length = 0;
+    this.length = 0;
+  }
+}


### PR DESCRIPTION
## Summary

PR 29 of issue #147 — **first seam in the Render.js wave**.

The Render-side `Set` collection class is essentially the engine-side `OrderedSet` (`scripts/game/OrderedSet.ts`) plus six bulk-action methods used by the renderer's `children` / `decorators` / `cables` / `listeners` / `collisionNodes` collections. Extracted to a new `scripts/render/RenderSet.ts` that **extends `OrderedSet`** with the Render-specific surface (`hide` / `show` / `fade` / `draw` / `removeAll` / `clear`).

## Why this scope

I attempted a wholesale `Render.js → Render.ts` conversion first; it surfaced 1100+ type errors (mostly `TS2683` `this`-implicitly-any from the legacy function-constructor pattern, plus heavy untyped vendor surface from EaselJS / TweenJS / Zynga Scroller / jQuery DOM). That's a multi-day, multi-PR effort.

This PR establishes the **incremental-extraction** approach for the Render wave — same pattern that worked for the GamePerp/GameRoot subclasses. Each subsequent PR pulls one or two classes from Render.js into `scripts/render/*.ts`. Render.js stays `@ts-nocheck`'d until the last extraction lands.

## What changed

**New file: `scripts/render/RenderSet.ts`** (~52 LOC)
- `class RenderSet<T extends RenderNodeLike> extends OrderedSet<T>`.
- Adds the 6 bulk-action methods. Local `RenderNodeLike` forward-ref types the per-node surface (`hide?`, `show?`, `setOpacity?`, `draw?`, `remove?`).
- Optional-chain calls accommodate sets containing items without all methods (e.g. SlowTicker.listeners holds tick objects with only `tick`, not the full Node surface).

**`Render.js`** (still `@ts-nocheck`'d):
- Imports `RenderSet` from the new module.
- Aliases it as `var Set = RenderSet;` so the 5 in-IIFE `new Set()` call sites (DragHandler.collisionNodes, SlowTicker.listeners, Node.children, Node.decorators, Perp.cables) keep working unchanged.
- Drops the inline `var Set = function ...` constructor and the 8 `Set.prototype.X = ...` assignments (~76 lines).

## Architecture invariants — preserved

- No `setTimeout` / `sendUpdate` paths touched.
- Engine layer untouched.
- `@ts-nocheck` on Render.js retained until the wave completes.
- Publisher `Set: Set` entry preserved for API compatibility (no external readers found via tree-wide grep, but legacy `getRender().Set` access stays valid).

## Verification

- `npx tsc --noEmit` — clean.
- `pnpm exec biome check .` — clean.
- `pnpm test` — 624/624 pass.
- `pnpm test:e2e` — 45/45 pass (1 skipped, unrelated).
- `pnpm run build` — both `.xdc` variants build green.

## Test plan

- [ ] CI lint / typecheck / unit-tests / build / playwright all green.
- [ ] Drop the `.xdc` into Delta Chat; smoke-test:
  - [ ] Children / decorator / cable bulk-actions still work — drag a perp around (DragHandler.collisionNodes), open a popup (Node.decorators.draw), buy a perp (Node.children.removeAll on view-switch).
  - [ ] Mission goal animation (FXMissionGoalComplete) — uses Set.each on mission_goals.

## What remains for #147 (Render wave)

Subsequent PRs in the wave (estimated 5-6 PRs):
- Foundation classes: `Node` (the base), `DragHandler`, `SlowTicker` (the singleton).
- Visual primitives: `Circle`, `Text`, `Sprite`, `PerpSprite`, `Perp`, `ButtonInline`.
- Decorator family: `Decorator`, `DecoratorReady`, `DecoratorAmount`, `DecoratorLabel`, `DecoratorTimer`, `DecoratorGear`, `DecoratorNew`.
- Cable: `Cable`, `PerpCable`.
- Views: `ViewTab`, `ViewMap`, `Stage`, `MainMenu`.
- Top-level UI: `Popup`, `Statusbar`, `StatusItem`, `DBQueue`, `MissionPerp`, `TopscorePerp`.
- Final cleanup PR — convert the remaining Render.js shell to `Render.ts`, drop the last `@ts-nocheck`, drop `allowJs`, close #147.

https://claude.ai/code/session_018qbFtLNgH4p39DmEBtouJu

---
_Generated by [Claude Code](https://claude.ai/code/session_018qbFtLNgH4p39DmEBtouJu)_