### PR TITLE
type-debt: widen RenderRootLike + Database.cue, drop bridge casts in Missions.ts

### DIFF
--- a/scripts/game/Database.ts
+++ b/scripts/game/Database.ts
@@ -443,21 +443,20 @@ export class Database extends GameNode {
     this.renderApi?.unlock?.();
   }
 
-  cue(
-    profileset: { profiles_value?: number; tokens_map?: Record<string, { amount?: number }> },
-    path: string,
-    collect_id: string
-  ): ProfileSet {
-    // Add a ProfileSet to the DB queue.
-    const origin = getByLastId(path);
+  cue(profileset: unknown, path: unknown, collect_id: unknown): ProfileSet {
+    // Add a ProfileSet to the DB queue.  Inputs come from server payloads
+    // (mission rewards, perp collect results) so the typed surface is
+    // intentionally permissive; we narrow what we actually read below.
+    const origin = typeof path === 'string' ? getByLastId(path) : undefined;
     const cfg: ConstructorParameters<typeof ProfileSet>[0] = {
-      psid: collect_id,
       markNew: true,
       sortByGestalt: true,
     };
+    if (typeof collect_id === 'string') cfg.psid = collect_id;
     if (origin) cfg.origin = origin;
-    if (typeof profileset.profiles_value === 'number')
-      cfg.profiles_value = profileset.profiles_value;
+    const profiles_value = (profileset as { profiles_value?: unknown } | null | undefined)
+      ?.profiles_value;
+    if (typeof profiles_value === 'number') cfg.profiles_value = profiles_value;
     const ps = new ProfileSet(cfg, profileset as ConstructorParameters<typeof ProfileSet>[1]);
     this.queue.prepend(ps);
     if (this.renderDBQueue) {

--- a/scripts/game/GameRoot.ts
+++ b/scripts/game/GameRoot.ts
@@ -92,6 +92,7 @@ interface RenderRootLike {
   // FX hooks driven by makeNotifications.  All optional; the Stage
   // owns the implementations (Render.js).
   FXMissionComplete?(): void;
+  FXMissionGoalComplete?(): void;
   FXLevelUpBling?(level: number | true): void;
   FXKarmaBling?(amount: number): void;
   FXNoCash?(): void;

--- a/scripts/game/Missions.ts
+++ b/scripts/game/Missions.ts
@@ -216,9 +216,7 @@ export class Missions extends GameNode {
     if (missions.mission_data && missions.mission_data.mission_goals) {
       missions.mission_data.mission_goals.forEach((goal) => {
         if ((goal as { complete?: boolean }).complete) {
-          (
-            groot.renderNode as { FXMissionGoalComplete?: () => void } | undefined
-          )?.FXMissionGoalComplete?.();
+          groot.renderNode?.FXMissionGoalComplete?.();
         }
       });
       this.updateMissionGoals(missions.mission_data.mission_goals);
@@ -232,15 +230,7 @@ export class Missions extends GameNode {
 
     if (missions.rewards && missions.rewards.profile_sets) {
       missions.rewards.profile_sets.forEach((ps) => {
-        groot
-          .getDatabase()
-          ?.cue(
-            ps.profile_set as Parameters<
-              NonNullable<ReturnType<typeof groot.getDatabase>>['cue']
-            >[0],
-            ps.origin,
-            ps.collect_id
-          );
+        groot.getDatabase()?.cue(ps.profile_set, ps.origin, ps.collect_id);
       });
     }
 


### PR DESCRIPTION
## Summary

Two follow-ups to #251 (which retired the `GameRootWithMissions` shim in `scripts/game/Missions.ts` and added two bridge casts to keep typecheck green).  This PR removes those casts by fixing the underlying surface gaps.

### 1. `RenderRootLike` gains `FXMissionGoalComplete`
`scripts/game/GameRoot.ts` `RenderRootLike` listed `FXMissionComplete`, `FXLevelUpBling`, `FXKarmaBling`, `FXNoCash`, `FXError` but not `FXMissionGoalComplete`.  Added the optional hook alongside the others, so `Missions.ts` can call:

```ts
groot.renderNode?.FXMissionGoalComplete?.();
```

…instead of the previous inline `as { FXMissionGoalComplete?: () => void } | undefined` cast.

### 2. `Database.cue` widens to `unknown`
`scripts/game/Database.ts:446` `cue` typed its first arg narrowly (`{ profiles_value?, tokens_map? }`) and `path`/`collect_id` as `string`, but every real caller funnels server-payload data:

- `Missions.ts` mission rewards (`profile_set: unknown`, `origin: string`, `collect_id: string`)
- `ProjectPerp.ts` / `ContactPerp.ts` collect results (`profile_set: { profiles_value: number; [k: string]: unknown }`, `origin: unknown`, `collect_id: unknown`)

`cue` only reads `profileset.profiles_value` and forwards the payload to the `ProfileSet` constructor (which already accepts a union of token shapes).  Widened all three params to `unknown` and narrow internally before use.  This drops the verbose

```ts
ps.profile_set as Parameters<NonNullable<ReturnType<typeof groot.getDatabase>>['cue']>[0]
```

cast at the `Missions.ts` call site, simplifying it to `groot.getDatabase()?.cue(ps.profile_set, ps.origin, ps.collect_id)`.

`?.` on `getDatabase()` is preserved because `GameRoot.getDatabase` returns `Database | undefined`.

### Cast delta in `scripts/`
- `Missions.ts`: 8 → 6 (-2)
- `Database.ts`: 39 → 40 (+1, the existing `ProfileSet` constructor `TokensInput` cast remains in `cue`'s body)
- Net: **-1**

### Cascade check
The `ProjectPerp` / `ContactPerp` call sites already passed wider types into `cue` than its narrow declared param accepted (origin/collect_id were `unknown`, profile_set used an index signature).  Widening to `unknown` accepts those without further changes — no other call-site touches needed.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [ ] Verify a mission reward profileset still cues correctly (manual smoke)
- [ ] Verify a project/contact collect still cues correctly (manual smoke)

Closes follow-up debt from #251.

https://claude.ai/code/session_017gPuFHF6MdaSov26RW5NTZ

---
_Generated by [Claude Code](https://claude.ai/code/session_017gPuFHF6MdaSov26RW5NTZ)_