### PR TITLE
Remove unnecessary type cast on setup in GameRoot.ts

### DIFF
--- a/scripts/game/GameRoot.ts
+++ b/scripts/game/GameRoot.ts
@@ -1804,11 +1804,10 @@ export class GameRoot extends GameNode {
     stage.gameNode = this;
     const $ = globalThis.$;
     if (!$) return;
-    const setupLike = setup as unknown as { debug?: boolean; renderContainer?: string };
-    if (setupLike.debug) {
-      $(setupLike.renderContainer ?? '').addClass?.('debugmode');
+    if (setup.debug) {
+      $(setup.renderContainer).addClass?.('debugmode');
     }
-    const containerSel = setupLike.renderContainer ?? '';
+    const containerSel = setup.renderContainer;
     $(containerSel).append(menu.domelem);
     menu.initUI?.();
     $(containerSel).append(stage.domelem);


### PR DESCRIPTION
## Summary

The `setup` object from `scripts/setup.ts` exports the `Setup` interface with `debug` and `renderContainer` as non-optional fields (lines 9 and 17). The cast in GameRoot.ts line 1807 was loosening the type by treating them as optional, which is unnecessary.

Removed the redundant cast and now use `setup.debug` and `setup.renderContainer` directly.

## Verification

- TypeScript type checking: PASS (no GameRoot.ts errors)
- Biome linter: PASS
- Changes verified against scripts/setup.ts interface definition

---
_Generated by [Claude Code](https://claude.ai/code/session_01RMa57RmuG7HhqqjiP3xKic)_