### PR TITLE
type-debt: retire GameRootWithMenu shim in Topscores.ts

### DIFF
--- a/scripts/game/GameNode.ts
+++ b/scripts/game/GameNode.ts
@@ -23,6 +23,7 @@ import { type RenderApi, getRender } from '../Render.js';
 import appModule from '../app.js';
 import setup from '../setup.js';
 import { getTypeSettings } from '../type_settings.js';
+import type { GameRoot } from './GameRoot.js';
 import { OrderedSet } from './OrderedSet.js';
 import { mergeData } from './mergeData.js';
 
@@ -279,7 +280,7 @@ export class GameNode {
   children!: OrderedSet<GameNode>;
   states!: Record<string, boolean>;
   /** Backlink to the GameRoot instance (always _instances[0]). */
-  GameRoot!: GameNode;
+  GameRoot!: GameRoot;
   /** jQuery wrapper used as the GameNode's event bus. */
   jq!: JQueryLike;
 
@@ -349,7 +350,9 @@ export class GameNode {
     // _instances[0] is GameRoot by convention (first GameNode constructed).
     // Cast away the `| undefined` from get() — by the time any non-Root
     // GameNode is created, the Root must have been constructed first.
-    this.GameRoot = (get(0) as GameNode | undefined) ?? this;
+    // The `this` fallback covers GameRoot's own bootstrap (where it's the
+    // only GameNode in existence and therefore *is* the GameRoot).
+    this.GameRoot = (get(0) ?? this) as GameRoot;
     this.setAttrs(cfg);
     this.makeRenderConfig();
     this.jq = _$()(this);

--- a/scripts/game/Imperium.ts
+++ b/scripts/game/Imperium.ts
@@ -2,13 +2,8 @@
 // Perp instances laid out).  Smallest extends-GameNode subclass.
 // Extracted from scripts/Game.js's IIFE in PR 8 of issue #147.
 
-import { type RenderApi } from '../Render.js';
 import i18n from '../i18n.js';
 import { GameNode } from './GameNode.js';
-
-interface GameRootWithMenu {
-  renderMenu: Pick<InstanceType<RenderApi['MainMenu']>, 'addButton'>;
-}
 
 interface ImperiumRenderNode {
   lock?(): void;
@@ -28,8 +23,7 @@ export class Imperium extends GameNode {
     this.setState('active', true);
     // FIXME: name should be in data
     // this.GameRoot.renderMenu.addButton(this.renderData.config.name, this.id, this.states);
-    const groot = this.GameRoot as unknown as GameRootWithMenu;
-    groot.renderMenu.addButton(i18n.gettext('My Empire'), this.id, this.states);
+    this.GameRoot.renderMenu?.addButton?.(i18n.gettext('My Empire'), this.id, this.states);
   }
 
   lock(): void {

--- a/scripts/game/Topscores.ts
+++ b/scripts/game/Topscores.ts
@@ -3,7 +3,6 @@
 // the Render API.  Extracted from scripts/Game.js's IIFE in PR 6 of
 // issue #147.
 
-import { type RenderApi } from '../Render.js';
 import * as bootMod from '../boot.js';
 import i18n from '../i18n.js';
 import {
@@ -23,17 +22,6 @@ interface TopscoreRenderNodeMenu {
   jdomelem?: {
     find?: (sel: string) => { addClass?: (c: string) => void };
   };
-}
-
-// Local view of GameRoot's surface used by Topscores — declared standalone
-// rather than as `extends GameNode` because GameNode types `renderMenu`
-// loosely (RenderNodeLike) for the base class's needs and this file needs
-// the narrower `addButton` shape.  The renderMenu property reuses the
-// MainMenu instance type from Render.ts (PR retired the local
-// `RenderMenuLike` triplicate).
-interface GameRootWithMenu {
-  renderMenu: Pick<InstanceType<RenderApi['MainMenu']>, 'addButton'>;
-  getTypeData(gestalt?: string): unknown;
 }
 
 export class Topscores extends GameNode {
@@ -59,7 +47,6 @@ export class Topscores extends GameNode {
 
   initTopscore(type: string | undefined): Topscore | undefined {
     if (type === undefined) return undefined;
-    const groot = this.GameRoot as unknown as GameRootWithMenu;
     const cfg: GameNodeConfig = {
       id: 'Topscore' + type,
       gestalt: 'topscore_' + type,
@@ -69,7 +56,7 @@ export class Topscores extends GameNode {
       ViewMap: getByFirstId('Topscores'),
       gameType: 'Topscore',
     };
-    const td = groot.getTypeData('Topscore') as Record<string, unknown> | undefined;
+    const td = this.GameRoot.getTypeData('Topscore') as Record<string, unknown> | undefined;
     if (td) cfg.data = td;
     const score = new Topscore(cfg);
     this.addChild(score);
@@ -86,8 +73,7 @@ export class Topscores extends GameNode {
   }
 
   override extendRender(): void {
-    const groot = this.GameRoot as unknown as GameRootWithMenu;
-    groot.renderMenu.addButton(i18n.gettext('Topscores'), this.id, this.states);
+    this.GameRoot.renderMenu?.addButton?.(i18n.gettext('Topscores'), this.id, this.states);
   }
 
   override extendEventHandlers(): void {


### PR DESCRIPTION
## Summary

Follow-up cleanup stacked on #248. Now that `GameNode.GameRoot` is typed as the actual `GameRoot` class (via `import type`), the local `GameRootWithMenu` shim in `scripts/game/Topscores.ts` is redundant.

Changes:
- Delete the `GameRootWithMenu` interface block.
- Delete both `const groot = this.GameRoot as unknown as GameRootWithMenu;` casts (in `initTopscore` and `extendRender`).
- Use `this.GameRoot` directly. `renderMenu` is optional on the real `GameRoot`, so `extendRender` now uses optional chaining (`this.GameRoot.renderMenu?.addButton?.(...)`), matching the style PR #248 used in `Imperium.ts`.
- Drop the now-unused `import { type RenderApi } from '../Render.js';`.

Net diff: 1 file changed, 2 insertions(+), 16 deletions(-). Removes 2 `as unknown as` casts from `scripts/` (126 -> 124).

## Test plan

- [x] `pnpm typecheck` introduces no new errors (101 pre-existing playwright/e2e errors unchanged before and after).
- [x] `pnpm lint` (biome) clean.

Base is set to `claude/typedebt-gamenode-backlink-spike` so this auto-retargets to master when #248 merges.

https://claude.ai/code/session_017gPuFHF6MdaSov26RW5NTZ

---
_Generated by [Claude Code](https://claude.ai/code/session_017gPuFHF6MdaSov26RW5NTZ)_