### PR TITLE
type-debt: retire GameRootForProfileSet shim

### DIFF
--- a/scripts/game/GameNode.ts
+++ b/scripts/game/GameNode.ts
@@ -23,6 +23,7 @@ import { type RenderApi, getRender } from '../Render.js';
 import appModule from '../app.js';
 import setup from '../setup.js';
 import { getTypeSettings } from '../type_settings.js';
+import type { GameRoot } from './GameRoot.js';
 import { OrderedSet } from './OrderedSet.js';
 import { mergeData } from './mergeData.js';
 
@@ -279,7 +280,7 @@ export class GameNode {
   children!: OrderedSet<GameNode>;
   states!: Record<string, boolean>;
   /** Backlink to the GameRoot instance (always _instances[0]). */
-  GameRoot!: GameNode;
+  GameRoot!: GameRoot;
   /** jQuery wrapper used as the GameNode's event bus. */
   jq!: JQueryLike;
 
@@ -349,7 +350,9 @@ export class GameNode {
     // _instances[0] is GameRoot by convention (first GameNode constructed).
     // Cast away the `| undefined` from get() — by the time any non-Root
     // GameNode is created, the Root must have been constructed first.
-    this.GameRoot = (get(0) as GameNode | undefined) ?? this;
+    // The `this` fallback covers GameRoot's own bootstrap (where it's the
+    // only GameNode in existence and therefore *is* the GameRoot).
+    this.GameRoot = (get(0) ?? this) as GameRoot;
     this.setAttrs(cfg);
     this.makeRenderConfig();
     this.jq = _$()(this);

--- a/scripts/game/GameRoot.ts
+++ b/scripts/game/GameRoot.ts
@@ -448,7 +448,11 @@ export class GameRoot extends GameNode {
   /** `raw_data` mirrors the engine's authoritative state snapshot for
    *  read-only helpers (mission-briefing-seen lookup, etc.).  Set by
    *  `loadGame` (still in Game.js). */
-  raw_data?: { mission_briefings_seen?: Record<string, boolean>; [key: string]: unknown };
+  raw_data?: {
+    mission_briefings_seen?: Record<string, boolean>;
+    tokens_seen?: Record<string, unknown>;
+    [key: string]: unknown;
+  };
 
   // Field assignments preserved from the legacy `GameRoot.prototype.X
   // = ...` block — exposed for callers that read `groot.get` / `groot.

--- a/scripts/game/Imperium.ts
+++ b/scripts/game/Imperium.ts
@@ -2,13 +2,8 @@
 // Perp instances laid out).  Smallest extends-GameNode subclass.
 // Extracted from scripts/Game.js's IIFE in PR 8 of issue #147.
 
-import { type RenderApi } from '../Render.js';
 import i18n from '../i18n.js';
 import { GameNode } from './GameNode.js';
-
-interface GameRootWithMenu {
-  renderMenu: Pick<InstanceType<RenderApi['MainMenu']>, 'addButton'>;
-}
 
 interface ImperiumRenderNode {
   lock?(): void;
@@ -28,8 +23,7 @@ export class Imperium extends GameNode {
     this.setState('active', true);
     // FIXME: name should be in data
     // this.GameRoot.renderMenu.addButton(this.renderData.config.name, this.id, this.states);
-    const groot = this.GameRoot as unknown as GameRootWithMenu;
-    groot.renderMenu.addButton(i18n.gettext('My Empire'), this.id, this.states);
+    this.GameRoot.renderMenu?.addButton?.(i18n.gettext('My Empire'), this.id, this.states);
   }
 
   lock(): void {

--- a/scripts/game/ProfileSet.ts
+++ b/scripts/game/ProfileSet.ts
@@ -49,16 +49,6 @@ interface ProfileSetOriginNode {
   id?: string;
 }
 
-/** GameRoot's surface this class touches.  Will collapse when GameRoot
- *  is extracted into its own typed module. */
-interface GameRootForProfileSet {
-  DBTokens: Record<string, number>;
-  DBTokensAbsolute: Record<string, number>;
-  profiles_value: number;
-  raw_data?: { tokens_seen?: Record<string, unknown>; [key: string]: unknown };
-  getTypeData(gestalt?: string): Record<string, unknown> | undefined;
-}
-
 /** ProfileSet config — extends the base GameNodeConfig with the
  *  ProfileSet-specific fields that callers stamp on at construction time
  *  (Database.cue and the various Perp `BuyToken` flows). */
@@ -102,7 +92,7 @@ export class ProfileSet extends GameNode {
   constructor(config: ProfileSetConfig, tokens: TokensInput) {
     // Used both as a Template and as a cued object in DBQueue.
     super(config);
-    const groot = this.GameRoot as unknown as GameRootForProfileSet;
+    const groot = this.GameRoot;
 
     // Shallow clone to match legacy `_.clone(tokens)` — array → slice
     // (elements shared by reference), object → top-level shallow copy
@@ -238,7 +228,7 @@ export class ProfileSet extends GameNode {
   }
 
   updateNewMarker(): void {
-    const groot = this.GameRoot as unknown as GameRootForProfileSet;
+    const groot = this.GameRoot;
     const seenMap: Record<string, unknown> = (groot.raw_data && groot.raw_data.tokens_seen) || {};
     this.tokens_set.forEach((token) => {
       if (


### PR DESCRIPTION
Follow-up to #248 — stacked on `claude/typedebt-gamenode-backlink-spike`.

## Summary

With `GameNode.GameRoot` now typed as the real `GameRoot` class (#248), the `GameRootForProfileSet` shim in `scripts/game/ProfileSet.ts` is redundant for 4 of its 5 members (`DBTokens`, `DBTokensAbsolute`, `profiles_value`, `getTypeData`) — they all resolve directly off the typed backlink.

The 5th member, `raw_data.tokens_seen`, was the only field genuinely missing from `GameRoot.raw_data`'s typed shape. The shim was masking that gap. `tokens_seen` is a real runtime field (read in `ProfileSet.updateNewMarker` and the constructor), so widening `raw_data` to declare it is a legitimate fix, not a workaround.

## Changes

- `scripts/game/GameRoot.ts`: add `tokens_seen?: Record<string, unknown>` to the `raw_data` typed shape.
- `scripts/game/ProfileSet.ts`: delete the `GameRootForProfileSet` interface and both `as unknown as GameRootForProfileSet` casts; use `this.GameRoot` directly.

ProfileSet's shim docblock literally predicted this collapse: *"Will collapse when GameRoot is extracted into its own typed module."* That's now true.

## Cast-count delta

- `scripts/`: -2 `as unknown as` casts.

## Test plan

- [x] `pnpm typecheck` passes (clean — including tests/e2e once `node_modules` is installed).
- [x] `pnpm lint` passes (114 files, 0 issues).

https://claude.ai/code/session_017gPuFHF6MdaSov26RW5NTZ

---
_Generated by [Claude Code](https://claude.ai/code/session_017gPuFHF6MdaSov26RW5NTZ)_