### PR TITLE
type-debt: consolidate DoneFailChain type, drop 2 duplicate declarations

### DIFF
--- a/scripts/game/Database.ts
+++ b/scripts/game/Database.ts
@@ -20,7 +20,7 @@ import {
   getByType,
   getFirstId,
 } from './GameNode.js';
-import { type RenderPopupLike } from './GamePerp.js';
+import { type DoneFailChain, type RenderPopupLike } from './GamePerp.js';
 import { type GameRoot } from './GameRoot.js';
 import { OrderedSet } from './OrderedSet.js';
 import { ProfileSet } from './ProfileSet.js';
@@ -141,11 +141,6 @@ interface BuyPerpResult {
     instance_data?: Record<string, unknown>;
   };
   error?: number;
-}
-
-interface DoneFailChain<T> {
-  done(cb: (data: { result?: T }) => void): DoneFailChain<T>;
-  fail(cb: (data: { error?: string | number; message?: string }) => void): DoneFailChain<T>;
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/game/Missions.ts
+++ b/scripts/game/Missions.ts
@@ -5,6 +5,7 @@
 import appModule from '../app.js';
 import i18n from '../i18n.js';
 import { GameNode, type GameNodeConfig, getByFirstId, getFirstId } from './GameNode.js';
+import { type DoneFailChain } from './GamePerp.js';
 import { Mission } from './Mission.js';
 import { OrderedSet } from './OrderedSet.js';
 
@@ -22,11 +23,6 @@ interface RecheckMissionsResult {
     complete_missions?: string[];
     mission_data?: { mission_goals?: Array<Record<string, unknown>> };
   };
-}
-
-interface DoneFailChain<T> {
-  done(cb: (data: { result?: T }) => void): DoneFailChain<T>;
-  fail(cb: (data: { error?: string | number; message?: string }) => void): DoneFailChain<T>;
 }
 
 export class Missions extends GameNode {


### PR DESCRIPTION
## Summary

Consolidates duplicate `DoneFailChain<T>` interface declarations onto the canonical export at [`scripts/game/GamePerp.ts:104`](../blob/master/scripts/game/GamePerp.ts#L104).

Files updated (local declaration deleted, now import from `./GamePerp.js`):
- `scripts/game/Database.ts`
- `scripts/game/Missions.ts`

Both local declarations were verified **byte-for-byte identical** to the canonical before deletion.

## Findings on the original 6-file list

The original task listed 6 files. Three of them already import the canonical type on master (no local copy to delete) — likely cleaned up by recent type-debt PRs (#254–#257):

- `scripts/game/ClientPerp.ts` — already imports
- `scripts/game/ContactPerp.ts` — already imports
- `scripts/game/DatabasePerp.ts` — already imports

One file has a **structurally divergent** declaration and is intentionally left untouched here:

- `scripts/game/Topscore.ts` — declares `interface DoneFailChain` (non-generic, with `RankingResult` hardcoded into the `done` callback). Functionally equivalent to `DoneFailChain<RankingResult>` after substitution, but it's a different shape than the canonical generic. Per the task brief ("STOP and report" on divergence), this one wants a deliberate decision rather than a mechanical dedup — flagging for follow-up.

## Cast sites

Intentionally untouched. The 17 `as unknown as DoneFailChain<…>` cast sites in `scripts/` remain; they need the remote API (`app.remote.*`) to be typed before they can go away. Separate Level-2 task.

## Test plan

- [x] `pnpm typecheck` passes (clean)
- [x] `pnpm lint` passes (clean)

https://claude.ai/code/session_017gPuFHF6MdaSov26RW5NTZ

---
_Generated by [Claude Code](https://claude.ai/code/session_017gPuFHF6MdaSov26RW5NTZ)_