### PR TITLE
fix(game-root): forward silent through useAP — closes #207

### DIFF
--- a/scripts/game/GameRoot.ts
+++ b/scripts/game/GameRoot.ts
@@ -1053,7 +1053,7 @@ export class GameRoot extends GameNode {
       this.setCash(gv.cash_value, silent);
     }
     if (gv.ap_increment) {
-      this.useAP(gv.ap_increment);
+      this.useAP(gv.ap_increment, silent);
     }
     if (gv.karma_value !== undefined && gv.karma_value !== this.karma_value) {
       this.setKarma(gv.karma_value, silent);
@@ -1078,13 +1078,13 @@ export class GameRoot extends GameNode {
     }
   }
 
-  /** Additive AP delta wrapper.  Note: legacy `updateGameValues`
-   *  passed a `silent` arg here that was silently dropped (the
-   *  legacy signature accepted one param).  Preserved as-is to keep
-   *  this PR a pure migration; the latent flicker bug is tracked in
-   *  issue #207. */
-  useAP(inc: number): void {
-    this.setAP(this.ap_value + inc);
+  /** Additive AP delta wrapper.  `silent` forwards to `setAP` so
+   *  silent updateGameValues paths don't flicker the AP bar — fixed
+   *  in #228 (closes #207).  Legacy Game.js passed `silent` here
+   *  but `useAP`'s signature only ever accepted one arg, so the
+   *  silent flag was dropped at the call boundary. */
+  useAP(inc: number, silent?: boolean): void {
+    this.setAP(this.ap_value + inc, silent);
   }
 
   setAP(num?: number, silent?: boolean): void {


### PR DESCRIPTION
Closes #207.

## Summary

Legacy `Game.js` passed `silent` as the second arg to `useAP`, but `useAP`'s signature accepted only one parameter, so the flag was silently dropped at the call boundary. Server deltas with `gv.ap_increment` always re-rendered the AP bar through the FX (Tween-queued) path even on silent paths — a flicker source on partial deltas where `ap_snapshot` and `ap_increment` arrive together (the `ap_snapshot` branch correctly honored `silent`, but the `ap_increment` branch above it did not).

## Fix

Two-line change:

```diff
-  useAP(inc: number): void {
-    this.setAP(this.ap_value + inc);
-  }
+  useAP(inc: number, silent?: boolean): void {
+    this.setAP(this.ap_value + inc, silent);
+  }
```

…plus the matching forward in `updateGameValues`:

```diff
   if (gv.ap_increment) {
-    this.useAP(gv.ap_increment);
+    this.useAP(gv.ap_increment, silent);
   }
```

The latent-bug comment that was sitting on `useAP` since PR #206 is updated to point at this PR as the closing change.

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run test` — 626/626 passing
- [x] `npm run test:e2e` — 45/45 passing on a fresh Vite dev server
- [x] `npm run build` — green

---
_Generated by [Claude Code](https://claude.ai/code/session_018qbFtLNgH4p39DmEBtouJu)_