### PR TITLE
type-debt: widen render GameNodeLike (RenderDecorators spike)

### DIFF
--- a/scripts/render/RenderDecorators.ts
+++ b/scripts/render/RenderDecorators.ts
@@ -339,10 +339,7 @@ export class RenderDecoratorGear extends RenderSprite implements DecoratorBase {
   override onAddInit(): void {
     const dec = this.decoratedNode;
     if (dec) {
-      const gameNode = dec.gameNode as unknown as
-        | { data?: { is_supertoken?: boolean } }
-        | undefined;
-      const isSupertoken = gameNode?.data?.is_supertoken === true;
+      const isSupertoken = dec.gameNode?.data?.is_supertoken === true;
       if (!isSupertoken) {
         this.offsetToParent = {
           x: dec.width / 2 - 11,
@@ -583,10 +580,8 @@ export class RenderDecoratorAmount extends RenderSprite implements DecoratorBase
     this.jdomelem2.animate({ width: Math.round((a / 100) * 60) }, 600);
     if (a < 25) {
       this.jdomelem3.show();
-      const dec = this.decoratedNode as unknown as
-        | { gameNode?: { data?: { absoluteAmount?: number } } }
-        | undefined;
-      const absolute = dec?.gameNode?.data?.absoluteAmount ?? 0;
+      const dec = this.decoratedNode;
+      const absolute = (dec?.gameNode?.data?.absoluteAmount as number | undefined) ?? 0;
       this.jdomelem3.text(toKSNum(absolute));
     } else {
       this.jdomelem3.hide();

--- a/scripts/render/RenderNode.ts
+++ b/scripts/render/RenderNode.ts
@@ -7,6 +7,7 @@
 // Injection seams for `setRenderNodeRegistry` and `setRenderNodeTickers`
 // have been retired in favor of direct imports.
 
+import type { GameRoot } from '../game/GameRoot.js';
 import { OrderedSet } from '../game/OrderedSet.js';
 import { RenderSet } from './RenderSet.js';
 import { RenderSlowTicker } from './RenderSlowTicker.js';
@@ -59,6 +60,9 @@ interface CableLike {
 interface GameNodeLike {
   trigger(ev: string, params?: unknown[]): void;
   parentNode?: { renderNode: RenderNode };
+  GameRoot?: GameRoot;
+  states?: Record<string, boolean>;
+  data?: Record<string, unknown>;
 }
 
 // ── decorator slot typing ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Mirror of #248 for the render layer. `#248` retyped `GameNode.GameRoot` as the real `GameRoot` via a type-only import and unlocked a wave of game-side cleanups; this spike applies the same pattern to render's `GameNodeLike` structural shim.

`scripts/render/RenderNode.ts` declared `GameNodeLike` with only `trigger()` + `parentNode`, so every consumer that needed to reach `GameRoot`, `states`, or `data` off the gameNode backlink had to re-cast through a per-file shape (`GameRootForUI` / `GameRootForView` / `GameRootForMain`, etc.). ~10-15 such casts live across `RenderTopLevelUI.ts`, `RenderViews.ts`, and `RenderDecorators.ts`.

This PR:
- Widens `GameNodeLike` with `GameRoot?: GameRoot`, `states?: Record<string, boolean>`, `data?: Record<string, unknown>`.
- Uses `import type { GameRoot }` so the render -> game edge stays erased at compile time (no runtime cycle), mirroring #248.
- Retires the two `as unknown as { ... }` casts in `RenderDecorators.ts` as a proof point.

`RenderTopLevelUI.ts` (10 casts) and `RenderViews.ts` (9 casts) intentionally untouched — those land as follow-up cleanup PRs against this widened surface.

## Validation

- `pnpm typecheck` clean
- `pnpm lint` clean
- No cascade errors elsewhere — the widening is purely additive on the structural surface, and existing render-internal types that declare their own narrow `gameNode?: { ... }` (e.g. `RenderViews.ts:885`) shadow `GameNodeLike` and continue to work as-is.

## Field selection rationale

- `GameRoot?: GameRoot` — needed by RenderTopLevelUI, RenderViews, RenderViewMain follow-ups.
- `states?: Record<string, boolean>` — matches `GameNode.states!: Record<string, boolean>` shape.
- `data?: Record<string, unknown>` — matches `GameNode.data?: Record<string, unknown>`; consumed by RenderDecorators (`is_supertoken`, `absoluteAmount`).

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [ ] Manual smoke: gear / amount decorators still render correctly in-game (untouched behavior — pure type cleanup).

https://claude.ai/code/session_017gPuFHF6MdaSov26RW5NTZ

---
_Generated by [Claude Code](https://claude.ai/code/session_017gPuFHF6MdaSov26RW5NTZ)_