### PR TITLE
refactor(i18n): type I18nTable over actual JSON key union

### DIFF
--- a/scripts/LocalEngine.ts
+++ b/scripts/LocalEngine.ts
@@ -187,9 +187,12 @@ interface Ruleset {
   [key: string]: unknown;
 }
 
-/** i18n table entry: [msgctxt, msgstr]. */
-type I18nEntry = readonly [string, string];
-type I18nTable = Record<string, I18nEntry | undefined>;
+/** Union of all known translation keys derived from the canonical locale file. */
+type I18nKey = keyof typeof i18nEn;
+/** Locale-table entry: the actual value type from the JSON (metadata object or [msgctxt, msgstr] tuple). */
+type I18nEntry = (typeof i18nEn)[I18nKey];
+/** Typed over the exact key set of the canonical locale file. */
+type I18nTable = typeof i18nEn;
 
 /** Indexes built lazily over state.nodes. */
 interface NodeMaps {
@@ -339,9 +342,9 @@ export function setSendAchievement(fn: AchievementSender): void {
 function _t(msgid: string, ...subs: unknown[]): string {
   var state = getState();
   var locale: Locale = state && state.locale === 'en' ? 'en' : 'de';
-  var table = (locale === 'en' ? i18nEn : i18nDe) as unknown as I18nTable;
-  var entry = table[msgid];
-  var tmpl: string = entry && entry[1] ? entry[1] : msgid;
+  var table: I18nTable = locale === 'en' ? i18nEn : i18nDe;
+  var entry = table[msgid as I18nKey];
+  var tmpl: string = Array.isArray(entry) && entry[1] ? entry[1] : msgid;
   for (var i = 0; i < subs.length; i++) {
     tmpl = tmpl.replace('%s', String(subs[i]));
   }

--- a/scripts/i18n.ts
+++ b/scripts/i18n.ts
@@ -12,9 +12,12 @@ import deAT from '../i18n/de_AT.json' with { type: 'json' };
 import enUS from '../i18n/en_US.json' with { type: 'json' };
 import setup from './setup.js';
 
-/** Locale-table entry: msgctxt at [0], singular msgstr at [1], optional plural msgstr at [2]. */
-type I18nEntry = readonly (string | undefined)[];
-type I18nTable = Record<string, I18nEntry | undefined>;
+/** Union of all known translation keys derived directly from the canonical locale file. */
+type I18nKey = keyof typeof enUS;
+/** Locale-table entry: the actual value type from the JSON (metadata object or [msgctxt, msgstr] tuple). */
+type I18nEntry = (typeof enUS)[I18nKey];
+/** Typed over the exact key set of the canonical locale file — no unknown-key undefined overhead. */
+type I18nTable = typeof enUS;
 
 interface I18nApi {
   de_AT: I18nTable;
@@ -31,8 +34,8 @@ interface I18nApi {
 let locale = 'en_US';
 
 const i18n: I18nApi = {
-  de_AT: deAT as unknown as I18nTable,
-  en_US: enUS as unknown as I18nTable,
+  de_AT: deAT,
+  en_US: enUS,
 
   getLocale(): string {
     return locale;
@@ -55,9 +58,9 @@ const i18n: I18nApi = {
   gettext(msgid: string): string {
     const language = i18n[locale] as I18nTable | undefined;
     if (language) {
-      const message = language[msgid];
-      if (message && message.length > 0) {
-        return (message[1] as string | undefined) ?? msgid;
+      const message = language[msgid as I18nKey];
+      if (Array.isArray(message) && message[1]) {
+        return message[1];
       }
       console.warn('No %s translation available for msgid "%s"', locale, msgid);
     } else {
@@ -69,9 +72,10 @@ const i18n: I18nApi = {
   ngettext(msgid: string, msgidPlural: string, amount: number): string {
     const language = i18n[locale] as I18nTable | undefined;
     if (language) {
-      const message = language[msgid];
-      if (message && message.length > 0) {
-        const text = (amount === 1 ? message[1] : message[2]) as string | undefined;
+      const message = language[msgid as I18nKey];
+      if (Array.isArray(message) && message.length > 0) {
+        const arr = message as readonly (string | null | undefined)[];
+        const text = amount === 1 ? arr[1] : arr[2];
         if (text) return _.sprintf(text, _.toKSNum(amount));
       }
       console.warn('No %s translation available for msgid "%s"', locale, msgid);


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Replaces `Record<string, I18nEntry | undefined>` with `typeof enUS` so `I18nTable` is structurally tied to the 237-key union inferred directly from the canonical locale JSON files (`en_US.json` / `de_AT.json`).
- Both locales have identical key sets (verified), so `deAT` is directly assignable to `I18nTable` without any cast.
- Removes **3 `as unknown as I18nTable` casts** (2 in `scripts/i18n.ts`, 1 in `scripts/LocalEngine.ts`) and **1 downstream `as string | undefined` cast** on `message[1]` in `gettext` — the exact JSON tuple type `[null, string]` carries sufficient precision.
- Introduces `type I18nKey = keyof typeof enUS` in both files so dynamic `string` msgid lookups can be expressed as `table[msgid as I18nKey]` while runtime guards (`Array.isArray`) still protect against out-of-range keys.

## Test plan

- [x] `npx tsc --noEmit` — no new errors (pre-existing e2e/missing-module errors unchanged)
- [x] `npx biome check` — passes clean
- [x] `npm test` — 585 passed / 39 skipped (build.test.js failure is pre-existing worktree infra issue)
- [x] `npm run test:e2e` (from repo root) — 45 passed / 1 skipped
- [x] `npm run build` (from repo root) — builds successfully

https://claude.ai/code/session_0114s4tU5yhogGcgxRhTig2i
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_0114s4tU5yhogGcgxRhTig2i)_