### PR TITLE
type-debt: retire GameRootForTokenPerp shim

### DIFF
--- a/scripts/game/TokenPerp.ts
+++ b/scripts/game/TokenPerp.ts
@@ -17,10 +17,10 @@ import {
   type ChargeResult,
   type DoneFailChain,
   GamePerp,
-  type GameRootForPerp,
   type RenderNodeLike,
   type RenderPopupLike,
 } from './GamePerp.js';
+import type { GameRoot } from './GameRoot.js';
 import { ProfileSet } from './ProfileSet.js';
 
 interface DecoratorAmountLike {
@@ -73,18 +73,6 @@ interface NodeReadyPayload {
   last_upgrade_data?: unknown;
 }
 
-interface GameRootForTokenPerp extends GameRootForPerp {
-  ap_value: number;
-  profiles_value: number;
-  DBTokens: Record<string, number>;
-  DBTokensAbsolute: Record<string, number>;
-  getDatabase(): {
-    compileSuperTokens(): void;
-    checkNotifications(): void;
-  };
-  updateGears(): void;
-}
-
 interface TokenSetEntry {
   locked?: boolean;
   diffAmount?: number;
@@ -105,8 +93,8 @@ export class TokenPerp extends GamePerp {
   amount?: number;
   renderReady?: DecoratorReadyLike;
 
-  protected override get groot(): GameRootForTokenPerp {
-    return this.GameRoot as unknown as GameRootForTokenPerp;
+  protected override get groot(): GameRoot {
+    return this.GameRoot;
   }
 
   constructor(config: GameNodeConfig) {
@@ -366,7 +354,7 @@ export class TokenPerp extends GamePerp {
         if (data.result?.result) {
           if (popup) popup.trigger('popup_close');
           // FIXME: compile for checkNotifications
-          groot.getDatabase().compileSuperTokens();
+          groot.getDatabase()?.compileSuperTokens();
           gperp.setAmount(data.result.result.token_upgraded_amount);
           groot.updateGameValues(
             data.result.game_values || {},
@@ -381,7 +369,7 @@ export class TokenPerp extends GamePerp {
             rn?.DecoratorGear?.FXSproing();
             delete gperp.renderReady;
             window.setTimeout(function () {
-              groot.getDatabase().checkNotifications();
+              groot.getDatabase()?.checkNotifications();
               groot.updateGears();
             }, 2000);
           });


### PR DESCRIPTION
Follow-up to #248.  With `GameNode.GameRoot` typed as the real `GameRoot` class, the `GameRootForTokenPerp` structural shim is redundant — every member it listed (`ap_value`, `profiles_value`, `DBTokens`, `DBTokensAbsolute`, `getDatabase`, `updateGears`) resolves directly off the typed backlink.

## Changes
- Delete the `GameRootForTokenPerp` interface block.
- The `groot` getter override now returns `GameRoot` directly (no cast).
- Drop the no-longer-needed `GameRootForPerp` import.
- Two surviving call sites switch to `groot.getDatabase()?.compileSuperTokens()` / `?.checkNotifications()` — the shim modeled `getDatabase()` as never-undefined, but the real signature is `Database | undefined`, matching the optional-chaining pattern already used inside `GameRoot` itself.

## Cast count
Net `as unknown as` delta in `scripts/`: **-1**.

## Out of scope
The two `DoneFailChain<ChargeResult>` / `DoneFailChain<CollectResult>` casts on the chargePerp / collectPerp returns are intentionally left in place; they belong to a separate cleanup batch.

## Validation
- `pnpm typecheck` passes clean.
- `pnpm lint` passes clean.

https://claude.ai/code/session_017gPuFHF6MdaSov26RW5NTZ

---
_Generated by [Claude Code](https://claude.ai/code/session_017gPuFHF6MdaSov26RW5NTZ)_