### PR TITLE
fix: unlock data points when a venture upgrade is bought

### DIFF
--- a/scripts/LocalEngine.ts
+++ b/scripts/LocalEngine.ts
@@ -499,6 +499,10 @@ export function loadGame(): Promise<{ result: ReturnType<typeof _buildLoadGameRe
   // legacy code that didn't seed goals). This is the prerequisite for
   // mission progression: empty goals → progression handlers no-op.
   var seededState = _seedMissionGoals(mat.state);
+  // Repair instance_data.tokens for any ProjectPerp carrying active
+  // upgrades — covers legacy saves and historical-delta replay where the
+  // buyPowerup result landed before the upgrade-tokens merge existed.
+  seededState = _repairUpgradeTokens(seededState);
   setState(seededState);
 
   // Persist as a recheckMissions delta so the repair lands in durable
@@ -1063,6 +1067,55 @@ function _computeUpgradeTokens(perpTypeData: PerpTypeData, powerups: PowerupDef[
     }
   }
   return merged;
+}
+
+// Walks every node carrying active powerups and re-merges its
+// instance_data.tokens via _computeUpgradeTokens. This is the cold-start
+// counterpart to buyPowerup/sellPowerup: legacy saves (and any historical
+// delta replay) that landed before the buy/sell paths merged upgrade
+// tokens still carry amount=0 for upgrade-gated tokens, so the data tab
+// would render greyed out after a reload. Only nodes whose merged tokens
+// actually differ are rewritten so untouched nodes keep their reference
+// identity for downstream change-detection.
+function _repairUpgradeTokens(state: LocalState): LocalState {
+  var nodes = state.nodes || [];
+  var changed = false;
+  var newNodes = nodes.map(function (n) {
+    var idata = (n.instance_data || {}) as NodeInstanceData;
+    var powerups = idata.powerups;
+    if (!powerups || !powerups.length) return n;
+    var ft = n.full_type || '';
+    var colon = ft.indexOf(':');
+    var perpGestalt = colon >= 0 ? ft.slice(colon + 1) : n.gestalt || '';
+    var perpTypeDef = _getRuleset().perps[perpGestalt];
+    var perpTypeData = perpTypeDef && perpTypeDef.type_data;
+    if (!perpTypeData || !perpTypeData.tokens || !perpTypeData.tokens.length) return n;
+    var merged = _computeUpgradeTokens(perpTypeData, powerups);
+    var existing = idata.tokens || [];
+    if (_tokensEqual(existing, merged)) return n;
+    changed = true;
+    return Object.assign({}, n, {
+      instance_data: Object.assign({}, idata, { tokens: merged }),
+    });
+  });
+  if (!changed) return state;
+  return Object.assign({}, state, { nodes: newNodes });
+}
+
+function _tokensEqual(a: TokenSpec[], b: TokenSpec[]): boolean {
+  if (a.length !== b.length) return false;
+  var aByGestalt: Record<string, number> = {};
+  for (var i = 0; i < a.length; i++) {
+    var ta = a[i];
+    if (ta && ta.gestalt) aByGestalt[ta.gestalt] = ta.amount || 0;
+  }
+  for (var j = 0; j < b.length; j++) {
+    var tb = b[j];
+    if (!tb || !tb.gestalt) continue;
+    if (!Object.prototype.hasOwnProperty.call(aByGestalt, tb.gestalt)) return false;
+    if (aByGestalt[tb.gestalt] !== (tb.amount || 0)) return false;
+  }
+  return true;
 }
 
 function _getLevelByXP(xp: number): number {

--- a/scripts/LocalEngine.ts
+++ b/scripts/LocalEngine.ts
@@ -499,9 +499,6 @@ export function loadGame(): Promise<{ result: ReturnType<typeof _buildLoadGameRe
   // legacy code that didn't seed goals). This is the prerequisite for
   // mission progression: empty goals → progression handlers no-op.
   var seededState = _seedMissionGoals(mat.state);
-  // Repair instance_data.tokens for any ProjectPerp carrying active
-  // upgrades — covers legacy saves and historical-delta replay where the
-  // buyPowerup result landed before the upgrade-tokens merge existed.
   seededState = _repairUpgradeTokens(seededState);
   setState(seededState);
 
@@ -1030,13 +1027,11 @@ function _computeModifiers(perpTypeData: PerpTypeData, powerups: PowerupDef[]): 
   return { charge_cost: chargeCost, collect_amount: collectAmount, collect_risk: collectRisk };
 }
 
-// Merge an UpgradePowerup's tokens into the base venture tokens. Each
-// active upgrade lifts the per-gestalt `amount` to the upgrade's value
-// when it exceeds the current amount — base venture tokens for
-// upgrade-gated data points start at 0, so without this merge those
-// points stay locked (lockAmountZero) even after the upgrade is bought.
-// Overlapping upgrades take the maximum so toggling one upgrade off does
-// not silently un-unlock a token still provided by another.
+// Venture base tokens carry amount=0 for upgrade-gated data points; the
+// ProfileSet popup renders them greyed via lockAmountZero. Each active
+// upgrade lifts per-gestalt amounts to the upgrade's value; overlapping
+// upgrades take the max so removing one upgrade doesn't un-unlock a token
+// still provided by another.
 function _computeUpgradeTokens(perpTypeData: PerpTypeData, powerups: PowerupDef[]): TokenSpec[] {
   var merged: TokenSpec[] = (perpTypeData.tokens || []).map((t) => Object.assign({}, t));
   var byGestalt: Record<string, TokenSpec> = {};
@@ -1069,14 +1064,9 @@ function _computeUpgradeTokens(perpTypeData: PerpTypeData, powerups: PowerupDef[
   return merged;
 }
 
-// Walks every node carrying active powerups and re-merges its
-// instance_data.tokens via _computeUpgradeTokens. This is the cold-start
-// counterpart to buyPowerup/sellPowerup: legacy saves (and any historical
-// delta replay) that landed before the buy/sell paths merged upgrade
-// tokens still carry amount=0 for upgrade-gated tokens, so the data tab
-// would render greyed out after a reload. Only nodes whose merged tokens
-// actually differ are rewritten so untouched nodes keep their reference
-// identity for downstream change-detection.
+// Cold-start fixup for state where instance_data.tokens was persisted
+// without the upgrade merge (legacy saves, replayed historical deltas).
+// Reference identity is preserved for nodes whose tokens already match.
 function _repairUpgradeTokens(state: LocalState): LocalState {
   var nodes = state.nodes || [];
   var changed = false;
@@ -1084,9 +1074,7 @@ function _repairUpgradeTokens(state: LocalState): LocalState {
     var idata = (n.instance_data || {}) as NodeInstanceData;
     var powerups = idata.powerups;
     if (!powerups || !powerups.length) return n;
-    var ft = n.full_type || '';
-    var colon = ft.indexOf(':');
-    var perpGestalt = colon >= 0 ? ft.slice(colon + 1) : n.gestalt || '';
+    var perpGestalt = _gestaltFrom(n.full_type) || n.gestalt || '';
     var perpTypeDef = _getRuleset().perps[perpGestalt];
     var perpTypeData = perpTypeDef && perpTypeDef.type_data;
     if (!perpTypeData || !perpTypeData.tokens || !perpTypeData.tokens.length) return n;

--- a/scripts/LocalEngine.ts
+++ b/scripts/LocalEngine.ts
@@ -1026,6 +1026,45 @@ function _computeModifiers(perpTypeData: PerpTypeData, powerups: PowerupDef[]): 
   return { charge_cost: chargeCost, collect_amount: collectAmount, collect_risk: collectRisk };
 }
 
+// Merge an UpgradePowerup's tokens into the base venture tokens. Each
+// active upgrade lifts the per-gestalt `amount` to the upgrade's value
+// when it exceeds the current amount — base venture tokens for
+// upgrade-gated data points start at 0, so without this merge those
+// points stay locked (lockAmountZero) even after the upgrade is bought.
+// Overlapping upgrades take the maximum so toggling one upgrade off does
+// not silently un-unlock a token still provided by another.
+function _computeUpgradeTokens(perpTypeData: PerpTypeData, powerups: PowerupDef[]): TokenSpec[] {
+  var merged: TokenSpec[] = (perpTypeData.tokens || []).map((t) => Object.assign({}, t));
+  var byGestalt: Record<string, TokenSpec> = {};
+  for (var i = 0; i < merged.length; i++) {
+    var bt = merged[i];
+    if (bt && bt.gestalt) byGestalt[bt.gestalt] = bt;
+  }
+  var ruleset = _getRuleset();
+  for (var p = 0; p < powerups.length; p++) {
+    var pu = powerups[p];
+    if (!pu || !pu.gestalt) continue;
+    var puDef = ruleset.powerups[pu.gestalt];
+    var puTokens: TokenSpec[] =
+      (puDef && puDef.type_data && (puDef.type_data as { tokens?: TokenSpec[] }).tokens) || [];
+    for (var t = 0; t < puTokens.length; t++) {
+      var ut = puTokens[t];
+      if (!ut || !ut.gestalt) continue;
+      var added = ut.amount || 0;
+      var slot = byGestalt[ut.gestalt];
+      if (slot) {
+        var existing = slot.amount || 0;
+        if (added > existing) slot.amount = added;
+      } else {
+        var clone: TokenSpec = Object.assign({}, ut);
+        merged.push(clone);
+        byGestalt[ut.gestalt] = clone;
+      }
+    }
+  }
+  return merged;
+}
+
 function _getLevelByXP(xp: number): number {
   var levels = _getRuleset().levels;
   for (var i = 0; i < levels.length; i++) {
@@ -1116,7 +1155,7 @@ export function buyPowerup(
     charge_cost: mods.charge_cost,
     collect_amount: mods.collect_amount,
     collect_risk: mods.collect_risk,
-    tokens: perpTypeData.tokens || [],
+    tokens: _computeUpgradeTokens(perpTypeData, newPowerups),
   });
 
   var newXp = (state.game_values.xp_value || 0) + (perpTypeData.xp_inc || 1);
@@ -1231,7 +1270,7 @@ export function sellPowerup(
     charge_cost: mods.charge_cost,
     collect_amount: mods.collect_amount,
     collect_risk: mods.collect_risk,
-    tokens: perpTypeData.tokens || [],
+    tokens: _computeUpgradeTokens(perpTypeData, newPowerups),
   });
 
   var newXp = (state.game_values.xp_value || 0) + 1;

--- a/tests/e2e/preventive-checkup-upgrade.spec.ts
+++ b/tests/e2e/preventive-checkup-upgrade.spec.ts
@@ -1,0 +1,142 @@
+/**
+ * Preventive Checkup (project009) upgrade-tokens e2e.
+ *
+ * End-to-end regression for the "bought upgrade, data points still
+ * greyed out" bug. The unit tests in tests/handlers/upgradeTokens.test.js
+ * pin down the LocalEngine contract; this spec exercises the same flow
+ * inside the real boot pipeline so a regression in the runtime wiring
+ * (boot/setState, loadGame's repair pass) gets caught too.
+ *
+ * project009 base venture tokens list token018 / token053 / token125 with
+ * amount: 0 (gated by Blood test, upgrade073). The ProfileSet popup runs
+ * with lockAmountZero=true, so any token still at amount 0 after the
+ * upgrade is bought would render greyed in the UI.
+ */
+
+import { expect, test } from '@playwright/test';
+
+const PROJECT_PATH = 'Imperium.CityVienna.project009';
+const PROJECT_NODE = {
+  game_id: 'node_project009',
+  game_type: 'ProjectPerp',
+  full_type: 'ProjectPerp:project009',
+  gestalt: 'project009',
+  full_path: PROJECT_PATH,
+  instance_data: { powerups: [] },
+};
+
+async function seedProjectState(page: import('@playwright/test').Page) {
+  await page.evaluate(
+    async ({ projectNode }) => {
+      const boot = await new Promise<any>((res, rej) =>
+        (window as any).require(['boot'], res, rej)
+      );
+      const state = boot.getState();
+      boot.setState(
+        Object.assign({}, state, {
+          nodes: state.nodes.concat([projectNode]),
+          game_values: Object.assign({}, state.game_values, {
+            cash_value: 5000,
+            xp_level: 15,
+            xp_value: 500,
+            ap_snapshot: 6,
+            ap_max: 6,
+          }),
+          node_counter: (state.node_counter || 0) + 1,
+        })
+      );
+    },
+    { projectNode: PROJECT_NODE }
+  );
+}
+
+test('preventive checkup: Blood test unlocks token018/053/125 in instance_data', async ({
+  page,
+}) => {
+  await page.goto('/?devtools=1');
+  await expect(page.locator('[data-testid="game-container"]')).toBeVisible({ timeout: 50_000 });
+
+  await seedProjectState(page);
+
+  const result = await page.evaluate(async (path) => {
+    const eng = await new Promise<any>((res, rej) =>
+      (window as any).require(['LocalEngine'], res, rej)
+    );
+    return eng.buyPowerup(path, 0, 'upgrade073');
+  }, PROJECT_PATH);
+
+  expect(result.result).not.toHaveProperty('error');
+
+  const tokens = result.result.node.instance_data.tokens;
+  const byGestalt: Record<string, number> = {};
+  for (const t of tokens) byGestalt[t.gestalt] = t.amount;
+
+  // upgrade073 (Blood test) raises token018=25, token053=25, token125=100.
+  expect(byGestalt.token018).toBe(25);
+  expect(byGestalt.token053).toBe(25);
+  expect(byGestalt.token125).toBe(100);
+  // Always-on base tokens stay at 100.
+  expect(byGestalt.token001).toBe(100);
+  expect(byGestalt.token007).toBe(100);
+});
+
+test('preventive checkup: loadGame repairs unmerged tokens on cold start', async ({ page }) => {
+  await page.goto('/?devtools=1');
+  await expect(page.locator('[data-testid="game-container"]')).toBeVisible({ timeout: 50_000 });
+
+  // Seed a legacy-shaped node: powerup already installed, but tokens stuck
+  // at the unmerged base values (the shape a pre-fix save would carry).
+  await page.evaluate(async () => {
+    const boot = await new Promise<any>((res, rej) => (window as any).require(['boot'], res, rej));
+    const state = boot.getState();
+    boot.setState(
+      Object.assign({}, state, {
+        nodes: state.nodes.concat([
+          {
+            game_id: 'node_project009',
+            game_type: 'ProjectPerp',
+            full_type: 'ProjectPerp:project009',
+            gestalt: 'project009',
+            full_path: 'Imperium.CityVienna.project009',
+            instance_data: {
+              powerups: [
+                { slot: 0, gestalt: 'upgrade073', full_type: 'UpgradePowerup:upgrade073' },
+              ],
+              tokens: [
+                { gestalt: 'token001', amount: 100, full_type: 'TokenPerp:token001' },
+                { gestalt: 'token018', amount: 0, full_type: 'TokenPerp:token018' },
+                { gestalt: 'token053', amount: 0, full_type: 'TokenPerp:token053' },
+                { gestalt: 'token125', amount: 0, full_type: 'TokenPerp:token125' },
+              ],
+            },
+          },
+        ]),
+        node_counter: (state.node_counter || 0) + 5,
+      })
+    );
+  });
+
+  // Invoke loadGame — the path a cold reload would take.
+  await page.evaluate(async () => {
+    const eng = await new Promise<any>((res, rej) =>
+      (window as any).require(['LocalEngine'], res, rej)
+    );
+    await eng.loadGame();
+  });
+
+  // Read post-repair state and assert the upgrade-gated tokens are unlocked.
+  const tokens = await page.evaluate(async () => {
+    const boot = await new Promise<any>((res, rej) => (window as any).require(['boot'], res, rej));
+    const node = boot
+      .getState()
+      .nodes.find((n: { full_path: string }) => n.full_path === 'Imperium.CityVienna.project009');
+    return node.instance_data.tokens;
+  });
+  const byGestalt: Record<string, number> = {};
+  for (const t of tokens) byGestalt[t.gestalt] = t.amount;
+
+  expect(byGestalt.token018).toBe(25);
+  expect(byGestalt.token053).toBe(25);
+  expect(byGestalt.token125).toBe(100);
+  expect(byGestalt.token001).toBe(100);
+});

--- a/tests/handlers/upgradeTokens.test.js
+++ b/tests/handlers/upgradeTokens.test.js
@@ -18,9 +18,10 @@
  * amounts back to the base venture defaults (0 for upgrade-gated tokens).
  */
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { buyPowerup, sellPowerup } from '../../scripts/LocalEngine.js';
+import { buyPowerup, loadGame, sellPowerup } from '../../scripts/LocalEngine.js';
 import { getState, setState } from '../../scripts/boot.js';
 import { clearOverride, setOverride } from '../../scripts/clock.js';
+import { applyDelta } from '../../scripts/state.js';
 import { FIXED_NOW, mkState } from './_fixtures.js';
 
 // project009 = "Preventive checkup" (ruleset_3.en.json:7531)
@@ -130,6 +131,123 @@ describe('buyPowerup — upgrade tokens unlock venture data points', () => {
     await buyPowerup(PROJECT_PATH, 0, 'upgrade073');
     const node = getState().nodes[0];
     expect(findToken(node.instance_data.tokens, 'token125').amount).toBe(100);
+  });
+});
+
+describe('loadGame — repairs upgrade tokens on cold start', () => {
+  // Simulates a legacy save written before this fix existed: the player
+  // already owns Blood test (upgrade073 in slot 0) but instance_data.tokens
+  // still carries the unmerged base venture catalogue with amount: 0 for
+  // upgrade-gated tokens. Without a repair pass on load, the data tab
+  // stays greyed out forever — buyPowerup only runs when the player
+  // actively buys.
+  function legacySeededState() {
+    const legacyTokens = [
+      { gestalt: 'token001', amount: 100, full_type: 'TokenPerp:token001' },
+      { gestalt: 'token018', amount: 0, full_type: 'TokenPerp:token018' },
+      { gestalt: 'token053', amount: 0, full_type: 'TokenPerp:token053' },
+      { gestalt: 'token125', amount: 0, full_type: 'TokenPerp:token125' },
+    ];
+    const node = Object.assign({}, PROJECT_NODE, {
+      instance_data: {
+        powerups: [{ slot: 0, gestalt: 'upgrade073', full_type: 'UpgradePowerup:upgrade073' }],
+        tokens: legacyTokens,
+      },
+    });
+    return mkState({
+      nodes: [node],
+      game_values: { cash_value: 5000 },
+      // Mark as "not a new game" so loadGame doesn't hit the new-game branch.
+      node_counter: 5,
+    });
+  }
+
+  it('cold-load with buggy stored tokens restores upgrade token amounts', async () => {
+    setState(legacySeededState());
+
+    // Sanity: pre-load state mirrors the bug — token018/053/125 stuck at 0.
+    const before = getState().nodes[0].instance_data.tokens;
+    expect(findToken(before, 'token018').amount).toBe(0);
+    expect(findToken(before, 'token125').amount).toBe(0);
+
+    await loadGame();
+
+    const after = getState().nodes[0].instance_data.tokens;
+    expect(findToken(after, 'token018').amount).toBe(25);
+    expect(findToken(after, 'token053').amount).toBe(25);
+    expect(findToken(after, 'token125').amount).toBe(100);
+    // Always-on base token stays put.
+    expect(findToken(after, 'token001').amount).toBe(100);
+  });
+
+  it('leaves nodes without powerups untouched on cold load', async () => {
+    const noPowerupsNode = Object.assign({}, PROJECT_NODE, {
+      instance_data: {
+        powerups: [],
+        tokens: [{ gestalt: 'token001', amount: 100, full_type: 'TokenPerp:token001' }],
+      },
+    });
+    setState(mkState({ nodes: [noPowerupsNode], node_counter: 5 }));
+    const before = getState().nodes[0].instance_data.tokens;
+
+    await loadGame();
+
+    const after = getState().nodes[0].instance_data.tokens;
+    expect(after).toEqual(before);
+  });
+
+  it('cold-load is idempotent — running loadGame twice gives the same tokens', async () => {
+    setState(legacySeededState());
+    await loadGame();
+    const first = getState().nodes[0].instance_data.tokens.map((t) => ({
+      gestalt: t.gestalt,
+      amount: t.amount,
+    }));
+
+    await loadGame();
+    const second = getState().nodes[0].instance_data.tokens.map((t) => ({
+      gestalt: t.gestalt,
+      amount: t.amount,
+    }));
+
+    expect(second).toEqual(first);
+  });
+
+  it('replaying a buyPowerup delta then loadGame yields correctly merged tokens', async () => {
+    // Simulate a peer / cold reload: applyDelta directly with a legacy-shaped
+    // result whose instance_data.tokens are unmerged. loadGame must repair.
+    setState(projectState());
+    const buggyDelta = {
+      kind: 'delta',
+      addr: 'test@local',
+      ts: FIXED_NOW,
+      op: 'buyPowerup',
+      args: [PROJECT_PATH, 0, 'upgrade073'],
+      result: {
+        node: {
+          full_path: PROJECT_PATH,
+          instance_data: {
+            powerups: [{ slot: 0, gestalt: 'upgrade073', full_type: 'UpgradePowerup:upgrade073' }],
+            // Legacy: only base venture tokens, no upgrade merge.
+            tokens: [
+              { gestalt: 'token001', amount: 100, full_type: 'TokenPerp:token001' },
+              { gestalt: 'token018', amount: 0, full_type: 'TokenPerp:token018' },
+              { gestalt: 'token125', amount: 0, full_type: 'TokenPerp:token125' },
+            ],
+          },
+        },
+        game_values: {},
+      },
+    };
+    setState(applyDelta(getState(), buggyDelta));
+    // Confirm the bug landed in state.
+    expect(findToken(getState().nodes[0].instance_data.tokens, 'token125').amount).toBe(0);
+
+    await loadGame();
+
+    const after = getState().nodes[0].instance_data.tokens;
+    expect(findToken(after, 'token018').amount).toBe(25);
+    expect(findToken(after, 'token125').amount).toBe(100);
   });
 });
 

--- a/tests/handlers/upgradeTokens.test.js
+++ b/tests/handlers/upgradeTokens.test.js
@@ -1,0 +1,159 @@
+// @ts-nocheck — strict-TS quarantine; remove when this file is migrated to TS (issue #147)
+/**
+ * Regression for the "bought upgrade, data points still greyed out" bug.
+ *
+ * ProjectPerp ventures (e.g. project009 "Preventive checkup") list their
+ * complete token catalogue in `type_data.tokens` with `amount: 0` for the
+ * tokens that only become collectable once a corresponding upgrade is
+ * bought (Blood test → token018/053/125, Urine test → token018/120, etc.).
+ *
+ * When buyPowerup runs, it must merge the purchased upgrade's
+ * `type_data.tokens` into `instance_data.tokens`, raising the per-token
+ * amounts above zero. The ProfileSet popup is configured with
+ * `lockAmountZero: true`, so tokens with amount=0 render greyed out.
+ * Without this merge, "Blood test", "Medical Questionnaire", etc. have
+ * no visible effect on the data tab.
+ *
+ * sellPowerup is the mirror: removing the upgrade must drop those token
+ * amounts back to the base venture defaults (0 for upgrade-gated tokens).
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { buyPowerup, sellPowerup } from '../../scripts/LocalEngine.js';
+import { getState, setState } from '../../scripts/boot.js';
+import { clearOverride, setOverride } from '../../scripts/clock.js';
+import { FIXED_NOW, mkState } from './_fixtures.js';
+
+// project009 = "Preventive checkup" (ruleset_3.en.json:7531)
+const PROJECT_PATH = 'Imperium.CityVienna.project009';
+const PROJECT_NODE = {
+  game_id: 'node_project009',
+  game_type: 'ProjectPerp',
+  full_type: 'ProjectPerp:project009',
+  gestalt: 'project009',
+  full_path: PROJECT_PATH,
+  instance_data: { powerups: [] },
+};
+
+function findToken(tokens, gestalt) {
+  return (tokens || []).find((t) => t.gestalt === gestalt);
+}
+
+function projectState(overrides) {
+  return mkState(
+    Object.assign(
+      {
+        nodes: [PROJECT_NODE],
+        // upgrade073 (Blood test) costs 830; upgrade070/074 also pricey.
+        game_values: { cash_value: 5000 },
+      },
+      overrides || {}
+    )
+  );
+}
+
+beforeEach(() => {
+  setOverride(FIXED_NOW);
+});
+
+afterEach(() => {
+  clearOverride();
+});
+
+describe('buyPowerup — upgrade tokens unlock venture data points', () => {
+  beforeEach(() => setState(projectState()));
+
+  // Sanity: the base venture lists token018/053/125 with amount: 0.
+  // The UI's ProfileSet runs with lockAmountZero=true, so those tokens
+  // render greyed until an upgrade lifts their amount above 0.
+  it('base venture tokens for upgrade-gated data points start at amount 0', () => {
+    const node = getState().nodes[0];
+    // type_data.tokens is the source of truth pre-purchase, but the
+    // engine seeds instance_data.tokens from it during buyPowerup. Here
+    // we just assert the precondition via the ruleset shape that the
+    // upgrade-gated tokens carry amount 0 in the base venture.
+    expect(node.instance_data.powerups).toEqual([]);
+  });
+
+  it('buying Blood test (upgrade073) raises token018 amount above 0', async () => {
+    const { result } = await buyPowerup(PROJECT_PATH, 0, 'upgrade073');
+    expect(result.error).toBeUndefined();
+    const tokens = result.node.instance_data.tokens;
+    const t018 = findToken(tokens, 'token018');
+    expect(t018).toBeDefined();
+    expect(t018.amount).toBeGreaterThan(0);
+  });
+
+  it('buying Blood test sets token018/053/125 amounts to the upgrade-defined values', async () => {
+    const { result } = await buyPowerup(PROJECT_PATH, 0, 'upgrade073');
+    const tokens = result.node.instance_data.tokens;
+    // upgrade073 type_data.tokens: token018=25, token053=25, token125=100
+    expect(findToken(tokens, 'token018').amount).toBe(25);
+    expect(findToken(tokens, 'token053').amount).toBe(25);
+    expect(findToken(tokens, 'token125').amount).toBe(100);
+  });
+
+  it('keeps the base venture tokens (always-100 personal-data tokens) intact', async () => {
+    const { result } = await buyPowerup(PROJECT_PATH, 0, 'upgrade073');
+    const tokens = result.node.instance_data.tokens;
+    // project009 base: token001..token007 (First name, Last name, …) at 100.
+    expect(findToken(tokens, 'token001').amount).toBe(100);
+    expect(findToken(tokens, 'token002').amount).toBe(100);
+    expect(findToken(tokens, 'token007').amount).toBe(100);
+  });
+
+  it('buying Urine test (upgrade074) raises token120 above 0 and leaves unrelated upgrade tokens at 0', async () => {
+    const { result } = await buyPowerup(PROJECT_PATH, 0, 'upgrade074');
+    const tokens = result.node.instance_data.tokens;
+    // upgrade074 type_data.tokens: token018=50, token120=50
+    expect(findToken(tokens, 'token120').amount).toBe(50);
+    expect(findToken(tokens, 'token018').amount).toBe(50);
+    // token125 is gated by Blood test (upgrade073) only — must stay 0.
+    const t125 = findToken(tokens, 'token125');
+    expect(t125).toBeDefined();
+    expect(t125.amount).toBe(0);
+  });
+
+  it('overlapping upgrade tokens take the maximum amount when both are bought', async () => {
+    // upgrade073 (Blood test) gives token018=25
+    // upgrade074 (Urine test) gives token018=50
+    await buyPowerup(PROJECT_PATH, 0, 'upgrade073');
+    const { result } = await buyPowerup(PROJECT_PATH, 1, 'upgrade074');
+    const tokens = result.node.instance_data.tokens;
+    expect(findToken(tokens, 'token018').amount).toBe(50);
+    // Blood test's exclusive token must still be raised.
+    expect(findToken(tokens, 'token125').amount).toBe(100);
+    // Urine test's exclusive token must be raised.
+    expect(findToken(tokens, 'token120').amount).toBe(50);
+  });
+
+  it('persists the merged tokens into state.nodes[0].instance_data.tokens', async () => {
+    await buyPowerup(PROJECT_PATH, 0, 'upgrade073');
+    const node = getState().nodes[0];
+    expect(findToken(node.instance_data.tokens, 'token125').amount).toBe(100);
+  });
+});
+
+describe('sellPowerup — drops upgrade token amounts back to base', () => {
+  it('selling Blood test drops token125 back to 0 (base venture default)', async () => {
+    // Start with Blood test already installed in slot 0.
+    const seededNode = Object.assign({}, PROJECT_NODE, {
+      instance_data: {
+        powerups: [{ slot: 0, gestalt: 'upgrade073', full_type: 'UpgradePowerup:upgrade073' }],
+      },
+    });
+    setState(
+      mkState({
+        nodes: [seededNode],
+        game_values: { cash_value: 5000 },
+      })
+    );
+
+    const { result } = await sellPowerup(PROJECT_PATH, 0, 'upgrade073');
+    expect(result.error).toBeUndefined();
+    const tokens = result.node.instance_data.tokens;
+    // token125 is exclusive to Blood test → falls back to base amount 0.
+    expect(findToken(tokens, 'token125').amount).toBe(0);
+    // Base tokens (always-100 ones) remain unchanged.
+    expect(findToken(tokens, 'token001').amount).toBe(100);
+  });
+});


### PR DESCRIPTION
## Summary

- `buyPowerup` / `sellPowerup` now merge each active upgrade's `type_data.tokens` into `instance_data.tokens`, so upgrade-gated data points (e.g. Blood test → token018/053/125) clear `lockAmountZero` and stop rendering greyed out in the data tab.
- Overlapping upgrades take the max per-gestalt amount, so selling one upgrade doesn't un-unlock a token still provided by another.
- `loadGame` runs `_repairUpgradeTokens` after seeding mission goals — repairs legacy saves and any historical-delta replay that landed before the merge existed.

## Test plan

- [x] `pnpm test` — 651/651 pass, including 12 new tests in `tests/handlers/upgradeTokens.test.js`:
  - `buyPowerup` raises token amounts to the upgrade-defined values, keeps always-on base tokens at 100, handles overlapping upgrades via max, persists into state.
  - `sellPowerup` drops upgrade-exclusive tokens back to 0 while leaving base tokens intact.
  - `loadGame` repairs a legacy-shaped node (powerup installed + unmerged tokens), is idempotent, and recovers from a replayed buggy `buyPowerup` delta.
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [ ] Manual: open Preventive checkup, buy Blood test, confirm token018/053/125 are no longer greyed; reload and confirm they stay unlocked.

https://claude.ai/code/session_01UwXGK2eQCBwLWp2gmr4DbZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UwXGK2eQCBwLWp2gmr4DbZ)_