### PR TITLE
Prevent duplicate language picker overlay on touch devices

### DIFF
--- a/scripts/game/GameRoot.ts
+++ b/scripts/game/GameRoot.ts
@@ -374,6 +374,10 @@ function _preventDefaultFile(e: unknown): void {
 function _showLangPicker(canDismiss: boolean): void {
   const $ = globalThis.$;
   if (!$) return;
+  // Touch devices fire both `touchend` and a synthesized `click` for the
+  // same tap on the toggle, so the event handler can request the picker
+  // twice in quick succession.  Bail if an overlay is already mounted.
+  if (document.querySelector('.LangSelectOverlay')) return;
   const $overlay = $(
     '<div class="LangSelectOverlay" style="position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.75);z-index:9999;display:flex;align-items:center;justify-content:center;">' +
       '<div class="LangPickerBox" style="background:#BFE7F5;border:3px solid #009FD9;border-radius:12px;padding:24px 32px;text-align:center;box-shadow:3px 3px 0px #009FD9,3px 3px 8px rgba(0,0,0,0.5);">' +


### PR DESCRIPTION
## Summary
Fixed an issue where the language picker overlay could be mounted multiple times on touch devices due to both `touchend` and synthesized `click` events firing for the same tap.

## Changes
- Added a guard check in `_showLangPicker()` to prevent creating duplicate overlays by checking if `.LangSelectOverlay` already exists in the DOM before mounting a new one
- This prevents the event handler from being triggered twice in quick succession on touch devices

## Implementation Details
Touch devices fire both a `touchend` event and a synthesized `click` event for the same user tap on the language picker toggle. Without this guard, both events would trigger `_showLangPicker()` and create multiple overlay instances. The fix simply bails out early if an overlay is already mounted, ensuring only one picker is displayed at a time.

https://claude.ai/code/session_017bdG4pi7GFABgKa8YPfCra