### PR TITLE
fix(render): honour draggable:false and setFrameSrc src argument

### DIFF
--- a/scripts/render/RenderPerp.ts
+++ b/scripts/render/RenderPerp.ts
@@ -79,8 +79,7 @@ export class RenderPerp extends RenderSprite {
       // collapses to `true` always; preserved verbatim.
       clickable: true,
       detectCollisions: true,
-      // `||` would coerce `draggable: false` to true; use `??` so an
-      // explicit false survives.
+      // `??` so an explicit `draggable: false` survives.
       draggable: config.draggable ?? true,
       cables: cables as unknown as RenderNode['cables'],
       perpSprite: perpSpriteInstance,

--- a/scripts/render/RenderPerp.ts
+++ b/scripts/render/RenderPerp.ts
@@ -79,7 +79,9 @@ export class RenderPerp extends RenderSprite {
       // collapses to `true` always; preserved verbatim.
       clickable: true,
       detectCollisions: true,
-      draggable: config.draggable || true,
+      // `||` would coerce `draggable: false` to true; use `??` so an
+      // explicit false survives.
+      draggable: config.draggable ?? true,
       cables: cables as unknown as RenderNode['cables'],
       perpSprite: perpSpriteInstance,
       jdomelem: jdomelem,

--- a/scripts/render/RenderSprite.ts
+++ b/scripts/render/RenderSprite.ts
@@ -60,10 +60,8 @@ export class RenderSprite extends RenderNode {
   }
 
   setFrameSrc(src: string | undefined): void {
-    // Pre-fix this guarded on `this.frameSrc` and then used `this.frameSrc`
-    // to build the URL — so the `src` argument was effectively ignored
-    // (both existing callers happened to pass `this.frameSrc` already).
-    // Honour the argument so future callers can swap the sprite source.
+    // Honour the `src` arg; previously guarded on and read `this.frameSrc`,
+    // which silently ignored the argument.
     if (!src) {
       return;
     }

--- a/scripts/render/RenderSprite.ts
+++ b/scripts/render/RenderSprite.ts
@@ -60,12 +60,17 @@ export class RenderSprite extends RenderNode {
   }
 
   setFrameSrc(src: string | undefined): void {
-    if (!this.frameSrc) {
+    // Pre-fix this guarded on `this.frameSrc` and then used `this.frameSrc`
+    // to build the URL — so the `src` argument was effectively ignored
+    // (both existing callers happened to pass `this.frameSrc` already).
+    // Honour the argument so future callers can swap the sprite source.
+    if (!src) {
       return;
     }
+    this.frameSrc = src;
     this.spriteSrc = src;
     this.css({
-      'background-image': 'url(' + setup.imagePathPrefix + this.frameSrc + ')',
+      'background-image': 'url(' + setup.imagePathPrefix + src + ')',
     });
   }
 

--- a/tests/render/render-trivia.test.js
+++ b/tests/render/render-trivia.test.js
@@ -1,0 +1,57 @@
+// @ts-nocheck — strict-TS quarantine; remove when this file is migrated to TS (issue #147)
+/**
+ * Source-text guards for two low-risk render fixes:
+ *
+ *  - `RenderPerp.ts`: `config.draggable || true` silently coerced
+ *    `draggable: false` to `true`. Switched to `??`.
+ *  - `RenderSprite.ts`: `setFrameSrc(src)` guarded on `this.frameSrc` and
+ *    built the URL from `this.frameSrc`, so the `src` argument was
+ *    effectively dead. Now honoured.
+ *
+ * The render layer can't be instantiated under vitest (needs createjs +
+ * Scroller globals + real DOM), so these are pure regression guards
+ * against the specific source patterns rather than runtime tests.
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PERP_SRC = readFileSync(resolve(__dirname, '../../scripts/render/RenderPerp.ts'), 'utf8');
+const SPRITE_SRC = readFileSync(resolve(__dirname, '../../scripts/render/RenderSprite.ts'), 'utf8');
+
+describe('RenderPerp — draggable nullish-coalesce', () => {
+  it('uses `??` so an explicit draggable:false is preserved', () => {
+    expect(PERP_SRC).toMatch(/draggable\s*:\s*config\.draggable\s*\?\?\s*true/);
+    expect(PERP_SRC).not.toMatch(/draggable\s*:\s*config\.draggable\s*\|\|\s*true/);
+  });
+});
+
+describe('RenderSprite.setFrameSrc — honours the src argument', () => {
+  it('returns early on falsy `src`, not on `this.frameSrc`', () => {
+    // Extract the setFrameSrc body to bound the assertions.
+    const m = SPRITE_SRC.match(/setFrameSrc\s*\([^)]*\)\s*:\s*void\s*\{[\s\S]*?\n\s\s\}/);
+    expect(m, 'setFrameSrc body should match').toBeTruthy();
+    const body = m[0];
+
+    // Early-return is now on the argument, not the field.
+    expect(body).toMatch(/if\s*\(\s*!\s*src\s*\)/);
+    expect(body).not.toMatch(/if\s*\(\s*!\s*this\.frameSrc\s*\)/);
+  });
+
+  it('builds the background-image URL from `src`, not `this.frameSrc`', () => {
+    const m = SPRITE_SRC.match(/setFrameSrc\s*\([^)]*\)\s*:\s*void\s*\{[\s\S]*?\n\s\s\}/);
+    expect(m).toBeTruthy();
+    const body = m[0];
+
+    expect(body).toMatch(/imagePathPrefix\s*\+\s*src/);
+    expect(body).not.toMatch(/imagePathPrefix\s*\+\s*this\.frameSrc/);
+  });
+
+  it('writes `src` back into `this.frameSrc` so subsequent reads see it', () => {
+    const m = SPRITE_SRC.match(/setFrameSrc\s*\([^)]*\)\s*:\s*void\s*\{[\s\S]*?\n\s\s\}/);
+    expect(m).toBeTruthy();
+    expect(m[0]).toMatch(/this\.frameSrc\s*=\s*src/);
+  });
+});

--- a/tests/render/render-trivia.test.js
+++ b/tests/render/render-trivia.test.js
@@ -21,6 +21,11 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const PERP_SRC = readFileSync(resolve(__dirname, '../../scripts/render/RenderPerp.ts'), 'utf8');
 const SPRITE_SRC = readFileSync(resolve(__dirname, '../../scripts/render/RenderSprite.ts'), 'utf8');
 
+const setFrameSrcMatch = SPRITE_SRC.match(
+  /setFrameSrc\s*\([^)]*\)\s*:\s*void\s*\{[\s\S]*?\n\s\s\}/
+);
+const SET_FRAME_SRC_BODY = setFrameSrcMatch ? setFrameSrcMatch[0] : '';
+
 describe('RenderPerp — draggable nullish-coalesce', () => {
   it('uses `??` so an explicit draggable:false is preserved', () => {
     expect(PERP_SRC).toMatch(/draggable\s*:\s*config\.draggable\s*\?\?\s*true/);
@@ -29,29 +34,21 @@ describe('RenderPerp — draggable nullish-coalesce', () => {
 });
 
 describe('RenderSprite.setFrameSrc — honours the src argument', () => {
-  it('returns early on falsy `src`, not on `this.frameSrc`', () => {
-    // Extract the setFrameSrc body to bound the assertions.
-    const m = SPRITE_SRC.match(/setFrameSrc\s*\([^)]*\)\s*:\s*void\s*\{[\s\S]*?\n\s\s\}/);
-    expect(m, 'setFrameSrc body should match').toBeTruthy();
-    const body = m[0];
+  it('extracts a setFrameSrc body to assert against', () => {
+    expect(setFrameSrcMatch, 'setFrameSrc body must be locatable').toBeTruthy();
+  });
 
-    // Early-return is now on the argument, not the field.
-    expect(body).toMatch(/if\s*\(\s*!\s*src\s*\)/);
-    expect(body).not.toMatch(/if\s*\(\s*!\s*this\.frameSrc\s*\)/);
+  it('returns early on falsy `src`, not on `this.frameSrc`', () => {
+    expect(SET_FRAME_SRC_BODY).toMatch(/if\s*\(\s*!\s*src\s*\)/);
+    expect(SET_FRAME_SRC_BODY).not.toMatch(/if\s*\(\s*!\s*this\.frameSrc\s*\)/);
   });
 
   it('builds the background-image URL from `src`, not `this.frameSrc`', () => {
-    const m = SPRITE_SRC.match(/setFrameSrc\s*\([^)]*\)\s*:\s*void\s*\{[\s\S]*?\n\s\s\}/);
-    expect(m).toBeTruthy();
-    const body = m[0];
-
-    expect(body).toMatch(/imagePathPrefix\s*\+\s*src/);
-    expect(body).not.toMatch(/imagePathPrefix\s*\+\s*this\.frameSrc/);
+    expect(SET_FRAME_SRC_BODY).toMatch(/imagePathPrefix\s*\+\s*src/);
+    expect(SET_FRAME_SRC_BODY).not.toMatch(/imagePathPrefix\s*\+\s*this\.frameSrc/);
   });
 
   it('writes `src` back into `this.frameSrc` so subsequent reads see it', () => {
-    const m = SPRITE_SRC.match(/setFrameSrc\s*\([^)]*\)\s*:\s*void\s*\{[\s\S]*?\n\s\s\}/);
-    expect(m).toBeTruthy();
-    expect(m[0]).toMatch(/this\.frameSrc\s*=\s*src/);
+    expect(SET_FRAME_SRC_BODY).toMatch(/this\.frameSrc\s*=\s*src/);
   });
 });


### PR DESCRIPTION
## Summary

Two low-risk render-layer fixes re-applied against the extracted `scripts/render/*.ts` modules. Part 1 of 3 small PRs replacing the original PR #273, which targeted the now-removed monolithic `scripts/Render.js`.

| # | File | Fix |
|---|---|---|
| 1 | `scripts/render/RenderPerp.ts:82` | `config.draggable \|\| true` → `config.draggable ?? true`. The legacy `\|\|` silently coerced an explicit `draggable: false` to `true`. |
| 2 | `scripts/render/RenderSprite.ts:62` | `setFrameSrc(src)` guarded on and read `this.frameSrc`, so the `src` argument was dead. Now honours it and writes it back into `this.frameSrc`. |

Bug #2 didn't bite in practice because both existing callers happen to pass `this.frameSrc` already — but the contract `setFrameSrc(src: string)` implies the argument matters, and future callers can now actually swap the sprite source.

## Why this PR is "no manual testing required"

- Bug #1: pure correctness; if no perp config sets `draggable: false`, the fix is a no-op. If any does, the behaviour now matches the type signature.
- Bug #2: existing callers' behaviour is unchanged (they passed `this.frameSrc`, which is what the buggy code used; new code uses `src` which equals `this.frameSrc` for the same callers). The fix only changes behaviour for *new* callers that pass a different `src`.
- Source-text regression guards (`tests/render/render-trivia.test.js`, 4 assertions) pin the patterns so a future revert would fail loudly.

## Commits

1. **fix(render): honour draggable:false and setFrameSrc src argument** — the actual two patches plus the regression test.
2. **chore(render): simplify per simplify-skill review** — review agents found two cleanups: trim comments to surviving-WHY only, hoist the duplicated regex match into a module-scope const. No behaviour change.

## Test plan

- [x] `pnpm typecheck` clean.
- [x] `pnpm test` — 685 passing (was 681 + 4 new).
- [x] `pnpm lint` clean.
- [x] `pnpm build:all` builds both variants.

## Related

Bugs #1 and #2 from the original render-audit PR #273. Two more PRs to come for the remaining 6 still-relevant render fixes (split by risk: lifecycle/cleanup, then input/recovery).

https://claude.ai/code/session_01NhYApbEtp5AYkzbJyD5mnf

---
_Generated by [Claude Code](https://claude.ai/code/session_01NhYApbEtp5AYkzbJyD5mnf)_