### PR TITLE
type-debt: type the addDecorator slot writes via DecoType union

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ pnpm-debug.log
 /coverage/
 /test-results/
 /playwright-report/
+/.claude/

--- a/scripts/render/RenderDecorators.ts
+++ b/scripts/render/RenderDecorators.ts
@@ -13,7 +13,7 @@
 // the `setRenderDecoratorSlowTicker` injection seam this file
 // used to own — DecoratorTimer imports the singleton directly.
 
-import { type NodeConfig, RenderNode } from './RenderNode.js';
+import { type DecoType, type NodeConfig, RenderNode } from './RenderNode.js';
 import { RenderSlowTicker } from './RenderSlowTicker.js';
 import { RenderSprite, type SpriteConfig, type SpriteFrameMap } from './RenderSprite.js';
 import { RenderText, type TextConfig } from './RenderText.js';
@@ -139,7 +139,7 @@ function getReadyText(mode: 'profile' | 'money' | 'gear'): JQueryDecoratorElem {
 }
 
 export class RenderDecoratorReady extends RenderSprite implements DecoratorBase {
-  declare decoType: string;
+  declare decoType: DecoType;
   offsetToParent: { x: number; y: number };
 
   constructor(config: DecoratorReadyConfig = {}) {
@@ -210,7 +210,7 @@ export type DecoratorLabelConfig = TextConfig & {
 };
 
 export class RenderDecoratorLabel extends RenderText implements DecoratorBase {
-  declare decoType: string;
+  declare decoType: DecoType;
   offsetToParent: { x: number; y: number };
   textFontSize: string;
 
@@ -255,7 +255,7 @@ export type DecoratorNewConfig = TextConfig & {
 };
 
 export class RenderDecoratorNew extends RenderText implements DecoratorBase {
-  declare decoType: string;
+  declare decoType: DecoType;
   offsetToParent: { x: number; y: number };
   textFontSize: string;
   declare arrow: boolean | undefined;
@@ -323,7 +323,7 @@ export type DecoratorGearConfig = SpriteConfig & {
 };
 
 export class RenderDecoratorGear extends RenderSprite implements DecoratorBase {
-  declare decoType: string;
+  declare decoType: DecoType;
   offsetToParent: { x: number; y: number };
 
   constructor(config: DecoratorGearConfig = {}) {
@@ -400,7 +400,7 @@ export type DecoratorTimerConfig = SpriteConfig & {
 };
 
 export class RenderDecoratorTimer extends RenderSprite implements DecoratorBase {
-  declare decoType: string;
+  declare decoType: DecoType;
   offsetToParent: { x: number; y: number };
   serverTime: number;
   serverStartTime: number;
@@ -558,7 +558,7 @@ export type DecoratorAmountConfig = SpriteConfig & {
 };
 
 export class RenderDecoratorAmount extends RenderSprite implements DecoratorBase {
-  declare decoType: string;
+  declare decoType: DecoType;
   offsetToParent: { x: number; y: number };
   amount: number;
   declare text: string;

--- a/scripts/render/RenderNode.ts
+++ b/scripts/render/RenderNode.ts
@@ -66,6 +66,23 @@ interface GameNodeLike {
   parentNode?: { renderNode: RenderNode };
 }
 
+// ── decorator slot typing ───────────────────────────────────────────────────
+//
+// Every decorator subclass in scripts/render/RenderDecorators.ts pins a
+// fixed `decoType` string on its prototype.  `addDecorator` uses that
+// string to populate the matching same-name slot on the decorated
+// node (so callers can read e.g. `rn.DecoratorGear?.setFrame(...)`).
+// Pinning the union here lets the slot fields and the dynamic write
+// in `addDecorator` stay narrowly typed without a `Record<string, …>`
+// cast.
+export type DecoType =
+  | 'DecoratorReady'
+  | 'DecoratorAmount'
+  | 'DecoratorGear'
+  | 'DecoratorLabel'
+  | 'DecoratorTimer'
+  | 'DecoratorNew';
+
 // ── config / setAttrs ───────────────────────────────────────────────────────
 
 export type NodeConfig = {
@@ -131,8 +148,18 @@ export class RenderNode {
   declare perpFrom: { cables: RenderSet<RenderNode> } | undefined;
   declare cables: (RenderSet<RenderNode> & { set: CableLike[] }) | undefined;
   declare detectCollisions: boolean | undefined;
-  declare decoType: string | undefined;
+  declare decoType: DecoType | undefined;
   declare dragBound: ((pos: { x: number; y: number }) => void) | undefined;
+
+  // Per-decoType slots populated by `addDecorator`.  Keyed by the
+  // decorator's `decoType` string — readers (e.g. `rn.DecoratorGear`)
+  // hit these declared fields directly rather than a Record-cast.
+  declare DecoratorReady: RenderNode | undefined;
+  declare DecoratorAmount: RenderNode | undefined;
+  declare DecoratorGear: RenderNode | undefined;
+  declare DecoratorLabel: RenderNode | undefined;
+  declare DecoratorTimer: RenderNode | undefined;
+  declare DecoratorNew: RenderNode | undefined;
   declare dragStartPos: { x: number; y: number } | undefined;
 
   // setDraggable / setClickable timer state.
@@ -274,11 +301,17 @@ export class RenderNode {
     }
     this.decorators.add(deco);
     if (deco.decoType) {
-      const slot = (this as unknown as Record<string, RenderNode | undefined>)[deco.decoType];
-      if (slot) {
-        slot.remove();
+      // The DecoType union members are exactly the names of the
+      // decorator slot fields declared above, so the assignment is
+      // sound — the indexed write is just sugar for the per-slot
+      // `this.DecoratorGear = deco` etc.  Pulled out into a typed
+      // alias so the index is checked, not cast through `unknown`.
+      const slots = this as Pick<RenderNode, DecoType>;
+      const existing = slots[deco.decoType];
+      if (existing) {
+        existing.remove();
       }
-      (this as unknown as Record<string, RenderNode>)[deco.decoType] = deco;
+      slots[deco.decoType] = deco;
     }
     deco.decoratedNode = this;
     this.parentNode.addChild(deco);

--- a/scripts/render/RenderNodeFX.ts
+++ b/scripts/render/RenderNodeFX.ts
@@ -108,10 +108,13 @@ declare module './RenderNode.js' {
     // Transient FX state planted on the instance.
     FXAnimation?: TweenChain;
     spinner?: RenderSprite;
-    // Subclass fields the FX bodies touch — Decorator family, click
-    // handlers, statusbar bling tracking.  Declared optional here so
-    // the FX methods type-check against any RenderNode subclass.
-    DecoratorAmount?: DecoratorAmountLike;
+    // Subclass fields the FX bodies touch — click handlers,
+    // statusbar bling tracking.  Declared optional here so the FX
+    // methods type-check against any RenderNode subclass.  The
+    // `DecoratorAmount` slot is declared on RenderNode itself
+    // (typed `RenderNode | undefined`) — FX call sites cast through
+    // `DecoratorAmountLike` where the `setAmount()` surface is
+    // needed.
     userClickAbsPos?: { x: number; y: number };
     renderBlings?: Record<string, RenderText>;
     zoomScale?: number;
@@ -352,7 +355,7 @@ export function applyRenderNodeFX(deps: RenderNodeFXDeps): void {
         this.FXBounce();
         this.FXBling({ text, extendClass: 'ProfileBlingSmall' });
         this.DecoratorAmount?.show();
-        this.DecoratorAmount?.setAmount();
+        (this.DecoratorAmount as DecoratorAmountLike | undefined)?.setAmount();
         spinner.remove();
         delete this.spinner;
         if (cb) cb();


### PR DESCRIPTION
## Summary

`RenderNode.addDecorator` populated a same-name slot on the decorated node keyed by the decorator's `decoType` string, but used a `Record<string, RenderNode>` cast on `this` to do the write. The set of `decoType` values is closed (the six `RenderDecoratorReady` / `Amount` / `Gear` / `Label` / `Timer` / `New` subclasses each pin a literal on their prototype), so the dynamic-key write was load-bearing only because TS lacked the slot field declarations.

- Exports a `DecoType` string-literal union from `scripts/render/RenderNode.ts`.
- Declares the six per-decoType slot fields on `RenderNode` (`DecoratorReady`, `DecoratorAmount`, `DecoratorGear`, `DecoratorLabel`, `DecoratorTimer`, `DecoratorNew`), typed `RenderNode | undefined` to match the `rn.DecoratorGear?.…` read pattern callers already use.
- Narrows `RenderNode.decoType` from `string | undefined` to `DecoType | undefined`, and tightens each subclass's `declare decoType` from `string` to `DecoType` in `scripts/render/RenderDecorators.ts`.
- Replaces the `Record<string, RenderNode>`-cast write in `addDecorator` with a `Pick<RenderNode, DecoType>` alias so the indexed write is type-checked against the declared slot fields.
- Drops the `DecoratorAmount?: DecoratorAmountLike` augmentation in `scripts/render/RenderNodeFX.ts` (it would conflict with the now-declared slot field on the base) and casts through `DecoratorAmountLike` at the one FX call site that needs the `setAmount()` surface.

Read sites elsewhere in the codebase (`rn.DecoratorGear?.setFrame(...)`, `parentNode.renderNode?.DecoratorNew?.remove()`, etc.) keep their existing shape — option (b) was picked over option (a) precisely because that read API is wide.

## Test plan

- [x] `npx tsc --noEmit` — no new errors versus parent branch (only the pre-existing `node:*` / `import.meta.glob` / `@playwright/test` baseline errors)
- [x] `npx biome check` — clean
- [x] `npm test` — 626 / 626 passing (17 test files)
- [x] `npm run test:e2e` — 45 passing, 1 skipped (no failures)
- [x] `npm run build` — green (`dist/scripts/esm-bundle.js 1,098.58 kB`)

https://claude.ai/code/session_01Ah37AyDsgdqiCdLuTeeYDz

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ah37AyDsgdqiCdLuTeeYDz)_