### PR TITLE
fix: trigger mission completion when goals auto-complete at seed time

### DIFF
--- a/scripts/LocalEngine.ts
+++ b/scripts/LocalEngine.ts
@@ -1730,40 +1730,52 @@ function _completeMissionsIfReady(
 ): MissionAdvanceResult {
   var ruleset = _getRuleset();
   var completed: string[] = [];
-  var stillActive = activeMissions.filter(function (mGestalt) {
-    var goals = updatedGoals.filter(function (g) {
-      return g.mission === mGestalt;
-    });
-    if (!goals.length) return true;
-    if (
-      goals.every(function (g) {
-        return g.complete;
-      })
-    ) {
-      completed.push(mGestalt);
-      return false;
-    }
-    return true;
-  });
+  var newActive = activeMissions.slice();
 
-  var newActive = stillActive.slice();
-  if (ruleset && ruleset.missions && completed.length) {
-    _eachMissionDef(ruleset, function (def) {
-      var td = def.type_data;
-      if (!td) return;
-      var req = td.required_mission;
-      var gestalt = td.gestalt;
-      if (!req || !gestalt || newActive.indexOf(gestalt) !== -1) return;
-      if (completed.indexOf(req) === -1) return;
-      var seededGestalt: string = gestalt;
-      newActive.push(seededGestalt);
-      (td.goals || []).forEach(function (g) {
-        updatedGoals = updatedGoals.concat([_seedGoalRow(seededGestalt, g)]);
+  // Loop so a cascade activation whose buy_perp goals auto-complete (because
+  // the player already owns the targets) is itself recognized as finished
+  // in the same pass — otherwise the mission stays in active_missions with
+  // every goal checked off.
+  while (true) {
+    var newlyCompleted: string[] = [];
+    var stillActive = newActive.filter(function (mGestalt) {
+      var goals = updatedGoals.filter(function (g) {
+        return g.mission === mGestalt;
       });
+      if (!goals.length) return true;
+      if (
+        goals.every(function (g) {
+          return g.complete;
+        })
+      ) {
+        newlyCompleted.push(mGestalt);
+        return false;
+      }
+      return true;
     });
-    // Auto-complete buy_perp goals for items the player already owns so a
-    // mission that unlocks after the item was bought doesn't get stuck.
-    updatedGoals = _autoCompleteBuyPerpGoals(updatedGoals, getState().nodes);
+
+    if (!newlyCompleted.length) break;
+    completed = completed.concat(newlyCompleted);
+    newActive = stillActive;
+
+    if (ruleset && ruleset.missions) {
+      _eachMissionDef(ruleset, function (def) {
+        var td = def.type_data;
+        if (!td) return;
+        var req = td.required_mission;
+        var gestalt = td.gestalt;
+        if (!req || !gestalt || newActive.indexOf(gestalt) !== -1) return;
+        if (newlyCompleted.indexOf(req) === -1) return;
+        var seededGestalt: string = gestalt;
+        newActive.push(seededGestalt);
+        (td.goals || []).forEach(function (g) {
+          updatedGoals = updatedGoals.concat([_seedGoalRow(seededGestalt, g)]);
+        });
+      });
+      // Auto-complete buy_perp goals for items the player already owns so a
+      // mission that unlocks after the item was bought doesn't get stuck.
+      updatedGoals = _autoCompleteBuyPerpGoals(updatedGoals, getState().nodes);
+    }
   }
 
   var updatedMissions = activeMissions.filter(function (m) {
@@ -1814,7 +1826,19 @@ function _repairStuckMissionGoals(state: LocalState): MissionAdvanceResult | nul
     return goal;
   });
 
-  if (!changed) return null;
+  // Also catches missions whose goals were auto-completed at seed time
+  // (e.g. buy_perp targets the player already owned): the goals are flagged
+  // complete but the mission never left active_missions.
+  var hasFinishedActiveMission = activeMissions.some(function (mGestalt) {
+    var mg = updatedGoals.filter(function (g) {
+      return g.mission === mGestalt;
+    });
+    return mg.length > 0 && mg.every(function (g) {
+      return g.complete;
+    });
+  });
+
+  if (!changed && !hasFinishedActiveMission) return null;
   return _completeMissionsIfReady(updatedGoals, activeMissions);
 }
 

--- a/scripts/LocalEngine.ts
+++ b/scripts/LocalEngine.ts
@@ -1833,9 +1833,12 @@ function _repairStuckMissionGoals(state: LocalState): MissionAdvanceResult | nul
     var mg = updatedGoals.filter(function (g) {
       return g.mission === mGestalt;
     });
-    return mg.length > 0 && mg.every(function (g) {
-      return g.complete;
-    });
+    return (
+      mg.length > 0 &&
+      mg.every(function (g) {
+        return g.complete;
+      })
+    );
   });
 
   if (!changed && !hasFinishedActiveMission) return null;

--- a/scripts/LocalEngine.ts
+++ b/scripts/LocalEngine.ts
@@ -1803,7 +1803,9 @@ function _completeMissionsIfReady(
 }
 
 // Flips goals where current_amount >= amount but complete=false (caused by
-// progression handlers that updated current_amount without setting complete).
+// progression handlers that updated current_amount without setting complete),
+// and also drives mission completion for missions whose goals were all
+// flagged complete at seed time but never left active_missions.
 // Returns null when nothing needed repair so callers can skip persistence.
 function _repairStuckMissionGoals(state: LocalState): MissionAdvanceResult | null {
   var goals = state.mission_goals || [];

--- a/tests/handlers/handlers.test.js
+++ b/tests/handlers/handlers.test.js
@@ -1594,6 +1594,102 @@ describe('buyPerp — mission activating after nurse already owned seeds goal as
   });
 });
 
+// Regression: an active mission whose goals were all auto-completed at seed
+// time (e.g. buy_perp targets the player already owned) was left stuck in
+// active_missions because _repairStuckMissionGoals only inspected goals
+// where complete=false.
+describe('loadGame — completes mission whose goals were auto-completed at seed time', () => {
+  const HEIDI_MISSION = '16f302f84b84498a734dfdbe1a7794b9000';
+  const AGENT_NODE = {
+    game_id: 'node_agent',
+    game_type: 'AgentPerp',
+    full_type: 'AgentPerp:agent004',
+    gestalt: 'agent004',
+    full_path: 'Imperium.agent004',
+    instance_data: {},
+  };
+  const CONTACT_NODE = {
+    game_id: 'node_contact',
+    game_type: 'ContactPerp',
+    full_type: 'ContactPerp:contact026',
+    gestalt: 'contact026',
+    full_path: 'Imperium.contact026',
+    instance_data: {},
+  };
+
+  it('removes mission from active_missions when all buy_perp goals are already complete', async () => {
+    setState(
+      Object.assign(mkBuyPerpState(), {
+        active_missions: [HEIDI_MISSION],
+        mission_goals: [
+          {
+            mission: HEIDI_MISSION,
+            workflow: 'buy_perp',
+            target: 'agent004',
+            amount: 0,
+            position: 1,
+            current_amount: 1,
+            complete: true,
+          },
+          {
+            mission: HEIDI_MISSION,
+            workflow: 'buy_perp',
+            target: 'contact026',
+            amount: 0,
+            position: 2,
+            current_amount: 1,
+            complete: true,
+          },
+        ],
+        nodes: mkBuyPerpState().nodes.concat([AGENT_NODE, CONTACT_NODE]),
+      })
+    );
+
+    await loadGame();
+
+    expect(getState().active_missions).not.toContain(HEIDI_MISSION);
+  });
+
+  it('pays out the mission reward when an already-finished mission is detected at load time', async () => {
+    const baseGv = Object.assign({}, mkBuyPerpState().game_values, {
+      cash_value: 100,
+      xp_value: 0,
+    });
+    setState(
+      Object.assign(mkBuyPerpState(), {
+        game_values: baseGv,
+        active_missions: [HEIDI_MISSION],
+        mission_goals: [
+          {
+            mission: HEIDI_MISSION,
+            workflow: 'buy_perp',
+            target: 'agent004',
+            amount: 0,
+            position: 1,
+            current_amount: 1,
+            complete: true,
+          },
+          {
+            mission: HEIDI_MISSION,
+            workflow: 'buy_perp',
+            target: 'contact026',
+            amount: 0,
+            position: 2,
+            current_amount: 1,
+            complete: true,
+          },
+        ],
+        nodes: mkBuyPerpState().nodes.concat([AGENT_NODE, CONTACT_NODE]),
+      })
+    );
+
+    await loadGame();
+
+    expect(getState().game_values.cash_value).toBe(2100);
+    expect(getState().game_values.xp_value).toBe(1);
+  });
+});
+
 // ── setLocale ────────────────────────────────────────────────────────────────
 
 describe('setLocale', () => {

--- a/tests/handlers/handlers.test.js
+++ b/tests/handlers/handlers.test.js
@@ -1650,6 +1650,8 @@ describe('loadGame — completes mission whose goals were auto-completed at seed
     expect(getState().active_missions).not.toContain(HEIDI_MISSION);
   });
 
+  // Reward baseline (cash 2000, xp 1) comes from HEIDI_MISSION's rewards in
+  // the live ruleset; if those change this assertion will need updating.
   it('pays out the mission reward when an already-finished mission is detected at load time', async () => {
     const baseGv = Object.assign({}, mkBuyPerpState().game_values, {
       cash_value: 100,


### PR DESCRIPTION
## Summary

A mission whose goals were all flagged complete during seeding — e.g. `buy_perp` goals targeting nodes the player already owned — was left stuck in `active_missions` with every goal checked off but no completion event or rewards. This is the bug visible for "Unofficial Collaboration" (recruit Heidi Plum + Elly DeTelly): both goals 1/1 ✓, mission never finishes.

Two paths needed fixing in `scripts/LocalEngine.ts`:

- `_completeMissionsIfReady` cascade-activated the next mission and ran `_autoCompleteBuyPerpGoals` on its goals, but the completion check had already run earlier in the same call. Now it loops so a freshly activated mission whose goals auto-complete is recognized in the same pass.
- `_repairStuckMissionGoals` only looked at goals where `complete: false`, so it never triggered the completion check when a load-time seed had already flipped every goal to complete. It now also fires when any active mission has all goals already complete, so loadGame recovers stuck saves.

## Test plan

- [x] `pnpm test` — 626/626 pass, including two new regression tests in `tests/handlers/handlers.test.js` using the actual Unofficial Collaboration gestalt
- [ ] Manually load a save that's stuck on this mission and confirm the mission completes and rewards are paid out on next loadGame

https://claude.ai/code/session_01NYADeh7VcvbnkT2bcDZzL8

---
_Generated by [Claude Code](https://claude.ai/code/session_01NYADeh7VcvbnkT2bcDZzL8)_