### PR TITLE
seam audit: retire setRenderNodeTickers, extract renderCreatejsTicker

### DIFF
--- a/scripts/Render.ts
+++ b/scripts/Render.ts
@@ -8,13 +8,10 @@
 //   - vendor-globals binding (jQuery `$`, underscore `_`,
 //     `Scroller`, `core`, CreateJS `Easel` / `Tween` / `Sound` /
 //     `Ticker` / `Ease`),
-//   - the CreateJS `Ticker.{addListener,removeListener,setFPS}`
-//     compat-shim that bolts the legacy listener-array API onto
-//     the modern `EventDispatcher`,
 //   - one-time seam wirings for the modules that legitimately
 //     can't pull these vendor globals on their own
-//     (`setRenderNodeTickers` / `applyRenderNodeFX` /
-//     `setRenderCableResolution` / `setRenderViewsConfig`),
+//     (`applyRenderNodeFX` / `setRenderCableResolution` /
+//     `setRenderViewsConfig`),
 //   - the underscore `_.mixin({ RenderAmount, RenderSprite })`
 //     template-helper registration,
 //   - the publisher object that re-exports every Render* class /
@@ -41,7 +38,7 @@ import {
   RenderDecoratorTimer,
 } from './render/RenderDecorators.js';
 import { RenderDragHandler } from './render/RenderDragHandler.js';
-import { RenderNode, setRenderNodeTickers } from './render/RenderNode.js';
+import { RenderNode } from './render/RenderNode.js';
 import { applyRenderNodeFX } from './render/RenderNodeFX.js';
 import { RenderPerp } from './render/RenderPerp.js';
 import { RenderPerpSprite } from './render/RenderPerpSprite.js';
@@ -65,6 +62,7 @@ import {
   RenderViewTab,
   setRenderViewsConfig,
 } from './render/RenderViews.js';
+import { tickerSetFPS, tickerSetUseRAF } from './render/renderCreatejsTicker.js';
 import { _ids, _instances, clearAllNodes, getNode, getNodeById } from './render/renderRegistry.js';
 import { renderSpriteHtml } from './render/renderSpriteHelper.js';
 import setup from './setup.js';
@@ -74,19 +72,12 @@ import setup from './setup.js';
 // Read off `globalThis.createjs` at factory-call time (the
 // `<script>` tag for createjs-2015.11.26 loads before the ESM
 // bundle).  Typed locally since there's no `@types/createjs`.
-
-interface CreateJSTickerLike {
-  addListener?(target: object): void;
-  removeListener?(target: object): void;
-  addEventListener(event: 'tick', fn: () => void): void;
-  removeEventListener(event: 'tick', fn: () => void): void;
-  setFPS?(fps: number): void;
-  framerate: number;
-  useRAF: boolean;
-}
+// The CreateJS Ticker singleton + its legacy listener-array shim
+// live in `./render/renderCreatejsTicker.js` — Render.ts only needs
+// `Tween` / `Ease` for the FX seam now.
 
 interface CreateJSGlobal {
-  Ticker: CreateJSTickerLike;
+  Ticker: unknown;
   Tween: unknown;
   Ease: unknown;
 }
@@ -146,42 +137,8 @@ function Render(): RenderApi {
   if (!cj) {
     throw new Error('Render(): globalThis.createjs not loaded.');
   }
-  const Ticker = cj.Ticker;
   const Tween = cj.Tween;
   const Ease = cj.Ease;
-
-  // Shim CreateJS legacy Ticker.{addListener,removeListener,setFPS}
-  // onto the current EventDispatcher API so Render's tick-object
-  // callers work.
-  if (typeof Ticker.addListener !== 'function') {
-    const _tickHandlers = new WeakMap<object, () => void>();
-    Ticker.addListener = (obj: object): void => {
-      if (_tickHandlers.has(obj)) {
-        return;
-      }
-      const fn = (): void => {
-        const tickable = obj as { tick?: () => void };
-        if (typeof tickable.tick === 'function') {
-          tickable.tick();
-        }
-      };
-      _tickHandlers.set(obj, fn);
-      Ticker.addEventListener('tick', fn);
-    };
-    Ticker.removeListener = (obj: object): void => {
-      const fn = _tickHandlers.get(obj);
-      if (fn) {
-        Ticker.removeEventListener('tick', fn);
-        _tickHandlers.delete(obj);
-      }
-    };
-  }
-  // Always override setFPS so we use the modern `framerate=` setter
-  // even when the legacy method still exists (it logs a deprecation
-  // warning on every call in current TweenJS builds).
-  Ticker.setFPS = (fps: number): void => {
-    Ticker.framerate = fps;
-  };
 
   const renderConf = {
     cableResolution: 2,
@@ -191,27 +148,19 @@ function Render(): RenderApi {
     viewMapStopZone: setup.viewMapStopZone,
   };
 
-  Ticker.setFPS(renderConf.tickerFramerate);
-  Ticker.useRAF = true;
+  // First call into renderCreatejsTicker installs the legacy
+  // listener-array shim onto the CreateJS Ticker singleton, so
+  // RenderNodeFX's `Ticker.addListener` calls find a function.
+  tickerSetFPS(renderConf.tickerFramerate);
+  tickerSetUseRAF(true);
 
   // ── seam wirings ─────────────────────────────────────────────────────────
   //
-  // RenderNode's `remove()` unregisters from CreateJS Ticker and
-  // RenderSlowTicker — both targets are fully resolved at this
-  // point.  RenderNodeFX needs Ticker / Tween / Ease handed in
-  // since it can't read off the createjs global at module load
-  // (createjs script tag may not have parsed yet).
-  setRenderNodeTickers({
-    tickerRemove: (node) => {
-      Ticker.removeListener?.(node);
-    },
-    slowTickerRemove: (node) => {
-      RenderSlowTicker.removeListener(node);
-    },
-  });
-
+  // RenderNodeFX needs Ticker / Tween / Ease handed in since it
+  // can't read off the createjs global at module load (createjs
+  // script tag may not have parsed yet).
   applyRenderNodeFX({
-    Ticker: Ticker as unknown as Parameters<typeof applyRenderNodeFX>[0]['Ticker'],
+    Ticker: cj.Ticker as unknown as Parameters<typeof applyRenderNodeFX>[0]['Ticker'],
     Tween: Tween as Parameters<typeof applyRenderNodeFX>[0]['Tween'],
     Ease: Ease as Parameters<typeof applyRenderNodeFX>[0]['Ease'],
   });

--- a/scripts/render/RenderNode.ts
+++ b/scripts/render/RenderNode.ts
@@ -7,28 +7,17 @@
 // Extracted from scripts/Render.js's IIFE in PR 31 of issue #147.
 // PR 40 lands the `_instances` / `_ids` registry in
 // scripts/render/renderRegistry.ts and retires the
-// `setRenderNodeRegistry` injection seam this file used to own.
-// `setRenderNodeTickers` stays — it bridges to the CreateJS Ticker
-// singleton which remains shimmed inside Render.js's IIFE for the
-// time being.
+// `setRenderNodeRegistry` injection seam this file used to own.  The
+// `setRenderNodeTickers` injection seam retired alongside the
+// extraction of `renderCreatejsTicker.ts` and direct
+// `RenderSlowTicker` import.
 
 import { OrderedSet } from '../game/OrderedSet.js';
 import { RenderSet } from './RenderSet.js';
+import { RenderSlowTicker } from './RenderSlowTicker.js';
 import { type JQueryRenderElem, type JQueryRenderEvent, getRenderJQuery } from './_jqueryShim.js';
+import { tickerRemoveListener } from './renderCreatejsTicker.js';
 import { nodeCount, registerNode, unregisterNode } from './renderRegistry.js';
-
-// ── seam interfaces ─────────────────────────────────────────────────────────
-
-export interface RenderNodeTickers {
-  tickerRemove(node: RenderNode): void;
-  slowTickerRemove(node: RenderNode): void;
-}
-
-let _tickers: RenderNodeTickers | undefined;
-
-export function setRenderNodeTickers(t: RenderNodeTickers): void {
-  _tickers = t;
-}
 
 // ── DOM / jQuery surface that Node touches ──────────────────────────────────
 //
@@ -225,10 +214,8 @@ export class RenderNode {
   }
 
   remove(): void {
-    if (_tickers) {
-      _tickers.tickerRemove(this);
-      _tickers.slowTickerRemove(this);
-    }
+    tickerRemoveListener(this);
+    RenderSlowTicker.removeListener(this);
     if (this.decoratedNode) {
       this.decoratedNode.decorators.remove(this);
     }

--- a/scripts/render/renderCreatejsTicker.ts
+++ b/scripts/render/renderCreatejsTicker.ts
@@ -1,0 +1,85 @@
+// Render-side wrapper around the CreateJS `Ticker` singleton.
+//
+// CreateJS-2015's `Ticker.addListener` / `Ticker.removeListener` are
+// the legacy listener-array API; current TweenJS builds removed those
+// methods in favour of `addEventListener('tick', fn)`.  Render code
+// still wants the listener-array shape (`obj.tick()` is invoked once
+// per frame), so this module installs an idempotent shim that bridges
+// the legacy calls onto the modern EventDispatcher.
+//
+// The CreateJS `<script>` tag may not have parsed at module-load time,
+// so we lazy-resolve `globalThis.createjs` on first use and cache it.
+// Retires the `setRenderNodeTickers` injection seam that previously
+// handed `Ticker.removeListener` to RenderNode from Render.ts.
+
+interface CreateJSTickerLike {
+  addListener?(target: object): void;
+  removeListener?(target: object): void;
+  addEventListener(event: 'tick', fn: () => void): void;
+  removeEventListener(event: 'tick', fn: () => void): void;
+  setFPS?(fps: number): void;
+  framerate: number;
+  useRAF: boolean;
+}
+
+interface CreateJSGlobal {
+  Ticker: CreateJSTickerLike;
+}
+
+let _ticker: CreateJSTickerLike | undefined;
+
+function resolveTicker(): CreateJSTickerLike {
+  if (_ticker) return _ticker;
+  const cj = (globalThis as { createjs?: CreateJSGlobal }).createjs;
+  if (!cj) {
+    throw new Error('renderCreatejsTicker: globalThis.createjs not loaded.');
+  }
+  const ticker = cj.Ticker;
+  if (typeof ticker.addListener !== 'function') {
+    const _tickHandlers = new WeakMap<object, () => void>();
+    ticker.addListener = (obj: object): void => {
+      if (_tickHandlers.has(obj)) {
+        return;
+      }
+      const fn = (): void => {
+        const tickable = obj as { tick?: () => void };
+        if (typeof tickable.tick === 'function') {
+          tickable.tick();
+        }
+      };
+      _tickHandlers.set(obj, fn);
+      ticker.addEventListener('tick', fn);
+    };
+    ticker.removeListener = (obj: object): void => {
+      const fn = _tickHandlers.get(obj);
+      if (fn) {
+        ticker.removeEventListener('tick', fn);
+        _tickHandlers.delete(obj);
+      }
+    };
+  }
+  // Always override setFPS so the modern `framerate=` setter is used
+  // even when the legacy method still exists (it logs a deprecation
+  // warning on every call in current TweenJS builds).
+  ticker.setFPS = (fps: number): void => {
+    ticker.framerate = fps;
+  };
+  _ticker = ticker;
+  return ticker;
+}
+
+export function tickerAddListener(obj: object): void {
+  resolveTicker().addListener?.(obj);
+}
+
+export function tickerRemoveListener(obj: object): void {
+  resolveTicker().removeListener?.(obj);
+}
+
+export function tickerSetFPS(fps: number): void {
+  resolveTicker().setFPS?.(fps);
+}
+
+export function tickerSetUseRAF(useRAF: boolean): void {
+  resolveTicker().useRAF = useRAF;
+}


### PR DESCRIPTION
## Summary

`setRenderNodeTickers` was the last RenderNode injection seam from the issue #147 wave (`setRenderNodeRegistry` / `setRenderDecoratorSlowTicker` retired in #226). It existed because the CreateJS Ticker singleton needs a legacy listener-array shim installed at runtime, and that install lived inside `Render.ts`'s factory — `RenderNode.remove()` couldn't import-and-call `Ticker.removeListener` directly without the shim being in place first.

This PR extracts the shim + Ticker reference into a new `scripts/render/renderCreatejsTicker.ts` module. The module lazy-resolves `globalThis.createjs.Ticker` on first call, installs the legacy listener-array adapter idempotently, and exposes a thin helper surface:

- `tickerAddListener(obj)`
- `tickerRemoveListener(obj)`
- `tickerSetFPS(fps)`
- `tickerSetUseRAF(useRAF)`

**Result:**

- `RenderNode.remove()` calls `tickerRemoveListener(this)` and `RenderSlowTicker.removeListener(this)` directly — no seam.
- `setRenderNodeTickers` / `RenderNodeTickers` interface deleted.
- Inline Ticker shim block in `Render.ts` (≈30 LOC) deletes; the factory triggers the lazy install via `tickerSetFPS(60)` / `tickerSetUseRAF(true)`.
- `applyRenderNodeFX`'s Tween / Ease seam stays — out of scope for this PR (those globals don't have a shim to coordinate, and the seam still earns its keep for them).

**Net:** -64 LOC across `Render.ts` + `RenderNode.ts`, +88 LOC for the new module. One injection seam retired.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx biome check` clean
- [x] `npm test` — 626/626
- [x] `npm run test:e2e` — 45/45
- [x] `npm run build` — green

https://claude.ai/code/session_018qbFtLNgH4p39DmEBtouJu

---
_Generated by [Claude Code](https://claude.ai/code/session_018qbFtLNgH4p39DmEBtouJu)_