### PR TITLE
Document build pipeline and add bundle size monitoring

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,6 +107,12 @@ jobs:
         # Casual variant assets are pre-quantized in img-casual/ and
         # icon-casual.png; CI does not need pngquant/oxipng installed.
         # See README.md "Bundle variants" and `pnpm quantize-assets`.
+        #
+        # BUILD_RELEASE=1 on tag builds drops sourcemaps from the .xdc
+        # (vite.config.js: build.sourcemap = !isRelease).  PR / dispatch
+        # builds keep sourcemaps so testers can debug the artifact.
+        env:
+          BUILD_RELEASE: ${{ startsWith(github.ref, 'refs/tags/v') && '1' || '' }}
         run: pnpm build:all
 
       - name: Get .xdc bundle info
@@ -117,12 +123,21 @@ jobs:
           HQ_COUNT=$(unzip -l data-dealer-hq.xdc | tail -1 | awk '{print $2}')
           CASUAL_SIZE=$(du -h data-dealer-casual.xdc | cut -f1)
           CASUAL_COUNT=$(unzip -l data-dealer-casual.xdc | tail -1 | awk '{print $2}')
+          # JS bundle size: extracted byte count of scripts/esm-bundle.js
+          # inside the (already-built) HQ .xdc.  Variants share the same
+          # JS bundle, so HQ is sufficient; reading from the .xdc avoids
+          # leaving an unzipped dist/ around.
+          JS_BYTES=$(unzip -p data-dealer-hq.xdc scripts/esm-bundle.js | wc -c)
+          JS_SIZE=$(numfmt --to=iec --suffix=B "$JS_BYTES")
           {
             echo "hq_size=$HQ_SIZE"
             echo "hq_count=$HQ_COUNT"
             echo "casual_size=$CASUAL_SIZE"
             echo "casual_count=$CASUAL_COUNT"
+            echo "js_size=$JS_SIZE"
+            echo "js_bytes=$JS_BYTES"
           } >> "$GITHUB_OUTPUT"
+          echo "::notice title=Bundle size::scripts/esm-bundle.js = $JS_SIZE ($JS_BYTES bytes)"
 
       - name: Upload HQ .xdc artifact
         if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v')
@@ -159,6 +174,8 @@ jobs:
             quantizes sprite atlases to a 256-color palette (visually
             indistinguishable on cartoon art) for ~60% smaller bundle.
             Drop either file into Delta Chat to test.
+
+            **JS bundle:** `scripts/esm-bundle.js` = ${{ steps.xdc_info.outputs.js_size }} (${{ steps.xdc_info.outputs.js_bytes }} bytes), minified by esbuild and tree-shaken by Rollup. Sourcemap (`esm-bundle.js.map`) ships alongside in dev/test builds for in-app debugging — release tag builds (`BUILD_RELEASE=1`) strip it.
 
   playwright:
     name: Playwright e2e tests

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,34 @@
 # Architecture
 
+## Build pipeline
+
+`vite build` rolls every TypeScript module under `scripts/` (entry:
+`scripts/esm-entry.ts`) into a single iife at `dist/scripts/esm-bundle.js`.
+The legacy AMD layer is gone (#58); strict TS (#147) gives Rollup enough
+ESM signal to tree-shake unused exports.
+
+| Concern | Setting (`vite.config.js → build.*`) | Notes |
+|---|---|---|
+| Bundle shape | `rollupOptions.input = 'scripts/esm-entry.js'`, `output.format = 'iife'`, `output.name = '__DD'` | Single `<script defer>` in `index.html`. iife (not esm) so the .xdc loads without import-map plumbing. |
+| Minification | `minify: 'esbuild'` (explicit) | Vite's default; pinned so a future Vite major can't silently flip it off. |
+| Tree-shaking | Rollup default for ESM input | Verify after a bundle-affecting change: add an unused export to a small module, build, `unzip -p data-dealer-hq.xdc scripts/esm-bundle.js \| grep` — should be absent. |
+| Sourcemaps | `sourcemap: !isRelease` | `BUILD_RELEASE=1` env var (set by CI on tag builds) strips `.map` from the .xdc. Default builds keep them so PR-attached .xdc artifacts are debuggable. |
+| Asset inlining | `assetsInlineLimit: 4096` (explicit) | Files under 4 KB inline as base64; larger ones stay as separate dist files. |
+| CSS | Loaded via `<link>` tags in `index.html`, copied verbatim by `vite-plugin-static-copy` | Not bundle-processed by Vite. If a future task wants a single `dist/assets/style.[hash].css`, switch to `import`-ing the CSS from `esm-entry.ts` and remove the static-copy entries. |
+| Vendor libs | `vendor/*.js` shipped as separate files, loaded as plain `<script>` tags before the bundle (`index.html`) | Each lib attaches a browser global (`$`, `_`, `numeral`, `sprintf`, `createjs`, `Scroller`); the ESM bundle reads from `globalThis` via `scripts/webxdc-shim.ts` etc. Not rolled into the bundle — see #192 "Out of scope". |
+| Static data | `data/`, `i18n/`, `img/`, fonts copied via `vite-plugin-static-copy` | Runtime-loaded JSON (rulesets, i18n) stays as separate files; sprites and fonts likewise. |
+| `.xdc` packaging | `@webxdc/vite-plugins` `buildXDC` (last plugin) | Zips `dist/` to `data-dealer-{hq,casual}.xdc`. |
+
+CI (`.github/workflows/test.yml`) prints the post-build `scripts/esm-bundle.js`
+byte count on every PR / dispatch run and surfaces it in the sticky
+`xdc-artifact` comment alongside the .xdc downloads. Tag builds set
+`BUILD_RELEASE=1` so the released .xdc has no sourcemap.
+
+Background: filed in #192. Sequenced after #58 (AMD → ESM) and #147
+(strict TS) made real bundling possible; lands before the Phase 8 mobile
+work (#80) and the Preact dialog refactor so both have a clean baseline
+to compare against.
+
 ## Key frontend modules
 
 #### `scripts/app.js`

--- a/tests/build/build.test.js
+++ b/tests/build/build.test.js
@@ -95,6 +95,26 @@ describe('dist/scripts/esm-bundle.js', () => {
     const bundle = readFileSync(join(root, 'dist', 'scripts', 'esm-bundle.js'), 'utf8');
     expect(bundle).not.toContain('define.amd');
   });
+
+  // Regression guard for #192: catch a future config edit that disables
+  // `build.minify`.  esbuild keeps one statement per line at module
+  // boundaries (so line count alone isn't useful), but it strips all
+  // intra-statement whitespace — average line length jumps from ~30
+  // chars (unminified, indented Rollup output) to several hundred.
+  it('is minified (long packed lines, no leading whitespace)', async () => {
+    const { readFileSync } = await import('node:fs');
+    const bundle = readFileSync(join(root, 'dist', 'scripts', 'esm-bundle.js'), 'utf8');
+    const lines = bundle.split('\n');
+    const avgLineLen = bundle.length / lines.length;
+    expect(avgLineLen).toBeGreaterThan(100);
+  });
+
+  // Default builds (BUILD_RELEASE unset) emit a separate .map file; tag
+  // builds set BUILD_RELEASE=1 to drop it.  Local `pnpm test` always
+  // takes the dev/test branch, so the .map should be present.
+  it('ships a sourcemap for dev/test builds', () => {
+    expect(existsSync(join(root, 'dist', 'scripts', 'esm-bundle.js.map'))).toBe(true);
+  });
 });
 
 // Both variants ship the same files (manifest, icon, scripts, etc.) — the

--- a/vite.config.js
+++ b/vite.config.js
@@ -14,6 +14,11 @@ if (variant !== 'hq' && variant !== 'casual') {
   throw new Error(`BUILD_VARIANT must be 'hq' or 'casual', got '${variant}'`);
 }
 
+// Release builds (CI tag pipeline) set BUILD_RELEASE=1 to drop sourcemaps
+// from the .xdc.  Dev/test builds keep sourcemaps so a tester loading the
+// .xdc into Delta Chat can debug against the original sources.
+const isRelease = process.env.BUILD_RELEASE === '1';
+
 // Plugin: for the casual variant, after vite-plugin-static-copy has run,
 // replace the canonical dist/img/ + dist/icon.png with the pre-quantized
 // counterparts (img-casual/, icon-casual.png).  This keeps the in-bundle
@@ -176,6 +181,28 @@ export default defineConfig({
   build: {
     outDir: 'dist',
     emptyOutDir: true,
+    // Tree-shaking and minification (esbuild) come for free from Rollup
+    // + Vite defaults — set them explicitly so the .xdc artifact never
+    // accidentally regresses to an unminified bundle if a future Vite
+    // major flips a default.
+    minify: 'esbuild',
+    // Sourcemaps in dev/test (.xdc files attached to PRs); stripped from
+    // release artifacts to keep tag-built .xdc bytes lean and avoid
+    // shipping original-source paths to end users.  Gated via
+    // BUILD_RELEASE=1 (set by .github/workflows/test.yml on tag builds).
+    sourcemap: !isRelease,
+    // Default is 4096; pin it so the threshold for inlining small icons
+    // / fonts vs. shipping them as separate dist/ files is visible in
+    // config rather than implicit in Vite version bumps.
+    assetsInlineLimit: 4096,
+    // Vite's default 500 kB warning fires noisily on every build at the
+    // current ~1.1 MB minified bundle.  webxdc apps load once from local
+    // storage; HTTP-request elimination via code-splitting wouldn't help
+    // (every chunk just becomes another file inside the .xdc).  See #192
+    // "Out of scope".  Raise the threshold to 1500 kB so the warning
+    // resurfaces only if the bundle grows past where re-evaluating the
+    // single-chunk decision actually makes sense.
+    chunkSizeWarningLimit: 1500,
     rollupOptions: {
       input: 'scripts/esm-entry.js',
       output: {


### PR DESCRIPTION
## Summary
This PR adds comprehensive documentation of the build pipeline architecture and implements bundle size monitoring in CI. It makes build configuration explicit and visible, with regression guards to prevent accidental bundle bloat or loss of minification.

## Key Changes

- **Architecture documentation** (`docs/architecture.md`): Added detailed "Build pipeline" section documenting:
  - Bundle shape (single IIFE, entry point, output format)
  - Minification strategy (esbuild, explicitly pinned)
  - Tree-shaking verification approach
  - Sourcemap handling (dev/test vs. release builds)
  - Asset inlining thresholds
  - CSS and vendor library loading strategy
  - Static data handling
  - XDC packaging process
  - Background and sequencing context

- **Build configuration hardening** (`vite.config.js`):
  - Added `BUILD_RELEASE` environment variable support to conditionally strip sourcemaps from release builds
  - Explicitly pinned `minify: 'esbuild'` to prevent future Vite major versions from silently disabling minification
  - Explicitly set `sourcemap: !isRelease` to keep sourcemaps in dev/test builds for debugging
  - Explicitly set `assetsInlineLimit: 4096` to make the inlining threshold visible in config
  - Raised `chunkSizeWarningLimit` to 1500 kB to suppress noise from the current ~1.1 MB single-chunk bundle

- **Build regression tests** (`tests/build/build.test.js`):
  - Added minification verification test that checks for long packed lines (average line length > 100 chars)
  - Added sourcemap presence test for dev/test builds

- **CI bundle monitoring** (`.github/workflows/test.yml`):
  - Set `BUILD_RELEASE=1` environment variable on tag builds to strip sourcemaps from release artifacts
  - Added JS bundle size extraction and reporting from the built .xdc file
  - Display bundle size in CI notice and PR comment with both human-readable (IEC) and byte formats
  - Updated PR comment template to include JS bundle size and sourcemap information

## Notable Implementation Details

- Sourcemap stripping is gated by `BUILD_RELEASE=1` environment variable, set only on tag builds by CI
- Bundle size is extracted directly from the built .xdc file using `unzip -p`, avoiding the need to keep unzipped dist/ artifacts
- The minification test uses average line length as a proxy for minification state, since esbuild maintains one statement per line at module boundaries
- All build configuration changes include detailed comments explaining the rationale and linking to relevant issues (#192, #58, #147, #80)

https://claude.ai/code/session_017YJpnkDdgV1cimmqKyJ15S