### PR TITLE
type-debt: consolidate jQuery shim across Render* modules

### DIFF
--- a/scripts/render/RenderButtonInline.ts
+++ b/scripts/render/RenderButtonInline.ts
@@ -8,23 +8,9 @@
 // Trimmed since the legacy declared but never read `textFontSize` —
 // preserved here verbatim for any external config callers.
 
-import { type JQueryNodeElem, type NodeConfig } from './RenderNode.js';
+import { type NodeConfig } from './RenderNode.js';
 import { RenderText, type TextConfig } from './RenderText.js';
-
-interface JQueryButtonElem {
-  0: HTMLElement;
-  attr(name: string, value: string): unknown;
-}
-
-function getJQuery(): (selector: string) => JQueryButtonElem {
-  const jq = (globalThis.jQuery ?? globalThis.$) as
-    | ((selector: string) => JQueryButtonElem)
-    | undefined;
-  if (!jq) {
-    throw new Error('RenderButtonInline requires the jQuery global to be loaded.');
-  }
-  return jq;
-}
+import { getRenderJQuery } from './_jqueryShim.js';
 
 export type ButtonInlineConfig = TextConfig & {
   textFontSize?: string;
@@ -34,7 +20,7 @@ export class RenderButtonInline extends RenderText {
   textFontSize: string;
 
   constructor(config: ButtonInlineConfig = {}) {
-    const $ = getJQuery();
+    const $ = getRenderJQuery('RenderButtonInline');
     const jdomelem = $("<div class='Button'></div>");
     // Mirror the legacy in-constructor defaults that override Text /
     // RenderNode prototype values (display='inline-block',
@@ -44,7 +30,7 @@ export class RenderButtonInline extends RenderText {
       position: 'relative',
       textAlign: config.textAlign ?? 'center',
       ...config,
-      jdomelem: jdomelem as unknown as JQueryNodeElem,
+      jdomelem: jdomelem,
     } as TextConfig & NodeConfig);
     this.textFontSize = config.textFontSize ?? '20px';
   }

--- a/scripts/render/RenderCables.ts
+++ b/scripts/render/RenderCables.ts
@@ -16,25 +16,11 @@
 // `GulpImg`) used by the cable draw routine moved here too; they
 // were IIFE-locals in Render.js with no external readers.
 
-import { type JQueryNodeElem, type NodeConfig, RenderNode } from './RenderNode.js';
+import { type NodeConfig, RenderNode } from './RenderNode.js';
 // Type-only import breaks the runtime cycle with RenderPerp.
 import type { RenderPerp } from './RenderPerp.js';
 import { RenderSet } from './RenderSet.js';
-
-interface JQueryCableElem {
-  0: HTMLCanvasElement;
-  attr(name: string, value: string): unknown;
-}
-
-function getJQuery(): (selector: string) => JQueryCableElem {
-  const jq = (globalThis.jQuery ?? globalThis.$) as
-    | ((selector: string) => JQueryCableElem)
-    | undefined;
-  if (!jq) {
-    throw new Error('RenderCables requires the jQuery global to be loaded.');
-  }
-  return jq;
-}
+import { getRenderJQuery } from './_jqueryShim.js';
 
 // ── shared sprite tiles for the cable draw routine ──────────────────────────
 //
@@ -126,8 +112,7 @@ export class RenderCable extends RenderNode {
 
   constructor(config: CableConfig = {}) {
     const jdomelem =
-      config.jdomelem ??
-      (getJQuery()("<canvas class='Cable'></canvas>") as unknown as JQueryNodeElem);
+      config.jdomelem ?? getRenderJQuery('RenderCables')("<canvas class='Cable'></canvas>");
     super({
       ...config,
       z: config.z ?? -1,
@@ -388,7 +373,7 @@ export class RenderPerpCable extends RenderCable {
   perpTo: RenderPerp;
 
   constructor(config: PerpCableConfig, perpFrom: RenderPerp, perpTo: RenderPerp) {
-    const $ = getJQuery();
+    const $ = getRenderJQuery('RenderCables');
     const jdomelem = $("<canvas class='Cable'></canvas>");
     // Clip to 480px, so Cables usually are never longer than 512 (texture size)
     super({
@@ -397,7 +382,7 @@ export class RenderPerpCable extends RenderCable {
       cableMaxLength: config.cableMaxLength ?? 480,
       offsetX: config.offsetX ?? 16,
       offsetY: config.offsetY ?? 16,
-      jdomelem: jdomelem as unknown as JQueryNodeElem,
+      jdomelem: jdomelem,
       pointFrom: perpFrom.getPosition(),
       pointTo: perpTo.getPosition(),
     });

--- a/scripts/render/RenderCircle.ts
+++ b/scripts/render/RenderCircle.ts
@@ -5,22 +5,8 @@
 //
 // Extracted from scripts/Render.js's IIFE in PR 34 of issue #147.
 
-import { type JQueryNodeElem, type NodeConfig, RenderNode } from './RenderNode.js';
-
-interface JQueryCircleElem {
-  0: HTMLCanvasElement;
-  attr(name: string, value: string): unknown;
-}
-
-function getJQuery(): (selector: string) => JQueryCircleElem {
-  const jq = (globalThis.jQuery ?? globalThis.$) as
-    | ((selector: string) => JQueryCircleElem)
-    | undefined;
-  if (!jq) {
-    throw new Error('RenderCircle requires the jQuery global to be loaded.');
-  }
-  return jq;
-}
+import { type NodeConfig, RenderNode } from './RenderNode.js';
+import { getRenderJQuery } from './_jqueryShim.js';
 
 export type CircleConfig = NodeConfig & {
   radius?: number;
@@ -37,9 +23,9 @@ export class RenderCircle extends RenderNode {
   strokeWidth: number;
 
   constructor(config: CircleConfig = {}) {
-    const $ = getJQuery();
+    const $ = getRenderJQuery('RenderCircle');
     const jdomelem = $("<canvas class='Circle'></canvas>");
-    super({ ...config, jdomelem: jdomelem as unknown as JQueryNodeElem });
+    super({ ...config, jdomelem: jdomelem });
     this.radius = config.radius ?? 32;
     this.fill = config.fill ?? '#C00';
     this.stroke = config.stroke ?? '#F00';

--- a/scripts/render/RenderDecorators.ts
+++ b/scripts/render/RenderDecorators.ts
@@ -13,36 +13,15 @@
 // the `setRenderDecoratorSlowTicker` injection seam this file
 // used to own — DecoratorTimer imports the singleton directly.
 
-import { type JQueryNodeElem, type NodeConfig, RenderNode } from './RenderNode.js';
+import { type NodeConfig, RenderNode } from './RenderNode.js';
 import { RenderSlowTicker } from './RenderSlowTicker.js';
 import { RenderSprite, type SpriteConfig, type SpriteFrameMap } from './RenderSprite.js';
 import { RenderText, type TextConfig } from './RenderText.js';
+import { type JQueryRenderElem, getRenderJQuery } from './_jqueryShim.js';
 
-// ── jQuery / underscore vendor surfaces ─────────────────────────────────────
-
-interface JQueryDecoratorElem {
-  0: HTMLElement;
-  attr(name: string, value?: string | Record<string, unknown>): unknown;
-  append(child: unknown): unknown;
-  find(selector: string): { remove(): void };
-  show(): unknown;
-  hide(): unknown;
-  text(value: string): unknown;
-  animate(props: Record<string, unknown>, duration?: number): unknown;
-  clone(): JQueryDecoratorElem;
-  addClass(cls: string): unknown;
-  hidden?: boolean;
-}
-
-type JQueryFactory = (selector: string | Element | object) => JQueryDecoratorElem;
-
-function getJQuery(): JQueryFactory {
-  const jq = (globalThis.jQuery ?? globalThis.$) as JQueryFactory | undefined;
-  if (!jq) {
-    throw new Error('RenderDecorators requires the jQuery global to be loaded.');
-  }
-  return jq;
-}
+// Local alias kept for the internal `getReadyText` template-cache
+// type; functionally equivalent to JQueryRenderElem.
+type JQueryDecoratorElem = JQueryRenderElem;
 
 interface UnderscoreI18nLike {
   _(key: string): string;
@@ -88,9 +67,9 @@ export class RenderDecorator extends RenderNode implements DecoratorBase {
   offsetToParent: { x: number; y: number };
 
   constructor(config: DecoratorConfig = {}) {
-    const $ = getJQuery();
+    const $ = getRenderJQuery('RenderDecorators');
     const jdomelem = $("<div class='Decorator'></div>");
-    super({ ...config, jdomelem: jdomelem as unknown as JQueryNodeElem });
+    super({ ...config, jdomelem: jdomelem });
     this.offsetToParent = config.offsetToParent ?? { x: 0, y: 0 };
   }
 
@@ -139,7 +118,7 @@ let _textCollectGear: JQueryDecoratorElem | undefined;
 let _textCollectCash: JQueryDecoratorElem | undefined;
 
 function getReadyText(mode: 'profile' | 'money' | 'gear'): JQueryDecoratorElem {
-  const $ = getJQuery();
+  const $ = getRenderJQuery('RenderDecorators');
   const _u = getUnderscore();
   if (mode === 'money') {
     if (!_textCollectCash) {
@@ -164,7 +143,7 @@ export class RenderDecoratorReady extends RenderSprite implements DecoratorBase 
   offsetToParent: { x: number; y: number };
 
   constructor(config: DecoratorReadyConfig = {}) {
-    const $ = getJQuery();
+    const $ = getRenderJQuery('RenderDecorators');
     const jdomelem = $("<div class='DecoratorReady'></div>");
     jdomelem.attr('data-testid', 'dd-collect-ready');
 
@@ -180,7 +159,7 @@ export class RenderDecoratorReady extends RenderSprite implements DecoratorBase 
       frameMap,
       frame: config.frame ?? 'normal',
       clickable: true,
-      jdomelem: jdomelem as unknown as JQueryNodeElem,
+      jdomelem: jdomelem,
     } as SpriteConfig);
 
     this.offsetToParent = config.offsetToParent ?? { x: 0, y: -30 };
@@ -201,7 +180,7 @@ export class RenderDecoratorReady extends RenderSprite implements DecoratorBase 
   initUI(): void {
     this.on('vclick', (e) => {
       e.stopPropagation();
-      (this.jdomelem as unknown as JQueryDecoratorElem).find('.DecoratorReadyText').remove();
+      this.jdomelem.find('.DecoratorReadyText').remove();
     });
     this.on('vdblclick', (e) => {
       e.stopPropagation();
@@ -236,13 +215,13 @@ export class RenderDecoratorLabel extends RenderText implements DecoratorBase {
   textFontSize: string;
 
   constructor(config: DecoratorLabelConfig = {}) {
-    const $ = getJQuery();
+    const $ = getRenderJQuery('RenderDecorators');
     const jdomelem = $("<div class='DecoratorLabel'></div>");
     super({
       ...config,
       text: config.text ?? 'Label',
       clickable: false,
-      jdomelem: jdomelem as unknown as JQueryNodeElem,
+      jdomelem: jdomelem,
     } as TextConfig);
     this.offsetToParent = config.offsetToParent ?? { x: 0, y: 0 };
     this.textFontSize = '13px';
@@ -282,7 +261,7 @@ export class RenderDecoratorNew extends RenderText implements DecoratorBase {
   declare arrow: boolean | undefined;
 
   constructor(config: DecoratorNewConfig = {}) {
-    const $ = getJQuery();
+    const $ = getRenderJQuery('RenderDecorators');
     const jdomelem = $("<div class='DecoratorNew'></div>");
     if (config.extendClass) {
       jdomelem.addClass(config.extendClass);
@@ -291,7 +270,7 @@ export class RenderDecoratorNew extends RenderText implements DecoratorBase {
       ...config,
       text: config.text ?? 'New!',
       clickable: true,
-      jdomelem: jdomelem as unknown as JQueryNodeElem,
+      jdomelem: jdomelem,
     } as TextConfig);
     this.offsetToParent = config.offsetToParent ?? { x: 0, y: 0 };
     this.textFontSize = '13px';
@@ -311,9 +290,7 @@ export class RenderDecoratorNew extends RenderText implements DecoratorBase {
     this.initUI();
     this.updateText();
     if (this.arrow) {
-      (this.jdomelem as unknown as JQueryDecoratorElem).append(
-        '<br /><div class="DecoratorNewArrow"></div>'
-      );
+      this.jdomelem.append('<br /><div class="DecoratorNewArrow"></div>');
     }
     this.draw();
   }
@@ -350,7 +327,7 @@ export class RenderDecoratorGear extends RenderSprite implements DecoratorBase {
   offsetToParent: { x: number; y: number };
 
   constructor(config: DecoratorGearConfig = {}) {
-    const $ = getJQuery();
+    const $ = getRenderJQuery('RenderDecorators');
     const jdomelem = $("<div class='DecoratorGear'></div>");
     const frameMap = config.frameMap ?? FRAME_GEAR_DEFAULT;
     super({
@@ -361,7 +338,7 @@ export class RenderDecoratorGear extends RenderSprite implements DecoratorBase {
       clickable: true,
       width: frameMap.normal?.width,
       height: frameMap.normal?.height,
-      jdomelem: jdomelem as unknown as JQueryNodeElem,
+      jdomelem: jdomelem,
     } as SpriteConfig);
     this.offsetToParent = config.offsetToParent ?? { x: 30, y: -30 };
   }
@@ -440,7 +417,7 @@ export class RenderDecoratorTimer extends RenderSprite implements DecoratorBase 
   static readonly textReadyIn: () => string = () => getUnderscore()._('Ready in') + ' ';
 
   constructor(config: DecoratorTimerConfig = {}) {
-    const $ = getJQuery();
+    const $ = getRenderJQuery('RenderDecorators');
     const jdomelem = $("<div class='DecoratorTimer'></div>");
 
     const frameMap = config.frameMap ?? FRAME_TIMER_DEFAULT;
@@ -467,7 +444,7 @@ export class RenderDecoratorTimer extends RenderSprite implements DecoratorBase 
       clickable: true,
       width: frameMap.normal?.width,
       height: frameMap.normal?.height,
-      jdomelem: jdomelem as unknown as JQueryNodeElem,
+      jdomelem: jdomelem,
     } as SpriteConfig);
 
     this.serverTime = serverTime;
@@ -589,7 +566,7 @@ export class RenderDecoratorAmount extends RenderSprite implements DecoratorBase
   jdomelem3: JQueryDecoratorElem;
 
   constructor(config: DecoratorAmountConfig = {}) {
-    const $ = getJQuery();
+    const $ = getRenderJQuery('RenderDecorators');
     const jdomelem = $("<div class='DecoratorAmount'></div>");
     const jdomelem2 = $("<div class='DecoratorAmountValue'></div>");
     const jdomelem3 = $("<div class='DecoratorAmountNum'></div>");
@@ -601,7 +578,7 @@ export class RenderDecoratorAmount extends RenderSprite implements DecoratorBase
       frameSrc: 'MainSprites.png',
       frameMap: FRAME_AMOUNT_DEFAULT,
       frame: 'normal',
-      jdomelem: jdomelem as unknown as JQueryNodeElem,
+      jdomelem: jdomelem,
     } as SpriteConfig);
 
     this.offsetToParent = { x: 0, y: 35 };

--- a/scripts/render/RenderNode.ts
+++ b/scripts/render/RenderNode.ts
@@ -14,6 +14,7 @@
 
 import { OrderedSet } from '../game/OrderedSet.js';
 import { RenderSet } from './RenderSet.js';
+import { type JQueryRenderElem, type JQueryRenderEvent, getRenderJQuery } from './_jqueryShim.js';
 import { nodeCount, registerNode, unregisterNode } from './renderRegistry.js';
 
 // ── seam interfaces ─────────────────────────────────────────────────────────
@@ -30,40 +31,15 @@ export function setRenderNodeTickers(t: RenderNodeTickers): void {
 }
 
 // ── DOM / jQuery surface that Node touches ──────────────────────────────────
+//
+// `JQueryNodeElem` is re-exported as a type alias to the shared
+// `JQueryRenderElem` so existing config-type imports
+// (`NodeConfig.jdomelem: JQueryNodeElem`) and the cross-module
+// boundary type stay stable while the underlying surface
+// consolidates.  See scripts/render/_jqueryShim.ts.
 
-export interface JQueryNodeElem {
-  0: HTMLElement;
-  attr(name: string): string | undefined;
-  attr(name: string, value: string): unknown;
-  addClass(cls: string): unknown;
-  removeClass(cls: string): unknown;
-  append(child: unknown): unknown;
-  empty(): unknown;
-  remove(): unknown;
-  css(props: Record<string, string | number>): unknown;
-  on(ev: string, handler: (e: NodeDomEvent) => void): unknown;
-  off(ev?: string): unknown;
-  trigger(ev: string, args?: unknown[]): unknown;
-}
-
-interface NodeDomEvent {
-  shiftKey?: boolean;
-  pageX?: number;
-  pageY?: number;
-  timeStamp?: number;
-  preventDefault(): void;
-  stopPropagation(): void;
-}
-
-type JQueryFactory = (selector: string | Element | object) => JQueryNodeElem;
-
-function getJQuery(): JQueryFactory {
-  const jq = (globalThis.jQuery ?? globalThis.$) as JQueryFactory | undefined;
-  if (!jq) {
-    throw new Error('RenderNode requires the jQuery global to be loaded.');
-  }
-  return jq;
-}
+export type JQueryNodeElem = JQueryRenderElem;
+type NodeDomEvent = JQueryRenderEvent;
 
 // ── structural surfaces for cross-class fields ──────────────────────────────
 
@@ -205,7 +181,7 @@ export class RenderNode {
     if (cfg.jdomelem) {
       this.jdomelem = cfg.jdomelem;
     } else {
-      this.jdomelem = getJQuery()("<div class='Node'></div>");
+      this.jdomelem = getRenderJQuery('RenderNode')("<div class='Node'></div>");
     }
     this.domelem = cfg.domelem ?? this.jdomelem[0];
     this.init(cfg);
@@ -222,7 +198,7 @@ export class RenderNode {
 
     this.setAttrs(cfg);
     if (!this.jdomelem) {
-      this.jdomelem = getJQuery()(this.domelem);
+      this.jdomelem = getRenderJQuery('RenderNode')(this.domelem);
     }
     this.jdomelem.attr('id', this.id);
     this.updateClass();

--- a/scripts/render/RenderPerp.ts
+++ b/scripts/render/RenderPerp.ts
@@ -14,10 +14,11 @@
 // own — `cableTo` now constructs `RenderPerpCable` directly.
 
 import { type PerpCableConfig, RenderPerpCable } from './RenderCables.js';
-import { type JQueryNodeElem, RenderNode } from './RenderNode.js';
+import { RenderNode } from './RenderNode.js';
 import { type PerpSpriteConfig, RenderPerpSprite } from './RenderPerpSprite.js';
 import { RenderSet } from './RenderSet.js';
 import { RenderSprite, type SpriteConfig, type SpriteFrameMap } from './RenderSprite.js';
+import { getRenderJQuery } from './_jqueryShim.js';
 
 // `RenderPerpCable` is the concrete cable type Perp.cableTo returns.
 // Re-exported under the prior `PerpCableLike` name so external
@@ -26,22 +27,6 @@ import { RenderSprite, type SpriteConfig, type SpriteFrameMap } from './RenderSp
 // compiling.
 export type PerpCableLike = RenderPerpCable;
 export type { PerpCableConfig };
-
-// ── jQuery surface ──────────────────────────────────────────────────────────
-
-interface JQueryPerpElem {
-  0: HTMLElement;
-}
-
-function getJQuery(): (selector: string) => JQueryPerpElem {
-  const jq = (globalThis.jQuery ?? globalThis.$) as
-    | ((selector: string) => JQueryPerpElem)
-    | undefined;
-  if (!jq) {
-    throw new Error('RenderPerp requires the jQuery global to be loaded.');
-  }
-  return jq;
-}
 
 interface UnderscoreEachLike {
   each<T>(list: T[] | Record<string, T>, fn: (item: T, key: number | string) => void): void;
@@ -71,7 +56,7 @@ export class RenderPerp extends RenderSprite {
   declare dragalong: boolean;
 
   constructor(config: PerpConfig = {}) {
-    const $ = getJQuery();
+    const $ = getRenderJQuery('RenderPerp');
     const jdomelem = $("<div class='Perp'></div>");
     const placeRandom =
       config.x === undefined || config.y === undefined ? { x: 1024, y: 800 } : undefined;
@@ -109,7 +94,7 @@ export class RenderPerp extends RenderSprite {
       draggable: config.draggable || true,
       cables: cables as unknown as RenderNode['cables'],
       perpSprite: perpSpriteInstance,
-      jdomelem: jdomelem as unknown as JQueryNodeElem,
+      jdomelem: jdomelem,
     } as SpriteConfig);
 
     if (placeRandom) {

--- a/scripts/render/RenderPerpSprite.ts
+++ b/scripts/render/RenderPerpSprite.ts
@@ -8,23 +8,9 @@
 // Pairs with RenderPerp — Perp's ctor wires `new RenderPerpSprite()`
 // when `config.perpSprite` is set.
 
-import { type JQueryNodeElem, RenderNode } from './RenderNode.js';
+import { RenderNode } from './RenderNode.js';
 import { RenderSprite, type SpriteConfig, type SpriteFrame } from './RenderSprite.js';
-
-interface JQueryPerpSpriteElem {
-  0: HTMLElement;
-  attr(name: string, value: string): unknown;
-}
-
-function getJQuery(): (selector: string) => JQueryPerpSpriteElem {
-  const jq = (globalThis.jQuery ?? globalThis.$) as
-    | ((selector: string) => JQueryPerpSpriteElem)
-    | undefined;
-  if (!jq) {
-    throw new Error('RenderPerpSprite requires the jQuery global to be loaded.');
-  }
-  return jq;
-}
+import { getRenderJQuery } from './_jqueryShim.js';
 
 export type PerpSpriteConfig = SpriteConfig & {
   frame_src?: string;
@@ -33,14 +19,14 @@ export type PerpSpriteConfig = SpriteConfig & {
 
 export class RenderPerpSprite extends RenderSprite {
   constructor(config: PerpSpriteConfig = {}) {
-    const $ = getJQuery();
+    const $ = getRenderJQuery('RenderPerpSprite');
     const jdomelem = $("<div class='PerpSprite'></div>");
     super({
       ...config,
       frameSrc: config.frameSrc ?? config.frame_src,
       frameMap: config.frameMap ?? config.frame_map,
       frame: config.frame ?? 'normal',
-      jdomelem: jdomelem as unknown as JQueryNodeElem,
+      jdomelem: jdomelem,
     } as SpriteConfig);
   }
 

--- a/scripts/render/RenderSprite.ts
+++ b/scripts/render/RenderSprite.ts
@@ -7,7 +7,8 @@
 // of the Render wave depends on.
 
 import setup from '../setup.js';
-import { type JQueryNodeElem, type NodeConfig, RenderNode } from './RenderNode.js';
+import { type NodeConfig, RenderNode } from './RenderNode.js';
+import { getRenderJQuery } from './_jqueryShim.js';
 
 export interface SpriteFrame {
   x: number;
@@ -19,21 +20,6 @@ export interface SpriteFrame {
 }
 
 export type SpriteFrameMap = Record<string, SpriteFrame>;
-
-interface JQuerySpriteElem {
-  0: HTMLElement;
-  attr(name: string, value: string): unknown;
-}
-
-function getJQuery(): (selector: string) => JQuerySpriteElem {
-  const jq = (globalThis.jQuery ?? globalThis.$) as
-    | ((selector: string) => JQuerySpriteElem)
-    | undefined;
-  if (!jq) {
-    throw new Error('RenderSprite requires the jQuery global to be loaded.');
-  }
-  return jq;
-}
 
 export type SpriteConfig = NodeConfig & {
   frame?: string;
@@ -60,7 +46,7 @@ export class RenderSprite extends RenderNode {
     // holds the canvas + text children).  Only fall through to the
     // default Sprite container when no subclass overrode it.
     const jdomelem =
-      config.jdomelem ?? (getJQuery()("<div class='Sprite'></div>") as unknown as JQueryNodeElem);
+      config.jdomelem ?? getRenderJQuery('RenderSprite')("<div class='Sprite'></div>");
     super({ ...config, jdomelem });
     // super → RenderNode.init → setAttrs(config) has already assigned
     // frameSrc / frameMap / frame from `config` (when present).  Apply

--- a/scripts/render/RenderText.ts
+++ b/scripts/render/RenderText.ts
@@ -7,27 +7,11 @@
 // Pairs with RenderSprite as the two leaf visual primitives every
 // remaining Render class either is or extends.
 
-import { type JQueryNodeElem, type NodeConfig, RenderNode } from './RenderNode.js';
-
-interface JQueryTextElem {
-  0: HTMLElement;
-  attr(name: string, value: string): unknown;
-  html(content: string): unknown;
-  width(): number | undefined;
-}
+import { type NodeConfig, RenderNode } from './RenderNode.js';
+import { getRenderJQuery } from './_jqueryShim.js';
 
 interface UnderscoreCrlf {
   crlf2html(text: string): string;
-}
-
-function getJQuery(): (selector: string) => JQueryTextElem {
-  const jq = (globalThis.jQuery ?? globalThis.$) as
-    | ((selector: string) => JQueryTextElem)
-    | undefined;
-  if (!jq) {
-    throw new Error('RenderText requires the jQuery global to be loaded.');
-  }
-  return jq;
 }
 
 export type TextConfig = NodeConfig & {
@@ -48,8 +32,7 @@ export class RenderText extends RenderNode {
     // Respect a subclass-supplied jdomelem (e.g. ButtonInline's
     // `<div class='Button'>` wrapper).  Only fall through to the
     // default Text container when no subclass overrode it.
-    const jdomelem =
-      config.jdomelem ?? (getJQuery()("<div class='Text'></div>") as unknown as JQueryNodeElem);
+    const jdomelem = config.jdomelem ?? getRenderJQuery('RenderText')("<div class='Text'></div>");
     super({ ...config, jdomelem });
   }
 
@@ -83,10 +66,10 @@ export class RenderText extends RenderNode {
     t = _.crlf2html(t);
     this.text = t;
     this.updateRenderProp();
-    (this.jdomelem as unknown as JQueryTextElem).html(t);
+    this.jdomelem.html(t);
     this.updateSize();
     const newOffset = { x: 0, y: 0 };
-    const width = (this.jdomelem as unknown as JQueryTextElem).width() ?? 200;
+    const width = this.jdomelem.width() ?? 200;
     if (this.textAlign === 'center') {
       newOffset.x = Math.round(width / 2);
     } else if (this.textAlign === 'right') {
@@ -96,7 +79,7 @@ export class RenderText extends RenderNode {
   }
 
   updateSize(): void {
-    this.width = (this.jdomelem as unknown as JQueryTextElem).width() ?? 200;
+    this.width = this.jdomelem.width() ?? 200;
   }
 
   /** Note the legacy double-`s` typo: `ssetSize`.  Preserved here

--- a/scripts/render/RenderTopLevelUI.ts
+++ b/scripts/render/RenderTopLevelUI.ts
@@ -40,67 +40,15 @@
 
 import appModule from '../app.js';
 import setup from '../setup.js';
-import { type JQueryNodeElem, type NodeConfig, RenderNode } from './RenderNode.js';
+import { type NodeConfig, RenderNode } from './RenderNode.js';
 import { RenderSprite, type SpriteConfig, type SpriteFrameMap } from './RenderSprite.js';
+import { type JQueryRenderElem, type JQueryRenderEvent, getRenderJQuery } from './_jqueryShim.js';
 import { renderSpriteHtml } from './renderSpriteHelper.js';
 
 // ── jQuery / underscore vendor surfaces ─────────────────────────────────────
 
-interface JQueryUIElem {
-  0: HTMLElement;
-  attr(name: string, value?: string | number): string | undefined | JQueryUIElem;
-  addClass(cls: string): JQueryUIElem;
-  removeClass(cls: string): JQueryUIElem;
-  toggleClass(cls: string, force?: boolean): JQueryUIElem;
-  hasClass(cls: string): boolean;
-  append(child: unknown): JQueryUIElem;
-  empty(): JQueryUIElem;
-  remove(): JQueryUIElem;
-  html(content?: string): string | JQueryUIElem;
-  find(selector: string): JQueryUIElem;
-  filter(selector: string): JQueryUIElem;
-  parents(selector: string): JQueryUIElem;
-  parent(): JQueryUIElem;
-  nextAll(selector: string): JQueryUIElem;
-  text(value?: string): string;
-  show(): JQueryUIElem;
-  hide(): JQueryUIElem;
-  toggle(): JQueryUIElem;
-  width(value?: number): number | JQueryUIElem;
-  height(value?: number): number | JQueryUIElem;
-  on(
-    ev: string,
-    selectorOrHandler: string | ((e: UIEventLike) => void),
-    handler?: (e: UIEventLike) => void
-  ): JQueryUIElem;
-  off(ev?: string, handler?: (...args: unknown[]) => unknown): JQueryUIElem;
-  trigger(ev: string, params?: unknown[]): JQueryUIElem;
-  offset(): { left: number; top: number };
-  css(props: Record<string, string | number>): JQueryUIElem;
-  animate(props: Record<string, string | number>, duration?: number, cb?: () => void): JQueryUIElem;
-  each(fn: (this: HTMLElement) => void): JQueryUIElem;
-  clone(): JQueryUIElem;
-  length: number;
-}
-
-interface UIEventLike {
-  pageX?: number;
-  pageY?: number;
-  shiftKey?: boolean;
-  type?: string;
-  preventDefault(): void;
-  stopPropagation(): void;
-}
-
-function getJQuery(): (selector: string | Element | object) => JQueryUIElem {
-  const jq = (globalThis.jQuery ?? globalThis.$) as
-    | ((selector: string | Element | object) => JQueryUIElem)
-    | undefined;
-  if (!jq) {
-    throw new Error('RenderTopLevelUI requires the jQuery global to be loaded.');
-  }
-  return jq;
-}
+type JQueryUIElem = JQueryRenderElem;
+type UIEventLike = JQueryRenderEvent;
 
 interface UnderscoreUILike {
   _(key: string): string;
@@ -209,9 +157,9 @@ export class RenderStatusbar extends RenderNode {
   }
 
   constructor(config: StatusbarConfig = {}) {
-    const $ = getJQuery();
+    const $ = getRenderJQuery('RenderTopLevelUI');
     const jdomelem = (config.jdomelem ?? $("<div class='Statusbar'></div>")) as JQueryUIElem;
-    super({ ...config, jdomelem: jdomelem as unknown as JQueryNodeElem });
+    super({ ...config, jdomelem: jdomelem });
 
     if (this.profiles) {
       this.profiles_val = this.profiles.val;
@@ -259,7 +207,7 @@ export class RenderStatusbar extends RenderNode {
     if (this.parentNode) {
       this.x = this.parentNode.getSize().width / 2;
     }
-    const jq = this.jdomelem as unknown as JQueryUIElem;
+    const jq = this.jdomelem;
     jq.empty();
     const html = getApp().renderView(this.template, this);
     jq.append(html);
@@ -384,8 +332,8 @@ export class RenderStatusbar extends RenderNode {
 
   initUI(): void {
     const node = this;
-    const $ = getJQuery();
-    const jq = node.jdomelem as unknown as JQueryUIElem;
+    const $ = getRenderJQuery('RenderTopLevelUI');
+    const jq = node.jdomelem;
 
     jq.on('click touchend', '.StatusItem', function (this: HTMLElement, e: UIEventLike) {
       e.stopPropagation();
@@ -429,14 +377,14 @@ export type StatusItemConfig = SpriteConfig;
 
 export class RenderStatusItem extends RenderSprite {
   constructor(config: StatusItemConfig = {}) {
-    const $ = getJQuery();
+    const $ = getRenderJQuery('RenderTopLevelUI');
     const jdomelem = $("<div class='StatusItem'></div>");
     super({
       ...config,
       frameSrc: config.frameSrc ?? 'MainSprites.png',
       frameMap: config.frameMap ?? STATUS_ITEM_DEFAULT_FRAMEMAP,
       frame: 'normal',
-      jdomelem: jdomelem as unknown as JQueryNodeElem,
+      jdomelem: jdomelem,
     } as SpriteConfig);
   }
 }
@@ -463,12 +411,12 @@ export class RenderDBQueue extends RenderNode {
   }
 
   constructor(config: DBQueueConfig = {}) {
-    const $ = getJQuery();
+    const $ = getRenderJQuery('RenderTopLevelUI');
     const jdomelem = (config.jdomelem ?? $("<div class='DatabaseQueue'></div>")) as JQueryUIElem;
-    super({ ...config, jdomelem: jdomelem as unknown as JQueryNodeElem });
+    super({ ...config, jdomelem: jdomelem });
 
     const node = this;
-    const jq = node.jdomelem as unknown as JQueryUIElem;
+    const jq = node.jdomelem;
     jq.off();
 
     jq.on('click touchend', '.Button:not(.disabled)[data-button-id="DatabaseUpgrades"]', (e) => {
@@ -510,9 +458,9 @@ export class RenderDBQueue extends RenderNode {
 
   FXMerge(psid: string, inc: number, dup: number, wait: number): void {
     const _u = getUnderscore();
-    const $ = getJQuery();
+    const $ = getRenderJQuery('RenderTopLevelUI');
     void $;
-    const jq = this.jdomelem as unknown as JQueryUIElem;
+    const jq = this.jdomelem;
     const ps = jq.find('.DatabaseQueueItem[data-psid=' + psid + ']');
     const after = ps.nextAll('.DatabaseQueueItem');
     ps.addClass('disabled');
@@ -533,7 +481,7 @@ export class RenderDBQueue extends RenderNode {
       ps.animate({ top: '102' }, 250, () => {
         let del = 0;
         after.each(function (this: HTMLElement) {
-          const $this = getJQuery()(this);
+          const $this = getRenderJQuery('RenderTopLevelUI')(this);
           $this.animate({ left: '-=100' }, 250 + del);
           del += 50;
         });
@@ -554,7 +502,7 @@ export class RenderDBQueue extends RenderNode {
       this.x = this.parentNode.parentNode.getSize().width / 2;
       this.y = this.parentNode.parentNode.getSize().height - this.height;
     }
-    const jq = this.jdomelem as unknown as JQueryUIElem;
+    const jq = this.jdomelem;
     jq.empty();
     const html = getApp().renderView(this.template, this);
     jq.append(html);
@@ -570,7 +518,7 @@ export class RenderDBQueue extends RenderNode {
 
 interface PopupContainerLike {
   renderNode: RenderNode & {
-    popupContainerDomelem?: JQueryNodeElem;
+    popupContainerDomelem?: JQueryRenderElem;
   };
   lock?(): void;
   unlock?(): void;
@@ -614,15 +562,15 @@ export class RenderPopup extends RenderNode {
   }
 
   constructor(config: PopupConfig = {}) {
-    const $ = getJQuery();
+    const $ = getRenderJQuery('RenderTopLevelUI');
     const jdomelem = (config.jdomelem ?? $("<div class='Popup'></div>")) as JQueryUIElem;
-    super({ ...config, jdomelem: jdomelem as unknown as JQueryNodeElem });
+    super({ ...config, jdomelem: jdomelem });
     this.initBaseUI();
   }
 
   initBaseUI(): void {
     const node = this;
-    const $ = getJQuery();
+    const $ = getRenderJQuery('RenderTopLevelUI');
     const tdata = this.templateData;
     if (tdata.data?.popup_sprite && !tdata.data.popup_sprite.html) {
       tdata.data.popup_sprite.html = renderSpriteHtml(
@@ -641,7 +589,7 @@ export class RenderPopup extends RenderNode {
 
     node.render();
 
-    const jq = node.jdomelem as unknown as JQueryUIElem;
+    const jq = node.jdomelem;
 
     jq.on('click touchend', (e) => {
       e.stopPropagation();
@@ -650,14 +598,15 @@ export class RenderPopup extends RenderNode {
 
     if (this.popupContainer) {
       this.popupContainer.lock?.();
-      const containerJ = this.popupContainer.renderNode
-        .popupContainerDomelem as unknown as JQueryUIElem;
-      containerJ.on('click touchend', function (this: HTMLElement, _e: UIEventLike) {
-        if (!$(this).hasClass('NoClose')) {
-          node.trigger('popup_close');
-          node.trigger('popup_cancel');
-        }
-      });
+      const containerJ = this.popupContainer.renderNode.popupContainerDomelem;
+      if (containerJ) {
+        containerJ.on('click touchend', function (this: HTMLElement, _e: UIEventLike) {
+          if (!$(this).hasClass('NoClose')) {
+            node.trigger('popup_close');
+            node.trigger('popup_cancel');
+          }
+        });
+      }
     }
 
     node.on('no_cash', () => {
@@ -749,15 +698,16 @@ export class RenderPopup extends RenderNode {
       };
       jq.on('touchend click', '.TutorialBody', advanceTutorial);
       if (this.popupContainer) {
-        const $tutorialContainer = this.popupContainer.renderNode
-          .popupContainerDomelem as unknown as JQueryUIElem;
-        $tutorialContainer.on('touchend click', advanceTutorial);
-        node.on('popup_close', () => {
-          $tutorialContainer.off(
-            'touchend click',
-            advanceTutorial as unknown as (...args: unknown[]) => unknown
-          );
-        });
+        const $tutorialContainer = this.popupContainer.renderNode.popupContainerDomelem;
+        if ($tutorialContainer) {
+          $tutorialContainer.on('touchend click', advanceTutorial);
+          node.on('popup_close', () => {
+            $tutorialContainer.off(
+              'touchend click',
+              advanceTutorial as unknown as (...args: unknown[]) => unknown
+            );
+          });
+        }
       }
     }
 
@@ -985,7 +935,7 @@ export class RenderPopup extends RenderNode {
   }
 
   render(): void {
-    const jq = this.jdomelem as unknown as JQueryUIElem;
+    const jq = this.jdomelem;
     const _u = getUnderscore();
     jq.empty();
     const html = getApp().renderView(this.template, this.templateData);
@@ -1009,7 +959,7 @@ export class RenderPopup extends RenderNode {
   }
 
   renderDataTab(): void {
-    const jq = this.jdomelem as unknown as JQueryUIElem;
+    const jq = this.jdomelem;
     const app = getApp();
     const htmlPS = app.renderView('profileset.html', this.templateData);
     const htmlButt = app.renderView('buttons_project.html', this.templateData);
@@ -1030,7 +980,7 @@ export class RenderPopup extends RenderNode {
       typelower: pcat.typelower,
       pkey,
     });
-    const jq = this.jdomelem as unknown as JQueryUIElem;
+    const jq = this.jdomelem;
     const jtab = jq.find('.PopupTab.Powerups[data-tab="' + pkey + '"]');
     jtab.find('.Subpop.InSelector').remove();
     jtab.find('.Subpop.Selector').remove();
@@ -1038,7 +988,7 @@ export class RenderPopup extends RenderNode {
   }
 
   override onAddInit(): void {
-    const jq = this.jdomelem as unknown as JQueryUIElem;
+    const jq = this.jdomelem;
     const heightVal = jq.height();
     if (typeof heightVal === 'number') this.height = heightVal;
     const pbody = jq.find('.PopupBody');
@@ -1064,7 +1014,7 @@ export class RenderPopup extends RenderNode {
 
   close(cb?: () => void): void {
     this.open = false;
-    const jq = this.jdomelem as unknown as JQueryUIElem;
+    const jq = this.jdomelem;
     jq.on('otransitionend MSTransitionEnd transitionend webkitTransitionEnd', () => {
       this.remove();
     });
@@ -1109,14 +1059,14 @@ export class RenderMissionPerp extends RenderNode {
   }
 
   constructor(config: MissionPerpConfig = {}) {
-    const $ = getJQuery();
+    const $ = getRenderJQuery('RenderTopLevelUI');
     const jdomelem = (config.jdomelem ?? $("<div class='MissionPerp'></div>")) as JQueryUIElem;
     super({
       ...config,
       position: 'relative',
       display: 'block',
       clickable: true,
-      jdomelem: jdomelem as unknown as JQueryNodeElem,
+      jdomelem: jdomelem,
     });
     this.frame = config.frame ?? 'normal';
     this.draw();
@@ -1154,7 +1104,7 @@ export class RenderMissionPerp extends RenderNode {
   }
 
   render(): void {
-    const jq = this.jdomelem as unknown as JQueryUIElem;
+    const jq = this.jdomelem;
     jq.removeClass('active');
     jq.removeClass('complete');
     const states = (
@@ -1221,14 +1171,14 @@ export class RenderTopscorePerp extends RenderNode {
   }
 
   constructor(config: TopscorePerpConfig = {}) {
-    const $ = getJQuery();
+    const $ = getRenderJQuery('RenderTopLevelUI');
     const jdomelem = (config.jdomelem ?? $("<div class='TopscorePerp'></div>")) as JQueryUIElem;
     super({
       ...config,
       position: 'relative',
       hidden: true,
       clickable: true,
-      jdomelem: jdomelem as unknown as JQueryNodeElem,
+      jdomelem: jdomelem,
     });
     this.frame = config.frame ?? 'normal';
     this.draw();
@@ -1258,7 +1208,7 @@ export class RenderTopscorePerp extends RenderNode {
   }
 
   render(): void {
-    const jq = this.jdomelem as unknown as JQueryUIElem;
+    const jq = this.jdomelem;
     jq.empty();
     const html = getApp().renderView(this.template, this);
     jq.append(html);
@@ -1284,7 +1234,7 @@ export class RenderTopscorePerp extends RenderNode {
       e.stopPropagation();
       const parent = this.parentNode;
       if (parent) {
-        (parent.jdomelem as unknown as JQueryUIElem).find('.TopscorePerp').removeClass('active');
+        parent.jdomelem.find('.TopscorePerp').removeClass('active');
       }
     });
     this.on('states', (e) => {
@@ -1297,7 +1247,7 @@ export class RenderTopscorePerp extends RenderNode {
   }
 
   renderRank(): void {
-    const jq = this.jdomelem as unknown as JQueryUIElem;
+    const jq = this.jdomelem;
     const rank = jq.find('.TopscoreRank');
     rank.empty();
     const gnode = this.gameNode as unknown as
@@ -1312,7 +1262,7 @@ export class RenderTopscorePerp extends RenderNode {
   }
 
   renderList(): void {
-    const jq = this.jdomelem as unknown as JQueryUIElem;
+    const jq = this.jdomelem;
     const list = jq.find('.TopscoreList');
     list.empty();
     const gnode = this.gameNode as unknown as
@@ -1344,7 +1294,7 @@ export function renderAmountHtml(
   upgradeAmount?: number,
   upgradeAbsAmount?: number
 ): string {
-  const $ = getJQuery();
+  const $ = getRenderJQuery('RenderTopLevelUI');
   const _u = getUnderscore();
 
   const frameSrc = 'MainSprites.png';

--- a/scripts/render/RenderViews.ts
+++ b/scripts/render/RenderViews.ts
@@ -28,7 +28,8 @@
 import appModule from '../app.js';
 import setup from '../setup.js';
 import { RenderDragHandler } from './RenderDragHandler.js';
-import { type JQueryNodeElem, type NodeConfig, RenderNode } from './RenderNode.js';
+import { type NodeConfig, RenderNode } from './RenderNode.js';
+import { type JQueryRenderElem, type JQueryRenderEvent, getRenderJQuery } from './_jqueryShim.js';
 import { type SpriteHelperConfig, renderSpriteHtml } from './renderSpriteHelper.js';
 
 // ── seam: app + renderConf ──────────────────────────────────────────────────
@@ -54,51 +55,10 @@ function getApp(): AppLike {
   return appModule.getApplication() as unknown as AppLike;
 }
 
-// ── jQuery surface ──────────────────────────────────────────────────────────
+// ── jQuery surface (consolidated) ──────────────────────────────────────────
 
-interface JQueryViewElem {
-  0: HTMLElement;
-  attr(name: string, value?: string): string | undefined | unknown;
-  addClass(cls: string): unknown;
-  removeClass(cls: string): unknown;
-  toggleClass(cls: string, force?: boolean): unknown;
-  append(child: unknown): unknown;
-  empty(): unknown;
-  html(content?: string): unknown;
-  find(selector: string): JQueryViewElem;
-  text(): string;
-  on(
-    ev: string,
-    selector: string | ((e: ViewDomEvent) => void),
-    handler?: (e: ViewDomEvent) => void
-  ): unknown;
-  off(ev?: string): unknown;
-  trigger(ev: string, params?: unknown[]): unknown;
-  offset(): { left: number; top: number };
-  css(props: Record<string, string | number>): unknown;
-}
-
-interface ViewDomEvent {
-  pageX?: number;
-  pageY?: number;
-  timeStamp?: number;
-  scale?: number;
-  deltaY?: number;
-  deltaMode?: number;
-  touches?: ArrayLike<{ pageX: number; pageY: number; target?: { tagName?: string } }>;
-  preventDefault(): void;
-  stopPropagation(): void;
-}
-
-function getJQuery(): (selector: string | object) => JQueryViewElem {
-  const jq = (globalThis.jQuery ?? globalThis.$) as
-    | ((selector: string | object) => JQueryViewElem)
-    | undefined;
-  if (!jq) {
-    throw new Error('RenderViews requires the jQuery global to be loaded.');
-  }
-  return jq;
-}
+type JQueryViewElem = JQueryRenderElem;
+type ViewDomEvent = JQueryRenderEvent;
 
 // ── Scroller (vendor) ───────────────────────────────────────────────────────
 
@@ -161,7 +121,7 @@ export class RenderViewTab extends RenderNode {
   declare lastButton: JQueryViewElem | undefined;
 
   constructor(config: ViewTabConfig = {}) {
-    const $ = getJQuery();
+    const $ = getRenderJQuery('RenderViews');
     const jdomelem = $("<div class='ViewTab'></div>");
     const jdomelem1 = $("<div class='ViewTabContainer'></div>");
     const jdomelem3 = $("<div class='PopupContainer'></div>");
@@ -181,12 +141,12 @@ export class RenderViewTab extends RenderNode {
       clickable: false,
       width: config.width ?? 960,
       height: config.height ?? 960,
-      jdomelem: jdomelem as unknown as JQueryNodeElem,
+      jdomelem: jdomelem,
     });
 
     this.jdomelem1 = jdomelem1;
     this.jdomelem3 = jdomelem3;
-    this.popupContainerDomelem = jdomelem3 as unknown as JQueryNodeElem;
+    this.popupContainerDomelem = jdomelem3;
     this.domelem1 = jdomelem1[0];
 
     const node = this;
@@ -233,9 +193,7 @@ export class RenderViewTab extends RenderNode {
         const root = (node.gameNode as unknown as { GameRoot?: GameRootForView } | undefined)
           ?.GameRoot;
         if (node.parentNode) {
-          (node.parentNode.jdomelem as unknown as JQueryViewElem).addClass(
-            'Active' + (jdomelem.attr('id') as string)
-          );
+          node.parentNode.jdomelem.addClass('Active' + (jdomelem.attr('id') as string));
         }
         if (root?.renderMenu) {
           root.renderMenu.jdomelem.find('.mm-tab').removeClass('active');
@@ -246,9 +204,7 @@ export class RenderViewTab extends RenderNode {
         node.trigger('viewtab_selected');
       } else {
         if (node.parentNode) {
-          (node.parentNode.jdomelem as unknown as JQueryViewElem).removeClass(
-            'Active' + (jdomelem.attr('id') as string)
-          );
+          node.parentNode.jdomelem.removeClass('Active' + (jdomelem.attr('id') as string));
         }
         node.FXHide();
       }
@@ -267,7 +223,7 @@ export class RenderViewTab extends RenderNode {
       child.hide();
     }
     if (ui_elem) {
-      (this.jdomelem as unknown as JQueryViewElem).append(child.domelem);
+      this.jdomelem.append(child.domelem);
     } else {
       this.jdomelem1.append(child.domelem);
     }
@@ -298,11 +254,11 @@ export class RenderViewTab extends RenderNode {
   }
 
   FXShow(): void {
-    (this.jdomelem as unknown as JQueryViewElem).addClass('active');
+    this.jdomelem.addClass('active');
   }
 
   FXHide(): void {
-    (this.jdomelem as unknown as JQueryViewElem).removeClass('active');
+    this.jdomelem.removeClass('active');
   }
 
   /** Legacy stub — body computed dimensions but didn't apply them.
@@ -351,7 +307,7 @@ export class RenderViewMap extends RenderNode {
   _cancelWheelZoom: () => void = () => undefined;
 
   constructor(config: ViewMapConfig = {}) {
-    const $ = getJQuery();
+    const $ = getRenderJQuery('RenderViews');
     const jdomelem = $("<div class='ViewMap'></div>");
     const jdomelem1 = $("<div class='ViewMapContainer'></div>");
     const jdomelem2 = $(
@@ -383,13 +339,13 @@ export class RenderViewMap extends RenderNode {
       offsetY: 0, // Scroller needs offset 0
       width: config.width ?? 2920,
       height: config.height ?? 2200,
-      jdomelem: jdomelem as unknown as JQueryNodeElem,
+      jdomelem: jdomelem,
     });
 
     this.jdomelem1 = jdomelem1;
     this.jdomelem2 = jdomelem2;
     this.jdomelem3 = jdomelem3;
-    this.popupContainerDomelem = jdomelem3 as unknown as JQueryNodeElem;
+    this.popupContainerDomelem = jdomelem3;
     this.jdomelemZoom = jdomelemZoom;
     this.domelem1 = jdomelem1[0];
     this.domelem2 = jdomelem2[0];
@@ -406,9 +362,7 @@ export class RenderViewMap extends RenderNode {
       if (value) {
         this.FXShow();
         if (this.parentNode) {
-          (this.parentNode.jdomelem as unknown as JQueryViewElem).addClass(
-            'Active' + (jdomelem.attr('id') as string)
-          );
+          this.parentNode.jdomelem.addClass('Active' + (jdomelem.attr('id') as string));
         }
         if (root?.renderMenu) {
           root.renderMenu.jdomelem.find('.mm-tab').removeClass('active');
@@ -418,9 +372,7 @@ export class RenderViewMap extends RenderNode {
         }
       } else {
         if (this.parentNode) {
-          (this.parentNode.jdomelem as unknown as JQueryViewElem).removeClass(
-            'Active' + (jdomelem.attr('id') as string)
-          );
+          this.parentNode.jdomelem.removeClass('Active' + (jdomelem.attr('id') as string));
         }
         this.FXHide();
       }
@@ -432,7 +384,7 @@ export class RenderViewMap extends RenderNode {
       child.hide();
     }
     if (ui_elem) {
-      (this.jdomelem as unknown as JQueryViewElem).append(child.domelem);
+      this.jdomelem.append(child.domelem);
     } else {
       this.jdomelem1.append(child.domelem);
     }
@@ -558,8 +510,8 @@ export class RenderViewMap extends RenderNode {
     this.updateScroller();
     scroller.scrollTo(-initx, -inity);
 
-    const $ = getJQuery();
-    const jq = this.jdomelem as unknown as JQueryViewElem;
+    const $ = getRenderJQuery('RenderViews');
+    const jq = this.jdomelem;
     jq.on('dblclick', '.ZoomControls', (e) => {
       e.stopPropagation();
     });
@@ -598,8 +550,8 @@ export class RenderViewMap extends RenderNode {
       e.preventDefault();
       const parent = this.parentNode;
       if (!parent) return;
-      const offset = (this.jdomelem as unknown as JQueryViewElem).offset();
-      const parentOffset = (parent.jdomelem as unknown as JQueryViewElem).offset();
+      const offset = this.jdomelem.offset();
+      const parentOffset = parent.jdomelem.offset();
       const pageX = e.pageX ?? 0;
       const pageY = e.pageY ?? 0;
       const dragScale = this.dragHandler?.scale ?? 1;
@@ -639,7 +591,7 @@ export class RenderViewMap extends RenderNode {
         const touch = touchEvt.touches[0];
         const parent = this.parentNode;
         if (!touch || !parent) return;
-        const parentOffset = (parent.jdomelem as unknown as JQueryViewElem).offset();
+        const parentOffset = parent.jdomelem.offset();
         this.userAbsPos = {
           x: touch.pageX - parentOffset.left,
           y: touch.pageY - parentOffset.top,
@@ -711,7 +663,7 @@ export class RenderViewMap extends RenderNode {
       );
     }
 
-    void $; // referenced inside delegated handlers via getJQuery() above.
+    void $; // referenced inside delegated handlers via getRenderJQuery('RenderViews') above.
 
     // Mouse-wheel zoom: continuous and smoothly tweened.
     this._wheelZoomTarget = null;
@@ -744,7 +696,7 @@ export class RenderViewMap extends RenderNode {
       (e) => {
         const wheelEvt = e as WheelEvent;
         wheelEvt.preventDefault();
-        const offset = (this.jdomelem as unknown as JQueryViewElem).offset();
+        const offset = this.jdomelem.offset();
         const unit = wheelEvt.deltaMode === 1 ? 16 : wheelEvt.deltaMode === 2 ? 400 : 1;
         const delta = Math.max(-400, Math.min(400, wheelEvt.deltaY * unit));
         const factor = 0.999 ** delta;
@@ -785,7 +737,7 @@ export class RenderViewMap extends RenderNode {
   setZoomScale(scale: number): void {
     this.zoomScale = scale;
     if (this.dragHandler) this.dragHandler.scale = 1 / scale;
-    const jq = this.jdomelem as unknown as JQueryViewElem;
+    const jq = this.jdomelem;
     if (scale < 0.75) {
       jq.addClass('zoomHide2');
     } else {
@@ -823,11 +775,11 @@ export class RenderViewMap extends RenderNode {
   }
 
   FXShow(): void {
-    (this.jdomelem as unknown as JQueryViewElem).addClass('active');
+    this.jdomelem.addClass('active');
   }
 
   FXHide(): void {
-    (this.jdomelem as unknown as JQueryViewElem).removeClass('active');
+    this.jdomelem.removeClass('active');
   }
 }
 
@@ -845,12 +797,11 @@ export class RenderStage extends RenderNode {
   declare userAbsPos: { x: number; y: number } | undefined;
 
   constructor(config: StageConfig = {}) {
-    const $ = getJQuery();
+    const $ = getRenderJQuery('RenderViews');
     // Respect a subclass-supplied jdomelem (e.g. MainMenu's
     // `<div class='MainMenu'>` wrapper).  Same pattern as the
     // PR #221 jdomelem-clobber fix in RenderSprite/RenderText.
-    const jdomelem =
-      (config.jdomelem as unknown as JQueryViewElem | undefined) ?? $("<div class='Stage'></div>");
+    const jdomelem = config.jdomelem ?? $("<div class='Stage'></div>");
     const jdomelem2 = $("<div class='PopupContainer Top NoClose'></div>");
     jdomelem.append(jdomelem2);
 
@@ -863,11 +814,11 @@ export class RenderStage extends RenderNode {
       width: config.width ?? 960,
       height: config.height ?? 600,
       position: 'relative',
-      jdomelem: jdomelem as unknown as JQueryNodeElem,
+      jdomelem: jdomelem,
     });
 
     this.jdomelem2 = jdomelem2;
-    this.popupContainerDomelem = jdomelem2 as unknown as JQueryNodeElem;
+    this.popupContainerDomelem = jdomelem2;
     this.dragHandler = new RenderDragHandler();
     this.useDragHandler = this.dragHandler;
     this.initUI();
@@ -878,7 +829,7 @@ export class RenderStage extends RenderNode {
     this.on('mousemove', (e) => {
       const pageX = (e as ViewDomEvent).pageX ?? 0;
       const pageY = (e as ViewDomEvent).pageY ?? 0;
-      const offset = (this.jdomelem as unknown as JQueryViewElem).offset();
+      const offset = this.jdomelem.offset();
       this.userAbsPos = { x: pageX - offset.left, y: pageY - offset.top };
     });
     this.on('mousedown touchstart', (e) => {
@@ -886,7 +837,7 @@ export class RenderStage extends RenderNode {
       document.getSelection()?.removeAllRanges();
       const pageX = (e as ViewDomEvent).pageX ?? 0;
       const pageY = (e as ViewDomEvent).pageY ?? 0;
-      const offset = (this.jdomelem as unknown as JQueryViewElem).offset();
+      const offset = this.jdomelem.offset();
       this.userClickAbsPos = { x: pageX - offset.left, y: pageY - offset.top };
     });
   }
@@ -957,7 +908,7 @@ export class RenderMainMenu extends RenderStage {
   }
 
   constructor(config: MainMenuConfig = {}) {
-    const $ = getJQuery();
+    const $ = getRenderJQuery('RenderViews');
     const jdomelem = $("<div class='MainMenu'></div>");
 
     super({
@@ -966,7 +917,7 @@ export class RenderMainMenu extends RenderStage {
       height: config.height ?? 48,
       z: 1000,
       position: 'relative',
-      jdomelem: jdomelem as unknown as JQueryNodeElem,
+      jdomelem: jdomelem,
     });
 
     this.data = config.data ?? { buttons: [] };
@@ -981,25 +932,17 @@ export class RenderMainMenu extends RenderStage {
     // Setup Button Events
     const root = (this.gameNode as unknown as { GameRoot?: GameRootForMain } | undefined)?.GameRoot;
 
-    (this.jdomelem as unknown as JQueryViewElem).on(
-      'click touchend',
-      '#LocaleToggle:not(.disabled)',
-      (e) => {
-        e.stopPropagation();
-        e.preventDefault();
-        root?.trigger?.('toggle_locale');
-      }
-    );
-    (this.jdomelem as unknown as JQueryViewElem).on(
-      'click touchend',
-      '#UserData:not(.disabled)',
-      (e) => {
-        e.stopPropagation();
-        e.preventDefault();
-        root?.trigger?.('user_data');
-      }
-    );
-    (this.jdomelem as unknown as JQueryViewElem).on(
+    this.jdomelem.on('click touchend', '#LocaleToggle:not(.disabled)', (e) => {
+      e.stopPropagation();
+      e.preventDefault();
+      root?.trigger?.('toggle_locale');
+    });
+    this.jdomelem.on('click touchend', '#UserData:not(.disabled)', (e) => {
+      e.stopPropagation();
+      e.preventDefault();
+      root?.trigger?.('user_data');
+    });
+    this.jdomelem.on(
       'click touchend',
       '.mm-tab:not(.disabled)',
       function (this: HTMLElement, e: ViewDomEvent) {
@@ -1011,7 +954,7 @@ export class RenderMainMenu extends RenderStage {
     );
 
     // Forward .mm-xp taps to the same `click_status.XP` event.
-    (this.jdomelem as unknown as JQueryViewElem).on(
+    this.jdomelem.on(
       'click touchend',
       '.mm-xp .StatusItem',
       function (this: HTMLElement, e: ViewDomEvent) {
@@ -1045,7 +988,7 @@ export class RenderMainMenu extends RenderStage {
 
   render(): void {
     const html = getApp().renderView(this.template, this.data);
-    (this.jdomelem as unknown as JQueryViewElem).html(html);
+    this.jdomelem.html(html);
     // Invalidate the in-place XP cache so the next renderXP repopulates
     // the freshly-emptied .mm-xp-bar slot instead of memo-skipping.
     this._xpSlot = null;
@@ -1077,7 +1020,7 @@ export class RenderMainMenu extends RenderStage {
       level: sb.XP_level,
     };
     if (!this._xpSlot) {
-      const slot = (this.jdomelem as unknown as JQueryViewElem).find('.mm-xp-bar') as unknown as {
+      const slot = this.jdomelem.find('.mm-xp-bar') as unknown as {
         0?: HTMLElement;
       };
       this._xpSlot = slot[0] ?? null;
@@ -1107,13 +1050,13 @@ export class RenderMainMenu extends RenderStage {
   }
 
   override lock(): void {
-    const jq = this.jdomelem as unknown as JQueryViewElem;
+    const jq = this.jdomelem;
     jq.addClass('locked');
     jq.find('.mm-user-btn, .mm-tab').addClass('disabled');
   }
 
   override unlock(): void {
-    const jq = this.jdomelem as unknown as JQueryViewElem;
+    const jq = this.jdomelem;
     jq.removeClass('locked');
     jq.find('.mm-user-btn, .mm-tab').removeClass('disabled');
   }

--- a/scripts/render/_jqueryShim.ts
+++ b/scripts/render/_jqueryShim.ts
@@ -1,0 +1,150 @@
+// Shared jQuery + underscore vendor-globals access for the Render
+// layer.  Consolidates two formerly-duplicated patterns from the
+// 12-module Render extraction:
+//
+//   1. The `getJQuery()` guard — every Render* module checked
+//      `globalThis.jQuery ?? globalThis.$` and threw a
+//      module-specific "requires the jQuery global to be loaded"
+//      error if absent.  `getRenderJQuery(callerName)` does that
+//      once.
+//
+//   2. The per-module narrow `JQuery*Elem` interfaces (one per
+//      Render* module, each with a slightly different subset of
+//      jQuery's surface).  The 73-some
+//      `as unknown as JQuery*Elem` casts those interfaces forced
+//      were noise that future contributors copy-paste because
+//      they look load-bearing.  `JQueryRenderElem` is the
+//      canonical wide surface — every Render* module imports it
+//      and the casts retire.
+//
+// Render-side jQuery use is uniform: a single jQuery wrapper, a
+// stable subset of methods (~30), and overloads where the legacy
+// API differs by arity (`attr(name)` vs `attr(name, value)`,
+// `width()` vs `width(value)`, etc.).
+
+// ── primary element wrapper ─────────────────────────────────────────────────
+
+/**
+ * The wide jQuery-wrapper surface that every Render* module needs.
+ * Generic in the underlying DOM element type so canvas-backed
+ * wrappers (Cable, Circle) can narrow `[0]` to `HTMLCanvasElement`
+ * via `JQueryRenderElem<HTMLCanvasElement>`.
+ *
+ * Method overload signatures match jQuery 3.x's runtime:
+ * `attr(name)` / `width()` / `height()` / `html()` are getters
+ * returning `string | undefined` / `number | undefined` /
+ * `string | undefined`; their setter forms return the wrapper for
+ * chaining.
+ */
+export interface JQueryRenderElem<E extends HTMLElement = HTMLElement> {
+  0: E;
+  length: number;
+
+  // attribute / class manipulation
+  attr(name: string): string | undefined;
+  attr(name: string, value: string | number): JQueryRenderElem<E>;
+  addClass(cls: string): JQueryRenderElem<E>;
+  removeClass(cls: string): JQueryRenderElem<E>;
+  toggleClass(cls: string, force?: boolean): JQueryRenderElem<E>;
+  hasClass(cls: string): boolean;
+
+  // dom manipulation / traversal
+  append(child: unknown): JQueryRenderElem<E>;
+  empty(): JQueryRenderElem<E>;
+  remove(): JQueryRenderElem<E>;
+  clone(): JQueryRenderElem<E>;
+  find(selector: string): JQueryRenderElem;
+  filter(selector: string): JQueryRenderElem;
+  parents(selector: string): JQueryRenderElem;
+  parent(): JQueryRenderElem;
+  nextAll(selector: string): JQueryRenderElem;
+
+  // content
+  html(): string;
+  html(content: string): JQueryRenderElem<E>;
+  text(): string;
+  text(value: string | number): JQueryRenderElem<E>;
+
+  // visibility
+  show(): JQueryRenderElem<E>;
+  hide(): JQueryRenderElem<E>;
+  toggle(): JQueryRenderElem<E>;
+
+  // dimensions
+  width(): number | undefined;
+  width(value: number): JQueryRenderElem<E>;
+  height(): number | undefined;
+  height(value: number): JQueryRenderElem<E>;
+
+  // events
+  on(
+    event: string,
+    selectorOrHandler: string | ((e: JQueryRenderEvent) => void),
+    handler?: (e: JQueryRenderEvent) => void
+  ): JQueryRenderElem<E>;
+  off(event?: string, handler?: (...args: unknown[]) => unknown): JQueryRenderElem<E>;
+  trigger(event: string, params?: unknown[]): JQueryRenderElem<E>;
+
+  // layout / styling
+  offset(): { left: number; top: number };
+  css(props: Record<string, string | number>): JQueryRenderElem<E>;
+  animate(
+    props: Record<string, string | number>,
+    duration?: number,
+    cb?: () => void
+  ): JQueryRenderElem<E>;
+
+  // iteration
+  each(fn: (this: HTMLElement) => void): JQueryRenderElem<E>;
+
+  // legacy: some Render* code stamps `hidden` directly on the
+  // wrapper as a memoised visibility flag (DecoratorTimer's text
+  // overlay, popup-tab show/hide).  Preserved on the structural
+  // surface so those assignments type-check without casts.
+  hidden?: boolean;
+}
+
+/**
+ * Render-side jQuery event surface.  Wide-but-narrow: every field
+ * actually read in a Render-side handler is here, nothing more.
+ * Native DOM events (Mouse/Touch/Wheel) merge into this through
+ * jQuery's normalisation.
+ */
+export interface JQueryRenderEvent {
+  pageX?: number;
+  pageY?: number;
+  shiftKey?: boolean;
+  type?: string;
+  scale?: number;
+  deltaY?: number;
+  deltaMode?: number;
+  timeStamp?: number;
+  touches?: ArrayLike<{ pageX: number; pageY: number; target?: { tagName?: string } }>;
+  originalEvent?: {
+    touches?: ArrayLike<{ pageX: number; pageY: number }>;
+    changedTouches?: ArrayLike<{ pageX: number; pageY: number }>;
+  };
+  target?: unknown;
+  preventDefault(): void;
+  stopPropagation(): void;
+}
+
+// ── factory accessor ────────────────────────────────────────────────────────
+
+export type JQueryRenderFactory = (
+  selector: string | Element | object
+) => JQueryRenderElem<HTMLElement>;
+
+/**
+ * Read jQuery off `globalThis.jQuery ?? globalThis.$`, throwing if
+ * the vendor `<script>` tag hasn't loaded yet.  `callerName` is
+ * baked into the error message so the failing module is obvious
+ * from a stack-less throw (mostly relevant in test environments).
+ */
+export function getRenderJQuery(callerName: string): JQueryRenderFactory {
+  const jq = (globalThis.jQuery ?? globalThis.$) as JQueryRenderFactory | undefined;
+  if (!jq) {
+    throw new Error(callerName + ' requires the jQuery global to be loaded.');
+  }
+  return jq;
+}

--- a/scripts/render/renderSpriteHelper.ts
+++ b/scripts/render/renderSpriteHelper.ts
@@ -8,6 +8,7 @@
 // function(...)` is retired in PR 38 of issue #147.
 
 import setup from '../setup.js';
+import { getRenderJQuery } from './_jqueryShim.js';
 
 interface SpriteFrame {
   x: number;
@@ -30,25 +31,6 @@ export interface SpriteHelperConfig {
   dataButtonId?: string;
 }
 
-interface JQuerySpriteElem {
-  0: HTMLElement;
-  attr(name: string, value: string): unknown;
-  addClass(cls: string): unknown;
-  width(value: number): unknown;
-  height(value: number): unknown;
-  css(props: Record<string, string | number>): unknown;
-}
-
-function getJQuery(): (selector: string) => JQuerySpriteElem {
-  const jq = (globalThis.jQuery ?? globalThis.$) as
-    | ((selector: string) => JQuerySpriteElem)
-    | undefined;
-  if (!jq) {
-    throw new Error('renderSpriteHtml requires the jQuery global to be loaded.');
-  }
-  return jq;
-}
-
 /** Builds a `<div class='RenderSprite'>` HTML string for the given
  *  frame-map config, with the background-image / background-position /
  *  width / height / pivot-offset CSS pre-baked.  Returns an empty
@@ -58,7 +40,7 @@ export function renderSpriteHtml(config: SpriteHelperConfig | undefined, frame?:
   if (!config || !config.frameSrc || !config.frameMap) {
     return '';
   }
-  const $ = getJQuery();
+  const $ = getRenderJQuery('renderSpriteHtml');
   const frameSrc = config.frameSrc || config.frame_src;
   const frameMap = config.frameMap || config.frame_map;
   if (!frameSrc || !frameMap) return '';


### PR DESCRIPTION
## Summary

The 12 Render* TS modules each carried a duplicate `interface JQuery*Elem` plus a local `getJQuery()` helper, and call sites needed ~73 `as unknown as JQuery*Elem` casts to bridge the narrow per-module surfaces back to jQuery's loose runtime API. The casts looked load-bearing but were noise — each interface only listed the methods that one module happened to use, so any cross-module movement of code required adding another method to the interface or another cast at the boundary.

This PR extracts a single shared `scripts/render/_jqueryShim.ts` module exporting:

- `JQueryRenderElem<E extends HTMLElement = HTMLElement>` — wide surface covering every method the 12 modules use
- `JQueryRenderEvent` — wide event surface
- `getRenderJQuery(callerName)` — factory that resolves `globalThis.jQuery` once and throws a labelled error if absent

All 12 modules now import from the shim, drop their local interface + `getJQuery`, and the casts vanish.

**Net:**
- ~70 of 73 jQuery casts removed (the 2 remaining are non-jQuery structural narrows)
- 12 duplicate `JQuery*Elem` interfaces collapsed to 1
- 12 duplicate `getJQuery` functions collapsed to 1
- 12 files: +325 / -450 lines

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx biome check` clean
- [x] `npm test` — 626/626
- [x] `npm run test:e2e` — 45/45
- [x] `npm run build` — green

https://claude.ai/code/session_018qbFtLNgH4p39DmEBtouJu

---
_Generated by [Claude Code](https://claude.ai/code/session_018qbFtLNgH4p39DmEBtouJu)_