### PR TITLE
type-debt: drop GameRootForView/Main shim casts in RenderViews.ts

### DIFF
--- a/scripts/render/RenderViews.ts
+++ b/scripts/render/RenderViews.ts
@@ -178,8 +178,7 @@ export class RenderViewTab extends RenderNode {
       void e;
       if (value) {
         node.FXShow();
-        const root = (node.gameNode as unknown as { GameRoot?: GameRootForView } | undefined)
-          ?.GameRoot;
+        const root = node.gameNode?.GameRoot as GameRootForView | undefined;
         if (node.parentNode) {
           node.parentNode.jdomelem.addClass('Active' + (jdomelem.attr('id') as string));
         }
@@ -261,9 +260,11 @@ export class RenderViewTab extends RenderNode {
 
 // ── ViewMap ─────────────────────────────────────────────────────────────────
 
+// `GameNodeLike.GameRoot` exists post-#261, but `GameRoot.renderMenu` lands
+// on the upstream `RenderNodeLike` shape where `jdomelem` is `unknown`.
+// This local shim narrows just that jQuery surface for the tab-active code.
 interface GameRootForView {
   renderMenu?: { jdomelem: JQueryViewElem };
-  _cancelPendingCenter?: () => void;
 }
 
 export type ViewMapConfig = NodeConfig & {
@@ -345,8 +346,7 @@ export class RenderViewMap extends RenderNode {
     // LISTEN TO STATES
     this.on('states_active', (e: ViewDomEvent, value: unknown) => {
       e.stopPropagation();
-      const root = (this.gameNode as unknown as { GameRoot?: GameRootForView } | undefined)
-        ?.GameRoot;
+      const root = this.gameNode?.GameRoot as GameRootForView | undefined;
       if (value) {
         this.FXShow();
         if (this.parentNode) {
@@ -713,7 +713,7 @@ export class RenderViewMap extends RenderNode {
     if (!this.parentNode || !this.scroller) return;
     const vpCenter = this.parentNode.getCenterPosition();
     const duration = dur !== undefined ? dur : 300;
-    const root = (this.gameNode as unknown as { GameRoot?: GameRootForView } | undefined)?.GameRoot;
+    const root = this.gameNode?.GameRoot;
     root?._cancelPendingCenter?.();
     this.scroller.options.animating = duration > 0;
     this.scroller.options.animationDuration = duration;
@@ -918,7 +918,7 @@ export class RenderMainMenu extends RenderStage {
     this.render();
 
     // Setup Button Events
-    const root = (this.gameNode as unknown as { GameRoot?: GameRootForMain } | undefined)?.GameRoot;
+    const root = this.gameNode?.GameRoot;
 
     this.jdomelem.on('click touchend', '#LocaleToggle:not(.disabled)', (e) => {
       e.stopPropagation();
@@ -1055,8 +1055,4 @@ export class RenderMainMenu extends RenderStage {
     this.data.buttons.push(button);
     this.render();
   }
-}
-
-interface GameRootForMain {
-  trigger?(ev: string, params?: unknown[]): void;
 }


### PR DESCRIPTION
Follow-up to #261 (now merged into master). The widened `GameNodeLike` (with `GameRoot?: GameRoot`, `states?`, `data?`) makes the local `as unknown as { GameRoot?: ... }` shape casts in `scripts/render/RenderViews.ts` redundant.

Originally planned as stacked on `claude/typedebt-rendernode-gamenode`, but #261 landed on master before this PR opened, so it now targets master directly.

## Done
- Removed `as unknown as { GameRoot?: ... }` casts at lines ~716 (`scrollTo`) and ~921 (RenderMain button events) — direct `this.gameNode?.GameRoot` access works post-#261.
- Simplified the two ViewMap `states_active` cast sites (lines ~181, ~348) to `this.gameNode?.GameRoot as GameRootForView | undefined`, eliminating the `gameNode as unknown as ...` shape cast (one fewer `as unknown as`).
- Deleted `interface GameRootForMain` (no longer referenced).

## Deferred / intentionally retained casts in RenderViews.ts
- `appModule.getApplication() as unknown as AppLike` (line 43) — bootstrap
- `touchEvt.touches as unknown as ArrayLike<...>` (lines 599, 630) — touch-event boundary
- `node as unknown as { scroller?, updateScroller? }` (line 848) — scroller probe
- `this.jdomelem.find('.mm-xp-bar') as unknown as { ... }` (line 1011) — jQuery DOM
- XPSubpop self-shadow at line ~878 (`gameNode?: { GameRoot?: { xp_level?: ... } }`) — by-design

## Why `GameRootForView` is retained (scope-limited)
At the two ViewMap tab-active sites, the access chain is `root.renderMenu.jdomelem.find(...).removeClass/addClass(...)`. `GameRoot.renderMenu` lands on the upstream `RenderNodeLike` shape from `scripts/game/GameNode.ts`, where `jdomelem` is typed as `unknown` and `removeClass` returns `void`. Removing this shim entirely would require widening `RenderNodeLike` (a separate downstream type-debt concern, out of scope for #261). The retained shim is now narrower (just `renderMenu?: { jdomelem: JQueryViewElem }`) and applied as a direct `as GameRootForView | undefined` on the GameRoot result rather than a two-step `as unknown as`.

## Cast-count delta
- `scripts/render/RenderViews.ts`: 9 `as unknown as` -> 5
- `scripts/` net: 86 -> 82

## Validation
- `pnpm typecheck` clean
- `pnpm lint` clean

https://claude.ai/code/session_017gPuFHF6MdaSov26RW5NTZ

---
_Generated by [Claude Code](https://claude.ai/code/session_017gPuFHF6MdaSov26RW5NTZ)_