### PR TITLE
Fix text measurement and centering for hidden elements

### DIFF
--- a/scripts/render/RenderText.ts
+++ b/scripts/render/RenderText.ts
@@ -17,6 +17,7 @@ export type TextConfig = NodeConfig & {
 export class RenderText extends RenderNode {
   declare text: string;
   declare textAlign: string;
+  private _remeasureScheduled = false;
 
   static {
     RenderText.prototype.text = '';
@@ -62,18 +63,39 @@ export class RenderText extends RenderNode {
     this.updateRenderProp();
     this.jdomelem.html(t);
     this.updateSize();
-    const newOffset = { x: 0, y: 0 };
-    const width = this.jdomelem.width() ?? 200;
-    if (this.textAlign === 'center') {
-      newOffset.x = Math.round(width / 2);
-    } else if (this.textAlign === 'right') {
-      newOffset.x = width;
+    const w = this.width;
+    this.setOffset({
+      x: this.textAlign === 'center' ? Math.round(w / 2) : this.textAlign === 'right' ? w : 0,
+      y: 0,
+    });
+    // When inserted under a display:none ancestor (e.g. an inactive
+    // Stage), offsetWidth is 0 and the surrounding setSize then locks
+    // the inline CSS to width:0px — the centering offset can never
+    // recover on its own.  Retry on rAF until the layout fires.
+    const el = this.domelem as HTMLElement;
+    if (el.offsetWidth === 0 && t.length > 0 && !this._remeasureScheduled) {
+      this._remeasureScheduled = true;
+      const retry = (): void => {
+        if (!this.domelem.isConnected) return;
+        el.style.width = 'auto';
+        el.style.height = 'auto';
+        if (el.offsetWidth === 0) {
+          requestAnimationFrame(retry);
+          return;
+        }
+        this._remeasureScheduled = false;
+        this.updateText();
+        this.draw();
+      };
+      requestAnimationFrame(retry);
     }
-    this.setOffset(newOffset);
   }
 
   updateSize(): void {
-    this.width = this.jdomelem.width() ?? 200;
+    // offsetWidth (the rendered content box) rather than jQuery.width(),
+    // which just echoes back a previously-locked CSS width.
+    const el = this.domelem as HTMLElement;
+    this.width = el.offsetWidth || el.scrollWidth || 200;
   }
 
   /** Note the legacy double-`s` typo: `ssetSize`.  Preserved here


### PR DESCRIPTION
## Summary
Fixed text rendering and alignment issues when text elements are initially rendered under hidden (display:none) ancestors, such as inactive Stages. The previous implementation would lock the element to width:0px and never recover.

## Key Changes
- Added `_remeasureScheduled` flag to prevent duplicate remeasure attempts
- Refactored text offset calculation to use a ternary expression for cleaner code
- Implemented retry logic using `requestAnimationFrame` to remeasure text dimensions when initially hidden
  - Resets inline CSS width/height to 'auto' to allow proper layout calculation
  - Retries until element has non-zero offsetWidth or is disconnected from DOM
  - Calls `updateText()` and `draw()` once valid dimensions are obtained
- Updated `updateSize()` to use `offsetWidth` (rendered content box) instead of jQuery's `width()` method
  - Falls back to `scrollWidth` if offsetWidth is 0, then to hardcoded default of 200
  - This prevents echoing back previously-locked CSS width values

## Implementation Details
The fix handles the edge case where text elements are inserted under display:none ancestors. In this scenario, `offsetWidth` returns 0, causing `setSize()` to lock the inline CSS to `width:0px`. The new retry mechanism waits for the element to become visible and properly laid out before finalizing measurements and applying text alignment offsets.

https://claude.ai/code/session_013hPyftEfJMyu4LfA9x1sfb