### PR TITLE
type-debt: retire GameRootWithMissions shim in Mission.ts

### DIFF
--- a/scripts/game/GameNode.ts
+++ b/scripts/game/GameNode.ts
@@ -23,6 +23,7 @@ import { type RenderApi, getRender } from '../Render.js';
 import appModule from '../app.js';
 import setup from '../setup.js';
 import { getTypeSettings } from '../type_settings.js';
+import type { GameRoot } from './GameRoot.js';
 import { OrderedSet } from './OrderedSet.js';
 import { mergeData } from './mergeData.js';
 
@@ -279,7 +280,7 @@ export class GameNode {
   children!: OrderedSet<GameNode>;
   states!: Record<string, boolean>;
   /** Backlink to the GameRoot instance (always _instances[0]). */
-  GameRoot!: GameNode;
+  GameRoot!: GameRoot;
   /** jQuery wrapper used as the GameNode's event bus. */
   jq!: JQueryLike;
 
@@ -349,7 +350,9 @@ export class GameNode {
     // _instances[0] is GameRoot by convention (first GameNode constructed).
     // Cast away the `| undefined` from get() — by the time any non-Root
     // GameNode is created, the Root must have been constructed first.
-    this.GameRoot = (get(0) as GameNode | undefined) ?? this;
+    // The `this` fallback covers GameRoot's own bootstrap (where it's the
+    // only GameNode in existence and therefore *is* the GameRoot).
+    this.GameRoot = (get(0) ?? this) as GameRoot;
     this.setAttrs(cfg);
     this.makeRenderConfig();
     this.jq = _$()(this);

--- a/scripts/game/Imperium.ts
+++ b/scripts/game/Imperium.ts
@@ -2,13 +2,8 @@
 // Perp instances laid out).  Smallest extends-GameNode subclass.
 // Extracted from scripts/Game.js's IIFE in PR 8 of issue #147.
 
-import { type RenderApi } from '../Render.js';
 import i18n from '../i18n.js';
 import { GameNode } from './GameNode.js';
-
-interface GameRootWithMenu {
-  renderMenu: Pick<InstanceType<RenderApi['MainMenu']>, 'addButton'>;
-}
 
 interface ImperiumRenderNode {
   lock?(): void;
@@ -28,8 +23,7 @@ export class Imperium extends GameNode {
     this.setState('active', true);
     // FIXME: name should be in data
     // this.GameRoot.renderMenu.addButton(this.renderData.config.name, this.id, this.states);
-    const groot = this.GameRoot as unknown as GameRootWithMenu;
-    groot.renderMenu.addButton(i18n.gettext('My Empire'), this.id, this.states);
+    this.GameRoot.renderMenu?.addButton?.(i18n.gettext('My Empire'), this.id, this.states);
   }
 
   lock(): void {

--- a/scripts/game/Mission.ts
+++ b/scripts/game/Mission.ts
@@ -33,17 +33,6 @@ interface TutorialStep {
   [key: string]: unknown;
 }
 
-interface GameRootWithMissions {
-  IPerps: Record<string, unknown>;
-  raw_data?: { mission_briefings_seen?: Record<string, unknown>; [key: string]: unknown };
-  DBTokensAbsolute: Record<string, number>;
-  Missions?: { children: { set: Mission[] } };
-  setState(state: string, value: boolean): void;
-  makeNotifications(data: Record<string, unknown>): void;
-  openGenericPopup(config: Record<string, unknown>): void;
-  hasOriginTokenForOrigin(originGestalt: string): boolean;
-}
-
 interface MissionsParent extends GameNode {
   Missions: Record<string, Mission>;
   getMission(gestalt: string): Mission | Record<string, never>;
@@ -89,7 +78,7 @@ export class Mission extends GameNode {
 
   updateGoal(goal: GoalShape): void {
     // TODO: take care of rendering
-    const groot = this.GameRoot as unknown as GameRootWithMissions;
+    const groot = this.GameRoot;
     // Legacy: `if ((goal.mission = this.gestalt)) { … }` — assigns the
     // gestalt onto goal and uses the truthy assigned value as the guard.
     // The translation below is behaviourally identical when `this.gestalt`
@@ -119,8 +108,7 @@ export class Mission extends GameNode {
   }
 
   openMissionPopup(): void {
-    const groot = this.GameRoot as unknown as GameRootWithMissions;
-    groot.openGenericPopup({
+    this.GameRoot.openGenericPopup({
       states: this.states,
       data: this.data,
       template: 'popup_mission.html',
@@ -129,7 +117,7 @@ export class Mission extends GameNode {
   }
 
   checkTutorial(): boolean {
-    const groot = this.GameRoot as unknown as GameRootWithMissions;
+    const groot = this.GameRoot;
     if (this.states.active && this.data.tutorial) {
       // If the player already dismissed the mission briefing, the NPC coach
       // intro has already been seen — skip re-queuing on reload.
@@ -152,7 +140,11 @@ export class Mission extends GameNode {
         }
       });
       steps = steps.slice(deletefrom);
-      groot.makeNotifications({ tutorial: steps });
+      // TutorialStep and Notification share most fields; their explicit
+      // `integrateProfileSet` types disagree (string vs boolean), but the
+      // legacy runtime schema (string) is preserved here.  Bridge via the
+      // unknown index signature.
+      groot.makeNotifications({ tutorial: steps as unknown as Record<string, unknown>[] });
       return true;
     }
     return false;
@@ -160,11 +152,11 @@ export class Mission extends GameNode {
 
   override extendEventHandlers(): void {
     const gnode = this;
-    const groot = this.GameRoot as unknown as GameRootWithMissions;
+    const groot = this.GameRoot;
 
     gnode.on('after_render', function () {
       if (gnode.states.active) {
-        if (gnode.checkTutorial()) {
+        if (gnode.checkTutorial() && gnode.gestalt !== undefined) {
           groot.makeNotifications({ mission_active: gnode.gestalt });
         }
       }
@@ -176,7 +168,9 @@ export class Mission extends GameNode {
       }
       if (!params) return;
       gnode.checkTutorial();
-      groot.makeNotifications({ mission_active: gnode.gestalt });
+      if (gnode.gestalt !== undefined) {
+        groot.makeNotifications({ mission_active: gnode.gestalt });
+      }
     });
 
     gnode.on('local_states_complete', function () {
@@ -195,7 +189,9 @@ export class Mission extends GameNode {
       if (gnode.data.tutorial) {
         groot.setState('tutorial_active', false);
       }
-      groot.makeNotifications({ mission_complete: gnode.gestalt });
+      if (gnode.gestalt !== undefined) {
+        groot.makeNotifications({ mission_complete: gnode.gestalt });
+      }
     });
 
     gnode.on('vclick', function (e: unknown) {


### PR DESCRIPTION
Follow-up to #248. With `GameNode.GameRoot` now typed as the real `GameRoot` class, the `GameRootWithMissions` structural shim and its 4 `as unknown as GameRootWithMissions` casts in `scripts/game/Mission.ts` are dead weight — every method/field the shim listed (`IPerps`, `raw_data`, `DBTokensAbsolute`, `Missions`, `setState`, `makeNotifications`, `openGenericPopup`, `hasOriginTokenForOrigin`) exists on the real `GameRoot` class.

## Schema gaps surfaced once the cast was removed

Two real schema mismatches were hiding behind the `Record<string, unknown>` shim signature; both are addressed locally rather than by re-widening `GameRoot`:

- `makeNotifications({ tutorial: steps })` — `TutorialStep` and `Notification` agree on most fields but disagree on `integrateProfileSet` (string in `TutorialStep`, boolean on `Notification`). The runtime behaviour is unchanged (legacy schema preserved); narrowed via a single structural bridge cast at the call site.
- `mission_active` / `mission_complete` on `MakeNotificationsPayload` are typed `string` (no `| undefined`); the call sites used `gnode.gestalt` (`string | undefined`). Guarded with explicit `gestalt !== undefined` checks — `gestalt` is set by the constructor flow before any of these handlers fire, so the guard is always-true at runtime.

## Cast count delta

`scripts/`: 126 → 123 (Mission.ts: 4 → 1; the remaining cast is the new tutorial-payload bridge described above).

## Validation

- `pnpm typecheck` passes clean (no new errors in `scripts/`).
- `pnpm lint` passes clean.

Stacked on #248; please merge that first.

https://claude.ai/code/session_017gPuFHF6MdaSov26RW5NTZ

---
_Generated by [Claude Code](https://claude.ai/code/session_017gPuFHF6MdaSov26RW5NTZ)_