### PR TITLE
Drop unused snake_case sprite config aliases

### DIFF
--- a/scripts/render/RenderPerp.ts
+++ b/scripts/render/RenderPerp.ts
@@ -35,8 +35,6 @@ interface UnderscoreEachLike {
 // ── config shape ────────────────────────────────────────────────────────────
 
 export type PerpConfig = SpriteConfig & {
-  frame_src?: string;
-  frame_map?: SpriteFrameMap;
   cables?: RenderSet<PerpCableLike>;
   perpSprite?: PerpSpriteConfig | RenderPerpSprite;
   draggable?: boolean;
@@ -61,11 +59,10 @@ export class RenderPerp extends RenderSprite {
     const placeRandom =
       config.x === undefined || config.y === undefined ? { x: 1024, y: 800 } : undefined;
 
-    const frameSrc = config.frameSrc ?? config.frame_src ?? 'MainSprites.png';
-    const frameMap: SpriteFrameMap = config.frameMap ??
-      config.frame_map ?? {
-        normal: { x: 0, y: 0, width: 80, height: 80, pivotx: 0, pivoty: 0 },
-      };
+    const frameSrc = config.frameSrc ?? 'MainSprites.png';
+    const frameMap: SpriteFrameMap = config.frameMap ?? {
+      normal: { x: 0, y: 0, width: 80, height: 80, pivotx: 0, pivoty: 0 },
+    };
     const frame = config.frame ?? 'normal';
     const cables = config.cables ?? new RenderSet<PerpCableLike>();
 

--- a/scripts/render/RenderPerpSprite.ts
+++ b/scripts/render/RenderPerpSprite.ts
@@ -12,10 +12,7 @@ import { RenderNode } from './RenderNode.js';
 import { RenderSprite, type SpriteConfig, type SpriteFrame } from './RenderSprite.js';
 import { getRenderJQuery } from './_jqueryShim.js';
 
-export type PerpSpriteConfig = SpriteConfig & {
-  frame_src?: string;
-  frame_map?: SpriteConfig['frameMap'];
-};
+export type PerpSpriteConfig = SpriteConfig;
 
 export class RenderPerpSprite extends RenderSprite {
   constructor(config: PerpSpriteConfig = {}) {
@@ -23,8 +20,6 @@ export class RenderPerpSprite extends RenderSprite {
     const jdomelem = $("<div class='PerpSprite'></div>");
     super({
       ...config,
-      frameSrc: config.frameSrc ?? config.frame_src,
-      frameMap: config.frameMap ?? config.frame_map,
       frame: config.frame ?? 'normal',
       jdomelem: jdomelem,
     } as SpriteConfig);

--- a/scripts/render/renderSpriteHelper.ts
+++ b/scripts/render/renderSpriteHelper.ts
@@ -23,9 +23,7 @@ type SpriteFrameMap = Record<string, SpriteFrame>;
 
 export interface SpriteHelperConfig {
   frameSrc?: string;
-  frame_src?: string;
   frameMap?: SpriteFrameMap;
-  frame_map?: SpriteFrameMap;
   frame?: string;
   className?: string;
   dataButtonId?: string;
@@ -41,8 +39,8 @@ export function renderSpriteHtml(config: SpriteHelperConfig | undefined, frame?:
     return '';
   }
   const $ = getRenderJQuery('renderSpriteHtml');
-  const frameSrc = config.frameSrc || config.frame_src;
-  const frameMap = config.frameMap || config.frame_map;
+  const frameSrc = config.frameSrc;
+  const frameMap = config.frameMap;
   if (!frameSrc || !frameMap) return '';
   const activeFrame = frame || config.frame || 'normal';
 


### PR DESCRIPTION
## Summary
Remove the unused snake_case aliases (frame_src, frame_map) from sprite config types. Codebase grep confirms zero callers use these variants.

## Changes
- **renderSpriteHelper.ts**: Removed frame_src and frame_map from SpriteHelperConfig interface; simplified fallback logic to direct property access
- **RenderPerp.ts**: Removed frame_src and frame_map from PerpConfig type; consolidated ?? operator chains
- **RenderPerpSprite.ts**: Removed frame_src and frame_map overrides; simplified PerpSpriteConfig to be a direct alias of SpriteConfig

## Testing
- TypeScript: `npx tsc --noEmit` passes
- Linter: `npx biome check` passes
- Unit tests: `npm test` - 626 tests passed
- E2E tests: `npm run test:e2e` - 45 tests passed (1 skipped)
- Build: `npm run build` completes successfully

---
_Generated by [Claude Code](https://claude.ai/code/session_01RMa57RmuG7HhqqjiP3xKic)_