### PR TITLE
type-debt: type AppRemote methods, drop ~17 DoneFailChain casts

### DIFF
--- a/scripts/app.ts
+++ b/scripts/app.ts
@@ -13,7 +13,12 @@ import { getGame } from './Game.js';
 import LocalEngine from './LocalEngine.js';
 import { getRender } from './Render.js';
 import { compileTemplate, registerTemplateHelpers } from './dd-helpers.js';
+import type { IntegrateResult } from './game/Database.js';
+import type { BuyPerpResult, ChargeResult, DoneFailChain } from './game/GamePerp.js';
+import type { RecheckMissionsResult } from './game/Missions.js';
+import type { RankingResult } from './game/Topscore.js';
 import i18n from './i18n.js';
+import type { BuyPowerupResult, CollectResult } from './remote-types.js';
 import setup from './setup.js';
 
 // All view sources are inlined at bundle time; templates are compiled
@@ -38,10 +43,37 @@ function compileTemplates(): Record<string, (data?: unknown) => string> {
   return out;
 }
 
+// Each LocalEngine handler is wrapped to return a jQuery Deferred so the
+// legacy Game.js call sites can keep their .done()/.fail() chains.
+//
+// Known handlers are typed individually so consumers don't need to cast
+// `remote.foo() as unknown as DoneFailChain<FooResult>` — drops ~17
+// casts across `scripts/`.  All entries are optional because the
+// wrapping pass in `Application()` is dynamic (`Object.keys(LocalEngine)`),
+// so consumers must guard before calling — matching the prior shape
+// where every access was already nullable in practice.
+//
+// `getSessionLocale` / `loadGame` keep `JQueryLike`-style returns
+// because their consumers (`app.start()`, `GameRoot.continueStart`)
+// chain `.then(...)` — `JQueryLike` exposes `.then`, `DoneFailChain`
+// doesn't.  Future cleanup could collapse them once the GameRoot
+// boot path is rewritten.
 interface AppRemote {
-  // Each LocalEngine handler is wrapped to return a jQuery Deferred so the
-  // legacy Game.js call sites can keep their .done()/.fail() chains.
-  [name: string]: (...args: unknown[]) => JQueryLike;
+  recheckMissions?(): DoneFailChain<RecheckMissionsResult>;
+  chargePerp?(path: string): DoneFailChain<ChargeResult>;
+  collectPerp?(path: string): DoneFailChain<CollectResult>;
+  buyPerp?(path: string, gestalt: string): DoneFailChain<BuyPerpResult>;
+  buyPowerup?(
+    path: string,
+    slot: number | string,
+    gestalt: string
+  ): DoneFailChain<BuyPowerupResult>;
+  sellPowerup?(path: string, slot: number, gestalt: string): DoneFailChain<BuyPowerupResult>;
+  buySlots?(path: string, slotType: string, num: number | string): DoneFailChain<BuyPowerupResult>;
+  integrateCollected?(psid: string): DoneFailChain<IntegrateResult>;
+  getRanking?(type: string): DoneFailChain<RankingResult>;
+  getSessionLocale?(): JQueryLike;
+  loadGame?(): JQueryLike;
 }
 
 interface ApplicationApi {
@@ -74,9 +106,12 @@ const Application = function (): ApplicationApi {
   const templates = compileTemplates();
 
   // Here we store the stuff we might need throughout the whole application.
+  // `remote` is filled in below by the `Object.keys(LocalEngine).forEach`
+  // wrapping pass; AppRemote's entries are all optional so the empty
+  // object here is a valid starting state.
   const app: ApplicationApi = {
     debug: {},
-    remote: {},
+    remote: {} as AppRemote,
     loadViews,
     renderView,
     start,
@@ -119,13 +154,22 @@ const Application = function (): ApplicationApi {
     setPrngSeed: true,
   };
   const engineRecord = LocalEngine as unknown as Record<string, unknown>;
+  // Cast seam: every wrapped handler returns a jQuery Deferred at
+  // runtime, which structurally implements both `JQueryLike` and
+  // `DoneFailChain<unknown>` — but the two interfaces are declared
+  // separately, so TypeScript can't see they're the same thing.  The
+  // cast is local to this assignment and lets `AppRemote`'s typed
+  // method signatures (recheckMissions, chargePerp, …) bind cleanly,
+  // dropping ~17 `as unknown as DoneFailChain<…>` casts at consumer
+  // call sites.
   Object.keys(engineRecord).forEach(function (name) {
     if (INTERNAL_API[name]) return;
     const fn = engineRecord[name];
     if (typeof fn !== 'function') return;
-    app.remote[name] = function (...args: unknown[]): JQueryLike {
+    const wrapped = function (...args: unknown[]): JQueryLike {
       return $.when((fn as (...a: unknown[]) => unknown).apply(LocalEngine, args));
     };
+    (app.remote as Record<string, unknown>)[name] = wrapped;
   });
 
   function start(): JQueryLike {

--- a/scripts/game/ClientPerp.ts
+++ b/scripts/game/ClientPerp.ts
@@ -11,8 +11,6 @@ import appModule from '../app.js';
 import { toKSNum } from '../dd-helpers.js';
 import { type GameNodeConfig } from './GameNode.js';
 import {
-  type ChargeResult,
-  type DoneFailChain,
   GamePerp,
   type GameRootForPerp,
   type RenderNodeLike,
@@ -44,15 +42,6 @@ interface ClientRenderNodeLike extends RenderNodeLike {
 interface TokenRef {
   gestalt: string;
   amount: number;
-}
-
-interface CollectResult {
-  result?: { cash: number; [k: string]: unknown };
-  error?: number;
-  game_values?: Record<string, unknown> & { karma_value?: number };
-  levelup?: boolean;
-  missions?: unknown;
-  karma_incident?: string;
 }
 
 interface GameRootForClientPerp extends GameRootForPerp {
@@ -175,13 +164,14 @@ export class ClientPerp extends GamePerp {
     const collectFn = appModule.getApplication().remote.collectPerp;
     if (!collectFn) return;
     const path = gperp.path || '';
-    const call = collectFn(path) as unknown as DoneFailChain<CollectResult>;
+    const call = collectFn(path);
     call
       .done(function (data) {
         // FIXME: It would be better if data.result was in a predefined
         // state to prevent testing for both, undefined _and_ null...
         if (data.result?.result) {
           const inner = data.result.result;
+          if (inner.cash === undefined) return;
           const amount = inner.cash;
           if (popup) popup.trigger('popup_close');
           groot.updateGameValues(
@@ -259,7 +249,7 @@ export class ClientPerp extends GamePerp {
     const chargeFn = appModule.getApplication().remote.chargePerp;
     if (!chargeFn) return;
     const path = gnode.path || '';
-    const call = chargeFn(path) as unknown as DoneFailChain<ChargeResult>;
+    const call = chargeFn(path);
     call
       .done(function (data) {
         if (!data.result) {

--- a/scripts/game/ContactPerp.ts
+++ b/scripts/game/ContactPerp.ts
@@ -12,8 +12,6 @@ import appModule from '../app.js';
 import { toKSNum } from '../dd-helpers.js';
 import { type GameNodeConfig } from './GameNode.js';
 import {
-  type ChargeResult,
-  type DoneFailChain,
   GamePerp,
   type GameRootForPerp,
   type RenderNodeLike,
@@ -39,19 +37,6 @@ interface ContactRenderNodeLike extends RenderNodeLike {
   FXCharge?(): void;
   FXNoAP?(): void;
   FXDataOut?(): void;
-}
-
-interface CollectResult {
-  result?: {
-    profile_set: { profiles_value: number; [k: string]: unknown };
-    origin: unknown;
-    collect_id: unknown;
-  };
-  error?: number;
-  game_values?: Record<string, unknown> & { karma_value?: number };
-  levelup?: boolean;
-  missions?: unknown;
-  karma_incident?: string;
 }
 
 interface GameRootForContactPerp extends GameRootForPerp {
@@ -121,7 +106,7 @@ export class ContactPerp extends GamePerp {
     const chargeFn = appModule.getApplication().remote.chargePerp;
     if (!chargeFn) return;
     const path = gnode.path || '';
-    const call = chargeFn(path) as unknown as DoneFailChain<ChargeResult>;
+    const call = chargeFn(path);
     call
       .done(function (data) {
         if (!data.result) {
@@ -178,13 +163,14 @@ export class ContactPerp extends GamePerp {
     const collectFn = appModule.getApplication().remote.collectPerp;
     if (!collectFn) return;
     const path = gperp.path || '';
-    const call = collectFn(path) as unknown as DoneFailChain<CollectResult>;
+    const call = collectFn(path);
     call
       .done(function (data) {
         // FIXME: It would be better if data.result was in a predefined
         // state to prevent testing for both, undefined _and_ null...
         if (data.result?.result) {
           const inner = data.result.result;
+          if (!inner.profile_set) return;
           const amount = inner.profile_set.profiles_value;
           if (popup) popup.trigger('popup_close');
           groot.updateGameValues(

--- a/scripts/game/Database.ts
+++ b/scripts/game/Database.ts
@@ -20,7 +20,10 @@ import {
   getByType,
   getFirstId,
 } from './GameNode.js';
-import { type DoneFailChain, type RenderPopupLike } from './GamePerp.js';
+import { type RenderPopupLike } from './GamePerp.js';
+// `BuyPerpResult` lives on GamePerp where it's the canonical shape;
+// Database's BuyToken consumer reads the same fields the perp BuyPerp
+// flow consumes, so re-using it here drops a structural duplicate.
 import { type GameRoot } from './GameRoot.js';
 import { OrderedSet } from './OrderedSet.js';
 import { ProfileSet } from './ProfileSet.js';
@@ -112,7 +115,10 @@ interface TokenPerpLike extends GameNode {
   path?: string;
 }
 
-interface IntegrateResult {
+/** Result payload for `app.remote.integrateCollected(psid)`.  Exported
+ *  so `AppRemote`'s typed method signature in `scripts/app.ts` can pull
+ *  the shape via `import type` without circular runtime deps. */
+export interface IntegrateResult {
   game_values?: { profiles_value?: number; [key: string]: unknown };
   levelup?: boolean;
   missions?: unknown;
@@ -126,19 +132,6 @@ interface IntegrateResult {
       full_path?: string;
       instance_data?: { amount?: number; [key: string]: unknown };
     }>;
-  };
-  error?: number;
-}
-
-interface BuyPerpResult {
-  game_values?: Record<string, unknown>;
-  levelup?: boolean;
-  missions?: unknown;
-  node?: {
-    game_id?: string;
-    game_type?: string;
-    full_path?: string;
-    instance_data?: Record<string, unknown>;
   };
   error?: number;
 }
@@ -295,7 +288,7 @@ export class Database extends GameNode {
     if (!buyPerpFn) return;
     const Render = this.getRenderModule();
     const path = gnode.path || '';
-    const call = buyPerpFn(path, bgestalt) as unknown as DoneFailChain<BuyPerpResult>;
+    const call = buyPerpFn(path, bgestalt);
     call.done(function (data) {
       if (!data.result) {
         // Server Error
@@ -464,7 +457,7 @@ export class Database extends GameNode {
     if (!integrateFn) return;
     const Render = this.getRenderModule();
 
-    const call = integrateFn(psid) as unknown as DoneFailChain<IntegrateResult>;
+    const call = integrateFn(psid);
     call.done(function (data) {
       if (!data.result) {
         gnode.Error?.('The computer says NOOOO', data);

--- a/scripts/game/DatabasePerp.ts
+++ b/scripts/game/DatabasePerp.ts
@@ -12,8 +12,6 @@ import appModule from '../app.js';
 import i18n from '../i18n.js';
 import { getByFirstId, getByType, getFirstId } from './GameNode.js';
 import {
-  type BuyPerpResult,
-  type DoneFailChain,
   GamePerp,
   type GameRootForPerp,
   type RenderNodeLike,
@@ -22,12 +20,11 @@ import {
 import { mergeData } from './mergeData.js';
 import { perpCtors } from './perpCtors.js';
 
-/** Database BuyPerp returns one extra field (`profile_set`) that the
- *  generic perp BuyPerp doesn't — the Database queues it after the
- *  city renders. */
-interface BuyCityResult extends BuyPerpResult {
-  profile_set?: { profile_set?: unknown; origin?: unknown; collect_id?: unknown };
-}
+// `BuyPerpResult` (in GamePerp.ts) now carries the optional
+// `profile_set` field that the Database BuyCity flow queues after the
+// city renders — the local `BuyCityResult` extension is no longer
+// needed and the `as unknown as DoneFailChain<…>` cast at the call
+// site below drops out with it.
 
 interface GameRootForDatabasePerp extends GameRootForPerp {
   renderPopup?: RenderPopupLike;
@@ -58,7 +55,7 @@ export class DatabasePerp extends GamePerp {
     const buyPerpFn = appModule.getApplication().remote.buyPerp;
     if (!buyPerpFn) return;
     const path = gnode.path || '';
-    const call = buyPerpFn(path, bgestalt) as unknown as DoneFailChain<BuyCityResult>;
+    const call = buyPerpFn(path, bgestalt);
     call.done(function (data) {
       if (!data.result) {
         gnode._serverError(data);

--- a/scripts/game/GamePerp.ts
+++ b/scripts/game/GamePerp.ts
@@ -88,6 +88,10 @@ export interface BuyPerpResult {
     full_path?: string;
     instance_data?: Record<string, unknown>;
   };
+  /** Database BuyPerp returns one extra field — the Database queues it
+   *  after the city renders.  Optional, ignored by non-Database
+   *  consumers. */
+  profile_set?: { profile_set?: unknown; origin?: unknown; collect_id?: unknown };
   error?: number;
 }
 
@@ -352,7 +356,7 @@ export class GamePerp extends GameNode {
     const buyPerpFn = remote.buyPerp;
     if (!buyPerpFn) return;
     const path = gnode.path || '';
-    const call = buyPerpFn(path, bgestalt) as unknown as DoneFailChain<BuyPerpResult>;
+    const call = buyPerpFn(path, bgestalt);
     call.done(function (data) {
       if (!data.result) {
         // Server Error

--- a/scripts/game/Missions.ts
+++ b/scripts/game/Missions.ts
@@ -5,7 +5,6 @@
 import appModule from '../app.js';
 import i18n from '../i18n.js';
 import { GameNode, type GameNodeConfig, getByFirstId, getFirstId } from './GameNode.js';
-import { type DoneFailChain } from './GamePerp.js';
 import { Mission } from './Mission.js';
 import { OrderedSet } from './OrderedSet.js';
 
@@ -15,7 +14,10 @@ interface RawMissionsData {
   mission_goals?: Array<Record<string, unknown>>;
 }
 
-interface RecheckMissionsResult {
+/** Result payload for `app.remote.recheckMissions()`.  Exported so
+ *  `AppRemote`'s typed method signature in `scripts/app.ts` can pull
+ *  the shape via `import type` without circular runtime deps. */
+export interface RecheckMissionsResult {
   repaired?: boolean;
   game_values?: Record<string, unknown>;
   levelup?: boolean;
@@ -53,7 +55,7 @@ export class Missions extends GameNode {
       if (!params || !remote || !remote.recheckMissions) {
         return;
       }
-      const call = remote.recheckMissions() as unknown as DoneFailChain<RecheckMissionsResult>;
+      const call = remote.recheckMissions();
       call.done(function (data) {
         const r = data.result;
         if (!r || !r.repaired) return;

--- a/scripts/game/ProjectPerp.ts
+++ b/scripts/game/ProjectPerp.ts
@@ -16,13 +16,7 @@ import appModule from '../app.js';
 import { toKSNum } from '../dd-helpers.js';
 import i18n from '../i18n.js';
 import { type GameNodeConfig } from './GameNode.js';
-import {
-  type ChargeResult,
-  type DoneFailChain,
-  GamePerp,
-  type RenderNodeLike,
-  type RenderPopupLike,
-} from './GamePerp.js';
+import { GamePerp, type RenderNodeLike, type RenderPopupLike } from './GamePerp.js';
 import { ProfileSet } from './ProfileSet.js';
 import { mergeData } from './mergeData.js';
 import { convertPowerupType, getPowerupTypeFromGestalt } from './powerupTypes.js';
@@ -67,28 +61,6 @@ interface ProjectRenderPopupLike extends RenderPopupLike {
   jdomelem?: JQueryElemLike;
   renderDataTab?(): void;
   renderPowerupSelectors?(pcat: string): void;
-}
-
-interface CollectResult {
-  result?: {
-    profile_set: { profiles_value: number; [k: string]: unknown };
-    origin: unknown;
-    collect_id: unknown;
-    [k: string]: unknown;
-  };
-  error?: number;
-  game_values?: Record<string, unknown> & { karma_value?: number };
-  levelup?: boolean;
-  missions?: unknown;
-  karma_incident?: string;
-}
-
-interface BuyPowerupResult {
-  error?: number;
-  game_values?: Record<string, unknown>;
-  levelup?: boolean;
-  missions?: unknown;
-  node?: { instance_data?: Record<string, unknown> };
 }
 
 interface PowerupRow {
@@ -292,7 +264,7 @@ export class ProjectPerp extends GamePerp {
     const buyFn = appModule.getApplication().remote.buyPowerup;
     if (!buyFn) return;
     const path = gnode.path || '';
-    const call = buyFn(path, bslot, bgestalt) as unknown as DoneFailChain<BuyPowerupResult>;
+    const call = buyFn(path, bslot, bgestalt);
     call
       .done(function (data) {
         if (!data.result) {
@@ -345,11 +317,7 @@ export class ProjectPerp extends GamePerp {
     const sellFn = appModule.getApplication().remote.sellPowerup;
     if (!sellFn) return;
     const path = gnode.path || '';
-    const call = sellFn(
-      path,
-      Number.parseInt(String(bslot), 10),
-      bgestalt
-    ) as unknown as DoneFailChain<BuyPowerupResult>;
+    const call = sellFn(path, Number.parseInt(String(bslot), 10), bgestalt);
     call
       .done(function (data) {
         if (!data.result) {
@@ -396,7 +364,7 @@ export class ProjectPerp extends GamePerp {
     const buyFn = appModule.getApplication().remote.buySlots;
     if (!buyFn) return;
     const path = gnode.path || '';
-    const call = buyFn(path, pcat, buyNum) as unknown as DoneFailChain<BuyPowerupResult>;
+    const call = buyFn(path, pcat, buyNum);
     call
       .done(function (data) {
         if (!data.result) {
@@ -535,7 +503,7 @@ export class ProjectPerp extends GamePerp {
     const chargeFn = appModule.getApplication().remote.chargePerp;
     if (!chargeFn) return;
     const path = gnode.path || '';
-    const call = chargeFn(path) as unknown as DoneFailChain<ChargeResult>;
+    const call = chargeFn(path);
     call
       .done(function (data) {
         if (!data.result) {
@@ -602,13 +570,14 @@ export class ProjectPerp extends GamePerp {
     const collectFn = appModule.getApplication().remote.collectPerp;
     if (!collectFn) return;
     const path = gperp.path || '';
-    const call = collectFn(path) as unknown as DoneFailChain<CollectResult>;
+    const call = collectFn(path);
     call
       .done(function (data) {
         // FIXME: It would be better if data.result was in a predefined
         // state to prevent testing for both, undefined _and_ null...
         if (data.result?.result) {
           const inner = data.result.result;
+          if (!inner.profile_set) return;
           const amount = inner.profile_set.profiles_value;
           if (popup) popup.trigger('popup_close');
           groot.updateGameValues(

--- a/scripts/game/TokenPerp.ts
+++ b/scripts/game/TokenPerp.ts
@@ -13,13 +13,7 @@ import { type RenderApi, getRender } from '../Render.js';
 import appModule from '../app.js';
 import { toKSNum } from '../dd-helpers.js';
 import { type GameNodeConfig, getByGestalt } from './GameNode.js';
-import {
-  type ChargeResult,
-  type DoneFailChain,
-  GamePerp,
-  type RenderNodeLike,
-  type RenderPopupLike,
-} from './GamePerp.js';
+import { GamePerp, type RenderNodeLike, type RenderPopupLike } from './GamePerp.js';
 import type { GameRoot } from './GameRoot.js';
 import { ProfileSet } from './ProfileSet.js';
 
@@ -59,14 +53,6 @@ interface TokenRenderNodeLike extends RenderNodeLike {
   cableAnimatedRemove?(target: unknown): void;
   cableAnimatedTo?(target: unknown, opts: Record<string, unknown>, cb?: () => void): CableLike;
   cableTo?(target: unknown, opts: Record<string, unknown>): void;
-}
-
-interface CollectResult {
-  result?: { token_upgraded_amount: number; [k: string]: unknown };
-  error?: number;
-  game_values?: Record<string, unknown>;
-  levelup?: boolean;
-  missions?: unknown;
 }
 
 interface NodeReadyPayload {
@@ -279,7 +265,7 @@ export class TokenPerp extends GamePerp {
     const chargeFn = appModule.getApplication().remote.chargePerp;
     if (!chargeFn) return;
     const path = gnode.path || '';
-    const call = chargeFn(path) as unknown as DoneFailChain<ChargeResult>;
+    const call = chargeFn(path);
     call
       .done(function (data) {
         if (!data.result) {
@@ -348,13 +334,14 @@ export class TokenPerp extends GamePerp {
     const collectFn = appModule.getApplication().remote.collectPerp;
     if (!collectFn) return;
     const path = gperp.path || '';
-    const call = collectFn(path) as unknown as DoneFailChain<CollectResult>;
+    const call = collectFn(path);
     call
       .done(function (data) {
         if (data.result?.result) {
           if (popup) popup.trigger('popup_close');
           // FIXME: compile for checkNotifications
           groot.getDatabase()?.compileSuperTokens();
+          if (data.result.result.token_upgraded_amount === undefined) return;
           gperp.setAmount(data.result.result.token_upgraded_amount);
           groot.updateGameValues(
             data.result.game_values || {},

--- a/scripts/game/Topscore.ts
+++ b/scripts/game/Topscore.ts
@@ -7,7 +7,6 @@
 
 import appModule from '../app.js';
 import { GameNode } from './GameNode.js';
-import { type DoneFailChain } from './GamePerp.js';
 import { mergeData } from './mergeData.js';
 
 // app.remote handlers are wired up by app.start(); Topscore is only
@@ -24,7 +23,10 @@ interface RankingRow {
   self: boolean;
 }
 
-interface RankingResult {
+/** Result payload for `app.remote.getRanking(scoretype)`.  Exported so
+ *  `AppRemote`'s typed method signature in `scripts/app.ts` can pull
+ *  the shape via `import type` without circular runtime deps. */
+export interface RankingResult {
   top?: RankingRow[];
   user_rank?: number;
   user_in_top?: boolean;
@@ -70,7 +72,7 @@ export class Topscore extends GameNode {
     const gnode = this;
     const getRanking = appModule.getApplication().remote.getRanking;
     if (!getRanking) return;
-    const rankingCall = getRanking(t) as unknown as DoneFailChain<RankingResult>;
+    const rankingCall = getRanking(t);
     rankingCall
       .done(function (data) {
         if (data.result && data.result.error === undefined) {

--- a/scripts/remote-types.ts
+++ b/scripts/remote-types.ts
@@ -1,0 +1,45 @@
+// Shared result-payload types for `app.remote.*` handlers used by
+// multiple consumer files (perp lifecycle handlers, buy/sell flows).
+//
+// Per-handler types that are only consumed in one file stay co-located
+// with that consumer and are referenced from `app.ts` via `import type`
+// (see `AppRemote` in `scripts/app.ts`).
+//
+// The shapes are intentionally permissive supersets — each consumer
+// narrows further locally.  This module is the seam introduced by the
+// AppRemote-typing PR: it lets `AppRemote.collectPerp` etc. return
+// `DoneFailChain<…>` instead of the raw `JQueryLike` that previously
+// forced every call site through an `as unknown as DoneFailChain<…>`
+// cast.
+
+/** Shared shape returned by `app.remote.collectPerp` for any
+ *  lifecycle-style perp (ContactPerp / ClientPerp / ProjectPerp /
+ *  TokenPerp).  The `result?` payload differs per perp subtype — the
+ *  superset shape below covers every consumer's expected fields. */
+export interface CollectResult {
+  result?: {
+    profile_set?: { profiles_value: number; [k: string]: unknown };
+    origin?: unknown;
+    collect_id?: unknown;
+    cash?: number;
+    token_upgraded_amount?: number;
+    [k: string]: unknown;
+  };
+  error?: number;
+  game_values?: Record<string, unknown> & { karma_value?: number };
+  levelup?: boolean;
+  missions?: unknown;
+  karma_incident?: string;
+}
+
+/** Shared shape returned by `app.remote.buyPowerup` / `sellPowerup` /
+ *  `buySlots`.  All three handlers funnel through the same
+ *  `_persistDelta` machinery in LocalEngine and produce the same payload
+ *  shape. */
+export interface BuyPowerupResult {
+  error?: number;
+  game_values?: Record<string, unknown>;
+  levelup?: boolean;
+  missions?: unknown;
+  node?: { instance_data?: Record<string, unknown> };
+}


### PR DESCRIPTION
## Summary

Replace `AppRemote`'s index-signature-only interface (`[name: string]: (...args: unknown[]) => JQueryLike`) with explicit method signatures returning `DoneFailChain<…>`, so callers no longer need `remote.foo(…) as unknown as DoneFailChain<FooResult>` at every call site. Builds on #258 (canonical `DoneFailChain<T>`) and #259.

## Methods typed

| Method | Result type | Source |
| --- | --- | --- |
| `recheckMissions()` | `RecheckMissionsResult` | `game/Missions.ts` (now exported) |
| `chargePerp(path)` | `ChargeResult` | `game/GamePerp.ts` (already exported) |
| `collectPerp(path)` | `CollectResult` | `scripts/remote-types.ts` (new) |
| `buyPerp(path, gestalt)` | `BuyPerpResult` | `game/GamePerp.ts` (already exported) |
| `buyPowerup(path, slot, gestalt)` | `BuyPowerupResult` | `scripts/remote-types.ts` (new) |
| `sellPowerup(path, slot, gestalt)` | `BuyPowerupResult` | same |
| `buySlots(path, type, num)` | `BuyPowerupResult` | same |
| `integrateCollected(psid)` | `IntegrateResult` | `game/Database.ts` (now exported) |
| `getRanking(type)` | `RankingResult` | `game/Topscore.ts` (now exported) |
| `getSessionLocale()` / `loadGame()` | `JQueryLike` | kept — call sites in `app.start()` / `GameRoot.continueStart` chain `.then(...)` |

## Type relocations

Per-handler `*Result` types used in a single consumer stay there and are pulled into `app.ts` via `import type` — minimises new imports. The only relocations are the multi-consumer types that were duplicated:

- `BuyPowerupResult` and `CollectResult` move to a new `scripts/remote-types.ts` (covered ProjectPerp / ContactPerp / ClientPerp / TokenPerp's structurally-similar locals).
- `BuyCityResult` (`DatabasePerp.ts`) and the duplicate `BuyPerpResult` (`Database.ts`) collapse into the canonical `BuyPerpResult` in `GamePerp.ts` — the optional `profile_set?` field that distinguished BuyCity is folded in.

## LocalEngine boundary

Option A from the brief: a single localized cast in `app.ts`'s `Object.keys(LocalEngine).forEach(...)` wrapping pass. The wrapped function still returns `JQueryLike` at runtime (a structural subtype of every typed `DoneFailChain<…>`). `LocalEngine.ts` itself is untouched.

## Cast-count delta

`scripts/`: **17 → 0** matches for `as unknown as DoneFailChain` in code paths. The 4 remaining matches are all in explanatory comments (`scripts/app.ts`, `scripts/remote-types.ts`, `scripts/game/DatabasePerp.ts`).

## Cascade narrowing

The shared `CollectResult.result?` types per-perp-specific fields (`profile_set`, `cash`, `token_upgraded_amount`) as optional — each consumer gained a narrowing guard:

- `ContactPerp.collect`: `if (!inner.profile_set) return;`
- `ProjectPerp.collect`: same
- `ClientPerp.collect`: `if (inner.cash === undefined) return;`
- `TokenPerp.collect`: `if (data.result.result.token_upgraded_amount === undefined) return;`

This was already the latent runtime contract (server can fail mid-flight); the guards make it explicit.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` clean (639/639)

https://claude.ai/code/session_017gPuFHF6MdaSov26RW5NTZ

---
_Generated by [Claude Code](https://claude.ai/code/session_017gPuFHF6MdaSov26RW5NTZ)_