### PR TITLE
fix(engine): level up when xp lands exactly on xp_max

### DIFF
--- a/scripts/LocalEngine.ts
+++ b/scripts/LocalEngine.ts
@@ -1115,13 +1115,27 @@ function _tokensEqual(a: TokenSpec[], b: TokenSpec[]): boolean {
 }
 
 function _getLevelByXP(xp: number): number {
+  // Ruleset levels are defined with a gap between consecutive ranges
+  // (L1: 0–10, L2: 11–30, …). A player whose xp lands exactly on a
+  // level's `xp_max` would otherwise stay on the lower level until the
+  // next +1 XP pushed them past the gap into the next `xp_min`. That's
+  // visible as "10/10" sitting at level 1 with no levelup notification.
+  //
+  // Treat `xp_max` as the promotion threshold: walk high-to-low and
+  // return the first level whose `xp_min` is reached, but if xp has
+  // already met or passed that level's `xp_max` AND a higher level
+  // exists, return the higher level instead.
   var levels = _getRuleset().levels;
-  for (var i = 0; i < levels.length; i++) {
+  for (var i = levels.length - 1; i >= 0; i--) {
     var lvl = levels[i];
-    if (lvl && xp >= lvl.xp_min && xp <= lvl.xp_max) return lvl.number;
+    if (lvl && xp >= lvl.xp_min) {
+      var next = levels[i + 1];
+      if (next && xp >= lvl.xp_max) return next.number;
+      return lvl.number;
+    }
   }
-  var last = levels[levels.length - 1];
-  return last ? last.number : 1;
+  var first = levels[0];
+  return first ? first.number : 1;
 }
 
 function _checkLevelup(currentLevel: number, newXp: number): boolean {

--- a/scripts/game/GameRoot.ts
+++ b/scripts/game/GameRoot.ts
@@ -1178,7 +1178,7 @@ export class GameRoot extends GameNode {
     if (num !== undefined && num > this.xp_value) {
       this.xp_value = num;
     }
-    if (this.xp_value > this.xp_level.xp_max) {
+    if (this.xp_value >= this.xp_level.xp_max) {
       this.setLevel(this.getLevelByXP(this.xp_value).number);
     }
     if (this.xp_value < this.xp_level.xp_min) {

--- a/tests/handlers/levelup-xp-max.test.js
+++ b/tests/handlers/levelup-xp-max.test.js
@@ -1,0 +1,94 @@
+// @ts-nocheck — strict-TS quarantine; remove when this file is migrated to TS (issue #147)
+/**
+ * Regression: level-up must fire when xp_value reaches the level's xp_max,
+ * not only when it crosses into the next level's xp_min.
+ *
+ * Ruleset levels have a gap between consecutive ranges:
+ *   L1: xp_min=0, xp_max=10
+ *   L2: xp_min=11, xp_max=30
+ *
+ * Pre-fix `_getLevelByXP` matched the inclusive upper bound first
+ * (`xp >= xp_min && xp <= xp_max`), so a player at xp=10 stayed at level 1
+ * until a stray +1 XP pushed them to 11. Visible symptom: "10/10" bar
+ * sitting at level 1 with no levelup notification — and chained
+ * symptoms like `buyPerp('proxy001')` failing the `required_level=2`
+ * check because the player was still level 1.
+ *
+ * Fix: treat xp_max as the promotion threshold — reaching it returns
+ * the next level.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  buyPerp,
+  setEmitter,
+  setSendAchievement,
+  setSendDelta,
+} from '../../scripts/LocalEngine.js';
+import { getState, setState } from '../../scripts/boot.js';
+import { clearOverride, setOverride } from '../../scripts/clock.js';
+import { FIXED_NOW, mkGv, mkState } from './_fixtures.js';
+
+function mkAchievementSpy() {
+  const spy = vi.fn();
+  setSendAchievement(spy);
+  return spy;
+}
+
+function callsOfKind(spy, achievementKind) {
+  return spy.mock.calls.filter((c) => c[0].payload.achievement_kind === achievementKind);
+}
+
+describe('levelup — fires when xp lands exactly on xp_max', () => {
+  beforeEach(() => {
+    setOverride(FIXED_NOW);
+    setState(
+      mkState({
+        display_name: 'Eve',
+        locale: 'en',
+        // xp_value=9, xp_level=1; buying client007 (xp_inc=1) lands
+        // xp_value at exactly 10, which equals L1's xp_max. Pre-fix this
+        // did NOT level up; post-fix it must.
+        game_values: mkGv({ xp_value: 9, xp_level: 1, cash_value: 5000 }),
+      })
+    );
+  });
+
+  afterEach(() => {
+    clearOverride();
+    setSendAchievement(null);
+    setSendDelta(null);
+    setEmitter(null);
+  });
+
+  it('promotes xp_level when xp_value reaches xp_max exactly', async () => {
+    const spy = mkAchievementSpy();
+
+    await buyPerp('Imperium', 'client007');
+
+    const gv = getState().game_values;
+    expect(gv.xp_value).toBe(10);
+    // The promotion threshold is L1.xp_max=10 → new level is 2.
+    expect(gv.xp_level).toBe(2);
+    // And the levelup achievement fires once.
+    expect(callsOfKind(spy, 'levelup')).toHaveLength(1);
+  });
+
+  it('does not fire levelup when xp_value stays below xp_max', async () => {
+    // Reset to a state where buyPerp keeps xp below xp_max.
+    setState(
+      mkState({
+        display_name: 'Eve',
+        locale: 'en',
+        game_values: mkGv({ xp_value: 5, xp_level: 1, cash_value: 5000 }),
+      })
+    );
+    const spy = mkAchievementSpy();
+
+    await buyPerp('Imperium', 'client007');
+
+    const gv = getState().game_values;
+    expect(gv.xp_value).toBe(6);
+    expect(gv.xp_level).toBe(1);
+    expect(callsOfKind(spy, 'levelup')).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Reported during manual testing of #272: in some cases the level-up notification doesn't fire even though the XP bar shows "10/10", and as a downstream symptom the **Bogus Company** (`proxy001`, `required_level: 2`) buy fails in the early game.

## Root cause

`_getLevelByXP` in `scripts/LocalEngine.ts:1117` matched levels with an *inclusive* upper bound:

```ts
if (lvl && xp >= lvl.xp_min && xp <= lvl.xp_max) return lvl.number;
```

Ruleset levels have a 1-XP gap between consecutive ranges:
- L1: `xp_min=0, xp_max=10`
- L2: `xp_min=11, xp_max=30`

At `xp=10`, the loop matches L1 first (`10 <= 10`) and returns. `_checkLevelup(currentLevel=1, newXp=10)` is then `1 > 1` = **false** → no level-up. The player is stuck on level 1 with "10/10" until the next XP event pushes them past 11.

**Chain reaction:** since `xp_level` stays at 1, `buyPerp('proxy001')` fails its `required_level=2` check (`LocalEngine.ts:1403`) and returns `error: 1`. The Bogus Company purchase silently errors out in the early game even though the UX implies it should work after the first mission completes.

**Why it's "sometimes":** only matters when an XP reward lands the player *exactly* on `xp_max` (e.g. xp=8 + a mission reward of 2 → xp=10). Players whose increments overshoot to 11+ level up normally.

## Fix

Walk levels high-to-low and treat `xp_max` as the promotion threshold:

```ts
for (var i = levels.length - 1; i >= 0; i--) {
  var lvl = levels[i];
  if (lvl && xp >= lvl.xp_min) {
    var next = levels[i + 1];
    if (next && xp >= lvl.xp_max) return next.number;
    return lvl.number;
  }
}
```

No ruleset data change. Players whose `xp_value` lands exactly on a `xp_max` now promote immediately. The matching visual check in `GameRoot.setXP` switches from `>` to `>=` so the status-bar level setter agrees with the engine.

## Test plan

- [x] New `tests/handlers/levelup-xp-max.test.js` directly exercises the regression — starts at xp=9 / level=1, buys client007 (`xp_inc=1`) to land at exactly 10, asserts `xp_level === 2` and the levelup achievement fires once.
- [x] Verified the new test **fails** without the fix (stashed the LocalEngine + GameRoot changes locally and saw the failure) — and passes with it.
- [x] Counter-test: xp=5 → xp=6 does **not** trigger levelup.
- [x] `pnpm typecheck` clean.
- [x] `pnpm test` — 680 passing (was 678 + 2 new).
- [x] `pnpm lint` clean.

## Related

- Originally listed as MEDIUM finding in the multi-agent code audit (`GameRoot.ts:1932 "XP until next level" off-by-one when at level cap`). Didn't make it into the 4 audit PRs (#270–#273); pulled out as a focused fix when a real player hit it.
- Closes the manual-test regression report from #272's post-merge sanity check.

https://claude.ai/code/session_01NhYApbEtp5AYkzbJyD5mnf

---
_Generated by [Claude Code](https://claude.ai/code/session_01NhYApbEtp5AYkzbJyD5mnf)_