### PR TITLE
type-debt: consume RenderApi via Pick at game/* call sites, retire structural shims

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ pnpm-debug.log
 /coverage/
 /test-results/
 /playwright-report/
+/.claude/

--- a/scripts/game/ClientPerp.ts
+++ b/scripts/game/ClientPerp.ts
@@ -6,7 +6,7 @@
 //
 // Extracted from scripts/Game.js's IIFE in PR 15 of issue #147.
 
-import { getRender } from '../Render.js';
+import { type RenderApi, getRender } from '../Render.js';
 import appModule from '../app.js';
 import { type GameNodeConfig } from './GameNode.js';
 import {
@@ -230,11 +230,9 @@ export class ClientPerp extends GamePerp {
     gperp.setState('chargeRunning', false);
     const timer = gperp.renderTimer as { FXPuff?(): void } | undefined;
     timer?.FXPuff?.();
-    const Render = getRender() as unknown as {
-      DecoratorReady: new (cfg: { mode: string }) => DecoratorReadyLike;
-    };
+    const Render = getRender() as Pick<RenderApi, 'DecoratorReady'>;
     const deco = new Render.DecoratorReady({ mode: 'money' });
-    gperp.renderReady = deco;
+    gperp.renderReady = deco as unknown as DecoratorReadyLike;
     const rn = this.renderNode as RenderNodeLike | undefined;
     rn?.addDecorator?.(deco);
     deco.FXSproing();

--- a/scripts/game/ContactPerp.ts
+++ b/scripts/game/ContactPerp.ts
@@ -7,7 +7,7 @@
 //
 // Extracted from scripts/Game.js's IIFE in PR 14 of issue #147.
 
-import { getRender } from '../Render.js';
+import { type RenderApi, getRender } from '../Render.js';
 import appModule from '../app.js';
 import { type GameNodeConfig } from './GameNode.js';
 import {
@@ -230,9 +230,7 @@ export class ContactPerp extends GamePerp {
     gperp.setState('chargeRunning', false);
     const timer = gperp.renderTimer as { FXPuff?(): void } | undefined;
     timer?.FXPuff?.();
-    const Render = getRender() as unknown as {
-      DecoratorReady: new () => DecoratorReadyLike;
-    };
+    const Render = getRender() as Pick<RenderApi, 'DecoratorReady'>;
     const rn = this.renderNode as RenderNodeLike | undefined;
     const deco = rn?.addDecorator?.(new Render.DecoratorReady()) as DecoratorReadyLike | undefined;
     if (!deco) return;

--- a/scripts/game/Database.ts
+++ b/scripts/game/Database.ts
@@ -7,7 +7,7 @@
 // `perpCtors[name]` (typed direct map, PR 17 of issue #147); the
 // known-name `Game.TokenPerp` reference uses a direct import.
 
-import { getRender } from '../Render.js';
+import { type RenderApi, getRender } from '../Render.js';
 import appModule from '../app.js';
 import i18n from '../i18n.js';
 import {
@@ -20,6 +20,7 @@ import {
   getByType,
   getFirstId,
 } from './GameNode.js';
+import { type RenderPopupLike } from './GamePerp.js';
 import { OrderedSet } from './OrderedSet.js';
 import { ProfileSet } from './ProfileSet.js';
 import { TokenPerp } from './TokenPerp.js';
@@ -30,9 +31,10 @@ import { perpCtors } from './perpCtors.js';
 // Local types
 // ---------------------------------------------------------------------------
 
-interface RenderMenuLike {
-  addButton(label: string, id: string, states: Record<string, boolean>): void;
-}
+// RenderMenuLike — replaced with a Pick of the actual MainMenu instance
+// type to retire the structural triplicate that lived here, in
+// Imperium.ts, Missions.ts, and Topscores.ts.
+type RenderMenuLike = Pick<InstanceType<RenderApi['MainMenu']>, 'addButton'>;
 
 interface RenderNodeLike {
   addChild?(node: unknown, ...args: unknown[]): void;
@@ -62,12 +64,8 @@ interface RenderNodeLike {
   trigger(ev: string, args?: unknown[]): void;
 }
 
-interface RenderPopupLike {
-  open?: boolean;
-  trigger(ev: string, args?: unknown[]): void;
-  close(): void;
-  on(ev: string, handler: (...args: unknown[]) => void): void;
-}
+// RenderPopupLike — re-imported from GamePerp.ts (canonical definition).
+// Was triplicated across Database / GameRoot / GameNode prior to this PR.
 
 /** GameRoot's surface this class touches.  Narrow forward-ref interface;
  *  will collapse when GameRoot is extracted to its own typed module. */
@@ -225,28 +223,8 @@ export class Database extends GameNode {
     return this.renderNode as RenderNodeLike | undefined;
   }
 
-  private getRenderModule(): {
-    Popup: new (cfg: unknown) => RenderPopupLike;
-    DBQueue: new (
-      cfg: unknown
-    ) => RenderNodeLike & {
-      gameNode?: Database;
-      render(): void;
-    };
-    DecoratorNew: new (cfg: unknown) => unknown;
-    getById(id: unknown): unknown;
-  } {
-    return getRender() as unknown as {
-      Popup: new (cfg: unknown) => RenderPopupLike;
-      DBQueue: new (
-        cfg: unknown
-      ) => RenderNodeLike & {
-        gameNode?: Database;
-        render(): void;
-      };
-      DecoratorNew: new (cfg: unknown) => unknown;
-      getById(id: unknown): unknown;
-    };
+  private getRenderModule(): Pick<RenderApi, 'Popup' | 'DBQueue' | 'DecoratorNew' | 'getById'> {
+    return getRender();
   }
 
   compileSuperTokens(): void {
@@ -330,7 +308,9 @@ export class Database extends GameNode {
       popupContainer: this,
     };
 
-    const popup = new Render.Popup(popupConfig);
+    const popup = new Render.Popup(
+      popupConfig as unknown as ConstructorParameters<RenderApi['Popup']>[0]
+    ) as unknown as RenderPopupLike;
     this.renderPopup = popup;
     this.renderApi?.addPopup?.(popup);
 
@@ -443,7 +423,12 @@ export class Database extends GameNode {
     // FIXME: name should be in data
     groot.renderMenu.addButton(i18n.gettext('Database'), this.id, this.states);
     this.compileSuperTokens();
-    this.renderDBQueue = new Render.DBQueue({ data: this.data, queue: this.queue });
+    this.renderDBQueue = new Render.DBQueue({
+      data: this.data,
+      queue: this.queue,
+    } as unknown as ConstructorParameters<RenderApi['DBQueue']>[0]) as unknown as NonNullable<
+      Database['renderDBQueue']
+    >;
     this.renderDBQueue.gameNode = this;
     this.renderApi?.addChild?.(this.renderDBQueue, true);
   }
@@ -722,7 +707,9 @@ export class Database extends GameNode {
       popupContainer: this,
     };
 
-    const popup = new Render.Popup(popupConfig);
+    const popup = new Render.Popup(
+      popupConfig as unknown as ConstructorParameters<RenderApi['Popup']>[0]
+    ) as unknown as RenderPopupLike;
     this.renderPopup = popup;
     (gnode.renderNode as RenderNodeLike | undefined)?.addPopup?.(popup);
 

--- a/scripts/game/DatabasePerp.ts
+++ b/scripts/game/DatabasePerp.ts
@@ -7,7 +7,7 @@
 //
 // Extracted from scripts/Game.js's IIFE in PR 12 of issue #147.
 
-import { getRender } from '../Render.js';
+import { type RenderApi, getRender } from '../Render.js';
 import appModule from '../app.js';
 import i18n from '../i18n.js';
 import { getByFirstId, getByType, getFirstId } from './GameNode.js';
@@ -54,9 +54,7 @@ export class DatabasePerp extends GamePerp {
   BuyCity(bgestalt: string, placePos?: { x: number; y: number }): void {
     const gnode = this;
     const groot = this.groot;
-    const Render = getRender() as unknown as {
-      DecoratorNew: new (cfg: unknown) => unknown;
-    };
+    const Render = getRender() as Pick<RenderApi, 'DecoratorNew'>;
     const buyPerpFn = appModule.getApplication().remote.buyPerp;
     if (!buyPerpFn) return;
     const path = gnode.path || '';

--- a/scripts/game/GameNode.ts
+++ b/scripts/game/GameNode.ts
@@ -19,12 +19,22 @@
 // don't crash on module load if those modules haven't initialised yet.
 
 import type { JQueryLike, JQueryStatic } from '../../types/env.d.ts';
-import { getRender } from '../Render.js';
+import { type RenderApi, getRender } from '../Render.js';
 import appModule from '../app.js';
 import setup from '../setup.js';
 import { getTypeSettings } from '../type_settings.js';
 import { OrderedSet } from './OrderedSet.js';
 import { mergeData } from './mergeData.js';
+
+// Typed dynamic constructor pick — replaces the loose
+// `(Render as Record<string, unknown>)[renderType]` lookup that used to
+// live in `render()`.  Constraining the key to `keyof RenderApi` makes
+// the lookup typed at the call site (`pickRenderCtor('Node')` → typeof
+// RenderNode etc.); callers that need to fall through to `undefined`
+// when `renderType` is empty / off-API check before calling.
+function pickRenderCtor<K extends keyof RenderApi>(k: K): RenderApi[K] {
+  return getRender()[k];
+}
 
 function _$(): JQueryStatic {
   const fn = jQuery ?? globalThis.$;
@@ -230,15 +240,18 @@ interface RenderNodeLike {
   [key: string]: unknown;
 }
 
-interface RenderPopupLike {
-  open?: boolean;
-  close(cb?: () => void): void;
-  trigger(ev: string, args?: unknown[]): void;
-  on(ev: string, handler: (...args: unknown[]) => void): void;
+// RenderPopupLike — was duplicated across GameNode / GameRoot / GamePerp
+// / Database / ProjectPerp.  Now imports the canonical declaration from
+// GamePerp.ts (a type-only import — no runtime cycle); the GameNode-side
+// extras (notification-popup tagging, jdomelem delegation handle) live
+// in `RenderPopupGameNodeExtras` below and merge in via `&`.
+import type { RenderPopupLike as RenderPopupBase } from './GamePerp.js';
+interface RenderPopupGameNodeExtras {
   jdomelem?: { on(ev: string, sel: string, handler: (e: unknown) => void): void };
   notificationMission?: string | null;
   callback?: () => void;
 }
+type RenderPopupLike = RenderPopupBase & RenderPopupGameNodeExtras;
 
 /** GameRoot surface this base class touches in its mixin methods.
  *  Narrow forward-ref interface; collapses when GameRoot itself
@@ -251,12 +264,10 @@ interface GameRootForGameNode {
 }
 
 // `Render[renderType]` is dynamic — each renderType key resolves to a
-// different constructor.  Captured loosely; the per-subclass extractions in
-// later PRs can tighten this once specific Render types are in scope.
-interface RenderModule {
-  getById(id: unknown): { addChild(node: RenderNodeLike): void } | null;
-  [key: string]: unknown;
-}
+// different constructor.  Resolved via the typed `pickRenderCtor` helper
+// at the top of this module; the previous `RenderModule` structural
+// surface (`[key:string]: unknown`) is retired in favour of a
+// `keyof RenderApi`-constrained lookup.
 
 // ---------------------------------------------------------------------------
 // GameNode
@@ -588,8 +599,14 @@ export class GameNode {
     const render = this.renderData;
 
     if (render && render.config && !render.config.no_render) {
-      const Render = getRender() as unknown as RenderModule;
-      const RenderCtor = (Render as Record<string, unknown>)[this.renderType ?? ''] as
+      const Render = getRender();
+      const renderType = this.renderType ?? '';
+      // Constrain the dynamic ctor lookup to `keyof RenderApi`; bail
+      // out for renderType values not on the API (e.g. unset / typo).
+      if (!(renderType in Render)) {
+        return;
+      }
+      const RenderCtor = pickRenderCtor(renderType as keyof RenderApi) as unknown as
         | (new (
             cfg: RenderConfig
           ) => RenderNodeLike)
@@ -603,9 +620,9 @@ export class GameNode {
       node.gameNode = this;
       // Put RenderNode in its place:
       if (render.parentNode) {
-        const parentNode = Render.getById(render.parentNode);
+        const parentNode = Render.getById(render.parentNode as string);
         if (parentNode) {
-          parentNode.addChild(node);
+          (parentNode as unknown as { addChild(n: RenderNodeLike): void }).addChild(node);
         }
       }
 
@@ -650,16 +667,14 @@ export class GameNode {
     ptd.groot = groot;
     gnode.popupTemplateData = ptd;
 
-    const Render = getRender() as unknown as {
-      Popup: new (cfg: unknown) => RenderPopupLike;
-    };
+    const Render = getRender() as Pick<RenderApi, 'Popup'>;
     const popup = new Render.Popup({
       gameNode: this,
       template: config.template || 'popup.html',
       extendClass: config.extendClass || '',
       templateData: gnode.popupTemplateData,
       popupContainer: this,
-    });
+    } as unknown as ConstructorParameters<RenderApi['Popup']>[0]) as unknown as RenderPopupLike;
     this.renderPopup = popup;
 
     (gnode.renderNode as RenderNodeLike | undefined)?.addPopup?.(popup);

--- a/scripts/game/GamePerp.ts
+++ b/scripts/game/GamePerp.ts
@@ -10,7 +10,7 @@
 // their own dynamic lookups against `perpCtors[name]` directly in
 // PR 17 of issue #147; this seam stays only for GamePerp's case.
 
-import { getRender } from '../Render.js';
+import { type RenderApi, getRender } from '../Render.js';
 import appModule from '../app.js';
 import i18n from '../i18n.js';
 import { GameNode, getAllByGestalt, getByFirstId, getFirstId } from './GameNode.js';
@@ -171,18 +171,11 @@ export class GamePerp extends GameNode {
     return this.renderNode as RenderNodeLike | undefined;
   }
 
-  private getRenderModule(): {
-    Popup: new (cfg: unknown) => RenderPopupLike;
-    DecoratorLabel: new (cfg: unknown) => unknown;
-    DecoratorNew: new (cfg: unknown) => unknown;
-    DecoratorTimer: new (cfg: unknown) => { FXSproing?(): void };
-  } {
-    return getRender() as unknown as {
-      Popup: new (cfg: unknown) => RenderPopupLike;
-      DecoratorLabel: new (cfg: unknown) => unknown;
-      DecoratorNew: new (cfg: unknown) => unknown;
-      DecoratorTimer: new (cfg: unknown) => { FXSproing?(): void };
-    };
+  private getRenderModule(): Pick<
+    RenderApi,
+    'Popup' | 'DecoratorLabel' | 'DecoratorNew' | 'DecoratorTimer'
+  > {
+    return getRender();
   }
 
   // -------------------------------------------------------------------
@@ -232,8 +225,8 @@ export class GamePerp extends GameNode {
     this.renderTimer = this.renderApi?.addDecorator?.(
       new Render.DecoratorTimer({
         duration: conf.duration,
-        serverTime: conf.serverTime,
-        serverStartTime: conf.serverStart,
+        ...(conf.serverTime !== undefined ? { serverTime: conf.serverTime } : {}),
+        ...(conf.serverStart !== undefined ? { serverStartTime: conf.serverStart } : {}),
       })
     ) as { FXSproing?(): void } | undefined;
     this.renderTimer?.FXSproing?.();
@@ -324,7 +317,7 @@ export class GamePerp extends GameNode {
       template: this.popupTemplate,
       templateData: this.popupTemplateData,
       popupContainer: this.ViewMap,
-    });
+    } as unknown as ConstructorParameters<RenderApi['Popup']>[0]) as unknown as RenderPopupLike;
 
     if (replaceExisting && this.renderPopup) {
       (this.renderPopup as RenderPopupLike).remove?.();

--- a/scripts/game/GameRoot.ts
+++ b/scripts/game/GameRoot.ts
@@ -17,7 +17,7 @@
 // `GameRoot.prototype.X = function () {...}` assignments in Game.js
 // for now; later PRs in the wave migrate them one batch at a time.
 
-import { getRender } from '../Render.js';
+import { type RenderApi, getRender } from '../Render.js';
 import appModule from '../app.js';
 import i18n from '../i18n.js';
 import setup from '../setup.js';
@@ -41,6 +41,7 @@ import {
   getGestalt,
   getParentFromPath,
 } from './GameNode.js';
+import type { RenderPopupLike } from './GamePerp.js';
 import { Imperium } from './Imperium.js';
 import { Mission } from './Mission.js';
 import { Missions } from './Missions.js';
@@ -132,15 +133,10 @@ interface Level {
   [key: string]: unknown;
 }
 
-/** Render Popup surface used by `openNotification`.  Same forward-
- *  ref shape as GamePerp's `RenderPopupLike` — duplicated here to
- *  keep this file self-contained until Render.js is typed. */
-interface RenderPopupLike {
-  open?: boolean;
-  trigger(ev: string, args?: unknown[]): void;
-  close(cb?: () => void): void;
-  on(ev: string, handler: (...args: unknown[]) => void): void;
-}
+// Render Popup surface used by `openNotification` — re-imports the
+// canonical `RenderPopupLike` from GamePerp.ts (was duplicated across
+// GameRoot / GameNode / GamePerp / Database / ProjectPerp before this
+// PR).
 
 /** Render MainMenu instance — created in `extendRender`. */
 interface MainMenuLike extends RenderRootLike {
@@ -1296,10 +1292,10 @@ export class GameRoot extends GameNode {
     config.templateData = popupTemplateData;
     config.popupContainer = this;
 
-    const Render = getRender() as unknown as {
-      Popup: new (cfg: unknown) => RenderPopupLike;
-    };
-    const popup = new Render.Popup(config) as RenderPopupLike & {
+    const Render = getRender() as Pick<RenderApi, 'Popup'>;
+    const popup = new Render.Popup(
+      config as unknown as ConstructorParameters<RenderApi['Popup']>[0]
+    ) as unknown as RenderPopupLike & {
       notificationMission?: string;
       callback?: () => void;
     };
@@ -1770,10 +1766,7 @@ export class GameRoot extends GameNode {
   }
 
   override extendRender(): void {
-    const Render = getRender() as unknown as {
-      MainMenu: new (cfg: unknown) => MainMenuLike;
-      Statusbar: new (data: unknown) => RenderStatusbarLike & { domelem?: unknown };
-    };
+    const Render = getRender() as Pick<RenderApi, 'MainMenu' | 'Statusbar'>;
     if (this.renderMenu) this.renderMenu.remove();
     const menu = new Render.MainMenu({
       gameNode: this,
@@ -1787,10 +1780,14 @@ export class GameRoot extends GameNode {
         userdata: this.userdata,
         buttons: [],
       },
-    });
+    } as unknown as ConstructorParameters<RenderApi['MainMenu']>[0]) as unknown as MainMenuLike & {
+      domelem?: unknown;
+    };
 
     this.initStatusBar();
-    const statusbar = new Render.Statusbar(this.data.status_bar);
+    const statusbar = new Render.Statusbar(
+      this.data.status_bar as unknown as ConstructorParameters<RenderApi['Statusbar']>[0]
+    ) as unknown as RenderStatusbarLike & { domelem?: unknown };
     this.renderStatusbar = statusbar as NonNullable<typeof this.renderStatusbar>;
 
     const stage = this.renderNode as

--- a/scripts/game/Imperium.ts
+++ b/scripts/game/Imperium.ts
@@ -2,15 +2,12 @@
 // Perp instances laid out).  Smallest extends-GameNode subclass.
 // Extracted from scripts/Game.js's IIFE in PR 8 of issue #147.
 
+import { type RenderApi } from '../Render.js';
 import i18n from '../i18n.js';
 import { GameNode } from './GameNode.js';
 
-interface RenderMenuLike {
-  addButton(label: string, id: string, states: Record<string, boolean>): void;
-}
-
 interface GameRootWithMenu {
-  renderMenu: RenderMenuLike;
+  renderMenu: Pick<InstanceType<RenderApi['MainMenu']>, 'addButton'>;
 }
 
 interface ImperiumRenderNode {

--- a/scripts/game/Missions.ts
+++ b/scripts/game/Missions.ts
@@ -2,15 +2,12 @@
 // one Mission child per active/completed mission gestalt.  Extracted from
 // scripts/Game.js's IIFE in PR 7 of issue #147.
 
+import { type RenderApi } from '../Render.js';
 import appModule from '../app.js';
 import i18n from '../i18n.js';
 import { GameNode, type GameNodeConfig, getByFirstId, getFirstId } from './GameNode.js';
 import { Mission } from './Mission.js';
 import { OrderedSet } from './OrderedSet.js';
-
-interface RenderMenuLike {
-  addButton(label: string, id: string, states: Record<string, boolean>): void;
-}
 
 interface RawMissionsData {
   missions: Array<{ gestalt?: string; type_data?: { gestalt?: string; [key: string]: unknown } }>;
@@ -19,7 +16,7 @@ interface RawMissionsData {
 }
 
 interface GameRootWithMissions {
-  renderMenu: RenderMenuLike;
+  renderMenu: Pick<InstanceType<RenderApi['MainMenu']>, 'addButton'>;
   renderNode?: { FXMissionGoalComplete?: () => void };
   addType(gestalt: string, data: unknown): unknown;
   getTypeData(gestalt?: string): Record<string, unknown> | undefined;

--- a/scripts/game/ProjectPerp.ts
+++ b/scripts/game/ProjectPerp.ts
@@ -11,7 +11,7 @@
 //
 // Extracted from scripts/Game.js's IIFE in PR 15 of issue #147.
 
-import { getRender } from '../Render.js';
+import { type RenderApi, getRender } from '../Render.js';
 import appModule from '../app.js';
 import i18n from '../i18n.js';
 import { type GameNodeConfig } from './GameNode.js';
@@ -664,9 +664,7 @@ export class ProjectPerp extends GamePerp {
     gperp.setState('chargeRunning', false);
     const timer = gperp.renderTimer as { FXPuff?(): void } | undefined;
     timer?.FXPuff?.();
-    const Render = getRender() as unknown as {
-      DecoratorReady: new () => DecoratorReadyLike;
-    };
+    const Render = getRender() as Pick<RenderApi, 'DecoratorReady'>;
     const rn = this.renderNode as RenderNodeLike | undefined;
     const deco = rn?.addDecorator?.(new Render.DecoratorReady()) as DecoratorReadyLike | undefined;
     if (!deco) return;

--- a/scripts/game/ProxyPerp.ts
+++ b/scripts/game/ProxyPerp.ts
@@ -3,7 +3,7 @@
 // label decorator that updates after every render.  Extracted from
 // scripts/Game.js's IIFE in PR 13 of issue #147.
 
-import { getRender } from '../Render.js';
+import { type RenderApi, getRender } from '../Render.js';
 import i18n from '../i18n.js';
 import { type GameNodeConfig } from './GameNode.js';
 import { GamePerp, type RenderNodeLike } from './GamePerp.js';
@@ -49,9 +49,7 @@ export class ProxyPerp extends GamePerp {
   updateRenderSlotStatus(): void {
     const node = this.renderNode as RenderNodeLike | undefined;
     if (!node) return;
-    const Render = getRender() as unknown as {
-      DecoratorLabel: new (cfg: { text: string }) => unknown;
-    };
+    const Render = getRender() as Pick<RenderApi, 'DecoratorLabel'>;
     const dataRec = this.data as {
       label?: string;
       used_slots?: number;

--- a/scripts/game/TokenPerp.ts
+++ b/scripts/game/TokenPerp.ts
@@ -9,7 +9,7 @@
 //
 // Extracted from scripts/Game.js's IIFE in PR 16 of issue #147.
 
-import { getRender } from '../Render.js';
+import { type RenderApi, getRender } from '../Render.js';
 import appModule from '../app.js';
 import { type GameNodeConfig, getByGestalt } from './GameNode.js';
 import {
@@ -153,7 +153,7 @@ export class TokenPerp extends GamePerp {
     const av = this.getUpgradeAverage();
     const frame = av > 0 ? 'normal' : 'inactive';
     if (!rn.DecoratorGear) {
-      const Render = getRender() as unknown as { DecoratorGear: new () => DecoratorGearLike };
+      const Render = getRender() as Pick<RenderApi, 'DecoratorGear'>;
       rn.addDecorator?.(new Render.DecoratorGear());
     }
     rn.DecoratorGear?.setFrame(frame);
@@ -181,11 +181,10 @@ export class TokenPerp extends GamePerp {
   }
 
   override extendRender(): void {
-    const Render = getRender() as unknown as {
-      DecoratorLabel: new (cfg: unknown) => unknown;
-      DecoratorAmount: new (cfg: unknown) => unknown;
-      DecoratorGear: new () => DecoratorGearLike;
-    };
+    const Render = getRender() as Pick<
+      RenderApi,
+      'DecoratorLabel' | 'DecoratorAmount' | 'DecoratorGear'
+    >;
     const render = this.renderData || {};
     const node = this.renderNode as TokenRenderNodeLike | undefined;
     if (!node) return;
@@ -374,9 +373,7 @@ export class TokenPerp extends GamePerp {
             data.result.missions
           );
           deco.FXSuck(function () {
-            const Render = getRender() as unknown as {
-              DecoratorGear: new () => DecoratorGearLike;
-            };
+            const Render = getRender() as Pick<RenderApi, 'DecoratorGear'>;
             const rn = gperp.renderNode as TokenRenderNodeLike | undefined;
             rn?.addDecorator?.(new Render.DecoratorGear());
             gperp.updateGear();
@@ -440,9 +437,7 @@ export class TokenPerp extends GamePerp {
     gperp.setState('chargeRunning', false);
     const timer = gperp.renderTimer as { FXPuff?(): void } | undefined;
     timer?.FXPuff?.();
-    const Render = getRender() as unknown as {
-      DecoratorReady: new (cfg: { mode: string }) => DecoratorReadyLike;
-    };
+    const Render = getRender() as Pick<RenderApi, 'DecoratorReady'>;
     const rn = this.renderNode as RenderNodeLike | undefined;
     const deco = rn?.addDecorator?.(new Render.DecoratorReady({ mode: 'gear' })) as
       | DecoratorReadyLike

--- a/scripts/game/Topscores.ts
+++ b/scripts/game/Topscores.ts
@@ -3,6 +3,7 @@
 // the Render API.  Extracted from scripts/Game.js's IIFE in PR 6 of
 // issue #147.
 
+import { type RenderApi } from '../Render.js';
 import * as bootMod from '../boot.js';
 import i18n from '../i18n.js';
 import {
@@ -24,18 +25,14 @@ interface TopscoreRenderNodeMenu {
   };
 }
 
-interface RenderMenuLike {
-  addButton(label: string, id: string, states: Record<string, boolean>): void;
-}
-
 // Local view of GameRoot's surface used by Topscores — declared standalone
 // rather than as `extends GameNode` because GameNode types `renderMenu`
 // loosely (RenderNodeLike) for the base class's needs and this file needs
-// the narrower `addButton` shape.  The cast at use sites goes through
-// `unknown` to bridge the two views; will dissolve when GameRoot is
-// extracted in a later PR.
+// the narrower `addButton` shape.  The renderMenu property reuses the
+// MainMenu instance type from Render.ts (PR retired the local
+// `RenderMenuLike` triplicate).
 interface GameRootWithMenu {
-  renderMenu: RenderMenuLike;
+  renderMenu: Pick<InstanceType<RenderApi['MainMenu']>, 'addButton'>;
   getTypeData(gestalt?: string): unknown;
 }
 


### PR DESCRIPTION
## Summary

Strict-TS migration left every game-side render touchpoint hand-rolling its own
`getRender() as unknown as { ... }` view of the publisher.  This PR routes all
of them through the `RenderApi` interface that `scripts/Render.ts` already
exports, using `Pick<RenderApi, 'X' | 'Y'>` per call site so each consumer keeps
its own narrow surface — but the surface now traces back to the real class
types instead of a parallel duplicate.

**`getRender() as unknown as { ... }` casts under `scripts/game/`: 15 → 0.**

Sites converted (file:line refers to pre-PR positions):
- `GameRoot.ts:1773` (MainMenu + Statusbar in `extendRender`) and `:1299` (Popup in `openNotification`)
- `GameNode.ts:591` (`Render[renderType]` ctor lookup) and `:653` (`openGenericPopup`)
- `ProjectPerp.ts:667` (DecoratorReady in `markReady`)
- `TokenPerp.ts:156`, `:184`, `:377`, `:443` (DecoratorGear / DecoratorLabel / DecoratorAmount / DecoratorReady across `updateGear` / `extendRender` / `collect` / `markReady`)
- `Database.ts:239` (`getRenderModule` Popup/DBQueue/DecoratorNew/getById)
- `GamePerp.ts:180` (`getRenderModule` Popup/DecoratorLabel/DecoratorNew/DecoratorTimer)
- `DatabasePerp.ts:57` (DecoratorNew in `BuyCity`)
- `ClientPerp.ts:233`, `ContactPerp.ts:233`, `ProxyPerp.ts:52` (per-perp DecoratorReady / DecoratorLabel)

### Structural shims dissolved

- **`RenderMenuLike`** (4×: `Imperium.ts`, `Missions.ts`, `Topscores.ts`, `Database.ts`) → `Pick<InstanceType<RenderApi['MainMenu']>, 'addButton'>` reused at each `GameRootWith*` interface.
- **`RenderPopupLike`** (5×: `GameRoot.ts:138`, `GameNode.ts:233`, `GamePerp.ts:47`, `Database.ts:65`, plus the `extends`-base referenced from `ProjectPerp.ts:65`) → single canonical declaration kept on `GamePerp.ts` and re-imported via `import type` everywhere else (`GameNode` keeps a `RenderPopupGameNodeExtras` mixin for its `notificationMission` / `callback` / `jdomelem.on` extras).
- **`RenderModule { [key: string]: unknown }`** in `GameNode.ts:256` → typed `pickRenderCtor<K extends keyof RenderApi>(k: K): RenderApi[K]` helper + runtime `(renderType in Render)` guard in `render()`.  The dynamic ctor lookup is now `keyof RenderApi`-constrained instead of stringly-keyed.

Strict-cast escape hatches at the popup-construction lines that didn't move (e.g. `popupContainer: this` not satisfying `PopupContainerLike` because GameNode types `renderNode` as `RenderNodeLike`) are localised to a single `as unknown as ConstructorParameters<RenderApi['Popup']>[0]` per call site instead of bleeding into a duplicated structural surface.

## Test plan

- [x] `npx tsc --noEmit` (clean — same as baseline)
- [x] `npx biome check` (clean after `--write` reordered the new imports)
- [x] `npm test` — 626 passed across 17 files
- [x] `npm run test:e2e` — 45 passed, 1 skipped
- [x] `npm run build` — `dist/scripts/esm-bundle.js` 1098.70 kB, gzip 198.75 kB

https://claude.ai/code/session_01Ah37AyDsgdqiCdLuTeeYDz

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ah37AyDsgdqiCdLuTeeYDz)_