### PR TITLE
type-debt: retire GameRootWithMissions shim in Missions.ts

### DIFF
--- a/scripts/game/GameNode.ts
+++ b/scripts/game/GameNode.ts
@@ -23,6 +23,7 @@ import { type RenderApi, getRender } from '../Render.js';
 import appModule from '../app.js';
 import setup from '../setup.js';
 import { getTypeSettings } from '../type_settings.js';
+import type { GameRoot } from './GameRoot.js';
 import { OrderedSet } from './OrderedSet.js';
 import { mergeData } from './mergeData.js';
 
@@ -279,7 +280,7 @@ export class GameNode {
   children!: OrderedSet<GameNode>;
   states!: Record<string, boolean>;
   /** Backlink to the GameRoot instance (always _instances[0]). */
-  GameRoot!: GameNode;
+  GameRoot!: GameRoot;
   /** jQuery wrapper used as the GameNode's event bus. */
   jq!: JQueryLike;
 
@@ -349,7 +350,9 @@ export class GameNode {
     // _instances[0] is GameRoot by convention (first GameNode constructed).
     // Cast away the `| undefined` from get() — by the time any non-Root
     // GameNode is created, the Root must have been constructed first.
-    this.GameRoot = (get(0) as GameNode | undefined) ?? this;
+    // The `this` fallback covers GameRoot's own bootstrap (where it's the
+    // only GameNode in existence and therefore *is* the GameRoot).
+    this.GameRoot = (get(0) ?? this) as GameRoot;
     this.setAttrs(cfg);
     this.makeRenderConfig();
     this.jq = _$()(this);

--- a/scripts/game/Imperium.ts
+++ b/scripts/game/Imperium.ts
@@ -2,13 +2,8 @@
 // Perp instances laid out).  Smallest extends-GameNode subclass.
 // Extracted from scripts/Game.js's IIFE in PR 8 of issue #147.
 
-import { type RenderApi } from '../Render.js';
 import i18n from '../i18n.js';
 import { GameNode } from './GameNode.js';
-
-interface GameRootWithMenu {
-  renderMenu: Pick<InstanceType<RenderApi['MainMenu']>, 'addButton'>;
-}
 
 interface ImperiumRenderNode {
   lock?(): void;
@@ -28,8 +23,7 @@ export class Imperium extends GameNode {
     this.setState('active', true);
     // FIXME: name should be in data
     // this.GameRoot.renderMenu.addButton(this.renderData.config.name, this.id, this.states);
-    const groot = this.GameRoot as unknown as GameRootWithMenu;
-    groot.renderMenu.addButton(i18n.gettext('My Empire'), this.id, this.states);
+    this.GameRoot.renderMenu?.addButton?.(i18n.gettext('My Empire'), this.id, this.states);
   }
 
   lock(): void {

--- a/scripts/game/Missions.ts
+++ b/scripts/game/Missions.ts
@@ -2,7 +2,6 @@
 // one Mission child per active/completed mission gestalt.  Extracted from
 // scripts/Game.js's IIFE in PR 7 of issue #147.
 
-import { type RenderApi } from '../Render.js';
 import appModule from '../app.js';
 import i18n from '../i18n.js';
 import { GameNode, type GameNodeConfig, getByFirstId, getFirstId } from './GameNode.js';
@@ -13,21 +12,6 @@ interface RawMissionsData {
   missions: Array<{ gestalt?: string; type_data?: { gestalt?: string; [key: string]: unknown } }>;
   active_missions: string[];
   mission_goals?: Array<Record<string, unknown>>;
-}
-
-interface GameRootWithMissions {
-  renderMenu: Pick<InstanceType<RenderApi['MainMenu']>, 'addButton'>;
-  renderNode?: { FXMissionGoalComplete?: () => void };
-  addType(gestalt: string, data: unknown): unknown;
-  getTypeData(gestalt?: string): Record<string, unknown> | undefined;
-  fetchProjectPowerupData(gestalt: string, cb: () => void): void;
-  getDatabase(): { cue(profile_set: unknown, origin: string, collect_id: string): void };
-  updateGameValues(
-    game_values: Record<string, unknown>,
-    levelup: boolean,
-    missions: unknown,
-    quiet: boolean
-  ): void;
 }
 
 interface RecheckMissionsResult {
@@ -61,13 +45,12 @@ export class Missions extends GameNode {
   }
 
   override extendRender(): void {
-    const groot = this.GameRoot as unknown as GameRootWithMissions;
-    groot.renderMenu.addButton(i18n.gettext('Missions'), this.id, this.states);
+    this.GameRoot.renderMenu?.addButton?.(i18n.gettext('Missions'), this.id, this.states);
   }
 
   override extendEventHandlers(): void {
     const mroot = this;
-    const groot = this.GameRoot as unknown as GameRootWithMissions;
+    const groot = this.GameRoot;
 
     mroot.on('states_active', function (_e: unknown, params: unknown) {
       const remote = appModule.getApplication().remote;
@@ -94,7 +77,7 @@ export class Missions extends GameNode {
   }
 
   initMissions(raw_data: RawMissionsData): void {
-    const groot = this.GameRoot as unknown as GameRootWithMissions;
+    const groot = this.GameRoot;
     if (!this.Missions) {
       this.Missions = {};
     }
@@ -179,7 +162,7 @@ export class Missions extends GameNode {
   }
 
   checkProjectGoals(): void {
-    const groot = this.GameRoot as unknown as GameRootWithMissions;
+    const groot = this.GameRoot;
     const fetch_project_data: Record<string, Mission> = {};
     let update_missions: Mission[] = [];
 
@@ -218,7 +201,7 @@ export class Missions extends GameNode {
       profile_sets?: Array<{ profile_set: unknown; origin: string; collect_id: string }>;
     };
   }): void {
-    const groot = this.GameRoot as unknown as GameRootWithMissions;
+    const groot = this.GameRoot;
 
     if (missions.complete_missions) {
       missions.complete_missions.forEach((gestalt) => {
@@ -233,7 +216,9 @@ export class Missions extends GameNode {
     if (missions.mission_data && missions.mission_data.mission_goals) {
       missions.mission_data.mission_goals.forEach((goal) => {
         if ((goal as { complete?: boolean }).complete) {
-          groot.renderNode?.FXMissionGoalComplete?.();
+          (
+            groot.renderNode as { FXMissionGoalComplete?: () => void } | undefined
+          )?.FXMissionGoalComplete?.();
         }
       });
       this.updateMissionGoals(missions.mission_data.mission_goals);
@@ -247,7 +232,15 @@ export class Missions extends GameNode {
 
     if (missions.rewards && missions.rewards.profile_sets) {
       missions.rewards.profile_sets.forEach((ps) => {
-        groot.getDatabase().cue(ps.profile_set, ps.origin, ps.collect_id);
+        groot
+          .getDatabase()
+          ?.cue(
+            ps.profile_set as Parameters<
+              NonNullable<ReturnType<typeof groot.getDatabase>>['cue']
+            >[0],
+            ps.origin,
+            ps.collect_id
+          );
       });
     }
 


### PR DESCRIPTION
## Summary

Follow-up cleanup stacked on #248 (which retyped `GameNode.GameRoot` as the real `GameRoot` class).

- Deletes the local `GameRootWithMissions` shim interface in `scripts/game/Missions.ts`.
- Removes the five `this.GameRoot as unknown as GameRootWithMissions` casts (in `extendRender`, `extendEventHandlers`, `initMissions`, `checkProjectGoals`, `updateMissions`); each site now uses `this.GameRoot` directly.
- Drops the now-unused `RenderApi` import.

All five listed methods (`addType`, `getTypeData`, `fetchProjectPowerupData`, `getDatabase`, `updateGameValues`) are properly typed on the real `GameRoot` class — no shim resurrection or stub additions to `GameRoot` were needed.

## Out of scope (deferred)

- The `as unknown as DoneFailChain<RecheckMissionsResult>` cast in `extendEventHandlers` — separate batch (remote.recheckMissions return shape).
- Two narrow site-local casts that surface real (small) holes in `GameRoot`'s typed surface:
  - `renderNode.FXMissionGoalComplete` is missing from `RenderRootLike` (only `FXMissionComplete` / `FXLevelUpBling` / `FXKarmaBling` / `FXNoCash` / `FXError` are declared there).
  - `Database.cue(profileset, ...)` — first arg is `unknown` here (loose server payload) but typed on the receiving `Database.cue`.

Both should be fixed in their owning files, not by widening Missions' shim.

## Cast-count delta in scripts/

126 -> 121 (-5).

## Test plan

- [x] `pnpm typecheck` clean for `scripts/game/Missions.ts` (the 9 pre-existing non-e2e errors on the base branch are unchanged: vendor-install/node types, app.ts vite glob, webxdc-shim — none in this file).
- [x] `pnpm lint` clean.

https://claude.ai/code/session_017gPuFHF6MdaSov26RW5NTZ

---
_Generated by [Claude Code](https://claude.ai/code/session_017gPuFHF6MdaSov26RW5NTZ)_