### PR TITLE
fix(perps): swap TokenPerp/SupertokenPerp cableType — closes #191

### DIFF
--- a/scripts/game/SupertokenPerp.ts
+++ b/scripts/game/SupertokenPerp.ts
@@ -9,4 +9,9 @@ import { GamePerp } from './GamePerp.js';
 
 export class SupertokenPerp extends GamePerp {
   override renderType = 'Perp';
+  // `'inout'` matches the intended SuperToken behavior (it both
+  // contains tokens AND provides them upward).  Legacy Game.js had
+  // this assignment misrouted to TokenPerp via a copy-paste typo
+  // (line 2509) — fixed in PR #229; see issue #191 for context.
+  override cableType = 'inout' as const;
 }

--- a/scripts/game/TokenPerp.ts
+++ b/scripts/game/TokenPerp.ts
@@ -92,12 +92,13 @@ interface TokenSetEntry {
 
 export class TokenPerp extends GamePerp {
   override renderType = 'Perp';
-  // Note: legacy Game.js had `TokenPerp.prototype.cableType = 'inout'`
-  // assigned in the *Supertoken* prototype-defaults block at line 2509
-  // — almost certainly a typo (it overrides the earlier `'in'` set in
-  // the Token block).  Preserved as 'inout' here to match runtime; see
-  // issue #191 for the corrected value swap.
-  override cableType = 'inout' as const;
+  // `'in'` here, `'inout'` on SupertokenPerp.  Legacy Game.js had a
+  // copy-paste typo at line 2509 that swapped these (the SuperToken
+  // prototype-defaults block assigned `cableType = 'inout'` to
+  // *TokenPerp* and left SupertokenPerp inheriting GamePerp's
+  // `'in'` default).  PR #229 swaps to the intended values; see
+  // issue #191 for context.
+  override cableType = 'in' as const;
   override popupTemplate = 'popup_token.html';
 
   amount?: number;


### PR DESCRIPTION
Closes #191.

## Summary

Legacy `Game.js`'s SuperToken prototype-defaults block at line ~2509 contained a copy-paste typo:

```js
SupertokenPerp.prototype.renderType = 'Perp';
TokenPerp.prototype.cableType = 'inout';   // ← intended SupertokenPerp
```

The misrouted assignment overrode the earlier `TokenPerp.prototype.cableType = 'in'` set in the Token block (line ~2145), leaving runtime in this state:

| Class | Effective `cableType` |
|---|---|
| `TokenPerp`      | `'inout'` (typo override won) |
| `SupertokenPerp` | `'in'` (no override; inherits GamePerp default) |

The intended behavior is the opposite: **`TokenPerp` should be `'in'`** (it's a leaf consumer — cables draw data IN from contained tokens) and **`SupertokenPerp` should be `'inout'`** (it both contains tokens and provides them upward).

## Fix

Two-line value swap:

```diff
 // TokenPerp.ts
-override cableType = 'inout' as const;
+override cableType = 'in' as const;

 // SupertokenPerp.ts
+override cableType = 'inout' as const;
```

Both classes' inline comments now point at this PR + issue #191 instead of preserving the typo.

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run test` — 626/626 passing
- [x] `npm run test:e2e` — 45/45 passing on a fresh Vite dev server
- [x] `npm run build` — green

⚠️ **Cable visual orientation is hard to assert in e2e without screenshot-diff tooling.** The e2e suite covers buy/charge/integrate flows that exercise both perp types and pass with the swapped values, but doesn't directly assert the cable in/out direction. **Manual visual check in Delta Chat advisable** before release — the issue body warned of "downstream Render code (cable rendering, animation directions) that may have adapted to the buggy values"; if any did, this PR will surface the regression visually.

---
_Generated by [Claude Code](https://claude.ai/code/session_018qbFtLNgH4p39DmEBtouJu)_