### PR TITLE
fix(render): recover stuck drags + leaked Popup transitionend (needs manual smoke test)

### DIFF
--- a/scripts/render/RenderDragHandler.ts
+++ b/scripts/render/RenderDragHandler.ts
@@ -67,6 +67,12 @@ export class RenderDragHandler {
   dragStartPos: { x: number; y: number };
   dragMovePos: { x: number; y: number };
   collisionNodes: OrderedSet<DraggableNode>;
+  // Native recovery handlers attached in `init()`. Stored so `dispose()`
+  // can detach them — without this, releasing the pointer outside the
+  // canvas / alt-tabbing / receiving a system gesture cancellation
+  // would never fire `mouseup`/`touchend` and the drag stays stuck.
+  private _recoveryHandlers: Array<{ target: EventTarget; type: string; listener: EventListener }> =
+    [];
 
   constructor() {
     const $ = globalThis.jQuery ?? globalThis.$;
@@ -121,6 +127,9 @@ export class RenderDragHandler {
   }
 
   dragend(_e: DragEventLike): void {
+    // Idempotent: the recovery handlers below and the regular
+    // mouseup/touchend path can both funnel into here for the same
+    // gesture. The for-loop and flag flip are safe to repeat.
     this.state = 'stopped';
     for (const node of this.listeners) {
       node.dragging = false;
@@ -286,6 +295,28 @@ export class RenderDragHandler {
       e.stopPropagation();
       this.dragend(e);
     });
+    // Recovery: releasing the pointer outside the canvas, an OS gesture
+    // cancellation, alt-tabbing, or tab-hide all skip `mouseup`/
+    // `touchend`. Funnel them into the same `dragend` path so the drag
+    // state can't get stuck. `dragend` is idempotent against the normal
+    // release fire-twice case.
+    const recover = (): void => {
+      if (this.dragging) this.dragend({} as DragEventLike);
+    };
+    const onVisibility = (): void => {
+      if (document.hidden) recover();
+    };
+    const addRecovery = (target: EventTarget, type: string, listener: EventListener): void => {
+      target.addEventListener(type, listener);
+      this._recoveryHandlers.push({ target, type, listener });
+    };
+    if (typeof window !== 'undefined') {
+      addRecovery(window, 'pointercancel', recover);
+      addRecovery(window, 'blur', recover);
+    }
+    if (typeof document !== 'undefined') {
+      addRecovery(document, 'visibilitychange', onVisibility);
+    }
     this.on('mousemove touchmove', (e) => {
       if (!this.dragging) {
         return;
@@ -324,6 +355,13 @@ export class RenderDragHandler {
         node.moveTo(clipped);
       }
     });
+  }
+
+  dispose(): void {
+    for (const h of this._recoveryHandlers) {
+      h.target.removeEventListener(h.type, h.listener);
+    }
+    this._recoveryHandlers.length = 0;
   }
 
   private static _touchFrom(e: DragEventLike): PointerLike | undefined {

--- a/scripts/render/RenderDragHandler.ts
+++ b/scripts/render/RenderDragHandler.ts
@@ -6,6 +6,11 @@
 
 import { OrderedSet } from '../game/OrderedSet.js';
 
+// Module-load DOM-availability probes; both values are fixed for the
+// lifetime of this realm.
+const HAS_WINDOW = typeof window !== 'undefined';
+const HAS_DOC = typeof document !== 'undefined';
+
 interface PointerLike {
   pageX: number;
   pageY: number;
@@ -67,10 +72,7 @@ export class RenderDragHandler {
   dragStartPos: { x: number; y: number };
   dragMovePos: { x: number; y: number };
   collisionNodes: OrderedSet<DraggableNode>;
-  // Native recovery handlers attached in `init()`. Stored so `dispose()`
-  // can detach them — without this, releasing the pointer outside the
-  // canvas / alt-tabbing / receiving a system gesture cancellation
-  // would never fire `mouseup`/`touchend` and the drag stays stuck.
+  // Stored so `dispose()` can detach the recovery listeners init() attaches.
   private _recoveryHandlers: Array<{ target: EventTarget; type: string; listener: EventListener }> =
     [];
 
@@ -126,10 +128,10 @@ export class RenderDragHandler {
     this.dragVector.y = (this.dragMovePos.y - this.dragStartPos.y) * this.scale;
   }
 
-  dragend(_e: DragEventLike): void {
-    // Idempotent: the recovery handlers below and the regular
-    // mouseup/touchend path can both funnel into here for the same
-    // gesture. The for-loop and flag flip are safe to repeat.
+  // Idempotent — recovery handlers in init() may call this for the same
+  // gesture as the regular mouseup/touchend path; the empty-listeners
+  // loop and flag flip are safe to repeat.
+  dragend(_e?: DragEventLike): void {
     this.state = 'stopped';
     for (const node of this.listeners) {
       node.dragging = false;
@@ -290,32 +292,32 @@ export class RenderDragHandler {
   }
 
   init(): void {
+    // Guard against accidental re-init (constructor is the only current
+    // caller, but the recovery listeners would double up otherwise).
+    if (this._recoveryHandlers.length > 0) return;
     this.on('mouseup touchend', (e) => {
       e.preventDefault();
       e.stopPropagation();
       this.dragend(e);
     });
-    // Recovery: releasing the pointer outside the canvas, an OS gesture
-    // cancellation, alt-tabbing, or tab-hide all skip `mouseup`/
-    // `touchend`. Funnel them into the same `dragend` path so the drag
-    // state can't get stuck. `dragend` is idempotent against the normal
-    // release fire-twice case.
+    // Releasing the pointer outside the canvas, an OS gesture cancellation,
+    // alt-tabbing, or tab-hide all skip `mouseup`/`touchend` — funnel them
+    // through the same dragend path so the drag can't get stuck.
     const recover = (): void => {
-      if (this.dragging) this.dragend({} as DragEventLike);
-    };
-    const onVisibility = (): void => {
-      if (document.hidden) recover();
+      if (this.dragging) this.dragend();
     };
     const addRecovery = (target: EventTarget, type: string, listener: EventListener): void => {
       target.addEventListener(type, listener);
       this._recoveryHandlers.push({ target, type, listener });
     };
-    if (typeof window !== 'undefined') {
+    if (HAS_WINDOW) {
       addRecovery(window, 'pointercancel', recover);
       addRecovery(window, 'blur', recover);
     }
-    if (typeof document !== 'undefined') {
-      addRecovery(document, 'visibilitychange', onVisibility);
+    if (HAS_DOC) {
+      addRecovery(document, 'visibilitychange', () => {
+        if (document.hidden) recover();
+      });
     }
     this.on('mousemove touchmove', (e) => {
       if (!this.dragging) {

--- a/scripts/render/RenderNode.ts
+++ b/scripts/render/RenderNode.ts
@@ -48,6 +48,7 @@ interface DragHandlerLike {
     newPos: { x: number; y: number }
   ): { x: number; y: number; coll: boolean };
   testCollisions(node: RenderNode, newPos: { x: number; y: number }): boolean;
+  dispose(): void;
 }
 
 interface CableLike {

--- a/scripts/render/RenderTopLevelUI.ts
+++ b/scripts/render/RenderTopLevelUI.ts
@@ -1008,12 +1008,21 @@ export class RenderPopup extends RenderNode {
   close(cb?: () => void): void {
     this.open = false;
     const jq = this.jdomelem;
-    jq.on('otransitionend MSTransitionEnd transitionend webkitTransitionEnd', () => {
+    // One-shot transitionend → remove, with a 500ms safety net for when
+    // the transition doesn't fire (off-DOM, display:none, etc).
+    // Whichever runs first clears the other so remove() is called once.
+    const TRANSITION_EVENTS = 'otransitionend MSTransitionEnd transitionend webkitTransitionEnd';
+    let removeFallback: number | undefined;
+    const finish = (): void => {
+      jq.off(TRANSITION_EVENTS, finish);
+      if (removeFallback !== undefined) {
+        window.clearTimeout(removeFallback);
+        removeFallback = undefined;
+      }
       this.remove();
-    });
-    window.setTimeout(() => {
-      this.remove();
-    }, 500);
+    };
+    jq.on(TRANSITION_EVENTS, finish);
+    removeFallback = window.setTimeout(finish, 500);
     window.setTimeout(() => {
       if (cb) cb();
     }, 250);

--- a/scripts/render/RenderViews.ts
+++ b/scripts/render/RenderViews.ts
@@ -797,6 +797,7 @@ export class RenderViewMap extends RenderNode {
       entry.target.removeEventListener(entry.type, entry.listener, entry.options);
     }
     this._nativeListeners.length = 0;
+    this.dragHandler?.dispose();
     super.remove();
   }
 }

--- a/tests/render/_helpers.js
+++ b/tests/render/_helpers.js
@@ -1,0 +1,15 @@
+// @ts-nocheck — strict-TS quarantine; remove when this file is migrated to TS (issue #147)
+// Shared utilities for source-text guard tests under tests/render/.
+// The render layer can't be instantiated under vitest (needs createjs +
+// Scroller globals + real DOM), so the regression tests read the
+// extracted .ts source as text and assert on patterns.
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const RENDER_DIR = resolve(here, '../../scripts/render');
+
+export function readRenderSrc(file) {
+  return readFileSync(resolve(RENDER_DIR, file), 'utf8');
+}

--- a/tests/render/render-input.test.js
+++ b/tests/render/render-input.test.js
@@ -15,80 +15,61 @@
  * runtime tests. Manual smoke-test still required for the drag flow
  * (alt-tab mid-drag, touch cancel, etc) — see PR description.
  */
-import { readFileSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
+import { readRenderSrc } from './_helpers.js';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const RENDER_DIR = resolve(__dirname, '../../scripts/render');
-const readSrc = (file) => readFileSync(resolve(RENDER_DIR, file), 'utf8');
+const DRAG_SRC = readRenderSrc('RenderDragHandler.ts');
+const VIEWS_SRC = readRenderSrc('RenderViews.ts');
+const POPUP_SRC = readRenderSrc('RenderTopLevelUI.ts');
 
-const DRAG_SRC = readSrc('RenderDragHandler.ts');
-const VIEWS_SRC = readSrc('RenderViews.ts');
-const POPUP_SRC = readSrc('RenderTopLevelUI.ts');
+const INIT_BODY = DRAG_SRC.match(/init\(\)\s*:\s*void\s*\{[\s\S]*?\n  \}/)?.[0] ?? '';
+const DISPOSE_BODY = DRAG_SRC.match(/dispose\(\)\s*:\s*void\s*\{[\s\S]*?\n  \}/)?.[0] ?? '';
+const VIEW_REMOVE_BODY =
+  VIEWS_SRC.match(/override\s+remove\s*\(\)\s*:\s*void\s*\{[\s\S]*?\n  \}/)?.[0] ?? '';
+const CLOSE_BODY = POPUP_SRC.match(/close\(cb\?[\s\S]*?\n  \}/)?.[0] ?? '';
 
 describe('RenderDragHandler — recovery handlers', () => {
-  it('init() registers pointercancel, blur, and visibilitychange', () => {
-    const m = DRAG_SRC.match(/init\(\)\s*:\s*void\s*\{[\s\S]*?\n  \}/);
-    expect(m, 'init() body must be locatable').toBeTruthy();
-    const body = m[0];
-    expect(body).toMatch(/['"]pointercancel['"]/);
-    expect(body).toMatch(/['"]blur['"]/);
-    expect(body).toMatch(/['"]visibilitychange['"]/);
+  it('init() body is locatable', () => {
+    expect(INIT_BODY).not.toBe('');
   });
 
-  it('recovery handlers funnel into dragend when dragging', () => {
-    // The recover closure should call this.dragend(...) only if
-    // this.dragging is currently true (idempotent against the normal
-    // mouseup/touchend fire).
+  it('registers pointercancel, blur, and visibilitychange', () => {
+    expect(INIT_BODY).toMatch(/['"]pointercancel['"]/);
+    expect(INIT_BODY).toMatch(/['"]blur['"]/);
+    expect(INIT_BODY).toMatch(/['"]visibilitychange['"]/);
+  });
+
+  it('recovery handlers funnel into dragend only when dragging', () => {
     expect(DRAG_SRC).toMatch(/if\s*\(\s*this\.dragging\s*\)\s*this\.dragend/);
   });
 
-  it('exports a dispose() that detaches every recovery handler', () => {
-    const m = DRAG_SRC.match(/dispose\(\)\s*:\s*void\s*\{[\s\S]*?\n  \}/);
-    expect(m, 'dispose() body must be locatable').toBeTruthy();
-    expect(m[0]).toMatch(/removeEventListener/);
+  it('dispose() detaches every recovery handler', () => {
+    expect(DISPOSE_BODY).not.toBe('');
+    expect(DISPOSE_BODY).toMatch(/removeEventListener/);
   });
 });
 
 describe('RenderViewMap.remove — disposes the dragHandler', () => {
   it('calls dragHandler.dispose() before super.remove()', () => {
-    const m = VIEWS_SRC.match(/override\s+remove\s*\(\)\s*:\s*void\s*\{[\s\S]*?\n  \}/);
-    expect(m).toBeTruthy();
-    const body = m[0];
-    expect(body).toMatch(/this\.dragHandler\??\.dispose\??\(\)/);
-    // dispose must precede super.remove so the parent teardown sees
-    // the detached state.
-    const disposeIdx = body.indexOf('dispose(');
-    const superIdx = body.indexOf('super.remove');
+    expect(VIEW_REMOVE_BODY).toMatch(/this\.dragHandler\??\.dispose\??\(\)/);
+    const disposeIdx = VIEW_REMOVE_BODY.indexOf('dispose(');
+    const superIdx = VIEW_REMOVE_BODY.indexOf('super.remove');
     expect(disposeIdx).toBeGreaterThan(-1);
     expect(superIdx).toBeGreaterThan(disposeIdx);
   });
 });
 
 describe('RenderPopup.close — one-shot transitionend', () => {
-  it('detaches the transitionend handler and clears the fallback timer', () => {
-    const m = POPUP_SRC.match(/close\(cb\?[\s\S]*?\n  \}/);
-    expect(m, 'close() body must be locatable').toBeTruthy();
-    const body = m[0];
-    // .off() with the handler ref must appear inside the close body.
-    expect(body).toMatch(/jq\.off\(/);
-    // The fallback timer must be tracked so the early-firing path can
-    // clear it.
-    expect(body).toMatch(/clearTimeout\s*\(\s*removeFallback/);
+  it('close() body is locatable', () => {
+    expect(CLOSE_BODY).not.toBe('');
   });
 
-  it('no longer leaves the transitionend handler unbound', () => {
-    // Pre-fix the close() called jq.on('transitionend', () => this.remove())
-    // with no matching jq.off. Catch any future revert that drops the
-    // unbind logic.
-    const m = POPUP_SRC.match(/close\(cb\?[\s\S]*?\n  \}/);
-    const body = m[0];
-    const hasOn = /jq\.on\(\s*TRANSITION_EVENTS/.test(body) || /jq\.on\(/.test(body);
-    const hasOff = /jq\.off\(/.test(body);
-    expect(hasOn && hasOff, 'close() must both bind AND unbind the transitionend handler').toBe(
-      true
-    );
+  it('binds AND unbinds the transitionend handler', () => {
+    expect(CLOSE_BODY).toMatch(/jq\.on\(/);
+    expect(CLOSE_BODY).toMatch(/jq\.off\(/);
+  });
+
+  it('clears the fallback timer when the early path fires', () => {
+    expect(CLOSE_BODY).toMatch(/clearTimeout\s*\(\s*removeFallback/);
   });
 });

--- a/tests/render/render-input.test.js
+++ b/tests/render/render-input.test.js
@@ -22,11 +22,11 @@ const DRAG_SRC = readRenderSrc('RenderDragHandler.ts');
 const VIEWS_SRC = readRenderSrc('RenderViews.ts');
 const POPUP_SRC = readRenderSrc('RenderTopLevelUI.ts');
 
-const INIT_BODY = DRAG_SRC.match(/init\(\)\s*:\s*void\s*\{[\s\S]*?\n  \}/)?.[0] ?? '';
-const DISPOSE_BODY = DRAG_SRC.match(/dispose\(\)\s*:\s*void\s*\{[\s\S]*?\n  \}/)?.[0] ?? '';
+const INIT_BODY = DRAG_SRC.match(/init\(\)\s*:\s*void\s*\{[\s\S]*?\n {2}\}/)?.[0] ?? '';
+const DISPOSE_BODY = DRAG_SRC.match(/dispose\(\)\s*:\s*void\s*\{[\s\S]*?\n {2}\}/)?.[0] ?? '';
 const VIEW_REMOVE_BODY =
-  VIEWS_SRC.match(/override\s+remove\s*\(\)\s*:\s*void\s*\{[\s\S]*?\n  \}/)?.[0] ?? '';
-const CLOSE_BODY = POPUP_SRC.match(/close\(cb\?[\s\S]*?\n  \}/)?.[0] ?? '';
+  VIEWS_SRC.match(/override\s+remove\s*\(\)\s*:\s*void\s*\{[\s\S]*?\n {2}\}/)?.[0] ?? '';
+const CLOSE_BODY = POPUP_SRC.match(/close\(cb\?[\s\S]*?\n {2}\}/)?.[0] ?? '';
 
 describe('RenderDragHandler — recovery handlers', () => {
   it('init() body is locatable', () => {

--- a/tests/render/render-input.test.js
+++ b/tests/render/render-input.test.js
@@ -1,0 +1,94 @@
+// @ts-nocheck — strict-TS quarantine; remove when this file is migrated to TS (issue #147)
+/**
+ * Source-text guards for the render-input audit fixes:
+ *
+ *  - `RenderDragHandler.init()` registers `pointercancel` / `blur` /
+ *    `visibilitychange` recovery handlers funneling into `dragend`,
+ *    and tracks them so `dispose()` can detach. ViewMap.remove() now
+ *    calls `dragHandler.dispose()`.
+ *  - `RenderPopup.close()` uses a one-shot transitionend handler that
+ *    self-detaches and cancels the 500ms fallback when either path
+ *    fires.
+ *
+ * Render-layer code cannot be instantiated under vitest (no createjs /
+ * Scroller globals, no real DOM); these are pattern guards rather than
+ * runtime tests. Manual smoke-test still required for the drag flow
+ * (alt-tab mid-drag, touch cancel, etc) — see PR description.
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const RENDER_DIR = resolve(__dirname, '../../scripts/render');
+const readSrc = (file) => readFileSync(resolve(RENDER_DIR, file), 'utf8');
+
+const DRAG_SRC = readSrc('RenderDragHandler.ts');
+const VIEWS_SRC = readSrc('RenderViews.ts');
+const POPUP_SRC = readSrc('RenderTopLevelUI.ts');
+
+describe('RenderDragHandler — recovery handlers', () => {
+  it('init() registers pointercancel, blur, and visibilitychange', () => {
+    const m = DRAG_SRC.match(/init\(\)\s*:\s*void\s*\{[\s\S]*?\n  \}/);
+    expect(m, 'init() body must be locatable').toBeTruthy();
+    const body = m[0];
+    expect(body).toMatch(/['"]pointercancel['"]/);
+    expect(body).toMatch(/['"]blur['"]/);
+    expect(body).toMatch(/['"]visibilitychange['"]/);
+  });
+
+  it('recovery handlers funnel into dragend when dragging', () => {
+    // The recover closure should call this.dragend(...) only if
+    // this.dragging is currently true (idempotent against the normal
+    // mouseup/touchend fire).
+    expect(DRAG_SRC).toMatch(/if\s*\(\s*this\.dragging\s*\)\s*this\.dragend/);
+  });
+
+  it('exports a dispose() that detaches every recovery handler', () => {
+    const m = DRAG_SRC.match(/dispose\(\)\s*:\s*void\s*\{[\s\S]*?\n  \}/);
+    expect(m, 'dispose() body must be locatable').toBeTruthy();
+    expect(m[0]).toMatch(/removeEventListener/);
+  });
+});
+
+describe('RenderViewMap.remove — disposes the dragHandler', () => {
+  it('calls dragHandler.dispose() before super.remove()', () => {
+    const m = VIEWS_SRC.match(/override\s+remove\s*\(\)\s*:\s*void\s*\{[\s\S]*?\n  \}/);
+    expect(m).toBeTruthy();
+    const body = m[0];
+    expect(body).toMatch(/this\.dragHandler\??\.dispose\??\(\)/);
+    // dispose must precede super.remove so the parent teardown sees
+    // the detached state.
+    const disposeIdx = body.indexOf('dispose(');
+    const superIdx = body.indexOf('super.remove');
+    expect(disposeIdx).toBeGreaterThan(-1);
+    expect(superIdx).toBeGreaterThan(disposeIdx);
+  });
+});
+
+describe('RenderPopup.close — one-shot transitionend', () => {
+  it('detaches the transitionend handler and clears the fallback timer', () => {
+    const m = POPUP_SRC.match(/close\(cb\?[\s\S]*?\n  \}/);
+    expect(m, 'close() body must be locatable').toBeTruthy();
+    const body = m[0];
+    // .off() with the handler ref must appear inside the close body.
+    expect(body).toMatch(/jq\.off\(/);
+    // The fallback timer must be tracked so the early-firing path can
+    // clear it.
+    expect(body).toMatch(/clearTimeout\s*\(\s*removeFallback/);
+  });
+
+  it('no longer leaves the transitionend handler unbound', () => {
+    // Pre-fix the close() called jq.on('transitionend', () => this.remove())
+    // with no matching jq.off. Catch any future revert that drops the
+    // unbind logic.
+    const m = POPUP_SRC.match(/close\(cb\?[\s\S]*?\n  \}/);
+    const body = m[0];
+    const hasOn = /jq\.on\(\s*TRANSITION_EVENTS/.test(body) || /jq\.on\(/.test(body);
+    const hasOff = /jq\.off\(/.test(body);
+    expect(hasOn && hasOff, 'close() must both bind AND unbind the transitionend handler').toBe(
+      true
+    );
+  });
+});

--- a/tests/render/render-lifecycle.test.js
+++ b/tests/render/render-lifecycle.test.js
@@ -14,18 +14,12 @@
  * Scroller globals, no real DOM), so these are pattern guards rather
  * than runtime tests.
  */
-import { readFileSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
+import { readRenderSrc } from './_helpers.js';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const RENDER_DIR = resolve(__dirname, '../../scripts/render');
-const readSrc = (file) => readFileSync(resolve(RENDER_DIR, file), 'utf8');
-
-const NODE_SRC = readSrc('RenderNode.ts');
-const TICKER_SRC = readSrc('RenderSlowTicker.ts');
-const VIEWS_SRC = readSrc('RenderViews.ts');
+const NODE_SRC = readRenderSrc('RenderNode.ts');
+const TICKER_SRC = readRenderSrc('RenderSlowTicker.ts');
+const VIEWS_SRC = readRenderSrc('RenderViews.ts');
 
 const removeBodyMatch = NODE_SRC.match(/\n {2}remove\(\)\s*:\s*void\s*\{[\s\S]*?\n {2}\}/);
 const REMOVE_BODY = removeBodyMatch ? removeBodyMatch[0] : '';


### PR DESCRIPTION
## Summary

Last two render-audit fixes from the original PR #273, against the extracted `scripts/render/*.ts` modules. **Stacked on #287** (render-lifecycle) since this PR extends the `override remove()` that #287 introduces in `RenderViewMap`.

| # | File | Fix |
|---|---|---|
| 1 | `RenderDragHandler.ts` | `init()` binds three native recovery listeners (`pointercancel`, `blur`, `visibilitychange`) that funnel into `dragend` when `this.dragging` is true. New `dispose()` detaches them; `ViewMap.remove()` calls it before `super.remove()`. Releases stuck-down drag state when the gesture is interrupted outside the canvas. |
| 2 | `RenderTopLevelUI.ts` | `Popup.close()` previously bound a transitionend handler via `jq.on(...)` with no unbind, and a 500ms `setTimeout` fallback also called `this.remove()`. Now a single `finish` closure self-detaches via `jq.off()` and clears the fallback timer — whichever path runs first wins, the other no-ops. |

## ⚠️ Manual testing required (the only audit fix that genuinely needs it)

The DragHandler recovery is the riskiest one in the audit batch — it touches the mobile/desktop input path. Source-text guards pin the patterns but cannot exercise the runtime behavior.

**Required before merge:**
1. Start dragging a perp, alt-tab away, return → perp releases at its drag position, no stuck-down state.
2. Start dragging on touch, slide finger off the canvas edge → drag terminates cleanly.
3. Open a popup or modal mid-drag → drag terminates, popup interactive.
4. Open/close 10 popups in a row (any in-game popup) → no console warnings about double-remove or removed-node operations.

If any of those misbehave, the regression is in this PR; revert the offending fix.

## Commits

1. **fix(render): recover stuck drags + leaked Popup transitionend** — the two patches plus regression test (6 assertions).
2. **chore(render): simplify per simplify-skill review** — six cleanups: extract shared `tests/render/_helpers.js`, make `dragend()` parameter optional + drop synthetic event cast, hoist `HAS_WINDOW`/`HAS_DOC` module constants, add `init()` idempotency guard, hoist test regex constants, trim narrative comments.

## Test plan

- [x] `pnpm typecheck` clean.
- [x] `pnpm test` — 696 passing.
- [x] `pnpm lint` clean.
- [x] `pnpm build:all` clean.
- [ ] **Manual drag-recovery smoke test** (see above) — blocking.

## Related

Bugs #1 and #4 from the original render-audit PR #273. With this PR + #286 + #287, all 8 still-relevant render audit fixes are landed (bugs #4 sacaleY-typo and #5 FXPuff-double-remove were resolved during the original render extraction).

https://claude.ai/code/session_01NhYApbEtp5AYkzbJyD5mnf

---
_Generated by [Claude Code](https://claude.ai/code/session_01NhYApbEtp5AYkzbJyD5mnf)_