### PR TITLE
type(render): tighten _jqueryShim event handler types, drop ~5 casts

### DIFF
--- a/scripts/render/RenderNode.ts
+++ b/scripts/render/RenderNode.ts
@@ -43,7 +43,7 @@ interface DragHandlerLike {
   domelem: Window;
   collisionNodes: OrderedSet<{ getPosition(): { x: number; y: number } }>;
   addListener(node: RenderNode): void;
-  on(ev: string, fn: (e: NodeDomEvent) => void): void;
+  on(ev: string, fn: (e: NodeDomEvent, ...args: unknown[]) => void): void;
   off(ev: string): void;
   trigger(ev: string, params?: unknown[]): void;
   dragstart(e: NodeDomEvent): void;
@@ -568,7 +568,7 @@ export class RenderNode {
     this.draw();
   }
 
-  on(event: string, func: (e: NodeDomEvent) => void): void {
+  on(event: string, func: (e: NodeDomEvent, ...args: unknown[]) => void): void {
     this.jdomelem.on(event, func);
   }
 

--- a/scripts/render/RenderTopLevelUI.ts
+++ b/scripts/render/RenderTopLevelUI.ts
@@ -702,10 +702,7 @@ export class RenderPopup extends RenderNode {
         if ($tutorialContainer) {
           $tutorialContainer.on('touchend click', advanceTutorial);
           node.on('popup_close', () => {
-            $tutorialContainer.off(
-              'touchend click',
-              advanceTutorial as unknown as (...args: unknown[]) => unknown
-            );
+            $tutorialContainer.off('touchend click', advanceTutorial);
           });
         }
       }
@@ -859,7 +856,8 @@ export class RenderPopup extends RenderNode {
       }
     );
 
-    node.on('close_powerup', ((_e: UIEventLike, cb?: () => void) => {
+    node.on('close_powerup', (_e: UIEventLike, ...args: unknown[]) => {
+      const cb = args[0] as (() => void) | undefined;
       const jelem = node.lastButton;
       if (!jelem) return;
       jelem.removeClass('active');
@@ -872,7 +870,7 @@ export class RenderPopup extends RenderNode {
       if (cb) {
         window.setTimeout(cb, 400);
       }
-    }) as unknown as (e: UIEventLike) => void);
+    });
 
     jq.on(
       'click touchend',

--- a/scripts/render/RenderViews.ts
+++ b/scripts/render/RenderViews.ts
@@ -186,7 +186,7 @@ export class RenderViewTab extends RenderNode {
 
     // LISTEN TO STATES
     // FIXME: redundant to viewmap code
-    node.on('states_active', ((e: ViewDomEvent, value: unknown) => {
+    node.on('states_active', (e: ViewDomEvent, value: unknown) => {
       void e;
       if (value) {
         node.FXShow();
@@ -208,7 +208,7 @@ export class RenderViewTab extends RenderNode {
         }
         node.FXHide();
       }
-    }) as unknown as (e: ViewDomEvent) => void);
+    });
   }
 
   render(): void {
@@ -355,7 +355,7 @@ export class RenderViewMap extends RenderNode {
     this.zoomScale = config.zoomScale ?? 1;
 
     // LISTEN TO STATES
-    this.on('states_active', ((e: ViewDomEvent, value: unknown) => {
+    this.on('states_active', (e: ViewDomEvent, value: unknown) => {
       e.stopPropagation();
       const root = (this.gameNode as unknown as { GameRoot?: GameRootForView } | undefined)
         ?.GameRoot;
@@ -376,7 +376,7 @@ export class RenderViewMap extends RenderNode {
         }
         this.FXHide();
       }
-    }) as unknown as (e: ViewDomEvent) => void);
+    });
   }
 
   override addChild(child: RenderNode, ui_elem?: boolean): RenderNode {

--- a/scripts/render/_jqueryShim.ts
+++ b/scripts/render/_jqueryShim.ts
@@ -77,12 +77,12 @@ export interface JQueryRenderElem<E extends HTMLElement = HTMLElement> {
   height(value: number): JQueryRenderElem<E>;
 
   // events
-  on(
+  on<E2 extends JQueryRenderEvent = JQueryRenderEvent>(
     event: string,
-    selectorOrHandler: string | ((e: JQueryRenderEvent) => void),
-    handler?: (e: JQueryRenderEvent) => void
+    selectorOrHandler: string | ((e: E2, ...args: unknown[]) => void),
+    handler?: (e: E2, ...args: unknown[]) => void
   ): JQueryRenderElem<E>;
-  off(event?: string, handler?: (...args: unknown[]) => unknown): JQueryRenderElem<E>;
+  off(event?: string, handler?: (e: JQueryRenderEvent) => void): JQueryRenderElem<E>;
   trigger(event: string, params?: unknown[]): JQueryRenderElem<E>;
 
   // layout / styling


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Tightens `.off` handler type** in `JQueryRenderElem`: was `(...args: unknown[]) => unknown`, now `(e: JQueryRenderEvent) => void` — mirrors `.on` so handlers registered via `.on` can be passed directly to `.off` without casting
- **Adds generic `<E2>` to `.on`** so callers can narrow the event type; handler signature extended to `(e: E2, ...args: unknown[]) => void` to accommodate jQuery's extra trigger-data arguments (e.g. `states_active` passes a `value` and `close_powerup` passes a callback)
- **Updates `RenderNode.on`** (and `DragHandlerLike.on`) to accept `(e, ...args: unknown[]) => void` for consistency
- **Drops 5 `as unknown as` casts** that existed solely because of the old asymmetry:
  - `RenderTopLevelUI.ts:707` — `advanceTutorial` cast when passed to `.off`
  - `RenderTopLevelUI.ts:862-875` — `close_powerup` handler double-cast; `cb` extracted from `...args`
  - `RenderViews.ts:189-211` — `states_active` handler cast (`RenderViewTab`)
  - `RenderViews.ts:358-379` — `states_active` handler cast (`RenderViewMap`)

## Test plan

- [ ] `npx tsc --noEmit` — no errors in render scripts
- [ ] `npx biome check scripts/` — all 64 files pass
- [ ] `npm test` — 587 tests pass (build.test.js skipped due to worktree env; pre-existing)
- [ ] Note: `npm run build` and `npm run test:e2e` require the full vite/webxdc plugin stack not present in this worktree — both fail with the same ENOENT pre-existing to this PR

https://claude.ai/code/session_0114s4tU5yhogGcgxRhTig2i
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_0114s4tU5yhogGcgxRhTig2i)_