### PR TITLE
type-debt: retire GameRootForProjectPerp shim

### DIFF
--- a/scripts/game/ProjectPerp.ts
+++ b/scripts/game/ProjectPerp.ts
@@ -20,7 +20,6 @@ import {
   type ChargeResult,
   type DoneFailChain,
   GamePerp,
-  type GameRootForPerp,
   type RenderNodeLike,
   type RenderPopupLike,
 } from './GamePerp.js';
@@ -108,14 +107,6 @@ interface PowerupSlotsBucket {
   slots_left: number;
 }
 
-interface GameRootForProjectPerp extends GameRootForPerp {
-  cash_value: number;
-  ap_value: number;
-  karma_value: number;
-  fetchProjectPowerupData(gestalt: string, cb?: () => void): void;
-  getDatabase(): { cue(ps: unknown, origin: unknown, collect_id: unknown): unknown };
-}
-
 export class ProjectPerp extends GamePerp {
   override renderType = 'Perp';
   override sticky = false;
@@ -123,8 +114,8 @@ export class ProjectPerp extends GamePerp {
 
   renderReady?: DecoratorReadyLike;
 
-  protected override get groot(): GameRootForProjectPerp {
-    return this.GameRoot as unknown as GameRootForProjectPerp;
+  protected override get groot() {
+    return this.GameRoot;
   }
 
   constructor(config: GameNodeConfig) {
@@ -629,7 +620,7 @@ export class ProjectPerp extends GamePerp {
             const newKarma = data.result.game_values?.karma_value ?? 0;
             const karma_dec = newKarma - groot.karma_value;
             groot.makeNotifications({
-              karma: { gestalt: data.result.karma_incident, karma_value: karma_dec },
+              karma: { gestalt: data.result.karma_incident, dec: karma_dec },
             });
           }
           deco.FXBling({ text: toKSNum(amount), extendClass: 'ProfileBling' });
@@ -637,7 +628,7 @@ export class ProjectPerp extends GamePerp {
             (gperp.renderNode as ProjectRenderNodeLike | undefined)?.FXDataOut?.();
             delete gperp.renderReady;
           });
-          groot.getDatabase().cue(inner.profile_set, inner.origin, inner.collect_id);
+          groot.getDatabase()?.cue(inner.profile_set, inner.origin, inner.collect_id);
           gperp.setState('idle', true);
         } else if (data.result?.error) {
           if (popup) popup.trigger('no_AP');


### PR DESCRIPTION
## Summary

Follow-up to #248, which retyped `GameNode.GameRoot` as the real `GameRoot` class. The local `GameRootForProjectPerp` shim in `scripts/game/ProjectPerp.ts` (`cash_value`, `ap_value`, `karma_value`, `fetchProjectPowerupData`, `getDatabase`) is now redundant — all those members exist on the real `GameRoot` — so the `as unknown as` cast in the `groot` getter is dropped and the shim deleted.

Removing the shim surfaced two real issues that had been silently masked:

- A `karma:` notification was passing `karma_value: karma_dec` instead of `dec: karma_dec`, mismatching the `makeNotifications` typed shape and diverging from `ContactPerp` / `ClientPerp` which both correctly pass `dec`. Fixed.
- `groot.getDatabase().cue(...)` had no optional-chain; the real return type is `Database | undefined`. Added `?.` to match the rest of the codebase.

`DoneFailChain<*>` casts (~lines 304, 361, 547, 614) and the two jQuery `(globalThis.$ as unknown as JQueryStaticLike)` casts (~lines 488, 509) are intentionally deferred — separate concerns to be tackled in their own batches.

## Test plan

- [x] `pnpm typecheck` passes cleanly
- [x] `pnpm lint` passes cleanly
- [ ] Manual smoke: open a project perp popup, charge / collect a project, verify karma incident notification still fires correctly

https://claude.ai/code/session_017gPuFHF6MdaSov26RW5NTZ

---
_Generated by [Claude Code](https://claude.ai/code/session_017gPuFHF6MdaSov26RW5NTZ)_