### PR TITLE
phase 7 (#147): extract Render's SlowTicker + node registry, retire two injection seams

### DIFF
--- a/scripts/Render.js
+++ b/scripts/Render.js
@@ -19,14 +19,14 @@ import {
   RenderDecoratorNew as RenderDecoratorNewClass,
   RenderDecoratorReady as RenderDecoratorReadyClass,
   RenderDecoratorTimer as RenderDecoratorTimerClass,
-  setRenderDecoratorSlowTicker,
 } from './render/RenderDecorators.js';
 import { RenderDragHandler } from './render/RenderDragHandler.js';
-import { RenderNode, setRenderNodeRegistry, setRenderNodeTickers } from './render/RenderNode.js';
+import { RenderNode, setRenderNodeTickers } from './render/RenderNode.js';
 import { applyRenderNodeFX } from './render/RenderNodeFX.js';
 import { RenderPerp as RenderPerpClass } from './render/RenderPerp.js';
 import { RenderPerpSprite as RenderPerpSpriteClass } from './render/RenderPerpSprite.js';
 import { RenderSet } from './render/RenderSet.js';
+import { RenderSlowTicker } from './render/RenderSlowTicker.js';
 import { RenderSprite as RenderSpriteClass } from './render/RenderSprite.js';
 import { RenderText as RenderTextClass } from './render/RenderText.js';
 import {
@@ -45,6 +45,7 @@ import {
   RenderViewTab as RenderViewTabClass,
   setRenderViewsConfig,
 } from './render/RenderViews.js';
+import { _ids, _instances, clearAllNodes, getNode, getNodeById } from './render/renderRegistry.js';
 import { renderSpriteHtml } from './render/renderSpriteHelper.js';
 import setup from './setup.js';
 import utilDefault from './util.js';
@@ -125,40 +126,14 @@ var Render = function () {
   /////////////////////////////////////////////
   // Some generic tools and getter functions
   /////////////////////////////////////////////
-
-  var _instances = [];
-  var _ids = {};
-
-  var add = function (node) {
-    _instances[node._id] = node;
-    _ids[node.id] = node;
-  };
-
-  var get = function (_id) {
-    return _instances[_id];
-  };
-
-  var getById = function (id) {
-    return _ids[id];
-  };
-
-  var remove = function (_id) {
-    if (get(_id)) {
-      delete _ids[get(_id).id];
-    }
-    _instances[_id] = undefined;
-  };
-
-  var clear = function () {
-    // Clear everything that has been rendered so far
-    for (var n = 0; n < _instances.length; n++) {
-      var node = _instances[n];
-      if (node) {
-        node.remove();
-      }
-    }
-    _instances.length = 0;
-  };
+  //
+  // Extracted to scripts/render/renderRegistry.ts in PR 40 of
+  // issue #147.  Imported as live ESM bindings (`_instances`,
+  // `_ids`, `getNode`, `getNodeById`, `clearAllNodes`) so the
+  // publisher's `_instances:` / `_ids:` / `get:` / `getById:` /
+  // `clear:` entries keep working unchanged.  The seam from
+  // PR #216 (`setRenderNodeRegistry`) is retired — RenderNode
+  // imports the registry helpers directly now.
 
   /////////////////////////////////////////////
   // The Draghandler
@@ -186,40 +161,14 @@ var Render = function () {
   /////////////////////////////////////////////
   // The SlowTicker
   /////////////////////////////////////////////
+  //
+  // Extracted to scripts/render/RenderSlowTicker.ts in PR 40 of
+  // issue #147.  Aliased back to `SlowTicker` so the publisher
+  // entry keeps working unchanged.  The PR #221
+  // `setRenderDecoratorSlowTicker` injection seam is retired —
+  // RenderDecorators imports the singleton directly now.
 
-  // Written as Singleton, like original Ticker
-
-  var SlowTicker = {
-    start: function () {
-      if (!this.timeout) {
-        this.tick();
-      }
-    },
-    tick: function () {
-      this.listeners.each(function (node) {
-        node.tick();
-      });
-      this.timeout = window.setTimeout(function () {
-        SlowTicker.tick();
-      }, renderConf.slowTickerFrameRate);
-    },
-    addListener: function (node) {
-      this.listeners.add(node);
-    },
-    removeListener: function (node) {
-      this.listeners.remove(node);
-    },
-    stop: function () {
-      window.clearTimeout(this.timeout);
-      this.timeout = undefined;
-    },
-  };
-  SlowTicker.listeners = new Set();
-  SlowTicker.start();
-
-  // Wire the SlowTicker seam used by RenderDecoratorTimer (PR 36 of
-  // issue #147).
-  setRenderDecoratorSlowTicker(SlowTicker);
+  var SlowTicker = RenderSlowTicker;
 
   /////////////////////////////
   // The Node
@@ -231,30 +180,15 @@ var Render = function () {
   // existing in-IIFE call sites (`extend(Sprite, Node)`,
   // `Node.prototype.FXX = …`, `new Node(…)`) keep working unchanged.
   //
-  // RenderNode is decoupled from this IIFE's state via two seams:
-  //   - `setRenderNodeRegistry` wires up the `_instances` / `_ids`
-  //     registers that live in this file's outer scope.
-  //   - `setRenderNodeTickers` wires up `Ticker` and `SlowTicker` so
-  //     `RenderNode#remove()` can unregister from both.
-  // Both seams must be wired before any `new Node(…)` runs, which is
-  // why we set them up immediately after the alias.
-  //
-  // The FX/animation methods (FXSimple … FXElasticTo) below stay in
-  // this file for now — they construct Sprite/Text instances which
-  // themselves extend Node, so moving them needs constructor seams
-  // for every visual primitive.  They mutate `RenderNode.prototype`
-  // through the alias, so subclass instances pick them up via the
-  // prototype chain just like with the legacy class.
+  // PR 40 of issue #147 retired the `setRenderNodeRegistry` seam —
+  // RenderNode imports the registry helpers directly from
+  // scripts/render/renderRegistry.ts.  Only the Ticker bridge stays
+  // (CreateJS Ticker still lives in this IIFE; once it's extracted
+  // too the final cleanup PR can convert this whole file to TS and
+  // drop `setRenderNodeTickers` along with the rest of the IIFE
+  // shell).
 
   var Node = RenderNode;
-
-  setRenderNodeRegistry({
-    count: function () {
-      return _instances.length;
-    },
-    add: add,
-    remove: remove,
-  });
 
   setRenderNodeTickers({
     tickerRemove: function (node) {
@@ -449,9 +383,9 @@ var Render = function () {
     _instances: _instances,
     _ids: _ids,
     //_sets: _sets,
-    get: get,
-    getById: getById,
-    clear: clear,
+    get: getNode,
+    getById: getNodeById,
+    clear: clearAllNodes,
     DragHandler: DragHandler,
     Set: Set,
     Node: Node,

--- a/scripts/render/RenderDecorators.ts
+++ b/scripts/render/RenderDecorators.ts
@@ -8,38 +8,15 @@
 // with its own canvas-arc countdown render).
 //
 // Extracted from scripts/Render.js's IIFE in PR 36 of issue #147.
-//
-// `DecoratorTimer` registers itself with `SlowTicker` for the
-// per-second countdown sweep — that singleton still lives in
-// Render.js's IIFE, so a `setRenderDecoratorSlowTicker()` seam
-// late-binds it (Render.js wires the seam right after SlowTicker
-// is defined).
+// PR #225 (top-level UI) shrunk the IIFE further; PR 40 lands
+// `SlowTicker` in scripts/render/RenderSlowTicker.ts and retires
+// the `setRenderDecoratorSlowTicker` injection seam this file
+// used to own — DecoratorTimer imports the singleton directly.
 
 import { type JQueryNodeElem, type NodeConfig, RenderNode } from './RenderNode.js';
+import { RenderSlowTicker } from './RenderSlowTicker.js';
 import { RenderSprite, type SpriteConfig, type SpriteFrameMap } from './RenderSprite.js';
 import { RenderText, type TextConfig } from './RenderText.js';
-
-// ── seam: SlowTicker singleton lives in Render.js's IIFE ────────────────────
-
-export interface SlowTickerLike {
-  addListener(node: RenderNode): void;
-  removeListener(node: RenderNode): void;
-}
-
-let _slowTicker: SlowTickerLike | undefined;
-
-export function setRenderDecoratorSlowTicker(t: SlowTickerLike): void {
-  _slowTicker = t;
-}
-
-function getSlowTicker(): SlowTickerLike {
-  if (!_slowTicker) {
-    throw new Error(
-      'RenderDecorators: SlowTicker seam not wired (call setRenderDecoratorSlowTicker).'
-    );
-  }
-  return _slowTicker;
-}
 
 // ── jQuery / underscore vendor surfaces ─────────────────────────────────────
 
@@ -517,7 +494,7 @@ export class RenderDecoratorTimer extends RenderSprite implements DecoratorBase 
     }
 
     // FIXME: Write own slower Timer Ticker
-    getSlowTicker().addListener(this);
+    RenderSlowTicker.addListener(this);
 
     this.initUI();
     this.updateRenderProp();
@@ -556,7 +533,7 @@ export class RenderDecoratorTimer extends RenderSprite implements DecoratorBase 
 
     if (this.done) return;
     if (perc > 100) {
-      getSlowTicker().removeListener(this);
+      RenderSlowTicker.removeListener(this);
       this.FXSnooze();
       this.done = true;
       this.decoratedNode.trigger('TimerEnd');

--- a/scripts/render/RenderNode.ts
+++ b/scripts/render/RenderNode.ts
@@ -5,58 +5,28 @@
 // collections, and the click/drag wiring.
 //
 // Extracted from scripts/Render.js's IIFE in PR 31 of issue #147.
-// Densest seam in the Render.js wave: ~620 LOC of core methods.  The
-// FX/animation methods (FXBounce, FXSpark, FXKatsching, …) are
-// deliberately left inline in Render.js for now — they instantiate
-// Sprite/Text (which themselves extend Node), so moving them would
-// require constructor-injection seams for every visual primitive.
-// They will follow once Sprite + Text are extracted.
-//
-// Two seams keep this module decoupled from Render.js's IIFE state:
-//   - `setRenderNodeRegistry`  — the IIFE owns `_instances` / `_ids` /
-//     `add` / `remove`; we late-bind to those so Node's `init` and
-//     `remove` can allocate / release `_id`s without importing Render.
-//   - `setRenderNodeTickers` — `remove()` unregisters from the
-//     CreateJS Ticker and from Render's SlowTicker singleton.
-//
-// Render.js wires both seams immediately after importing this module.
+// PR 40 lands the `_instances` / `_ids` registry in
+// scripts/render/renderRegistry.ts and retires the
+// `setRenderNodeRegistry` injection seam this file used to own.
+// `setRenderNodeTickers` stays — it bridges to the CreateJS Ticker
+// singleton which remains shimmed inside Render.js's IIFE for the
+// time being.
 
 import { OrderedSet } from '../game/OrderedSet.js';
 import { RenderSet } from './RenderSet.js';
+import { nodeCount, registerNode, unregisterNode } from './renderRegistry.js';
 
 // ── seam interfaces ─────────────────────────────────────────────────────────
-
-export interface RenderNodeRegistry {
-  /** Number of slots in the underlying `_instances` array — used to
-   *  allocate a fresh `_id` for a new Node. */
-  count(): number;
-  /** Register a node in `_instances` (by `_id`) and `_ids` (by `id`). */
-  add(node: RenderNode): void;
-  /** Drop the node from both registries by its `_id`. */
-  remove(id: number): void;
-}
 
 export interface RenderNodeTickers {
   tickerRemove(node: RenderNode): void;
   slowTickerRemove(node: RenderNode): void;
 }
 
-let _registry: RenderNodeRegistry | undefined;
 let _tickers: RenderNodeTickers | undefined;
-
-export function setRenderNodeRegistry(r: RenderNodeRegistry): void {
-  _registry = r;
-}
 
 export function setRenderNodeTickers(t: RenderNodeTickers): void {
   _tickers = t;
-}
-
-function getRegistry(): RenderNodeRegistry {
-  if (!_registry) {
-    throw new Error('RenderNode: registry seam not wired (call setRenderNodeRegistry).');
-  }
-  return _registry;
 }
 
 // ── DOM / jQuery surface that Node touches ──────────────────────────────────
@@ -243,10 +213,9 @@ export class RenderNode {
 
   init(config?: NodeConfig): void {
     const cfg: NodeConfig = config ?? {};
-    const reg = getRegistry();
-    this._id = reg.count();
+    this._id = nodeCount();
     this.id = (cfg.id as string | undefined) ?? 'Node' + this._id;
-    reg.add(this);
+    registerNode(this);
 
     this.children = new RenderSet<RenderNode>();
     this.decorators = new RenderSet<RenderNode>();
@@ -306,7 +275,7 @@ export class RenderNode {
       this.perpFrom.cables.remove(this);
     }
     this.jdomelem.remove();
-    getRegistry().remove(this._id);
+    unregisterNode(this._id);
   }
 
   addChild(child: RenderNode): RenderNode {

--- a/scripts/render/RenderSlowTicker.ts
+++ b/scripts/render/RenderSlowTicker.ts
@@ -1,0 +1,76 @@
+// Render-side `SlowTicker` — the slow-cadence (120ms) tick driver
+// that DecoratorTimer registers itself with for the per-second
+// countdown sweep.  Written as a singleton, like the original
+// CreateJS Ticker, but with its own setTimeout loop instead of
+// hooking into the Easel render loop.
+//
+// Lifted out of Render.js's IIFE in PR 40 of issue #147.  Retires
+// the `setRenderDecoratorSlowTicker()` seam from PR #221 —
+// RenderDecorators imports this singleton directly now.
+//
+// Auto-starts on first import.  Module-load timing is fine: the
+// loop body just walks the (initially empty) `listeners` set, and
+// each tick costs one `setTimeout` call until a listener is added.
+
+import { OrderedSet } from '../game/OrderedSet.js';
+
+interface TickerListener {
+  tick(): void;
+}
+
+const _frameRate = 120;
+// `OrderedSet` rather than `RenderSet` — we only need `each` /
+// `add` / `remove`, none of the RenderSet bulk-action methods,
+// and `TickerListener`'s only-`tick()` shape doesn't satisfy the
+// `RenderNodeLike` constraint anyway.
+const _listeners = new OrderedSet<TickerListener>();
+let _timeout: number | undefined;
+
+function tick(): void {
+  _listeners.each((node) => {
+    node.tick();
+  });
+  if (typeof window !== 'undefined') {
+    _timeout = window.setTimeout(tick, _frameRate);
+  }
+}
+
+function start(): void {
+  if (_timeout === undefined && typeof window !== 'undefined') {
+    tick();
+  }
+}
+
+function stop(): void {
+  if (_timeout !== undefined) {
+    window.clearTimeout(_timeout);
+    _timeout = undefined;
+  }
+}
+
+function addListener(node: TickerListener): void {
+  _listeners.add(node);
+}
+
+function removeListener(node: TickerListener): void {
+  _listeners.remove(node);
+}
+
+// Keep the public surface identical to the legacy IIFE-local
+// singleton (`{ start, tick, addListener, removeListener, stop,
+// listeners }`) so the Render publisher's `SlowTicker:` entry and
+// any external consumer keeps working unchanged.
+export const RenderSlowTicker = {
+  start,
+  tick,
+  addListener,
+  removeListener,
+  stop,
+  listeners: _listeners,
+};
+
+// Auto-start when imported into a real DOM environment.  The
+// `typeof window !== 'undefined'` guard keeps Node-side toolchain
+// tests (which import the ESM bundle without a DOM) from booting
+// the recursive setTimeout loop.
+start();

--- a/scripts/render/renderRegistry.ts
+++ b/scripts/render/renderRegistry.ts
@@ -1,0 +1,66 @@
+// Render-side instance registry — the `_instances` array (indexed
+// by `_id`) and the `_ids` map (indexed by `id`) that every
+// RenderNode subclass auto-registers itself into in
+// RenderNode.init.  Lifted out of Render.js's IIFE in PR 40 of
+// issue #147.
+//
+// Retires the `setRenderNodeRegistry()` seam from PR #216 —
+// RenderNode imports these helpers directly now.
+
+import type { RenderNode } from './RenderNode.js';
+
+/** Public underlying array.  Held as a mutable export so the
+ *  Render publisher's `_instances:` entry can read it directly,
+ *  and so callers that walk the live registry (none currently)
+ *  see in-flight changes without a getter call. */
+export const _instances: Array<RenderNode | undefined> = [];
+
+/** Public id → node lookup.  Same accessibility note as
+ *  `_instances`. */
+export const _ids: Record<string, RenderNode> = {};
+
+/** Number of slots in `_instances` — used by RenderNode.init to
+ *  allocate a fresh `_id` for a new instance. */
+export function nodeCount(): number {
+  return _instances.length;
+}
+
+/** Register a node in `_instances` (by `_id`) and `_ids` (by `id`). */
+export function registerNode(node: RenderNode): void {
+  _instances[node._id] = node;
+  _ids[node.id] = node;
+}
+
+/** Drop the node from both registries by its `_id`.  Mirrors the
+ *  legacy slot-undefined pattern (rather than `splice`) so existing
+ *  `_id` slots stay stable for any in-flight reference. */
+export function unregisterNode(id: number): void {
+  const existing = _instances[id];
+  if (existing) {
+    delete _ids[existing.id];
+  }
+  _instances[id] = undefined;
+}
+
+/** Look up a node by its registry slot index. */
+export function getNode(id: number): RenderNode | undefined {
+  return _instances[id];
+}
+
+/** Look up a node by its string id (e.g. `"Node42"`, `"Sprite7"`). */
+export function getNodeById(id: string): RenderNode | undefined {
+  return _ids[id];
+}
+
+/** Clear everything that has been rendered so far — calls
+ *  `node.remove()` on each live node and truncates the
+ *  `_instances` array.  Used by Game.lock / reset paths. */
+export function clearAllNodes(): void {
+  for (let n = 0; n < _instances.length; n++) {
+    const node = _instances[n];
+    if (node) {
+      node.remove();
+    }
+  }
+  _instances.length = 0;
+}


### PR DESCRIPTION
## Summary

Twelfth Render seam — two small infrastructure pieces lifted out of Render.js's IIFE plus two injection seams retired.

- **`RenderSlowTicker`** — the slow-cadence (120ms) tick driver that DecoratorTimer registers itself with for the per-second countdown sweep. Kept as a singleton with the same public surface (`start` / `tick` / `addListener` / `removeListener` / `stop` / `listeners`) so the Render publisher's `SlowTicker:` entry stays unchanged.
- **`renderRegistry`** — the `_instances` array (indexed by `_id`) and `_ids` map (indexed by `id`) that every RenderNode auto-registers itself into. Exports `nodeCount` / `registerNode` / `unregisterNode` / `getNode` / `getNodeById` / `clearAllNodes`, plus the underlying `_instances` / `_ids` bindings so the publisher's `_instances:` / `_ids:` entries pass through as live ESM bindings.

## Seam retirements

- **`setRenderNodeRegistry`** (PR #216) — RenderNode now imports `nodeCount` / `registerNode` / `unregisterNode` directly from `renderRegistry.ts`.
- **`setRenderDecoratorSlowTicker`** (PR #221) — RenderDecorators now imports `RenderSlowTicker` directly.

`setRenderNodeTickers` (the CreateJS Ticker bridge) stays for now — the legacy `Ticker.addListener` / `removeListener` shim still lives inside Render.js's IIFE and will be rolled into the final cleanup PR.

## Notes

- SlowTicker auto-starts on first import (`start()` at module load), but `typeof window !== 'undefined'` guards the `setTimeout` call so the Node-side toolchain test (which imports the ESM bundle without a DOM) doesn't spin up an unsilenceable recursive timer loop. Caught locally by `tests/toolchain.test.js`.
- SlowTicker uses `OrderedSet` directly (not `RenderSet`) — the `TickerListener` shape (`tick(): void` only) doesn't satisfy `RenderNodeLike`'s structural constraint, and we only need `each` / `add` / `remove`. Documented inline.
- Render.js loses its inline `_instances` / `_ids` / `add` / `get` / `getById` / `remove` / `clear` block, the entire `var SlowTicker = {…}; SlowTicker.listeners = new Set(); SlowTicker.start();` block, and both `setRender*` seam wirings (~50 LOC).
- Zero `any`, zero `// @ts-*`, zero `!` non-null in the new files.

## What remains for #147

After this PR, the only remaining inline shape in Render.js's IIFE is:

- Vendor-globals binding (`_`, `$`, `Scroller`, `core`, `Easel`, `Tween`, `Sound`, `Ticker`, `Ease`).
- The CreateJS `Ticker.addListener` / `removeListener` / `setFPS` shim.
- The `applyRenderNodeFX(…)` + `setRenderViewsConfig(…)` / `setRenderNodeTickers(…)` / `setRenderCableResolution(…)` seam wirings.
- The 30-some `var X = RenderXClass;` aliases.
- The `_.mixin({ RenderAmount, RenderSprite })` underscore mixin registration.
- The publisher object + `getRender()` singleton wrapper.

The next (and **final**) PR converts that residual ~330-LOC IIFE shell to a typed TS module, drops the last `@ts-nocheck`, flips `allowJs: false`, and **closes #147**.

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx biome check` — clean
- [x] `npm run test` — 624/624 passing
- [x] `npm run test:e2e` — 45/45 passing on a fresh Vite dev server (1 pre-existing skip)
- [x] `npm run build` — green

---
_Generated by [Claude Code](https://claude.ai/code/session_018qbFtLNgH4p39DmEBtouJu)_