### PR TITLE
phase 7 (#147): extract Render's Perp + PerpSprite primitives to scripts/render/

### DIFF
--- a/scripts/Render.js
+++ b/scripts/Render.js
@@ -9,6 +9,8 @@ import { RenderCircle as RenderCircleClass } from './render/RenderCircle.js';
 import { RenderDragHandler } from './render/RenderDragHandler.js';
 import { RenderNode, setRenderNodeRegistry, setRenderNodeTickers } from './render/RenderNode.js';
 import { applyRenderNodeFX } from './render/RenderNodeFX.js';
+import { RenderPerp as RenderPerpClass, setPerpCableCtor } from './render/RenderPerp.js';
+import { RenderPerpSprite as RenderPerpSpriteClass } from './render/RenderPerpSprite.js';
 import { RenderSet } from './render/RenderSet.js';
 import { RenderSprite as RenderSpriteClass } from './render/RenderSprite.js';
 import { RenderText as RenderTextClass } from './render/RenderText.js';
@@ -281,391 +283,26 @@ var Render = function () {
   /////////////////////////////
   // The Perp
   /////////////////////////////
+  //
+  // Extracted to scripts/render/RenderPerp.ts in PR 35 of issue
+  // #147.  Aliased back to `Perp` so existing in-IIFE call sites
+  // and the publisher entry keep working unchanged.  Cable handling
+  // crosses an extraction boundary: `Cable` / `PerpCable` still
+  // live in this IIFE, so RenderPerp late-binds the PerpCable
+  // constructor through `setPerpCableCtor()` — wired below, just
+  // after PerpCable is defined.
 
-  var Perp = function (config) {
-    // Interactive Sprite with decorations, usually lives on a ViewMap.
-    // Special config settings:
-    // config.cables
-    config = config || {};
-    if (config.x === undefined || config.y === undefined) {
-      this.placeRandom = { x: 1024, y: 800 };
-    }
-    this._id = _instances.length;
-    this.frameSrc = config.frameSrc || config.frame_src || 'MainSprites.png';
-    this.frameMap = config.frameMap ||
-      config.frame_map || {
-        normal: { x: 0, y: 0, width: 80, height: 80, pivotx: 0, pivoty: 0 },
-      };
-    this.frame = config.frame || 'normal';
-    this.clickable = config.clickable || true;
-    this.detectCollisions = true;
-    this.draggable = config.draggable || true;
-    this.cables = config.cables || new Set();
-    this.perpSprite = config.perpSprite || undefined;
-    this.jdomelem = $("<div class='Perp'></div>");
-    this.domelem = this.jdomelem[0];
-    this.init(config);
-    this.initUI();
-
-    if (!config.frameSrc || !config.frameMap) {
-      console.log('ERROR: could not render perp ' + config.id, config);
-    }
-
-    if (this.perpSprite) {
-      this.perpSprite = new PerpSprite(this.perpSprite, this._id);
-      this.addChild(this.perpSprite);
-    }
-
-    this.setFrameSrc(this.frameSrc);
-    this.setFrame(this.frame);
-  };
-
-  extend(Perp, Sprite);
-
-  Perp.prototype.getCableTo = function (perpTo) {
-    var cable;
-    this.cables.each(function (c) {
-      if (c.perpTo === perpTo) {
-        cable = c;
-      }
-    });
-    return cable;
-  };
-
-  Perp.prototype.initUI = function () {
-    // Initialize Perp UI mouse and touch events
-    // TODO: wrap events in eventhandlers and move this to Node Class
-    var perp = this;
-
-    // FIXME: MANUAL ADD
-
-    perp.on('vclick', function (e) {
-      e.stopPropagation();
-    });
-    perp.on('vdblclick', function (e) {
-      e.stopPropagation();
-    });
-
-    perp.on('dragstart', function (e) {
-      e.stopPropagation();
-      perp.setFrame('drag');
-      perp.setZ(100);
-      if (perp.perpSprite) {
-        perp.perpSprite.offsetX += 2;
-        perp.perpSprite.offsetY += 5;
-        perp.perpSprite.draw();
-      }
-      perp.decorators.hide();
-      if (!perp.sticky && !perp.dragalong) {
-        perp.cables.each(function (cable) {
-          if (cable.noWobble) {
-            cable.FXToggleConnect(0);
-          } else {
-            cable.FXWobbleTension(0.5);
-          }
-        });
-      } else if (!perp.sticky && perp.dragalong) {
-        perp.cables.each(function (cable) {
-          cable.FXStraighten(0);
-        });
-      } else if (perp.sticky) {
-        perp.cables.each(function (cable) {
-          var othernode = cable.perpFrom === perp ? cable.perpTo : cable.perpFrom;
-          if (othernode.sticky) {
-            if (cable.noWobble) {
-              cable.FXToggleConnect(0);
-            } else {
-              cable.FXWobbleTension(0.5);
-            }
-          } else {
-            othernode.dragalong = true;
-            othernode.useDragHandler.addListener(othernode);
-          }
-        });
-      }
-      /*
-          perp.cables.each(function(cable){
-            if (perp.dragalong) {
-              cable.FXStraighten(0);
-            }
-            else if (cable.perpTo == perp) cable.FXWobbleTension(0.5);
-          });
-        */
-    });
-
-    perp.on('dragend', function (e) {
-      e.stopPropagation();
-
-      perp.setZ(0);
-
-      perp.setFrame('normal');
-      perp.draw();
-      if (perp.perpSprite) {
-        perp.perpSprite.offsetX -= 2;
-        perp.perpSprite.offsetY -= 5;
-        perp.perpSprite.draw();
-      }
-      perp.decorators.show();
-      perp.decorators.draw();
-      perp.cables.each(function (cable) {
-        if (perp.dragalong) {
-          cable.FXStraighten(1);
-        } else {
-          if (cable.noWobble) {
-            cable.FXToggleConnect(1);
-          } else {
-            cable.FXWobbleTension(1);
-          }
-        }
-      });
-      perp.dragalong = false;
-    });
-    perp.on('mousedown touchstart', function (e) {
-      e.stopPropagation();
-    });
-    perp.on('vmouseover', function (e) {
-      e.stopPropagation();
-      // FIXME: Write own Event Wrapper for hover events
-      if (e.target !== perp.domelem) {
-        return;
-      }
-      if (!perp.dragging) {
-        perp.setFrame('hover');
-        perp.FXBounce();
-      } else {
-        perp.setFrame('drag');
-      }
-    });
-    perp.on('vmouseout', function (e) {
-      e.stopPropagation();
-      if (perp.dragging) {
-        perp.setFrame('drag');
-      } else {
-        perp.setFrame('normal');
-      }
-    });
-  };
-
-  Perp.prototype.dragBound = function (pos) {
-    if (!this.parentNode) {
-      return;
-    }
-    if (pos.x < 35) {
-      pos.x = 35;
-    } else if (pos.x > this.parentNode.width - 35) {
-      pos.x = this.parentNode.width - 35;
-    }
-    if (pos.y < 100) {
-      pos.y = 100;
-    } else if (pos.y > this.parentNode.height - 100) {
-      pos.y = this.parentNode.height - 100;
-    }
-  };
-
-  Perp.prototype.moveTo = function (pos) {
-    // Used during animations, to also draw and render other Nodes affected by movement.
-    //if (this.dragging) this.setPosition({x:pos.x-2,y:pos.y-4});
-    //else this.setPosition(pos);
-    this.setPosition(pos);
-    this.cables.draw();
-    this.decorators.draw();
-  };
-
-  // FIXME random placement, remove
-  Perp.prototype.setRandomPosition = function (originPos) {
-    var tries = 0;
-    var originPos = originPos || { x: 1024, y: 800 };
-    var randomPos = function (pos) {
-      return {
-        x: pos.x + 60 * (Math.random() < 0.5 ? 1 : -1),
-        y: pos.y + 40 * (Math.random() < 0.5 ? 1 : -1),
-      };
-    };
-    var testPos = this.useDragHandler.getCollisionPos(this, originPos);
-    while (tries < 500 && testPos.coll === true) {
-      testPos = randomPos(testPos);
-      if (this.placeParentRadius) {
-        testPos = this.testParentRadius(testPos, this.placeParentRadius);
-      }
-      testPos.coll = this.useDragHandler.testCollisions(this, testPos);
-      tries += 1;
-    }
-    this.setPosition(testPos);
-  };
-
-  Perp.prototype.onAddInit = function () {
-    if (this.draggable) {
-      this.setDraggable(true);
-    }
-    if (this.clickable) {
-      this.setClickable(true);
-    }
-    if (this.placeRandom) {
-      this.setRandomPosition(this.placeRandom);
-    }
-    this.updateRenderProp();
-    this.draw();
-  };
-
-  Perp.prototype.cableTo = function (otherperp, config) {
-    // Connect this Perp to another one, Perps need to live on the same Node, usually a ViewMap.
-    if (!this.parentNode || !otherperp.parentNode || this.parentNode !== otherperp.parentNode) {
-      return 'Could not connect';
-    }
-    config = config || {};
-    var perpcable = new PerpCable(config, this, otherperp);
-    this.parentNode.addChild(perpcable);
-    return perpcable;
-  };
-
-  Perp.prototype.cableAnimatedTo = function (otherperp, config, cb) {
-    config = config || {};
-    config.hidden = true;
-    var cable = this.cableTo(otherperp, config);
-    cable.FXConnect(cb);
-    return cable;
-  };
-
-  Perp.prototype.cableAnimatedRemove = function (otherperp, config) {
-    var cable = this.getCableTo(otherperp);
-    if (!cable) {
-      return;
-    }
-    cable.FXDisconnect(function () {
-      cable.remove();
-    });
-  };
-
-  Perp.prototype.draw = function () {
-    // Update domelem to current settings
-    if (this.dragging) {
-      this.moveTo(this.getPosition());
-    } else {
-      this.setPosition(this.getPosition());
-    }
-    this.setTransform(this.getTransform());
-    this.setSize(this.getSize());
-    this.setOpacity(this.opacity);
-    if (this.perpSprite) {
-      this.perpSprite.updatePosition();
-    }
-  };
-
-  Perp.prototype.getCablesToOrigin = function () {
-    // Doesn't work on a graph, obviously
-    var cables = [];
-    var perp = this;
-    if (!perp.cables.set.length) {
-      return cables;
-    }
-    var parentPerp = this;
-    perp.cables.each(function (cable) {
-      if (cable.perpTo === perp) {
-        parentPerp = cable.perpFrom;
-        cables.push(cable);
-        _.each(parentPerp.getCablesToOrigin(), function (pcable) {
-          cables.push(pcable);
-        });
-      }
-    });
-    return cables;
-  };
-
-  Perp.prototype.FXDataOut = function (cb) {
-    var cables = this.getCablesToOrigin();
-    // Set duration to FXDataIn Duration
-    var duration = 500;
-    var delay = 0;
-    _.each(cables, function (cable, k) {
-      duration = cable.length * 2;
-      if (k === cables.length - 1) {
-        var endPerp = cable.perpFrom;
-        window.setTimeout(function () {
-          cable.FXDataIn(function () {
-            endPerp.FXFeedMe();
-            if (cb) {
-              cb();
-            }
-          });
-        }, delay);
-      } else {
-        window.setTimeout(function () {
-          cable.FXDataIn(function () {
-            if (cb) {
-              cb();
-            }
-          });
-        }, delay);
-      }
-      delay = delay + duration;
-    });
-    return delay;
-  };
-
-  // TODO: Make Loop with FX Start/Stop options
-  Perp.prototype.FXDataIn = function (cb) {
-    var cables = this.getCablesToOrigin().reverse();
-    // Set duration to FXDataOut Duration
-    var duration = 500;
-    var delay = 0;
-    _.each(cables, function (cable, k) {
-      duration = cable.length * 2;
-      if (k === cables.length - 1) {
-        window.setTimeout(function () {
-          cable.FXDataOut(cb);
-        }, delay);
-      } else {
-        window.setTimeout(function () {
-          cable.FXDataOut();
-        }, delay);
-      }
-      delay = delay + duration;
-    });
-    return delay;
-  };
+  var Perp = RenderPerpClass;
 
   /////////////////////////////
   // The PerpSprite
   /////////////////////////////
+  //
+  // Extracted to scripts/render/RenderPerpSprite.ts in PR 35 of
+  // issue #147.  Aliased back to `PerpSprite` so the publisher
+  // entry keeps working unchanged.
 
-  var PerpSprite = function (config) {
-    config = config || {};
-    this._id = _instances.length;
-    this.frameSrc = config.frameSrc || config.frame_src;
-    this.frameMap = config.frameMap || config.frame_map;
-    this.frame = config.frame || 'normal';
-    this.jdomelem = $("<div class='PerpSprite'></div>").attr('id', 'PerpSprite' + this._id);
-    this.domelem = this.jdomelem[0];
-    this.init(config);
-  };
-
-  extend(PerpSprite, Sprite);
-
-  PerpSprite.prototype.onAddInit = function () {
-    var node = this;
-    node.parentNode.perpSprite = this;
-
-    // Set position to parent pivot:
-    _.each(this.frameMap, function (frame, k) {
-      if (!frame.pivotx) {
-        frame.pivotx = node.parentNode.frameMap.normal.pivotx;
-      }
-      if (!frame.hasOwnProperty('pivoty')) {
-        frame.pivoty = node.parentNode.frameMap.normal.pivoty;
-      }
-    });
-
-    this.setFrameSrc(this.frameSrc);
-    this.setFrame(this.frame);
-    node.setPosition({ x: node.parentNode.offsetX, y: node.parentNode.offsetY });
-
-    this.draw();
-    this.updateRenderProp();
-  };
-
-  PerpSprite.prototype.updatePosition = function () {
-    this.setPosition({ x: this.parentNode.offsetX, y: this.parentNode.offsetY });
-  };
+  var PerpSprite = RenderPerpSpriteClass;
 
   /////////////////////////////
   // The Decorator (Dummy Example)
@@ -1574,6 +1211,10 @@ var Render = function () {
   };
 
   extend(PerpCable, Cable);
+
+  // Wire the late-bound PerpCable seam used by RenderPerp.cableTo /
+  // cableAnimatedTo (PR 35 of issue #147).
+  setPerpCableCtor(PerpCable);
 
   PerpCable.prototype.getPoints = function () {
     return {

--- a/scripts/render/RenderNode.ts
+++ b/scripts/render/RenderNode.ts
@@ -101,6 +101,11 @@ interface DragHandlerLike {
   off(ev: string): void;
   trigger(ev: string, params?: unknown[]): void;
   dragstart(e: NodeDomEvent): void;
+  getCollisionPos(
+    node: RenderNode,
+    newPos: { x: number; y: number }
+  ): { x: number; y: number; coll: boolean };
+  testCollisions(node: RenderNode, newPos: { x: number; y: number }): boolean;
 }
 
 interface CableLike {

--- a/scripts/render/RenderPerp.ts
+++ b/scripts/render/RenderPerp.ts
@@ -1,0 +1,446 @@
+// Render-side `Perp` — interactive Sprite that lives on a ViewMap.
+// Owns the per-Perp drag/click event wiring (frame swaps, decorator
+// hide/show, cable wobble/straighten on drag), random placement,
+// cable connection helpers (`cableTo`, `cableAnimatedTo`,
+// `cableAnimatedRemove`, `getCableTo`, `getCablesToOrigin`), and the
+// `FXDataIn` / `FXDataOut` data-flow choreography.  Extends
+// `RenderSprite` so the frame-map / setFrame / setFrameSrc surface
+// is inherited.
+//
+// Extracted from scripts/Render.js's IIFE in PR 35 of issue #147.
+//
+// Cable handling crosses an extraction boundary: `Cable` and
+// `PerpCable` still live in Render.js's IIFE.  `cableTo` constructs
+// a PerpCable, so we late-bind the constructor through
+// `setPerpCableCtor()` — Render.js wires it immediately after
+// PerpCable is defined.
+
+import { type JQueryNodeElem, RenderNode } from './RenderNode.js';
+import { type PerpSpriteConfig, RenderPerpSprite } from './RenderPerpSprite.js';
+import { RenderSet } from './RenderSet.js';
+import { RenderSprite, type SpriteConfig, type SpriteFrameMap } from './RenderSprite.js';
+
+// ── injection seam: PerpCable still lives in Render.js's IIFE ───────────────
+
+export interface PerpCableLike extends RenderNode {
+  perpFrom: RenderPerp;
+  perpTo: RenderPerp;
+  length: number;
+  cableMaxLength: number;
+  noWobble?: boolean;
+  FXConnect(cb?: () => void): void;
+  FXDisconnect(cb?: () => void): void;
+  FXWobbleTension(tension: number): void;
+  FXToggleConnect(progress: number): void;
+  FXStraighten(straightness: number): void;
+  FXDataIn(cb?: () => void): void;
+  FXDataOut(cb?: () => void): void;
+}
+
+export interface PerpCableCtor {
+  new (config: PerpCableConfig, perpFrom: RenderPerp, perpTo: RenderPerp): PerpCableLike;
+}
+
+export interface PerpCableConfig {
+  hidden?: boolean;
+  [key: string]: unknown;
+}
+
+let _perpCableCtor: PerpCableCtor | undefined;
+
+export function setPerpCableCtor(ctor: PerpCableCtor): void {
+  _perpCableCtor = ctor;
+}
+
+function newPerpCable(config: PerpCableConfig, from: RenderPerp, to: RenderPerp): PerpCableLike {
+  if (!_perpCableCtor) {
+    throw new Error('RenderPerp: PerpCable ctor seam not wired (call setPerpCableCtor).');
+  }
+  return new _perpCableCtor(config, from, to);
+}
+
+// ── jQuery surface ──────────────────────────────────────────────────────────
+
+interface JQueryPerpElem {
+  0: HTMLElement;
+}
+
+function getJQuery(): (selector: string) => JQueryPerpElem {
+  const jq = (globalThis.jQuery ?? globalThis.$) as
+    | ((selector: string) => JQueryPerpElem)
+    | undefined;
+  if (!jq) {
+    throw new Error('RenderPerp requires the jQuery global to be loaded.');
+  }
+  return jq;
+}
+
+interface UnderscoreEachLike {
+  each<T>(list: T[] | Record<string, T>, fn: (item: T, key: number | string) => void): void;
+}
+
+// ── config shape ────────────────────────────────────────────────────────────
+
+export type PerpConfig = SpriteConfig & {
+  frame_src?: string;
+  frame_map?: SpriteFrameMap;
+  cables?: RenderSet<PerpCableLike>;
+  perpSprite?: PerpSpriteConfig | RenderPerpSprite;
+  draggable?: boolean;
+  clickable?: boolean;
+  placeRandom?: { x: number; y: number };
+  placeParentRadius?: number;
+};
+
+// ── the class ───────────────────────────────────────────────────────────────
+
+export class RenderPerp extends RenderSprite {
+  declare cables: RenderSet<PerpCableLike>;
+  declare perpSprite: RenderPerpSprite | undefined;
+  declare placeRandom: { x: number; y: number } | undefined;
+  declare placeParentRadius: number | undefined;
+  declare sticky: boolean;
+  declare dragalong: boolean;
+
+  constructor(config: PerpConfig = {}) {
+    const $ = getJQuery();
+    const jdomelem = $("<div class='Perp'></div>");
+    const placeRandom =
+      config.x === undefined || config.y === undefined ? { x: 1024, y: 800 } : undefined;
+
+    const frameSrc = config.frameSrc ?? config.frame_src ?? 'MainSprites.png';
+    const frameMap: SpriteFrameMap = config.frameMap ??
+      config.frame_map ?? {
+        normal: { x: 0, y: 0, width: 80, height: 80, pivotx: 0, pivoty: 0 },
+      };
+    const frame = config.frame ?? 'normal';
+    const cables = config.cables ?? new RenderSet<PerpCableLike>();
+
+    // Pre-upgrade `perpSprite` to a real RenderPerpSprite before
+    // calling `super`.  RenderSprite's constructor calls
+    // `setFrame()` → `draw()` at the end, and our `draw` override
+    // dereferences `this.perpSprite.updatePosition()`, so leaving
+    // perpSprite as a plain config object during `super` would
+    // crash on `updatePosition is not a function`.
+    const perpSpriteInstance =
+      config.perpSprite instanceof RenderPerpSprite
+        ? config.perpSprite
+        : config.perpSprite
+          ? new RenderPerpSprite(config.perpSprite as PerpSpriteConfig)
+          : undefined;
+
+    super({
+      ...config,
+      frameSrc,
+      frameMap,
+      frame,
+      // Legacy short-circuit: `clickable: config.clickable || true`
+      // collapses to `true` always; preserved verbatim.
+      clickable: true,
+      detectCollisions: true,
+      draggable: config.draggable || true,
+      cables: cables as unknown as RenderNode['cables'],
+      perpSprite: perpSpriteInstance,
+      jdomelem: jdomelem as unknown as JQueryNodeElem,
+    } as SpriteConfig);
+
+    if (placeRandom) {
+      this.placeRandom = placeRandom;
+    }
+
+    this.initUI();
+
+    if (!config.frameSrc || !config.frameMap) {
+      console.log('ERROR: could not render perp ' + (config.id ?? '<no-id>'), config);
+    }
+
+    if (perpSpriteInstance) {
+      this.addChild(perpSpriteInstance);
+    }
+  }
+
+  getCableTo(perpTo: RenderPerp): PerpCableLike | undefined {
+    let cable: PerpCableLike | undefined;
+    this.cables.each((c) => {
+      if (c.perpTo === perpTo) {
+        cable = c;
+      }
+    });
+    return cable;
+  }
+
+  initUI(): void {
+    this.on('vclick', (e) => {
+      e.stopPropagation();
+    });
+    this.on('vdblclick', (e) => {
+      e.stopPropagation();
+    });
+
+    this.on('dragstart', (e) => {
+      e.stopPropagation();
+      this.setFrame('drag');
+      this.setZ(100);
+      if (this.perpSprite) {
+        this.perpSprite.offsetX += 2;
+        this.perpSprite.offsetY += 5;
+        this.perpSprite.draw();
+      }
+      this.decorators.hide();
+      if (!this.sticky && !this.dragalong) {
+        this.cables.each((cable) => {
+          if (cable.noWobble) {
+            cable.FXToggleConnect(0);
+          } else {
+            cable.FXWobbleTension(0.5);
+          }
+        });
+      } else if (!this.sticky && this.dragalong) {
+        this.cables.each((cable) => {
+          cable.FXStraighten(0);
+        });
+      } else if (this.sticky) {
+        this.cables.each((cable) => {
+          const othernode = (cable.perpFrom === this ? cable.perpTo : cable.perpFrom) as RenderPerp;
+          if (othernode.sticky) {
+            if (cable.noWobble) {
+              cable.FXToggleConnect(0);
+            } else {
+              cable.FXWobbleTension(0.5);
+            }
+          } else {
+            othernode.dragalong = true;
+            othernode.useDragHandler?.addListener(othernode);
+          }
+        });
+      }
+    });
+
+    this.on('dragend', (e) => {
+      e.stopPropagation();
+
+      this.setZ(0);
+      this.setFrame('normal');
+      this.draw();
+      if (this.perpSprite) {
+        this.perpSprite.offsetX -= 2;
+        this.perpSprite.offsetY -= 5;
+        this.perpSprite.draw();
+      }
+      this.decorators.show();
+      this.decorators.draw();
+      this.cables.each((cable) => {
+        if (this.dragalong) {
+          cable.FXStraighten(1);
+        } else {
+          if (cable.noWobble) {
+            cable.FXToggleConnect(1);
+          } else {
+            cable.FXWobbleTension(1);
+          }
+        }
+      });
+      this.dragalong = false;
+    });
+    this.on('mousedown touchstart', (e) => {
+      e.stopPropagation();
+    });
+    this.on('vmouseover', (e) => {
+      e.stopPropagation();
+      // FIXME: Write own Event Wrapper for hover events
+      const target = (e as unknown as { target?: unknown }).target;
+      if (target !== this.domelem) {
+        return;
+      }
+      if (!this.dragging) {
+        this.setFrame('hover');
+        this.FXBounce();
+      } else {
+        this.setFrame('drag');
+      }
+    });
+    this.on('vmouseout', (_e) => {
+      if (this.dragging) {
+        this.setFrame('drag');
+      } else {
+        this.setFrame('normal');
+      }
+    });
+  }
+
+  // RenderNode declares `dragBound` as an optional property
+  // (`((pos) => void) | undefined`), so we override with a property
+  // initializer rather than a method to satisfy the TS class-shape
+  // check.  The arrow keeps `this` bound to the Perp instance.
+  override dragBound: (pos: { x: number; y: number }) => void = (pos) => {
+    if (!this.parentNode) {
+      return;
+    }
+    if (pos.x < 35) {
+      pos.x = 35;
+    } else if (pos.x > this.parentNode.width - 35) {
+      pos.x = this.parentNode.width - 35;
+    }
+    if (pos.y < 100) {
+      pos.y = 100;
+    } else if (pos.y > this.parentNode.height - 100) {
+      pos.y = this.parentNode.height - 100;
+    }
+  };
+
+  override moveTo(pos: { x: number; y: number }): void {
+    // Used during animations, to also draw and render other Nodes affected by movement.
+    this.setPosition(pos);
+    this.cables.draw();
+    this.decorators.draw();
+  }
+
+  // FIXME random placement, remove
+  setRandomPosition(originPos?: { x: number; y: number }): void {
+    let tries = 0;
+    const start = originPos ?? { x: 1024, y: 800 };
+    const randomPos = (pos: { x: number; y: number }): { x: number; y: number } => ({
+      x: pos.x + 60 * (Math.random() < 0.5 ? 1 : -1),
+      y: pos.y + 40 * (Math.random() < 0.5 ? 1 : -1),
+    });
+    if (!this.useDragHandler) return;
+    let testPos = this.useDragHandler.getCollisionPos(this, start);
+    while (tries < 500 && testPos.coll === true) {
+      testPos = { ...testPos, ...randomPos(testPos) };
+      if (this.placeParentRadius) {
+        testPos = { ...testPos, ...this.testParentRadius(testPos, this.placeParentRadius) };
+      }
+      testPos.coll = this.useDragHandler.testCollisions(this, testPos);
+      tries += 1;
+    }
+    this.setPosition(testPos);
+  }
+
+  override onAddInit(): void {
+    if (this.draggable) {
+      this.setDraggable(true);
+    }
+    if (this.clickable) {
+      this.setClickable(true);
+    }
+    if (this.placeRandom) {
+      this.setRandomPosition(this.placeRandom);
+    }
+    this.updateRenderProp();
+    this.draw();
+  }
+
+  cableTo(otherperp: RenderPerp, config?: PerpCableConfig): PerpCableLike | string {
+    // Connect this Perp to another one, Perps need to live on the same Node, usually a ViewMap.
+    if (!this.parentNode || !otherperp.parentNode || this.parentNode !== otherperp.parentNode) {
+      return 'Could not connect';
+    }
+    const cfg = config ?? {};
+    const perpcable = newPerpCable(cfg, this, otherperp);
+    this.parentNode.addChild(perpcable);
+    return perpcable;
+  }
+
+  cableAnimatedTo(
+    otherperp: RenderPerp,
+    config?: PerpCableConfig,
+    cb?: () => void
+  ): PerpCableLike | string {
+    const cfg = { ...(config ?? {}), hidden: true };
+    const cable = this.cableTo(otherperp, cfg);
+    if (typeof cable === 'string') return cable;
+    cable.FXConnect(cb);
+    return cable;
+  }
+
+  cableAnimatedRemove(otherperp: RenderPerp): void {
+    const cable = this.getCableTo(otherperp);
+    if (!cable) {
+      return;
+    }
+    cable.FXDisconnect(() => {
+      cable.remove();
+    });
+  }
+
+  override draw(): void {
+    if (this.dragging) {
+      this.moveTo(this.getPosition());
+    } else {
+      this.setPosition(this.getPosition());
+    }
+    this.setTransform(this.getTransform());
+    this.setSize(this.getSize());
+    this.setOpacity(this.opacity);
+    if (this.perpSprite) {
+      this.perpSprite.updatePosition();
+    }
+  }
+
+  getCablesToOrigin(): PerpCableLike[] {
+    // Doesn't work on a graph, obviously
+    const cables: PerpCableLike[] = [];
+    if (!this.cables.set.length) {
+      return cables;
+    }
+    this.cables.each((cable) => {
+      if (cable.perpTo === this) {
+        const parentPerp = cable.perpFrom;
+        cables.push(cable);
+        for (const pcable of parentPerp.getCablesToOrigin()) {
+          cables.push(pcable);
+        }
+      }
+    });
+    return cables;
+  }
+
+  FXDataOut(cb?: () => void): number {
+    const _u = globalThis._ as unknown as UnderscoreEachLike;
+    const cables = this.getCablesToOrigin();
+    let duration = 500;
+    let delay = 0;
+    _u.each(cables, (cable, k) => {
+      duration = cable.length * 2;
+      if ((k as number) === cables.length - 1) {
+        const endPerp = cable.perpFrom;
+        window.setTimeout(() => {
+          cable.FXDataIn(() => {
+            endPerp.FXFeedMe();
+            if (cb) cb();
+          });
+        }, delay);
+      } else {
+        window.setTimeout(() => {
+          cable.FXDataIn(() => {
+            if (cb) cb();
+          });
+        }, delay);
+      }
+      delay = delay + duration;
+    });
+    return delay;
+  }
+
+  // TODO: Make Loop with FX Start/Stop options
+  FXDataIn(cb?: () => void): number {
+    const _u = globalThis._ as unknown as UnderscoreEachLike;
+    const cables = this.getCablesToOrigin().reverse();
+    let duration = 500;
+    let delay = 0;
+    _u.each(cables, (cable, k) => {
+      duration = cable.length * 2;
+      if ((k as number) === cables.length - 1) {
+        window.setTimeout(() => {
+          cable.FXDataOut(cb);
+        }, delay);
+      } else {
+        window.setTimeout(() => {
+          cable.FXDataOut();
+        }, delay);
+      }
+      delay = delay + duration;
+    });
+    return delay;
+  }
+}

--- a/scripts/render/RenderPerpSprite.ts
+++ b/scripts/render/RenderPerpSprite.ts
@@ -1,0 +1,85 @@
+// Render-side `PerpSprite` — an inner-sprite child layered onto a
+// Perp's domelem.  Reads its frame-map pivots from the parent Perp
+// when its own entries omit `pivotx`/`pivoty`, then snaps to the
+// parent's offset.  Used by Perp subclasses that need a secondary
+// foreground sprite (e.g. ContactPerp's expression layer).
+//
+// Extracted from scripts/Render.js's IIFE in PR 35 of issue #147.
+// Pairs with RenderPerp — Perp's ctor wires `new RenderPerpSprite()`
+// when `config.perpSprite` is set.
+
+import { type JQueryNodeElem, RenderNode } from './RenderNode.js';
+import { RenderSprite, type SpriteConfig, type SpriteFrame } from './RenderSprite.js';
+
+interface JQueryPerpSpriteElem {
+  0: HTMLElement;
+  attr(name: string, value: string): unknown;
+}
+
+function getJQuery(): (selector: string) => JQueryPerpSpriteElem {
+  const jq = (globalThis.jQuery ?? globalThis.$) as
+    | ((selector: string) => JQueryPerpSpriteElem)
+    | undefined;
+  if (!jq) {
+    throw new Error('RenderPerpSprite requires the jQuery global to be loaded.');
+  }
+  return jq;
+}
+
+export type PerpSpriteConfig = SpriteConfig & {
+  frame_src?: string;
+  frame_map?: SpriteConfig['frameMap'];
+};
+
+export class RenderPerpSprite extends RenderSprite {
+  constructor(config: PerpSpriteConfig = {}) {
+    const $ = getJQuery();
+    const jdomelem = $("<div class='PerpSprite'></div>");
+    super({
+      ...config,
+      frameSrc: config.frameSrc ?? config.frame_src,
+      frameMap: config.frameMap ?? config.frame_map,
+      frame: config.frame ?? 'normal',
+      jdomelem: jdomelem as unknown as JQueryNodeElem,
+    } as SpriteConfig);
+  }
+
+  override onAddInit(): void {
+    const parent = this.parentNode as
+      | (RenderNode & {
+          perpSprite?: RenderPerpSprite;
+          frameMap: { normal: SpriteFrame };
+          offsetX: number;
+          offsetY: number;
+        })
+      | undefined;
+    if (parent) {
+      parent.perpSprite = this;
+      // Set position to parent pivot — fill in any missing
+      // pivotx/pivoty entries from the parent's `normal` frame.
+      for (const frame of Object.values(this.frameMap)) {
+        if (!frame.pivotx) {
+          frame.pivotx = parent.frameMap.normal.pivotx;
+        }
+        if (!Object.prototype.hasOwnProperty.call(frame, 'pivoty')) {
+          frame.pivoty = parent.frameMap.normal.pivoty;
+        }
+      }
+    }
+
+    this.setFrameSrc(this.frameSrc);
+    this.setFrame(this.frame);
+    if (parent) {
+      this.setPosition({ x: parent.offsetX, y: parent.offsetY });
+    }
+
+    this.draw();
+    this.updateRenderProp();
+  }
+
+  updatePosition(): void {
+    const parent = this.parentNode;
+    if (!parent) return;
+    this.setPosition({ x: parent.offsetX, y: parent.offsetY });
+  }
+}


### PR DESCRIPTION
## Summary

Seventh Render seam — the two interactive in-game sprite primitives:

- **`RenderPerp`** (~340 LOC) — the user-draggable perp on the ViewMap. Owns the per-perp drag/click event wiring (frame swaps, decorator hide/show, cable wobble/straighten on drag), random placement (`setRandomPosition`), cable connection helpers (`cableTo`, `cableAnimatedTo`, `cableAnimatedRemove`, `getCableTo`, `getCablesToOrigin`), and the `FXDataIn` / `FXDataOut` data-flow choreography.
- **`RenderPerpSprite`** (~40 LOC) — an inner-sprite child layered onto a Perp's domelem. Reads its frame-map pivots from the parent Perp when its own entries omit them, then snaps to the parent's offset.

Render.js still carries `@ts-nocheck`; this PR shrinks its inline footprint by ~390 LOC. Quarantine count still 1.

## Seams

Cable handling crosses an extraction boundary: `Cable` and `PerpCable` still live in Render.js's IIFE. `RenderPerp.cableTo` constructs a PerpCable, so we late-bind the constructor through `setPerpCableCtor()` — Render.js wires it immediately after `extend(PerpCable, Cable)`. Same pattern as the `setRenderNodeRegistry` / `setRenderNodeTickers` seams from PR #216.

## Constructor-reordering bug caught locally

Legacy Perp's function-constructor called `init` (no `setFrame`), then `initUI`, then upgraded `perpSprite` from config object to `new PerpSprite(…)`, *then* finally `setFrameSrc` / `setFrame` (which calls `draw`). An ES `super()` to `RenderSprite` runs the final `setFrameSrc` / `setFrame` / `draw` block at the end of RenderSprite's constructor — so RenderPerp's `draw` override fires *during* `super`, before the Perp ctor body has had a chance to upgrade `perpSprite`. Since `draw` dereferences `this.perpSprite.updatePosition()`, leaving perpSprite as a plain config object during super crashes with "updatePosition is not a function" and detonates the boot.

**Fix**: pre-upgrade `perpSprite` to a real `RenderPerpSprite` *before* calling `super`, and drop the now-duplicate `setFrameSrc` / `setFrame` calls at the end of the Perp constructor (RenderSprite's super already runs them). PerpSprite's `updatePosition` already guards on `parentNode === undefined`, so the early super-time `draw` is a safe no-op until the Perp ctor body's `addChild(perpSprite)` runs.

Caught by the `collect-icon-after-charge` e2e test on a freshly-restarted Vite dev server — the PR #217 lesson on stale dev-server caching paid off again.

## Other notes

- `*Class` import-alias convention applied to both new modules (`RenderPerpClass`, `RenderPerpSpriteClass`) per the PR #217 IIFE-shadow lesson, even though grep found no `var Perp =` / `var PerpSprite =` collisions — prophylactic.
- `DragHandlerLike` in RenderNode.ts widened to declare `getCollisionPos` and `testCollisions`, which `setRandomPosition` needs. Two-line interface extension.
- `dragBound` overridden as a property initializer (arrow form) rather than a method — matches RenderNode's declared `((pos) => void) | undefined` shape under TS class-shape checks.
- Zero `any`, zero `// @ts-*`, zero `!` non-null in either new file.

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx biome check` — clean
- [x] `npm run test` — 624/624 passing
- [x] `npm run test:e2e` — 45/45 passing on a fresh Vite dev server (1 pre-existing skip), incl. the `collect-icon-after-charge` regression that flushed out the constructor-order bug
- [x] `npm run build` — green

---
_Generated by [Claude Code](https://claude.ai/code/session_018qbFtLNgH4p39DmEBtouJu)_