### PR TITLE
type-debt: close render-side surface gaps, drop residual shim casts

### DIFF
--- a/scripts/game/GameRoot.ts
+++ b/scripts/game/GameRoot.ts
@@ -83,6 +83,7 @@ interface RenderRootLike {
   jdomelem?: {
     find?(sel: string): {
       off?(ev?: string): void;
+      addClass?(cls: string): void;
       removeClass?(cls: string): void;
     };
     outerHeight?(): number;
@@ -90,6 +91,9 @@ interface RenderRootLike {
   setSize?(opts: { width?: number; height?: number }): void;
   render?(): void;
   addPopup?(popup: unknown): void;
+  /** Owned by RenderMainMenu (RenderViews.ts).  Cloned-XP-bar slot
+   *  refresh; `sb` is structurally a RenderStatusbar (XP_* scalars). */
+  renderXP?(sb: unknown): void;
   // FX hooks driven by makeNotifications.  All optional; the Stage
   // owns the implementations (Render.js).
   FXMissionComplete?(): void;
@@ -205,6 +209,9 @@ interface APTickerLike {
   reset(): void;
   start(offset?: number): void;
   addListener(node: GameNode): void;
+  /** Returns a Date whose epoch-ms equals the ms remaining until the
+   *  next AP tick — see Game.ts's APTicker singleton. */
+  getRemainingTime?(): Date;
 }
 
 /** Status-bar slot — one per game-value.  `val`/`max` drive the

--- a/scripts/render/RenderNode.ts
+++ b/scripts/render/RenderNode.ts
@@ -59,7 +59,7 @@ interface CableLike {
 
 interface GameNodeLike {
   trigger(ev: string, params?: unknown[]): void;
-  parentNode?: { renderNode: RenderNode };
+  parentNode?: { renderNode: RenderNode; data?: Record<string, unknown> };
   GameRoot?: GameRoot;
   states?: Record<string, boolean>;
   data?: Record<string, unknown>;

--- a/scripts/render/RenderTopLevelUI.ts
+++ b/scripts/render/RenderTopLevelUI.ts
@@ -63,13 +63,6 @@ function getApp(): AppLike {
 
 // ── shared structural surfaces ──────────────────────────────────────────────
 
-interface GameRootForUI {
-  renderMenu?: { renderXP?(sb: RenderStatusbar): void };
-  ap_value: number;
-  xp_level: { ap_max: number; xp_min?: number; xp_max?: number };
-  APTicker: { getRemainingTime(): number };
-}
-
 interface StatusbarValueChannel {
   val: number;
   max: number;
@@ -200,7 +193,7 @@ export class RenderStatusbar extends RenderNode {
     this.draw();
 
     // Mirror to the MainMenu's mobile XP slot (CSS hides it on desktop).
-    const groot = (this.gameNode as unknown as { GameRoot?: GameRootForUI } | undefined)?.GameRoot;
+    const groot = this.gameNode?.GameRoot;
     if (groot?.renderMenu?.renderXP) {
       groot.renderMenu.renderXP(this);
     }
@@ -329,8 +322,7 @@ export class RenderStatusbar extends RenderNode {
 
     jq.on('mouseenter', '.StatusItem.AP', function (this: HTMLElement, e: UIEventLike) {
       e.stopPropagation();
-      const groot = (node.gameNode as unknown as { GameRoot?: GameRootForUI } | undefined)
-        ?.GameRoot;
+      const groot = node.gameNode?.GameRoot;
       if (!groot) return;
       if (groot.ap_value >= groot.xp_level.ap_max) {
         return;
@@ -339,7 +331,10 @@ export class RenderStatusbar extends RenderNode {
       jtext.show();
       const APT = groot.APTicker;
       node.startLoop(() => {
-        jtext.html(RenderStatusbar.textMoreIn() + span(toTime(APT.getRemainingTime())));
+        // APTicker.getRemainingTime() returns a Date (Game.ts) whose
+        // epoch-ms is the remaining ms; coerce to number for `toTime`.
+        const ms = APT?.getRemainingTime?.();
+        jtext.html(RenderStatusbar.textMoreIn() + span(toTime(ms ? +ms : 0)));
       }, 1000);
     });
 
@@ -1139,11 +1134,28 @@ export type TopscorePerpConfig = NodeConfig & {
   frame?: string;
 };
 
+// Topscore-specific gameNode shape: the `Topscore` GameNode subclass
+// owns a `scoretype` field (Topscore.ts).  Shadow-declared on the
+// render-side `gameNode` field so the rank/list templates can read
+// it without the residual `as unknown as` cast.  Mirrors the
+// (unexported) `GameNodeLike` in RenderNode.ts plus `scoretype`.
+interface TopscoreGameNodeLike {
+  trigger(ev: string, params?: unknown[]): void;
+  parentNode?: { renderNode: RenderNode; data?: Record<string, unknown> };
+  states?: Record<string, boolean>;
+  data?: Record<string, unknown>;
+  scoretype?: string;
+}
+
 export class RenderTopscorePerp extends RenderNode {
   declare frameSrc: string | undefined;
   declare frameMap: SpriteFrameMap | undefined;
   declare frame: string;
   declare template: string;
+  // Shadow the inherited `gameNode: GameNodeLike | undefined` with a
+  // Topscore-specific shape so renderRank/renderList can read
+  // `scoretype` without a cast.
+  declare gameNode: TopscoreGameNodeLike | undefined;
 
   static {
     RenderTopscorePerp.prototype.template = 'topscore.html';
@@ -1229,9 +1241,7 @@ export class RenderTopscorePerp extends RenderNode {
     const jq = this.jdomelem;
     const rank = jq.find('.TopscoreRank');
     rank.empty();
-    const gnode = this.gameNode as unknown as
-      | { data?: unknown; parentNode?: { data?: unknown }; scoretype?: string }
-      | undefined;
+    const gnode = this.gameNode;
     const html = getApp().renderView('topscore_rank.html', {
       data: gnode?.data,
       parentdata: gnode?.parentNode?.data,
@@ -1244,9 +1254,7 @@ export class RenderTopscorePerp extends RenderNode {
     const jq = this.jdomelem;
     const list = jq.find('.TopscoreList');
     list.empty();
-    const gnode = this.gameNode as unknown as
-      | { data?: unknown; parentNode?: { data?: unknown }; scoretype?: string }
-      | undefined;
+    const gnode = this.gameNode;
     const html = getApp().renderView('topscore_list.html', {
       data: gnode?.data,
       parentdata: gnode?.parentNode?.data,

--- a/scripts/render/RenderViews.ts
+++ b/scripts/render/RenderViews.ts
@@ -178,15 +178,15 @@ export class RenderViewTab extends RenderNode {
       void e;
       if (value) {
         node.FXShow();
-        const root = node.gameNode?.GameRoot as GameRootForView | undefined;
+        const root = node.gameNode?.GameRoot;
         if (node.parentNode) {
           node.parentNode.jdomelem.addClass('Active' + (jdomelem.attr('id') as string));
         }
-        if (root?.renderMenu) {
-          root.renderMenu.jdomelem.find('.mm-tab').removeClass('active');
+        if (root?.renderMenu?.jdomelem) {
+          root.renderMenu.jdomelem.find?.('.mm-tab')?.removeClass?.('active');
           root.renderMenu.jdomelem
-            .find('.mm-tab[data-button-id=' + node.id + ']')
-            .addClass('active');
+            .find?.('.mm-tab[data-button-id=' + node.id + ']')
+            ?.addClass?.('active');
         }
         node.trigger('viewtab_selected');
       } else {
@@ -259,13 +259,6 @@ export class RenderViewTab extends RenderNode {
 }
 
 // ── ViewMap ─────────────────────────────────────────────────────────────────
-
-// `GameNodeLike.GameRoot` exists post-#261, but `GameRoot.renderMenu` lands
-// on the upstream `RenderNodeLike` shape where `jdomelem` is `unknown`.
-// This local shim narrows just that jQuery surface for the tab-active code.
-interface GameRootForView {
-  renderMenu?: { jdomelem: JQueryViewElem };
-}
 
 export type ViewMapConfig = NodeConfig & {
   width?: number;
@@ -346,17 +339,17 @@ export class RenderViewMap extends RenderNode {
     // LISTEN TO STATES
     this.on('states_active', (e: ViewDomEvent, value: unknown) => {
       e.stopPropagation();
-      const root = this.gameNode?.GameRoot as GameRootForView | undefined;
+      const root = this.gameNode?.GameRoot;
       if (value) {
         this.FXShow();
         if (this.parentNode) {
           this.parentNode.jdomelem.addClass('Active' + (jdomelem.attr('id') as string));
         }
-        if (root?.renderMenu) {
-          root.renderMenu.jdomelem.find('.mm-tab').removeClass('active');
+        if (root?.renderMenu?.jdomelem) {
+          root.renderMenu.jdomelem.find?.('.mm-tab')?.removeClass?.('active');
           root.renderMenu.jdomelem
-            .find('.mm-tab[data-button-id=' + this.id + ']')
-            .addClass('active');
+            .find?.('.mm-tab[data-button-id=' + this.id + ']')
+            ?.addClass?.('active');
         }
       } else {
         if (this.parentNode) {


### PR DESCRIPTION
Wraps up the 4 typed-surface gaps surfaced by the render cleanup wave (#261 / #262 / #263) and drops the residual `as unknown as` casts those PRs intentionally left behind.

## Gaps closed

### Gap 1 — `RenderRootLike.renderXP` missing
- Added `renderXP?(sb: unknown): void` to `RenderRootLike` in `scripts/game/GameRoot.ts`.
- Verified runtime impl at `scripts/render/RenderViews.ts:992` (`RenderMainMenu.renderXP(sb: StatusbarLikeForXP)`); call sites at `RenderTopLevelUI.ts:~203` and `~332`.

### Gap 2 — `APTickerLike.getRemainingTime` missing
- Added `getRemainingTime?(): Date` to `APTickerLike` in `scripts/game/GameRoot.ts`. Mirrors `Game.ts:36/108` (the canonical declaration on `APTickerSingleton`).
- Worth flagging: the dropped `GameRootForUI` shim falsely typed this as `getRemainingTime(): number`. The actual runtime returns a `Date`. `toTime(ms: number)` was getting a `Date` and "working" only via JS coercion (`date >= 3600000` → valueOf, `new Date(date)` → copy). Today's runtime semantics are preserved by coercing at the call site (`+ms`), which yields the same epoch-ms `toTime` was already seeing implicitly. Not a behavior change — but a type-level bug the shim had been masking. Worth a follow-up if `toTime` should accept `number | Date` more broadly.

### Gap 3 — `RenderRootLike.jdomelem.find()` chain
- Added `addClass?(c: string): void` to the chained return shape of `RenderRootLike.jdomelem.find()` in `scripts/game/GameRoot.ts`. (The shape already had `removeClass?` and `off?`; the cast was just to add `addClass`.)
- Did **not** widen `RenderNodeLike.jdomelem` (in `scripts/game/GameNode.ts`, currently `unknown`) — surveyed consumers (TokenPerp, ProjectPerp, ClientPerp, ContactPerp, Database, Topscore, Topscores, GameNode itself) and they all already use their own narrower shapes via local interface extensions. Widening at the source would have rippled.

### Gap 4 — `GameNodeLike.parentNode.data` + `scoretype`
- Widened `GameNodeLike.parentNode` in `scripts/render/RenderNode.ts` to `{ renderNode: RenderNode; data?: Record<string, unknown> }`.
- For `scoretype`, picked **Option B**: declared a local `TopscoreGameNodeLike` near `RenderTopscorePerp` and shadowed `gameNode` on that class. Cleaner than polluting the cross-file `GameNodeLike` with a Topscore-specific field.

## Cast cleanup
- `RenderTopLevelUI.ts`: dropped `interface GameRootForUI` + 2 cast sites (~203, ~332); dropped 2 RenderTopscorePerp casts (~1232, ~1247).
- `RenderViews.ts`: dropped `interface GameRootForView` + 2 cast sites (~181, ~349).
- Net `as unknown as` count in `scripts/`: 80 → 77 (-3).

## Validation
- `pnpm typecheck` clean.
- `pnpm lint` clean.

## Notable finding (#255-style?)
`getRemainingTime` returning `Date` while the local cast claimed `number` is in the same family as the `karma_value`→`dec` bug #255 caught — the cast was hiding a real type-runtime mismatch. Behavior happens to work via JS coercion, so this is a near-miss rather than a live bug, but worth keeping in mind for future cast audits.

https://claude.ai/code/session_017gPuFHF6MdaSov26RW5NTZ

---
_Generated by [Claude Code](https://claude.ai/code/session_017gPuFHF6MdaSov26RW5NTZ)_