### PR TITLE
type-debt: reconcile TutorialStep/Notification, tighten gestalt typing

### DIFF
--- a/scripts/game/GameRoot.ts
+++ b/scripts/game/GameRoot.ts
@@ -287,7 +287,7 @@ interface Notification {
   buyPerp?: string | undefined;
   buyParent?: string | undefined;
   buyPerpPos?: { x: number; y: number } | undefined;
-  integrateProfileSet?: boolean | undefined;
+  integrateProfileSet?: string | undefined;
   nodelay?: boolean | undefined;
   nonblocking?: number | undefined;
   [key: string]: unknown;

--- a/scripts/game/Mission.ts
+++ b/scripts/game/Mission.ts
@@ -41,6 +41,11 @@ interface MissionsParent extends GameNode {
 export class Mission extends GameNode {
   override renderType = 'MissionPerp';
   declare data: MissionDataShape;
+  // Mission instances are always constructed with a gestalt by Missions.ts
+  // (the loader skips entries lacking one — see Missions.ts:96).  Narrow
+  // the base class's `gestalt?: string` to required so handlers below can
+  // pass it to APIs typed `string` without `!== undefined` guards.
+  declare gestalt: string;
   popupTemplate = 'popup_mission.html';
 
   getBranch(_gestalt?: string): Mission[] {
@@ -81,12 +86,7 @@ export class Mission extends GameNode {
     const groot = this.GameRoot;
     // Legacy: `if ((goal.mission = this.gestalt)) { … }` — assigns the
     // gestalt onto goal and uses the truthy assigned value as the guard.
-    // The translation below is behaviourally identical when `this.gestalt`
-    // is defined (always true at runtime — `gestalt` is set by the
-    // constructor flow before any subclass method runs); the
-    // `this.gestalt !== undefined` skip exists only to satisfy
-    // exactOptionalPropertyTypes on `goal.mission?: string`.
-    if (this.gestalt !== undefined) goal.mission = this.gestalt;
+    goal.mission = this.gestalt;
     if (!goal.mission) return;
     const goals = this.data.goals || [];
     for (let k = 0; k < goals.length; k++) {
@@ -140,11 +140,7 @@ export class Mission extends GameNode {
         }
       });
       steps = steps.slice(deletefrom);
-      // TutorialStep and Notification share most fields; their explicit
-      // `integrateProfileSet` types disagree (string vs boolean), but the
-      // legacy runtime schema (string) is preserved here.  Bridge via the
-      // unknown index signature.
-      groot.makeNotifications({ tutorial: steps as unknown as Record<string, unknown>[] });
+      groot.makeNotifications({ tutorial: steps });
       return true;
     }
     return false;
@@ -156,7 +152,7 @@ export class Mission extends GameNode {
 
     gnode.on('after_render', function () {
       if (gnode.states.active) {
-        if (gnode.checkTutorial() && gnode.gestalt !== undefined) {
+        if (gnode.checkTutorial()) {
           groot.makeNotifications({ mission_active: gnode.gestalt });
         }
       }
@@ -168,9 +164,7 @@ export class Mission extends GameNode {
       }
       if (!params) return;
       gnode.checkTutorial();
-      if (gnode.gestalt !== undefined) {
-        groot.makeNotifications({ mission_active: gnode.gestalt });
-      }
+      groot.makeNotifications({ mission_active: gnode.gestalt });
     });
 
     gnode.on('local_states_complete', function () {
@@ -189,9 +183,7 @@ export class Mission extends GameNode {
       if (gnode.data.tutorial) {
         groot.setState('tutorial_active', false);
       }
-      if (gnode.gestalt !== undefined) {
-        groot.makeNotifications({ mission_complete: gnode.gestalt });
-      }
+      groot.makeNotifications({ mission_complete: gnode.gestalt });
     });
 
     gnode.on('vclick', function (e: unknown) {


### PR DESCRIPTION
## Summary

Follow-up to #250 (Mission.ts cleanup), which had to leave two bridging
casts in place to keep typecheck green after retiring the
`GameRootWithMissions` shim. Both bridges are now removed by fixing the
underlying surface gaps.

### 1. `TutorialStep` vs `Notification.integrateProfileSet`

`Notification.integrateProfileSet` was typed `boolean | undefined`, but
the runtime data (see `data/ruleset_3.en.json`, `…de.json` —
`"integrateProfileSet": "city002"`) and the local `TutorialStep` type in
`Mission.ts` both treat it as a string. The consumer in
`makeNotifications` only uses it as a truthy guard, then hardcodes
`'city002'` as the profile-set lookup, so neither shape was wrong about
the value — only about the type.

Fix: change `Notification.integrateProfileSet` to `string | undefined` to
match the runtime schema. Drop the
`as unknown as Record<string, unknown>[]` cast in `checkTutorial()` and
pass `steps` directly.

### 2. `GameNode.gestalt` tightening — scoped to `Mission`

`GameNode.gestalt` is genuinely `string | undefined` on the base class —
the bootstrap nodes `Imperium`, `Database`, `Missions`, `Topscores` are
constructed without one (see `GameRoot.ts` ~line 1990–2030). So we
cannot tighten it on `GameNode`. However, `Mission` instances *do*
always have a gestalt: `Missions.ts:96` skips entries lacking one before
calling `new Mission(cfg)`.

Fix: narrow `gestalt` per-subclass via `declare gestalt: string;` in
`Mission`. This lets us drop the three `gnode.gestalt !== undefined`
guards added in #250 around `makeNotifications({ mission_active })` /
`mission_complete`, plus the matching guard in `updateGoal()`.

### Cast-count delta

`scripts/game/Mission.ts` lost both bridges: 1 `as unknown as` cast and
4 `gestalt !== undefined` guards (3 in `extendEventHandlers`, 1 in
`updateGoal`). No new casts introduced anywhere.

### Validation

- `pnpm typecheck`: clean, no cascade errors.
- `pnpm lint`: clean.

## Test plan

- [ ] Tutorial briefing fires correctly when a mission with a
  `tutorial` array activates (`integrateProfileSet` step still
  recognised as truthy).
- [ ] `mission_active` and `mission_complete` notifications still fire
  on the corresponding mission events.

https://claude.ai/code/session_017gPuFHF6MdaSov26RW5NTZ

---
_Generated by [Claude Code](https://claude.ai/code/session_017gPuFHF6MdaSov26RW5NTZ)_