### PR TITLE
type-debt: tighten DoneFailChain.fail from unknown to typed error envelope

### DIFF
--- a/scripts/game/Database.ts
+++ b/scripts/game/Database.ts
@@ -185,7 +185,7 @@ interface BuyPerpResult {
 
 interface DoneFailChain<T> {
   done(cb: (data: { result?: T }) => void): DoneFailChain<T>;
-  fail(cb: (data: unknown) => void): DoneFailChain<T>;
+  fail(cb: (data: { error?: string | number; message?: string }) => void): DoneFailChain<T>;
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/game/GamePerp.ts
+++ b/scripts/game/GamePerp.ts
@@ -103,7 +103,7 @@ export interface ChargeResult {
 
 export interface DoneFailChain<T> {
   done(cb: (data: { result?: T }) => void): DoneFailChain<T>;
-  fail(cb: (data: unknown) => void): DoneFailChain<T>;
+  fail(cb: (data: { error?: string | number; message?: string }) => void): DoneFailChain<T>;
 }
 
 /** Animation-singleton interface from Game.js's AniTicker. */

--- a/scripts/game/Missions.ts
+++ b/scripts/game/Missions.ts
@@ -45,7 +45,7 @@ interface RecheckMissionsResult {
 
 interface DoneFailChain<T> {
   done(cb: (data: { result?: T }) => void): DoneFailChain<T>;
-  fail(cb: (data: unknown) => void): DoneFailChain<T>;
+  fail(cb: (data: { error?: string | number; message?: string }) => void): DoneFailChain<T>;
 }
 
 export class Missions extends GameNode {

--- a/scripts/game/Topscore.ts
+++ b/scripts/game/Topscore.ts
@@ -37,7 +37,7 @@ interface RankingResult {
 // app.remote's return type is widened.
 interface DoneFailChain {
   done(cb: (data: { result?: RankingResult }) => void): DoneFailChain;
-  fail(cb: (data: unknown) => void): DoneFailChain;
+  fail(cb: (data: { error?: string | number; message?: string }) => void): DoneFailChain;
 }
 
 interface TopscoreRenderNode {
@@ -93,7 +93,7 @@ export class Topscore extends GameNode {
           console.error('getRanking failed', data);
         }
       })
-      .fail(function (data: unknown) {
+      .fail(function (data) {
         console.error('getRanking failed', data);
       });
   }


### PR DESCRIPTION
## Summary

Tightens `DoneFailChain<T>.fail`'s callback parameter from `unknown` to a typed envelope:

```ts
fail(cb: (data: { error?: string | number; message?: string }) => void): DoneFailChain<T>
```

Applied to all four files that declare a local `DoneFailChain` interface: `GamePerp.ts`, `Database.ts`, `Missions.ts`, `Topscore.ts`. Removed the explicit `data: unknown` annotation from the one TS-side `.fail()` call site in `Topscore.ts:96`; TypeScript now infers the typed envelope.

## Envelope verification

Surveyed all `.fail()` handlers in `scripts/game/` (TS) and `scripts/Game.js`. Typed-side handlers either ignore the param or pass it to `console.error`. JS-side handlers access `data.error`, `data.error.message`, `data.message`. The `{ error?: string | number; message?: string }` envelope covers all typed usage.

## Cast-count delta

- Before: 138 `as unknown as` occurrences in `scripts/`
- After: 138

The original task estimated ~17 fewer casts, but those casts (`X as unknown as DoneFailChain<Y>` at chain-construction sites like `ProjectPerp.ts:303`) cast the chain object itself — they're orthogonal to the `.fail` parameter typing. The interface tightening's real value is that all `.fail((data) => …)` call sites now receive a typed `data` parameter without needing handler-side casts. Future call sites that destructure `data.error` or `data.message` will type-check directly.

## Rebase note

This branch was originally based on `146adbc` (pre-dating the perp-extraction commits). It has been rebased onto current `master`; the four interface tightenings carry over cleanly with no conflicts.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx biome check scripts/` — 64/64 files pass
- [x] `npm test` — 587 passed (only failure is `tests/build/build.test.js`, a pre-existing missing-symlink issue in the worktree env, unrelated)
- [x] `npm run test:e2e` — 45 passed / 1 skipped

https://claude.ai/code/session_0114s4tU5yhogGcgxRhTig2i