### PR TITLE
fix: show collected delta in money overlay and DecoratorAmount

### DIFF
--- a/scripts/LocalEngine.ts
+++ b/scripts/LocalEngine.ts
@@ -2424,7 +2424,7 @@ export function collectPerp(
     newGv = Object.assign({}, newGv, {
       cash_value: (ms.game_values.cash_value || 0) + cashGain,
     });
-    innerResult = { cash: newGv.cash_value };
+    innerResult = { cash: cashGain };
   } else if (gameType === 'TokenPerp') {
     var tpIdata: NodeInstanceData = node.instance_data || {};
     var prevAmount = typeof tpIdata.amount === 'number' ? tpIdata.amount : 0;

--- a/scripts/game/TokenPerp.ts
+++ b/scripts/game/TokenPerp.ts
@@ -99,13 +99,16 @@ export class TokenPerp extends GamePerp {
       absoluteIncPerc?: number;
     };
     const absoluteAmount = (groot.profiles_value * amount) / 100;
-    // FIXME: previousAbsoluteAmount is only correct for newly-set tokens;
-    // game-load path leaves it at 0.
-    dataRec.previousAbsoluteAmount = dataRec.absoluteAmount ?? 0;
+    // The first call after construction is the load/seed path, not a
+    // collection event — seed `previousAbsoluteAmount` to the current
+    // absolute so `absoluteInc` is 0 on load and only reflects real
+    // deltas from subsequent integration ticks.
+    const previousAbsoluteAmount = dataRec.absoluteAmount ?? absoluteAmount;
+    dataRec.previousAbsoluteAmount = previousAbsoluteAmount;
     dataRec.absoluteAmount = absoluteAmount;
     this.amount = amount;
     dataRec.amount = amount;
-    dataRec.absoluteInc = absoluteAmount - (dataRec.previousAbsoluteAmount ?? 0);
+    dataRec.absoluteInc = absoluteAmount - previousAbsoluteAmount;
     dataRec.absoluteIncPerc =
       absoluteAmount === 0 ? 0 : (100 / absoluteAmount) * dataRec.absoluteInc;
     if (this.gestalt !== undefined) {

--- a/scripts/render/RenderDecorators.ts
+++ b/scripts/render/RenderDecorators.ts
@@ -581,17 +581,15 @@ export class RenderDecoratorAmount extends RenderSprite implements DecoratorBase
 
   setAmount(amount?: number): void {
     const a = amount ?? this.amount;
-    /* FIXME: TURN THIS ON/OFF FOR DEMO BEHAVIOUR */
     this.jdomelem2.animate({ width: Math.round((a / 100) * 60) }, 600);
-    if (a < 25) {
+    const dec = this.decoratedNode;
+    const inc = (dec?.gameNode?.data?.absoluteInc as number | undefined) ?? 0;
+    if (inc > 0) {
+      this.jdomelem3.text(toKSNum(inc));
       this.jdomelem3.show();
-      const dec = this.decoratedNode;
-      const absolute = (dec?.gameNode?.data?.absoluteAmount as number | undefined) ?? 0;
-      this.jdomelem3.text(toKSNum(absolute));
     } else {
       this.jdomelem3.hide();
     }
-    /* END FIXME */
   }
 
   override onAddInit(): void {

--- a/tests/e2e/collected-delta-display.spec.ts
+++ b/tests/e2e/collected-delta-display.spec.ts
@@ -1,0 +1,55 @@
+/**
+ * The `FXBling({ text: $${cash} })` overlay in `scripts/game/ClientPerp.ts`
+ * reads `inner.cash` from the `collectPerp` response. The engine used to
+ * return `cash: newGv.cash_value` (the player's new running total), so
+ * the overlay flashed e.g. `$47.882` over a single client whenever the
+ * player had $47,842 banked and just collected $40. The engine now
+ * returns the gain, so the overlay matches what was just collected.
+ *
+ * Drives the engine directly (no canvas clicks), matching the strategy
+ * in `share-merge.spec.ts` and `collect-icon-after-charge.spec.ts`.
+ */
+
+import { expect, test } from '@playwright/test';
+
+test('ClientPerp collect: response carries the cash gain, not the new total', async ({ page }) => {
+  await page.goto('/?devtools=1');
+  await expect(page.locator('[data-testid="game-container"]')).toBeVisible({
+    timeout: 50_000,
+  });
+
+  const out = await page.evaluate(async () => {
+    const boot = await new Promise<any>((res, rej) => (window as any).require(['boot'], res, rej));
+    const eng = await new Promise<any>((res, rej) =>
+      (window as any).require(['LocalEngine'], res, rej)
+    );
+
+    const path = 'Imperium.test.City.test.Pusher.test.client.test';
+    const state = boot.getState();
+    state.game_values = Object.assign({}, state.game_values, {
+      cash_value: 47_842,
+      ap_snapshot: 10,
+    });
+    state.nodes = [
+      ...(state.nodes ?? []),
+      {
+        full_path: path,
+        game_type: 'ClientPerp',
+        full_type: 'ClientPerp:test',
+        gestalt: 'client_test_money_overlay',
+        instance_data: {},
+      },
+    ];
+    state.nodes_collect = [{ path, result: { amount: 40 } }];
+    boot.setState(state);
+
+    const { result } = await eng.collectPerp(path);
+    return {
+      cash: result.result.cash,
+      cashValueAfter: result.game_values?.cash_value,
+    };
+  });
+
+  expect(out.cash).toBe(40);
+  expect(out.cashValueAfter).toBe(47_882);
+});

--- a/tests/handlers/collect-integrate.test.js
+++ b/tests/handlers/collect-integrate.test.js
@@ -273,7 +273,7 @@ describe('collectPerp — ClientPerp', () => {
   beforeEach(() => setOverride(FIXED_NOW));
   afterEach(() => clearOverride());
 
-  it('returns cash (new cash_value) in result.result', async () => {
+  it('returns the cash gain in result.result.cash and the new total in game_values.cash_value', async () => {
     setState(
       mkState({
         nodes: [mkNode('ClientPerp', PATH)],
@@ -283,7 +283,7 @@ describe('collectPerp — ClientPerp', () => {
     );
 
     const { result } = await collectPerp(PATH);
-    expect(result.result.cash).toBe(400);
+    expect(result.result.cash).toBe(100);
     expect(result.game_values.cash_value).toBe(400);
   });
 


### PR DESCRIPTION
Replaces #267 (closed). That PR did the right swap (`absoluteAmount` → `absoluteInc`) in the render layer but left an upstream FIXME in place that made the new value wrong on the load path, then ended with the regression test deleted across five churn commits.

## What was wrong

### 1. ClientPerp money overlay flashed the new total, not the gain
`scripts/game/ClientPerp.ts` renders `FXBling({ text: \`$${cash}\` })` over a collected client using `result.result.cash`. The engine was returning `newGv.cash_value` (the player's new running total) there, so collecting a $40 client while the player held $47,842 flashed `$47.882` over the sprite — identical to the status-bar cash counter. The user reported this on #267 with a screenshot showing the overlay value matching the top-bar total exactly.

### 2. TokenPerp database tile rendered the cumulative absolute, not the delta
`RenderDecoratorAmount.setAmount` rendered `gameNode.data.absoluteAmount` (= `profiles_value * amount / 100`, the saturation-weighted profile count) under the per-TokenPerp bar — a persistent total, not the "what was just collected" number the UI is meant to convey.

### 3. The straightforward `absoluteInc` swap was blocked by a load-time bug
`TokenPerp.setAmount` (`scripts/game/TokenPerp.ts:102-104`) carried an active FIXME: `previousAbsoluteAmount` was defaulted to `0` on the first call, so after a game load `absoluteInc === absoluteAmount` and a naive swap to `absoluteInc` would still display the full count, just relabelled as a delta. This is what #267 shipped.

### 4. Demo-mode bar-fill gate
The `if (a < 25)` gate above the changed line, sitting under a `/* FIXME: TURN THIS ON/OFF FOR DEMO BEHAVIOUR */` comment, hid the number once the bar passed 25 % — independent of whether anything was collected.

## Fix

- `scripts/LocalEngine.ts:2427` — return `cash: cashGain` (the per-collect delta) instead of `cash: newGv.cash_value`. The new total still rides on `result.game_values.cash_value` for `groot.updateGameValues`.
- `scripts/game/TokenPerp.ts` — seed `previousAbsoluteAmount` to the current absolute on the initial `setAmount` call (load / fresh seed has no preceding integration to diff against), retiring the FIXME. `absoluteInc` now reads as `0` on load and only carries real deltas from subsequent integration ticks.
- `scripts/render/RenderDecorators.ts` — surface `absoluteInc` instead of `absoluteAmount`, and drop the demo-mode `< 25` gate. The number is hidden when `absoluteInc <= 0` so the tile is silent outside an integration.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 639/639 passing; updated the `collectPerp — ClientPerp` unit test (`tests/handlers/collect-integrate.test.js:276`) that pinned the prior wrong behaviour.
- [x] `pnpm test:e2e tests/e2e/collected-delta-display.spec.ts` — new Playwright spec drives `LocalEngine.collectPerp` against a seeded ClientPerp and asserts `result.result.cash === gain` and `result.game_values.cash_value === total` independently.
- [ ] Manual smoke: collect a client with a non-trivial cash balance, verify the floating $ overlay shows the per-client amount rather than the running total. Verify a TokenPerp tile shows the just-collected count after an integration and is silent outside one / on reload.

https://claude.ai/code/session_011a2RSr1A2WGZKbzAoCuzpJ