### PR TITLE
fix: spawn newly bought perps near their parent company

### DIFF
--- a/scripts/game/GamePerp.ts
+++ b/scripts/game/GamePerp.ts
@@ -16,6 +16,7 @@ import i18n from '../i18n.js';
 import { GameNode, getAllByGestalt, getByFirstId, getFirstId } from './GameNode.js';
 import { mergeData } from './mergeData.js';
 import { lookupPerpClass } from './perpRegistry.js';
+import { computeBuyPerpSpawnPos } from './spawnPosition.js';
 
 // ---------------------------------------------------------------------------
 // Local types
@@ -414,24 +415,21 @@ export class GamePerp extends GameNode {
         data: { contained_tokens?: unknown[]; provided_perps?: string[]; [key: string]: unknown };
       };
       gnode.addChild(perp);
-      // FIXME: fishy but works?
       const gnodeRn = gnode.renderNode as RenderNodeLike | undefined;
       const parentRn = gnode.parentNode?.renderNode as RenderNodeLike | undefined;
-      if (gnodeRn && parentRn) {
-        const vector = parentRn.getVectorTo?.(gnodeRn);
-        // Golden ratio.
-        if (!placePos && vector) {
-          const calced = gnodeRn.getVectorPos?.(vector, 0.61803398875);
-          if (calced) {
-            placePos = calced;
-            perp.renderData.config.placeRandom = placePos;
-            perp.renderData.config.placeParentRadius = 320;
-          }
-        }
+      const parentPos = gnodeRn?.getPosition?.();
+      if (parentPos) {
+        const spawn = computeBuyPerpSpawnPos({
+          explicitPos: placePos,
+          parentPos,
+          grandparentPos: parentRn?.getPosition?.(),
+        });
+        placePos = spawn.pos;
+        perp.renderData.config.placeRandom = spawn.pos;
+        perp.renderData.config.placeParentRadius = spawn.parentRadius;
+      } else if (placePos) {
+        perp.renderData.config.placeRandom = placePos;
       }
-
-      if (placePos) perp.renderData.config.placeRandom = placePos;
-      perp.renderData.config.placeParentRadius = 0;
       perp.renderData.config.hidden = true;
 
       perp.render();

--- a/scripts/game/spawnPosition.ts
+++ b/scripts/game/spawnPosition.ts
@@ -1,0 +1,49 @@
+export interface Vec2 {
+  x: number;
+  y: number;
+}
+
+export interface ComputeBuyPerpSpawnPosArgs {
+  explicitPos?: Vec2 | null | undefined;
+  parentPos: Vec2;
+  grandparentPos?: Vec2 | null | undefined;
+}
+
+export interface BuyPerpSpawnPos {
+  pos: Vec2;
+  parentRadius: number;
+}
+
+const GOLDEN_RATIO = 0.61803398875;
+const PARENT_RADIUS = 320;
+// Mirrors DatabasePerp's offset style; keeps the venture inside
+// PARENT_RADIUS so the engine's circular clamp never moves it.
+const FALLBACK_OFFSET: Vec2 = { x: -250, y: 50 };
+
+export function computeBuyPerpSpawnPos(args: ComputeBuyPerpSpawnPosArgs): BuyPerpSpawnPos {
+  const { explicitPos, parentPos, grandparentPos } = args;
+
+  if (explicitPos) {
+    return { pos: { x: explicitPos.x, y: explicitPos.y }, parentRadius: PARENT_RADIUS };
+  }
+
+  if (grandparentPos) {
+    const vx = parentPos.x - grandparentPos.x;
+    const vy = parentPos.y - grandparentPos.y;
+    return {
+      pos: {
+        x: parentPos.x + vx * GOLDEN_RATIO,
+        y: parentPos.y + vy * GOLDEN_RATIO,
+      },
+      parentRadius: PARENT_RADIUS,
+    };
+  }
+
+  return {
+    pos: {
+      x: parentPos.x + FALLBACK_OFFSET.x,
+      y: parentPos.y + FALLBACK_OFFSET.y,
+    },
+    parentRadius: PARENT_RADIUS,
+  };
+}

--- a/tests/game/spawn-position.test.js
+++ b/tests/game/spawn-position.test.js
@@ -1,0 +1,76 @@
+// Tests for computeBuyPerpSpawnPos — pure helper that picks a spawn
+// position for a newly bought perp ("venture") relative to its parent
+// ("company") node.
+//
+// Pre-existing bug (issue: venture spawns far from Bogus Company):
+//   In scripts/game/GamePerp.ts the spawn-position calc only worked
+//   when the parent had a grandparent.  Top-level companies like the
+//   Bogus Company (proxy001) sit directly under Imperium, so no
+//   grandparent vector existed — the helper fell back to a hard-coded
+//   canvas-center (1024, 800) inside RenderPerp.setRandomPosition.
+//   Additionally, `placeParentRadius` was force-overwritten to 0 right
+//   after being set to 320, disabling the engine's "stay near parent"
+//   clamp during collision-avoidance jitter.
+
+import { describe, expect, it } from 'vitest';
+import { computeBuyPerpSpawnPos } from '../../scripts/game/spawnPosition.ts';
+
+const PHI = 0.61803398875;
+
+describe('computeBuyPerpSpawnPos', () => {
+  it('returns the explicit position when one is provided (mission/tutorial wins)', () => {
+    const result = computeBuyPerpSpawnPos({
+      explicitPos: { x: 123, y: 456 },
+      parentPos: { x: 500, y: 500 },
+      grandparentPos: { x: 300, y: 300 },
+    });
+    expect(result.pos).toEqual({ x: 123, y: 456 });
+  });
+
+  it('extends the grandparent→parent vector by the golden ratio when a grandparent exists', () => {
+    // Preserve the legacy math: companyPos + φ * (companyPos - grandparentPos)
+    const result = computeBuyPerpSpawnPos({
+      parentPos: { x: 500, y: 500 },
+      grandparentPos: { x: 300, y: 300 },
+    });
+    expect(result.pos.x).toBeCloseTo(500 + PHI * 200);
+    expect(result.pos.y).toBeCloseTo(500 + PHI * 200);
+  });
+
+  it('falls back to a position near the parent when no grandparent exists (top-level company like Bogus Co.)', () => {
+    // This is the bug: previously placePos stayed undefined, and the
+    // render layer used the hard-coded canvas centre (1024, 800).
+    const parentPos = { x: 500, y: 500 };
+    const result = computeBuyPerpSpawnPos({ parentPos });
+
+    // Must NOT be the legacy hard-coded canvas centre.
+    expect(result.pos).not.toEqual({ x: 1024, y: 800 });
+
+    // Must land inside the parent-radius clamp around the company.
+    const dx = result.pos.x - parentPos.x;
+    const dy = result.pos.y - parentPos.y;
+    const distance = Math.sqrt(dx * dx + dy * dy);
+    expect(distance).toBeLessThanOrEqual(result.parentRadius);
+    expect(distance).toBeGreaterThan(0);
+  });
+
+  it('returns a non-zero parentRadius so the engine clamps collision-jitter near the parent', () => {
+    // Regression guard for the stray `placeParentRadius = 0` overwrite
+    // that disabled RenderPerp.setRandomPosition's circular clamp.
+    const result = computeBuyPerpSpawnPos({
+      parentPos: { x: 500, y: 500 },
+      grandparentPos: { x: 300, y: 300 },
+    });
+    expect(result.parentRadius).toBeGreaterThan(0);
+
+    const fallback = computeBuyPerpSpawnPos({ parentPos: { x: 500, y: 500 } });
+    expect(fallback.parentRadius).toBeGreaterThan(0);
+  });
+
+  it('is deterministic given identical inputs (no Math.random in the helper)', () => {
+    const args = { parentPos: { x: 500, y: 500 } };
+    const a = computeBuyPerpSpawnPos(args);
+    const b = computeBuyPerpSpawnPos(args);
+    expect(a).toEqual(b);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a long-standing bug (flagged in-code by `// FIXME: fishy but works?`): when buying a venture from a **top-level company** like proxy001 (the Bogus Company), the new perp node spawned at the hard-coded canvas centre `(1024, 800)` instead of near its parent.

### Root cause

In `scripts/game/GamePerp.ts:BuyPerp` the spawn-position math was:

```ts
const vector = parentRn.getVectorTo?.(gnodeRn);            // grandparent → company
const calced = gnodeRn.getVectorPos?.(vector, 0.61803398875);
```

Two problems:

1. **No fallback when the parent has no grandparent.** Top-level companies sit directly under Imperium, so `parentRn` was undefined, `placePos` stayed undefined, and `RenderPerp.setRandomPosition` fell through to its hard-coded `{ x: 1024, y: 800 }` origin. Compare with the sibling `scripts/game/DatabasePerp.ts:118`, which correctly falls back to `{ x: pos.x - 250, y: pos.y + 50 }` from the parent's own position.
2. **Stray `placeParentRadius = 0` overwrite.** The line `perp.renderData.config.placeParentRadius = 0;` ran unconditionally and clobbered the `320` set immediately above. This disabled the `if (this.placeParentRadius)` clamp in `RenderPerp.setRandomPosition:251` so the collision-avoidance jitter (±60/±40 × up to 500 iterations) could drift the node arbitrarily far from the parent. With `DatabasePerp.ts:134` keeping `placeParentRadius = 400`, this was clearly a `GamePerp`-local regression.

History check: both issues were extracted as-is from the legacy `Render.js` into TS in commit `993511c` ("phase 7 (#147)"). The `FIXME` comment flagged it from day one.

### Changes

- **New pure helper** `scripts/game/spawnPosition.ts` → `computeBuyPerpSpawnPos({ explicitPos, parentPos, grandparentPos })`:
  - Explicit position (mission/tutorial `buyPerpPos`) wins.
  - Else if a grandparent vector exists → preserve the legacy golden-ratio extension `parentPos + φ · (parentPos − grandparentPos)`.
  - Else → fallback to a sensible parent-relative offset (mirrors the `DatabasePerp` style), inside the radius clamp.
  - Always returns `parentRadius = 320` so the engine's circular clamp re-engages.
- **Wired into `GamePerp.BuyPerp`** (`scripts/game/GamePerp.ts:417-432`): replaces the FIXME block, drops the stray `placeParentRadius = 0` line.
- **Collision-avoidance** with sibling nodes already exists in `RenderPerp.setRandomPosition` / `RenderDragHandler.getCollisionPos`. Restoring the non-zero `placeParentRadius` is what re-enables both the radius clamp **and** keeps the existing collision-jitter loop bounded near the parent — so the new node won't overlap siblings either.

### TDD

Tests written first in `tests/game/spawn-position.test.js` (5 cases): explicit-wins, grandparent golden-ratio path, top-level fallback near parent (asserts not `1024,800` and within `parentRadius`), non-zero `parentRadius` regression guard, determinism.

## Test plan

- [x] `npm test` — 644/644 pass (5 new)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [ ] Manual: buy a venture from Bogus Company in dev build, confirm the new node appears adjacent to the company and not at canvas centre
- [ ] Manual: buy several ventures in a row from the same company, confirm they don't overlap each other

---
_Generated by [Claude Code](https://claude.ai/code/session_0145TNDPvHjANuxuNdJD9RwX)_