### PR TITLE
type-debt: widen toTime to accept number | Date, drop call-site coercion

### DIFF
--- a/scripts/dd-helpers.ts
+++ b/scripts/dd-helpers.ts
@@ -45,9 +45,11 @@ export function span(text: string | number, cls?: string): string {
   return '<span class="' + (cls || 'highlight') + '">' + text + '</span>';
 }
 
-export function toTime(ms: number): string {
-  const date = new Date(ms || 0);
-  if (ms >= 3600000) {
+export function toTime(ms: number | Date): string {
+  // `+ms` handles both `Date` (via valueOf) and `number` identically.
+  const n = +ms || 0;
+  const date = new Date(n);
+  if (n >= 3600000) {
     return (
       pad0(date.getUTCHours(), 2) +
       ':' +

--- a/scripts/render/RenderTopLevelUI.ts
+++ b/scripts/render/RenderTopLevelUI.ts
@@ -331,10 +331,7 @@ export class RenderStatusbar extends RenderNode {
       jtext.show();
       const APT = groot.APTicker;
       node.startLoop(() => {
-        // APTicker.getRemainingTime() returns a Date (Game.ts) whose
-        // epoch-ms is the remaining ms; coerce to number for `toTime`.
-        const ms = APT?.getRemainingTime?.();
-        jtext.html(RenderStatusbar.textMoreIn() + span(toTime(ms ? +ms : 0)));
+        jtext.html(RenderStatusbar.textMoreIn() + span(toTime(APT?.getRemainingTime?.() ?? 0)));
       }, 1000);
     });
 


### PR DESCRIPTION
## Summary

Follow-up to #264. The wrap-up PR closed a type-lie on `APTicker.getRemainingTime` (it returns `Date`, not `number`) but had to coerce at the consumer call site with `+ms` to satisfy `toTime`'s `number`-only signature. This PR widens `toTime` to accept the actual surface and drops the coercion.

## Changes

- `scripts/dd-helpers.ts`: `toTime(ms: number | Date)`. Internal unification with `const n = +ms || 0` — `+ms` invokes `valueOf` on `Date` (epoch-ms) and is identity on `number`. Both pre-existing call paths preserved (`new Date(n)`, `n >= 3600000` HH:MM:SS threshold).
- `scripts/render/RenderTopLevelUI.ts`: drop the `+ms` coercion at the AP-status remaining-time call site. `toTime(APT?.getRemainingTime?.() ?? 0)` now passes `Date | 0` directly.
- `scripts/game/Database.ts` other caller (`toTime(this.remainTime + 800)`) already passes `number`, no change.

## Validation

- `pnpm typecheck` clean
- `pnpm lint` clean

## Why

The Date/number near-miss caught in #264 was preserved by JS coercion (`Date.valueOf` → epoch-ms) but the type-level disagreement was resolved by coercing at the consumer rather than fixing the helper. This puts the truth in the helper signature.

https://claude.ai/code/session_017gPuFHF6MdaSov26RW5NTZ

---
_Generated by [Claude Code](https://claude.ai/code/session_017gPuFHF6MdaSov26RW5NTZ)_