### PR TITLE
seam audit: retire setRenderCableResolution + setRenderViewsConfig

### DIFF
--- a/scripts/Render.ts
+++ b/scripts/Render.ts
@@ -10,8 +10,7 @@
 //     `Ticker` / `Ease`),
 //   - one-time seam wirings for the modules that legitimately
 //     can't pull these vendor globals on their own
-//     (`applyRenderNodeFX` / `setRenderCableResolution` /
-//     `setRenderViewsConfig`),
+//     (`applyRenderNodeFX`),
 //   - the underscore `_.mixin({ RenderAmount, RenderSprite })`
 //     template-helper registration,
 //   - the publisher object that re-exports every Render* class /
@@ -21,7 +20,7 @@
 //     unchanged.
 
 import { RenderButtonInline } from './render/RenderButtonInline.js';
-import { RenderCable, RenderPerpCable, setRenderCableResolution } from './render/RenderCables.js';
+import { RenderCable, RenderPerpCable } from './render/RenderCables.js';
 import { RenderCircle } from './render/RenderCircle.js';
 import {
   RenderDecorator,
@@ -50,17 +49,10 @@ import {
   RenderTopscorePerp,
   renderAmountHtml,
 } from './render/RenderTopLevelUI.js';
-import {
-  RenderMainMenu,
-  RenderStage,
-  RenderViewMap,
-  RenderViewTab,
-  setRenderViewsConfig,
-} from './render/RenderViews.js';
+import { RenderMainMenu, RenderStage, RenderViewMap, RenderViewTab } from './render/RenderViews.js';
 import { tickerSetFPS, tickerSetUseRAF } from './render/renderCreatejsTicker.js';
 import { _ids, _instances, clearAllNodes, getNode, getNodeById } from './render/renderRegistry.js';
 import { renderSpriteHtml } from './render/renderSpriteHelper.js';
-import setup from './setup.js';
 
 // ── CreateJS vendor surface ────────────────────────────────────────────────
 //
@@ -135,18 +127,10 @@ function Render(): RenderApi {
   const Tween = cj.Tween;
   const Ease = cj.Ease;
 
-  const renderConf = {
-    cableResolution: 2,
-    tickerFramerate: 60,
-    slowTickerFrameRate: 120,
-    viewMapPerspective: setup.viewMapPerspective,
-    viewMapStopZone: setup.viewMapStopZone,
-  };
-
   // First call into renderCreatejsTicker installs the legacy
   // listener-array shim onto the CreateJS Ticker singleton, so
   // RenderNodeFX's `Ticker.addListener` calls find a function.
-  tickerSetFPS(renderConf.tickerFramerate);
+  tickerSetFPS(60);
   tickerSetUseRAF(true);
 
   // ── seam wirings ─────────────────────────────────────────────────────────
@@ -159,8 +143,6 @@ function Render(): RenderApi {
     Tween: Tween as Parameters<typeof applyRenderNodeFX>[0]['Tween'],
     Ease: Ease as Parameters<typeof applyRenderNodeFX>[0]['Ease'],
   });
-  setRenderCableResolution(renderConf.cableResolution);
-  setRenderViewsConfig({ viewMapStopZone: renderConf.viewMapStopZone });
 
   // ── underscore mixins (template-helper registration) ─────────────────────
 

--- a/scripts/render/RenderCables.ts
+++ b/scripts/render/RenderCables.ts
@@ -55,17 +55,11 @@ function getSprites(): CableSprites {
   return _sprites;
 }
 
-// ── the cableResolution config knob (Render.js owns this) ───────────────────
+// ── cable resolution ─────────────────────────────────────────────────────────
 //
-// Render.js sets `renderConf.cableResolution = 2` at IIFE-body time.
-// Pass it in via a setter so this module doesn't have to re-read
-// the global config object.
+// Static value 2 — controls the path step-size in the draw routine.
 
-let _cableResolution = 2;
-
-export function setRenderCableResolution(n: number): void {
-  _cableResolution = n;
-}
+const _cableResolution = 2;
 
 // ── Cable (base) ────────────────────────────────────────────────────────────
 

--- a/scripts/render/RenderViews.ts
+++ b/scripts/render/RenderViews.ts
@@ -16,12 +16,12 @@
 //     the .mm-tab nav, the cloned mobile XP bar, and forwards
 //     button clicks to GameRoot.
 //
-// Two seam dependencies:
+// One seam dependency remains:
 //   - `setRenderViewsApp` — for `app.renderView(template, data)` and
 //     `app.game.resetZoom()`.  app is a singleton initialised by
 //     scripts/app.ts; Render.js wires the seam at IIFE-body time.
-//   - `setRenderViewsConfig` — for `viewMapStopZone` (read off
-//     scripts/setup.ts).  Bundled with `app` in `setRenderViewsHooks`.
+//   `viewMapStopZone` is now read directly from `setup` (see
+//   scripts/setup.ts); the `setRenderViewsConfig` setter was retired.
 
 import appModule from '../app.js';
 import setup from '../setup.js';
@@ -30,23 +30,13 @@ import { type NodeConfig, RenderNode } from './RenderNode.js';
 import { type JQueryRenderElem, type JQueryRenderEvent, getRenderJQuery } from './_jqueryShim.js';
 import { type SpriteHelperConfig, renderSpriteHtml } from './renderSpriteHelper.js';
 
-// ── seam: app + renderConf ──────────────────────────────────────────────────
+// ── seam: app ───────────────────────────────────────────────────────────────
 
 interface AppLike {
   renderView(viewName: string, data?: unknown): string;
   game?: {
     resetZoom?(): void;
   };
-}
-
-export interface RenderViewsConfig {
-  viewMapStopZone: number;
-}
-
-let _config: RenderViewsConfig = { viewMapStopZone: 200 };
-
-export function setRenderViewsConfig(c: RenderViewsConfig): void {
-  _config = c;
 }
 
 function getApp(): AppLike {
@@ -421,8 +411,8 @@ export class RenderViewMap extends RenderNode {
   }
 
   override setPosition(pos: { x: number; y: number }): void {
-    if (_config.viewMapStopZone) {
-      const stopZone = _config.viewMapStopZone;
+    if (setup.viewMapStopZone) {
+      const stopZone = setup.viewMapStopZone;
       const parent = this.parentNode;
       if (parent) {
         const clipx = parent.width - this.getScaledSize().width - stopZone;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **`setRenderCableResolution`** (RenderCables.ts): the setter always received the literal `2` from Render.ts. Inlined as `const _cableResolution = 2` — the mutable `let` is gone along with the exported setter.

- **`setRenderViewsConfig`** (RenderViews.ts): the setter always passed `{ viewMapStopZone: setup.viewMapStopZone }`. RenderViews.ts already imports `setup`, so `setPosition` now reads `setup.viewMapStopZone` directly. The `_config` module-level var, the `RenderViewsConfig` interface, and the setter are all removed.

- **`renderConf` object** (Render.ts): fully removed — its only surviving consumer was `tickerFramerate`, now inlined as `tickerSetFPS(60)`. The `setup` import in Render.ts is also dropped.

Same playbook as PR #232 (`setRenderNodeTickers`).

## Test plan

- [x] `npx tsc --noEmit` — no new errors in modified files
- [x] `npx biome check` (via `pnpm exec biome`) — 3 files pass clean
- [x] `npm test` — 626 tests pass
- [x] `npm run build` — build succeeds
- [x] `npm run test:e2e` — 45 passed, 1 skipped

https://claude.ai/code/session_0114s4tU5yhogGcgxRhTig2i
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_0114s4tU5yhogGcgxRhTig2i)_