### PR TITLE
doc(game-root): flag active Mission.ts caller in #203 FIXME comment

### DIFF
--- a/scripts/game/GameRoot.ts
+++ b/scripts/game/GameRoot.ts
@@ -716,8 +716,19 @@ export class GameRoot extends GameNode {
   }
 
   /** Hardcoded `'city002'` lookup is preserved from legacy.  Suspected
-   *  copy-paste latent bug — should probably read `origintokengestalt`'s
-   *  origin link.  Tracked in issue #203. */
+   *  copy-paste latent bug — name says "given an origin-token
+   *  gestalt, return its origin gestalt", but the implementation
+   *  ignores the parameter and always probes for city002.  Tracked
+   *  in issue #203.
+   *
+   *  ⚠️ Has an active caller: `Mission.ts:151` uses this as a
+   *  truthiness gate in tutorial step-skip logic — a "naive" fix to
+   *  honor the parameter would change the truthy contract from
+   *  "city002 has any origin token" to "this specific profileset IS
+   *  an origin token", which would change which tutorial steps get
+   *  skipped.  The issue body's "zero callers" claim is stale; the
+   *  real fix needs gameplay-side investigation rather than a
+   *  refactor. */
   getOriginGestaltFromOriginTokenGestalt(_origintokengestalt: string): string | undefined {
     const origin = Object.values(this.DBOriginTokens).find(
       (ot) => ot.originGameNode?.gestalt === 'city002'


### PR DESCRIPTION
## Summary

Doc-only update to the inline FIXME comment on `GameRoot.getOriginGestaltFromOriginTokenGestalt`. The #203 issue body claims the method has zero callers, suggesting it could be safely dropped. **That claim is stale** — `Mission.ts:151` actively uses this function as a truthiness gate in tutorial step-skip logic:

```ts
if (
  step.integrateProfileSet &&
  groot.getOriginGestaltFromOriginTokenGestalt(step.integrateProfileSet)
) {
  deletefrom = k;
  step.nodelay = true;
}
```

So neither of #203's two fix options is straightforward:

1. **Drop the method** — would break the tutorial step-skip path.
2. **"Fix" the implementation** to honor the parameter — would change the truthy contract from "city002 has any origin token" to "this specific profileset IS an origin token", which is a *different* semantic that would change which tutorial steps get skipped. Whether that's desired or accidental needs gameplay-side investigation.

This PR doesn't fix #203. It just updates the inline FIXME comment so anyone reading `GameRoot.ts` sees the call-site context and the semantic gotcha — useful future context for whoever picks #203 back up after game-logic clarification.

No code path changes; no test impact. Leaving #203 open with this finding.

## Test plan

- [x] `npx tsc --noEmit` — 0 errors (doc-only change)

---
_Generated by [Claude Code](https://claude.ai/code/session_018qbFtLNgH4p39DmEBtouJu)_