### PR TITLE
type-debt: align Topscore.ts DoneFailChain with canonical generic

### DIFF
--- a/scripts/game/Topscore.ts
+++ b/scripts/game/Topscore.ts
@@ -7,6 +7,7 @@
 
 import appModule from '../app.js';
 import { GameNode } from './GameNode.js';
+import { type DoneFailChain } from './GamePerp.js';
 import { mergeData } from './mergeData.js';
 
 // app.remote handlers are wired up by app.start(); Topscore is only
@@ -35,10 +36,6 @@ interface RankingResult {
 // app.remote wrapping), not a native Promise — Game.js's call sites use
 // `.done()` / `.fail()`.  Captured loosely; later PRs may tighten when
 // app.remote's return type is widened.
-interface DoneFailChain {
-  done(cb: (data: { result?: RankingResult }) => void): DoneFailChain;
-  fail(cb: (data: { error?: string | number; message?: string }) => void): DoneFailChain;
-}
 
 interface TopscoreRenderNode {
   jdomelem?: {
@@ -73,7 +70,7 @@ export class Topscore extends GameNode {
     const gnode = this;
     const getRanking = appModule.getApplication().remote.getRanking;
     if (!getRanking) return;
-    const rankingCall = getRanking(t) as unknown as DoneFailChain;
+    const rankingCall = getRanking(t) as unknown as DoneFailChain<RankingResult>;
     rankingCall
       .done(function (data) {
         if (data.result && data.result.error === undefined) {


### PR DESCRIPTION
Follow-up to #258, which consolidated `DoneFailChain<T>` across most files but skipped `scripts/game/Topscore.ts` because its local declaration was a non-generic divergent variant.

This PR removes the local `interface DoneFailChain { ... }` and imports the canonical generic from `GamePerp.ts`, instantiated as `DoneFailChain<RankingResult>` at the single cast site. Behaviour-equivalent — the runtime call signature is identical; this just instantiates the generic rather than redeclaring it.

- `pnpm typecheck` clean
- `pnpm lint` clean

https://claude.ai/code/session_017gPuFHF6MdaSov26RW5NTZ

---
_Generated by [Claude Code](https://claude.ai/code/session_017gPuFHF6MdaSov26RW5NTZ)_