### PR TITLE
fix(game): restore mission tab for players who finished all missions (regression from #272)

### DIFF
--- a/scripts/game/Missions.ts
+++ b/scripts/game/Missions.ts
@@ -143,7 +143,11 @@ export class Missions extends GameNode {
       allGoalsDone.set(g.mission, prev === undefined ? done : prev && done);
     }
     for (const mission of Object.values(this.Missions)) {
-      if (mission.gestalt && allGoalsDone.get(mission.gestalt) === true && !mission.states.complete) {
+      if (
+        mission.gestalt &&
+        allGoalsDone.get(mission.gestalt) === true &&
+        !mission.states.complete
+      ) {
         mission.setState('complete', true);
         mission.setState('active', false);
       }

--- a/scripts/game/Missions.ts
+++ b/scripts/game/Missions.ts
@@ -109,13 +109,12 @@ export class Missions extends GameNode {
     if (raw_data.mission_goals) {
       this.updateMissionGoals(raw_data.mission_goals);
     }
-    // Only walk active_missions when the server actually handed us a list.
-    // Pre-fix, a falsy/empty `active_missions` (undefined or []) hit an
-    // unguarded else-branch that flagged *every* loaded mission complete,
-    // which on every reload re-fired spurious mission_complete state
-    // events for missions the player had not finished. The server uses
-    // a non-empty list of completed-mission gestalts to encode "all
-    // done"; an empty list simply means "nothing to mark active here".
+    // Walk active_missions when the server handed us a non-empty list:
+    // mark each active and its required-mission ancestors complete.
+    // Pre-fix, a falsy/empty `active_missions` hit an unguarded
+    // else-branch that flagged *every* loaded mission complete (even
+    // ones never started), re-firing spurious mission_complete events
+    // on every reload.
     if (Array.isArray(raw_data.active_missions) && active_missions.length) {
       active_missions.forEach((gestalt) => {
         const active_mission = this.getMission(gestalt);
@@ -127,6 +126,30 @@ export class Missions extends GameNode {
           });
         }
       });
+    }
+    // Independently, restore the `complete` flag for any mission whose
+    // goals are all done. Without this, a player who finished every
+    // available mission (the producer then emits `active_missions: []`)
+    // would see an EMPTY mission tab on reload — getVisibleMissions()
+    // needs active||complete, and the active-walk above sets neither
+    // when the list is empty. Deriving from goals is the correct source
+    // of truth and (unlike the old blanket else-branch) never marks a
+    // never-started mission complete, so it doesn't reintroduce the
+    // spurious-event bug.
+    const goalsByMission = new Map<string, boolean>();
+    for (const g of raw_data.mission_goals || []) {
+      const mg = g as { mission?: string; complete?: boolean };
+      if (typeof mg.mission !== 'string') continue;
+      const prev = goalsByMission.get(mg.mission);
+      const done = mg.complete === true;
+      goalsByMission.set(mg.mission, prev === undefined ? done : prev && done);
+    }
+    for (const mission of Object.values(this.Missions)) {
+      const allGoalsDone = mission.gestalt ? goalsByMission.get(mission.gestalt) : undefined;
+      if (allGoalsDone === true && !mission.states.complete) {
+        mission.setState('complete', true);
+        mission.setState('active', false);
+      }
     }
     this.checkProjectGoals();
   }

--- a/scripts/game/Missions.ts
+++ b/scripts/game/Missions.ts
@@ -4,6 +4,7 @@
 
 import appModule from '../app.js';
 import i18n from '../i18n.js';
+import type { MissionGoal } from '../state.js';
 import { GameNode, type GameNodeConfig, getByFirstId, getFirstId } from './GameNode.js';
 import { Mission } from './Mission.js';
 import { OrderedSet } from './OrderedSet.js';
@@ -127,26 +128,22 @@ export class Missions extends GameNode {
         }
       });
     }
-    // Independently, restore the `complete` flag for any mission whose
-    // goals are all done. Without this, a player who finished every
-    // available mission (the producer then emits `active_missions: []`)
-    // would see an EMPTY mission tab on reload — getVisibleMissions()
-    // needs active||complete, and the active-walk above sets neither
-    // when the list is empty. Deriving from goals is the correct source
-    // of truth and (unlike the old blanket else-branch) never marks a
-    // never-started mission complete, so it doesn't reintroduce the
-    // spurious-event bug.
-    const goalsByMission = new Map<string, boolean>();
-    for (const g of raw_data.mission_goals || []) {
-      const mg = g as { mission?: string; complete?: boolean };
-      if (typeof mg.mission !== 'string') continue;
-      const prev = goalsByMission.get(mg.mission);
-      const done = mg.complete === true;
-      goalsByMission.set(mg.mission, prev === undefined ? done : prev && done);
+    // Derive `complete` from goal state, independent of active_missions.
+    // When the player has finished every available mission the producer
+    // emits `active_missions: []`, so the walk above sets nothing and
+    // getVisibleMissions() (active || complete) would render an EMPTY
+    // mission tab on reload. Goal-derived completion is the correct
+    // source of truth and never touches a never-started mission, so it
+    // doesn't reintroduce the spurious-event bug #272 removed.
+    const allGoalsDone = new Map<string, boolean>();
+    for (const g of (raw_data.mission_goals as MissionGoal[] | undefined) || []) {
+      if (typeof g.mission !== 'string') continue;
+      const prev = allGoalsDone.get(g.mission);
+      const done = g.complete === true;
+      allGoalsDone.set(g.mission, prev === undefined ? done : prev && done);
     }
     for (const mission of Object.values(this.Missions)) {
-      const allGoalsDone = mission.gestalt ? goalsByMission.get(mission.gestalt) : undefined;
-      if (allGoalsDone === true && !mission.states.complete) {
+      if (mission.gestalt && allGoalsDone.get(mission.gestalt) === true && !mission.states.complete) {
         mission.setState('complete', true);
         mission.setState('active', false);
       }

--- a/tests/game/missions-init.test.js
+++ b/tests/game/missions-init.test.js
@@ -1,17 +1,26 @@
 // @ts-nocheck — strict-TS quarantine; remove when this file is migrated to TS (issue #147)
 //
-// Regression guard for the Missions.initMissions completion-guard fix.
-// Pre-fix: when the server reported an empty/undefined `active_missions`
-// list, the `else` branch flipped every loaded mission to complete=true
-// and fired spurious `mission_complete` events on every reload from a
-// state where the player had not actually completed every mission.
-// Post-fix: that branch only runs when `active_missions` is a non-empty
-// array AND the mission's gestalt is actually in that array.
+// Regression guards for Missions.initMissions completion handling.
 //
-// A previous version of this test instantiated Missions/Mission at
-// runtime; that path drags in app.js → Game.js → game/* and is
-// CI-flaky under v8 coverage instrumentation (see mission-tutorial-slice
-// test for the matching note). Reduced to source-text assertions.
+// 1. Original #272 fix: when the server reports an empty/undefined
+//    `active_missions`, the old unguarded else-branch flipped EVERY
+//    loaded mission complete=true and re-fired spurious
+//    mission_complete events on reload. The active-walk must stay
+//    gated on Array.isArray(active_missions) && length.
+//
+// 2. Empty-mission-tab regression: removing that else-branch left
+//    finished missions with complete=false whenever the player had
+//    completed every available mission (producer emits
+//    `active_missions: []`). getVisibleMissions() needs active||
+//    complete, so the mission tab rendered EMPTY on reload. The fix
+//    derives `complete` from goal state independently of
+//    active_missions — a mission whose goals are all done is marked
+//    complete, which (unlike the blanket else-branch) never touches a
+//    never-started mission.
+//
+// Runtime instantiation of Missions drags in app.js → Game.js → game/*
+// and is CI-flaky under v8 coverage (see mission-tutorial-slice note),
+// so these stay source-text guards.
 import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -20,22 +29,52 @@ import { describe, expect, it } from 'vitest';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SRC = readFileSync(resolve(__dirname, '../../scripts/game/Missions.ts'), 'utf8');
 
-describe('Missions.initMissions completion guard', () => {
-  it('guards the completion branch on Array.isArray(active_missions)', () => {
-    // The pre-fix pattern unconditionally hit the else branch — including
-    // when active_missions was undefined or empty.  Post-fix, the
-    // completion path is gated on Array.isArray to reject falsy/non-array
-    // server payloads.
-    expect(SRC).toMatch(/Array\.isArray\s*\(\s*[A-Za-z_]+\.active_missions\s*\)/);
+// Anchor on the method signature (not the line-32 comment mention) and
+// take through the method's terminating `checkProjectGoals()` call.
+const initBodyMatch = SRC.match(
+  /initMissions\(raw_data[\s\S]*?this\.checkProjectGoals\(\);\n {2}\}/
+);
+const INIT_BODY = initBodyMatch ? initBodyMatch[0] : '';
+
+describe('Missions.initMissions — original #272 completion guard', () => {
+  it('init body is locatable', () => {
+    expect(initBodyMatch, 'initMissions body must be locatable').toBeTruthy();
   });
 
-  it('walks active_missions to mark complete instead of flipping every mission', () => {
-    // The post-fix pattern iterates `active_missions.forEach` and only
-    // sets `complete` on the gestalts the server actually reported. The
-    // pre-fix else branch unconditionally hit `m.setState('complete', true)`
-    // on every loaded mission.
-    expect(SRC).toMatch(
+  it('gates the active-walk on Array.isArray(active_missions)', () => {
+    expect(INIT_BODY).toMatch(/Array\.isArray\s*\(\s*[A-Za-z_]+\.active_missions\s*\)/);
+  });
+
+  it('marks complete via the active_missions walk, not a blanket else', () => {
+    expect(INIT_BODY).toMatch(
       /Array\.isArray[\s\S]{0,400}active_missions\.forEach[\s\S]{0,400}setState\(\s*['"]complete['"]/
     );
+    // The pre-fix `else { Object.values(this.Missions).forEach(... mark
+    // every mission complete ...) }` must not come back.
+    expect(INIT_BODY).not.toMatch(
+      /\}\s*else\s*\{[\s\S]{0,200}Object\.values\(this\.Missions\)[\s\S]{0,200}setState\(\s*['"]complete['"]\s*,\s*true/
+    );
+  });
+});
+
+describe('Missions.initMissions — empty-tab regression fix', () => {
+  it('derives complete from mission_goals independently of active_missions', () => {
+    // A goals-aggregation pass keyed by mission gestalt, followed by a
+    // setState('complete', true) for missions whose goals are all done.
+    expect(INIT_BODY).toMatch(/raw_data\.mission_goals/);
+    expect(INIT_BODY).toMatch(/goalsByMission/);
+    expect(INIT_BODY).toMatch(
+      /goalsByMission[\s\S]{0,300}setState\(\s*['"]complete['"]\s*,\s*true\s*\)/
+    );
+  });
+
+  it('the goal-derived pass is outside the active_missions length guard', () => {
+    // It must run even when active_missions is empty — i.e. it is not
+    // nested inside the `if (Array.isArray(...) && ....length)` block.
+    const guardIdx = INIT_BODY.indexOf('Array.isArray');
+    const guardClose = INIT_BODY.indexOf('\n    }', guardIdx);
+    const goalsIdx = INIT_BODY.indexOf('goalsByMission');
+    expect(guardIdx).toBeGreaterThan(-1);
+    expect(goalsIdx).toBeGreaterThan(guardClose);
   });
 });

--- a/tests/game/missions-init.test.js
+++ b/tests/game/missions-init.test.js
@@ -62,9 +62,9 @@ describe('Missions.initMissions — empty-tab regression fix', () => {
     // A goals-aggregation pass keyed by mission gestalt, followed by a
     // setState('complete', true) for missions whose goals are all done.
     expect(INIT_BODY).toMatch(/raw_data\.mission_goals/);
-    expect(INIT_BODY).toMatch(/goalsByMission/);
+    expect(INIT_BODY).toMatch(/allGoalsDone/);
     expect(INIT_BODY).toMatch(
-      /goalsByMission[\s\S]{0,300}setState\(\s*['"]complete['"]\s*,\s*true\s*\)/
+      /allGoalsDone[\s\S]{0,300}setState\(\s*['"]complete['"]\s*,\s*true\s*\)/
     );
   });
 
@@ -73,7 +73,7 @@ describe('Missions.initMissions — empty-tab regression fix', () => {
     // nested inside the `if (Array.isArray(...) && ....length)` block.
     const guardIdx = INIT_BODY.indexOf('Array.isArray');
     const guardClose = INIT_BODY.indexOf('\n    }', guardIdx);
-    const goalsIdx = INIT_BODY.indexOf('goalsByMission');
+    const goalsIdx = INIT_BODY.indexOf('allGoalsDone');
     expect(guardIdx).toBeGreaterThan(-1);
     expect(goalsIdx).toBeGreaterThan(guardClose);
   });


### PR DESCRIPTION
## Summary

**Regression fix.** After #272 merged, the mission tab renders **empty for any player who has completed every available mission**.

## Root cause

#272 removed `Missions.initMissions`' `else` branch — which marked *every* loaded mission `complete=true` whenever `active_missions` was empty — because it re-fired spurious `mission_complete` events on every reload. Removing it was correct for the spurious-event bug, but introduced a worse one:

When a player finishes the last available mission, the engine producer (`LocalEngine.ts`) emits `active_missions: []`. On reload, `initMissions` runs with an empty list, so the `active_missions` walk sets neither `active` nor `complete` on any mission. `getVisibleMissions()` filters on `active === true || complete === true` → returns `[]` → **empty mission tab**.

The #272 reviewer flagged this exact risk ("if any production path *does* send `active_missions: []` to mean 'all done'... the player will no longer see missions flip to complete on reload"). It was incorrectly dismissed at the time — owning that here.

## Fix

After the `active_missions` walk, independently derive each mission's `complete` flag from goal state: a mission whose goals are all complete is marked complete. This:

- Restores the finished-mission history in the tab when `active_missions` is empty.
- Is the correct source of truth (matches the engine-side `_completeMissionsIfReady` logic).
- Unlike the old blanket `else`, never marks a never-started mission complete — so the original #272 spurious-event bug stays fixed.

## Test plan

- [x] `tests/game/missions-init.test.js` extended: keeps the original `Array.isArray` guard assertions, adds two pinning the goal-derived pass and verifying it runs *outside* the `active_missions` length guard.
- [x] Confirmed the two new assertions **fail** without the source fix (stashed it, saw 2 failures), pass with it.
- [x] `pnpm typecheck` clean.
- [x] `pnpm test` — 696 passing.
- [x] `pnpm lint` clean.
- [x] `pnpm build:all` clean.

## Manual verification recommended

Load a save where every mission is finished (or play through to all-complete, then reload). The mission tab should show the completed missions, not be blank.

## Commits

1. **fix(game): restore mission tab for players who finished all missions** — the fix + regression tests.
2. **chore(game): simplify per simplify-skill review** — use canonical `MissionGoal` type, tighten naming/comment. No behavior change.

https://claude.ai/code/session_01NhYApbEtp5AYkzbJyD5mnf

---
_Generated by [Claude Code](https://claude.ai/code/session_01NhYApbEtp5AYkzbJyD5mnf)_