### PR TITLE
phase 7 (#147): extract Render's Text + Sprite primitives to scripts/render/

### DIFF
--- a/scripts/Render.js
+++ b/scripts/Render.js
@@ -7,6 +7,8 @@ import appModule from './app.js';
 import { RenderDragHandler } from './render/RenderDragHandler.js';
 import { RenderNode, setRenderNodeRegistry, setRenderNodeTickers } from './render/RenderNode.js';
 import { RenderSet } from './render/RenderSet.js';
+import { RenderSprite } from './render/RenderSprite.js';
+import { RenderText } from './render/RenderText.js';
 import setup from './setup.js';
 import utilDefault from './util.js';
 
@@ -1250,130 +1252,25 @@ var Render = function () {
   /////////////////////////////
   // The Text
   /////////////////////////////
+  //
+  // Extracted to scripts/render/RenderText.ts in PR 32 of issue #147.
+  // Aliased back to `Text` so the existing in-IIFE call sites
+  // (`new Text(...)` in FXBling / FXBlingQueue, the publisher entry)
+  // keep working unchanged.
 
-  var Text = function (config) {
-    config = config || {};
-    this._id = _instances.length;
-    this.jdomelem = $("<div class='Text'></div>").attr('id', 'Text' + this._id);
-    this.domelem = this.jdomelem[0];
-    this.init(config);
-  };
-
-  extend(Text, Node);
-
-  Text.prototype.text = '';
-  Text.prototype.textAlign = 'center';
-
-  Text.prototype.updateRenderProp = function () {
-    // Update misc render properties, API for FONT-Settings etc...
-    this.css({
-      top: 0,
-      left: 0,
-      'text-align': this.textAlign,
-      'z-index': this.z,
-      position: this.position,
-    });
-  };
-
-  Text.prototype.draw = function () {
-    // Update domelem to current settings
-    this.setTransform(this.getTransform());
-    this.setPosition(this.getPosition());
-    this.setOpacity(this.opacity);
-  };
-
-  Text.prototype.onAddInit = function () {
-    this.updateText(this.text);
-    this.draw();
-  };
-
-  Text.prototype.updateText = function (text) {
-    if (!text) {
-      text = this.text;
-    }
-
-    this.text = text = _.crlf2html(text);
-    this.updateRenderProp();
-    this.jdomelem.html(text);
-    this.updateSize();
-    var newOffset = { x: 0, y: 0 };
-    var width = this.jdomelem.width() || 200;
-    if (this.textAlign === 'center') {
-      newOffset.x = Math.round(width / 2);
-    } else if (this.textAlign === 'right') {
-      newOffset.x = width;
-    }
-    this.setOffset(newOffset);
-  };
-
-  Text.prototype.updateSize = function () {
-    this.width = this.jdomelem.width() || 200;
-  };
-
-  Text.prototype.ssetSize = function () {
-    this.updateRenderProp();
-    this.updateSize();
-  };
+  var Text = RenderText;
 
   /////////////////////////////
   // The Sprite
   /////////////////////////////
+  //
+  // Extracted to scripts/render/RenderSprite.ts in PR 32 of issue #147.
+  // Aliased back to `Sprite` so the existing in-IIFE call sites
+  // (`new Sprite(...)` in many FX methods, `extend(Perp, Sprite)`,
+  // `extend(PerpSprite, Sprite)`, the publisher entry) keep working
+  // unchanged.
 
-  var Sprite = function (config) {
-    // Basic Sprite, div container with background image using spritemap
-    // Special config settings:
-    // config.frameSrc - Image source for the spritemap
-    // config.frameMap - framemap coordinates and offsets
-    // config.frame    - the currently active frame
-    config = config || {};
-    this._id = _instances.length;
-    this.frameSrc = config.frameSrc;
-    this.frameMap = config.frameMap;
-    this.frame = config.frame || 'normal';
-    this.jdomelem = $("<div class='Sprite'></div>").attr('id', 'Sprite' + this._id);
-    this.domelem = this.jdomelem[0];
-    this.init(config);
-    this.setFrameSrc(this.frameSrc);
-    this.setFrame(this.frame);
-    this.draw();
-  };
-
-  Sprite.prototype.frameSrc = '';
-  Sprite.prototype.frameMap = {
-    normal: { x: 0, y: 0, width: 0, height: 0, pivotx: 0, pivoty: 0 },
-  };
-
-  extend(Sprite, Node);
-
-  Sprite.prototype.setFrameSrc = function (src) {
-    // Set the Framemap source
-    if (!this.frameSrc) {
-      return;
-    }
-    this.spriteSrc = src;
-    this.css({
-      'background-image': 'url(' + setup.imagePathPrefix + this.frameSrc + ')',
-    });
-  };
-
-  Sprite.prototype.setFrame = function (frame) {
-    // Switch to a named frame on the spritemap
-    if (!this.frameMap || !this.frameMap.hasOwnProperty(frame)) {
-      return;
-    }
-    var map = this.frameMap[frame];
-    this.frame = frame;
-    this.width = map.width;
-    this.height = map.height;
-    if (map.pivotx && map.pivoty) {
-      this.setOffset({
-        x: map.pivotx,
-        y: map.pivoty,
-      });
-    }
-    this.domelem.style.backgroundPosition = -map.x + 'px ' + -map.y + 'px';
-    this.draw();
-  };
+  var Sprite = RenderSprite;
 
   /////////////////////////////
   // The Perp

--- a/scripts/Render.js
+++ b/scripts/Render.js
@@ -7,8 +7,8 @@ import appModule from './app.js';
 import { RenderDragHandler } from './render/RenderDragHandler.js';
 import { RenderNode, setRenderNodeRegistry, setRenderNodeTickers } from './render/RenderNode.js';
 import { RenderSet } from './render/RenderSet.js';
-import { RenderSprite } from './render/RenderSprite.js';
-import { RenderText } from './render/RenderText.js';
+import { RenderSprite as RenderSpriteClass } from './render/RenderSprite.js';
+import { RenderText as RenderTextClass } from './render/RenderText.js';
 import setup from './setup.js';
 import utilDefault from './util.js';
 
@@ -1254,23 +1254,27 @@ var Render = function () {
   /////////////////////////////
   //
   // Extracted to scripts/render/RenderText.ts in PR 32 of issue #147.
-  // Aliased back to `Text` so the existing in-IIFE call sites
-  // (`new Text(...)` in FXBling / FXBlingQueue, the publisher entry)
-  // keep working unchanged.
+  // Imported as `RenderTextClass` and aliased back to `Text` so the
+  // existing in-IIFE call sites (`new Text(...)` in FXBling /
+  // FXBlingQueue, the publisher entry) keep working unchanged.
 
-  var Text = RenderText;
+  var Text = RenderTextClass;
 
   /////////////////////////////
   // The Sprite
   /////////////////////////////
   //
   // Extracted to scripts/render/RenderSprite.ts in PR 32 of issue #147.
-  // Aliased back to `Sprite` so the existing in-IIFE call sites
-  // (`new Sprite(...)` in many FX methods, `extend(Perp, Sprite)`,
-  // `extend(PerpSprite, Sprite)`, the publisher entry) keep working
-  // unchanged.
+  // Imported as `RenderSpriteClass` (not `RenderSprite`) because this
+  // IIFE already owns a legacy `var RenderSprite = function(...)`
+  // helper further down — `var` hoisting would otherwise shadow the
+  // imported binding and leave `Sprite` resolving to `undefined`,
+  // which detonates the first `extend(Perp, Sprite)` call.  Aliased
+  // back to `Sprite` so the in-IIFE call sites (`new Sprite(...)`
+  // in many FX methods, `extend(Perp, Sprite)`, `extend(PerpSprite,
+  // Sprite)`, the publisher entry) keep working unchanged.
 
-  var Sprite = RenderSprite;
+  var Sprite = RenderSpriteClass;
 
   /////////////////////////////
   // The Perp

--- a/scripts/render/RenderNode.ts
+++ b/scripts/render/RenderNode.ts
@@ -61,7 +61,7 @@ function getRegistry(): RenderNodeRegistry {
 
 // ── DOM / jQuery surface that Node touches ──────────────────────────────────
 
-interface JQueryNodeElem {
+export interface JQueryNodeElem {
   0: HTMLElement;
   attr(name: string): string | undefined;
   attr(name: string, value: string): unknown;

--- a/scripts/render/RenderSprite.ts
+++ b/scripts/render/RenderSprite.ts
@@ -1,0 +1,95 @@
+// Render-side `Sprite` primitive — a div with a CSS background-image
+// from a sprite-sheet, indexed by named frames.  Foundation for Perp,
+// PerpSprite, the FX bling animations, and several decorator types.
+//
+// Extracted from scripts/Render.js's IIFE in PR 32 of issue #147.
+// Pairs with RenderText as the two leaf visual primitives the rest
+// of the Render wave depends on.
+
+import setup from '../setup.js';
+import { type JQueryNodeElem, type NodeConfig, RenderNode } from './RenderNode.js';
+
+export interface SpriteFrame {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  pivotx: number;
+  pivoty: number;
+}
+
+export type SpriteFrameMap = Record<string, SpriteFrame>;
+
+interface JQuerySpriteElem {
+  0: HTMLElement;
+  attr(name: string, value: string): unknown;
+}
+
+function getJQuery(): (selector: string) => JQuerySpriteElem {
+  const jq = (globalThis.jQuery ?? globalThis.$) as
+    | ((selector: string) => JQuerySpriteElem)
+    | undefined;
+  if (!jq) {
+    throw new Error('RenderSprite requires the jQuery global to be loaded.');
+  }
+  return jq;
+}
+
+export type SpriteConfig = NodeConfig & {
+  frame?: string;
+  frameSrc?: string;
+  frameMap?: SpriteFrameMap;
+};
+
+export class RenderSprite extends RenderNode {
+  declare frameSrc: string;
+  declare frameMap: SpriteFrameMap;
+  frame: string;
+  spriteSrc: string | undefined = undefined;
+
+  static {
+    RenderSprite.prototype.frameSrc = '';
+    RenderSprite.prototype.frameMap = {
+      normal: { x: 0, y: 0, width: 0, height: 0, pivotx: 0, pivoty: 0 },
+    };
+  }
+
+  constructor(config: SpriteConfig = {}) {
+    const $ = getJQuery();
+    const jdomelem = $("<div class='Sprite'></div>") as unknown as JQueryNodeElem;
+    super({ ...config, jdomelem });
+    // super → RenderNode.init → setAttrs(config) has already assigned
+    // frameSrc / frameMap / frame from `config` (when present).  Apply
+    // the legacy `frame || 'normal'` fallback explicitly.
+    this.frame = config.frame ?? 'normal';
+    this.setFrameSrc(this.frameSrc);
+    this.setFrame(this.frame);
+    this.draw();
+  }
+
+  setFrameSrc(src: string | undefined): void {
+    if (!this.frameSrc) {
+      return;
+    }
+    this.spriteSrc = src;
+    this.css({
+      'background-image': 'url(' + setup.imagePathPrefix + this.frameSrc + ')',
+    });
+  }
+
+  setFrame(frame: string): void {
+    if (!this.frameMap || !Object.prototype.hasOwnProperty.call(this.frameMap, frame)) {
+      return;
+    }
+    const map = this.frameMap[frame];
+    if (!map) return;
+    this.frame = frame;
+    this.width = map.width;
+    this.height = map.height;
+    if (map.pivotx && map.pivoty) {
+      this.setOffset({ x: map.pivotx, y: map.pivoty });
+    }
+    this.domelem.style.backgroundPosition = -map.x + 'px ' + -map.y + 'px';
+    this.draw();
+  }
+}

--- a/scripts/render/RenderText.ts
+++ b/scripts/render/RenderText.ts
@@ -1,0 +1,106 @@
+// Render-side `Text` primitive — a div whose innerHTML is the
+// (CRLF-normalised) text content, with measured width fed back to the
+// Node bounding box so positioning honours `textAlign`.  Used by FXBling,
+// FXBlingQueue, the popup body and several decorator subtypes.
+//
+// Extracted from scripts/Render.js's IIFE in PR 32 of issue #147.
+// Pairs with RenderSprite as the two leaf visual primitives every
+// remaining Render class either is or extends.
+
+import { type JQueryNodeElem, type NodeConfig, RenderNode } from './RenderNode.js';
+
+interface JQueryTextElem {
+  0: HTMLElement;
+  attr(name: string, value: string): unknown;
+  html(content: string): unknown;
+  width(): number | undefined;
+}
+
+interface UnderscoreCrlf {
+  crlf2html(text: string): string;
+}
+
+function getJQuery(): (selector: string) => JQueryTextElem {
+  const jq = (globalThis.jQuery ?? globalThis.$) as
+    | ((selector: string) => JQueryTextElem)
+    | undefined;
+  if (!jq) {
+    throw new Error('RenderText requires the jQuery global to be loaded.');
+  }
+  return jq;
+}
+
+export type TextConfig = NodeConfig & {
+  text?: string;
+  textAlign?: 'left' | 'center' | 'right';
+};
+
+export class RenderText extends RenderNode {
+  declare text: string;
+  declare textAlign: string;
+
+  static {
+    RenderText.prototype.text = '';
+    RenderText.prototype.textAlign = 'center';
+  }
+
+  constructor(config: TextConfig = {}) {
+    const $ = getJQuery();
+    const jdomelem = $("<div class='Text'></div>") as unknown as JQueryNodeElem;
+    super({ ...config, jdomelem });
+  }
+
+  override updateRenderProp(): void {
+    this.css({
+      top: 0,
+      left: 0,
+      'text-align': this.textAlign,
+      'z-index': this.z,
+      position: this.position,
+    });
+  }
+
+  override draw(): void {
+    this.setTransform(this.getTransform());
+    this.setPosition(this.getPosition());
+    this.setOpacity(this.opacity);
+  }
+
+  override onAddInit(): void {
+    this.updateText(this.text);
+    this.draw();
+  }
+
+  updateText(text?: string): void {
+    let t = text;
+    if (!t) {
+      t = this.text;
+    }
+    const _ = globalThis._ as unknown as UnderscoreCrlf;
+    t = _.crlf2html(t);
+    this.text = t;
+    this.updateRenderProp();
+    (this.jdomelem as unknown as JQueryTextElem).html(t);
+    this.updateSize();
+    const newOffset = { x: 0, y: 0 };
+    const width = (this.jdomelem as unknown as JQueryTextElem).width() ?? 200;
+    if (this.textAlign === 'center') {
+      newOffset.x = Math.round(width / 2);
+    } else if (this.textAlign === 'right') {
+      newOffset.x = width;
+    }
+    this.setOffset(newOffset);
+  }
+
+  updateSize(): void {
+    this.width = (this.jdomelem as unknown as JQueryTextElem).width() ?? 200;
+  }
+
+  /** Note the legacy double-`s` typo: `ssetSize`.  Preserved here
+   *  because Render.js's existing call sites — and any external code
+   *  exercising the publisher — already use this name. */
+  ssetSize(): void {
+    this.updateRenderProp();
+    this.updateSize();
+  }
+}


### PR DESCRIPTION
## Summary

- Fourth seam in the Render.js wave (after `RenderSet` #214, `RenderDragHandler` #215, `RenderNode` #216). Lifts the two leaf visual primitives every remaining Render class either is or extends:
  - **`scripts/render/RenderText.ts`** — `Text` (extends `RenderNode`): div whose innerHTML is the CRLF-normalised text content with a measured-width feedback into the Node bounding box.
  - **`scripts/render/RenderSprite.ts`** — `Sprite` (extends `RenderNode`): div with a sprite-sheet `background-image` indexed by named frames (`frameMap`). Foundation for Perp, PerpSprite, and most FX bling animations.
- Render.js still carries its `@ts-nocheck` marker; this PR shrinks its inline footprint by ~125 LOC.

## How it stays compatible

- `var Text = RenderText;` / `var Sprite = RenderSprite;` aliases keep all in-IIFE call sites working unchanged — `new Text(...)` / `new Sprite(...)` in the FX methods, `extend(Perp, Sprite)`, `extend(PerpSprite, Sprite)`, and the publisher entries.
- Both classes are real ES subclasses of `RenderNode` — `super(config)` runs the registry-allocating `init()`. Subclasses still using `util.extend` (PerpSprite, Perp) reach Sprite's methods through the prototype chain just like with the legacy class.
- Prototype-level defaults (`frameSrc=''`, `frameMap={...}`, `text=''`, `textAlign='center'`) preserved via `static {}` initialiser blocks so the chain-only subclasses pick them up.

## Strictness notes

- `JQueryNodeElem` is now exported from `RenderNode.ts` so subclasses can declare their `jdomelem` matches the parent shape under `exactOptionalPropertyTypes`.
- Zero `any`, zero `// @ts-*`, zero `!` non-null assertions.

## Behaviour-preserved drop of legacy dead code

- The legacy `this._id = _instances.length;` line at the top of both ctors and the `attr('id', 'Sprite' + this._id)` initial id were dead — `RenderNode.init` reassigns `_id` from the registry seam and rewrites the DOM id to `'Node' + _id`. Lines simply absent in the TS versions; observable result identical.
- Text's `ssetSize` typo preserved verbatim (existing call sites rely on the exact name).

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx biome check` — clean
- [x] `npm run test` — 624/624 passing
- [x] `npm run build` — green
- [ ] CI to verify Playwright e2e (45 specs)

---
_Generated by [Claude Code](https://claude.ai/code/session_018qbFtLNgH4p39DmEBtouJu)_