### PR TITLE
fix(popups): render level-up notification text as HTML (regression from #284)

### DIFF
--- a/scripts/components/popups/LevelUpNotification.tsx
+++ b/scripts/components/popups/LevelUpNotification.tsx
@@ -22,7 +22,9 @@ export function LevelUpNotification({
   onClose,
 }: LevelUpNotificationProps) {
   const says = i18n.gettext('Mark says:');
-  const text = sprintf(
+  // Legacy template rendered this as `<%= text %>` (raw HTML); the
+  // levelup i18n catalog string embeds spans (Level / XP / energy).
+  const textHtml = sprintf(
     i18n.gettext('levelup level %s! %s XP to level %s. %s energy'),
     toKSNum(xpLevel),
     toKSNum(xpToNext),
@@ -36,7 +38,8 @@ export function LevelUpNotification({
         <div class="NotificationBubble">
           <div class="NotificationAvatar" />
           <div class="NotificationSays">{says}</div>
-          <div class="NotificationText">{text}</div>
+          {/* biome-ignore lint/security/noDangerouslySetInnerHtml: trusted ruleset / i18n string */}
+          <div class="NotificationText" dangerouslySetInnerHTML={{ __html: textHtml }} />
           <div class="TutorialTapHint">tap anywhere to continue</div>
         </div>
       </div>

--- a/tests/e2e/dialog-lifecycle.spec.ts
+++ b/tests/e2e/dialog-lifecycle.spec.ts
@@ -254,6 +254,24 @@ test.describe('Section B — notification queue popups', () => {
     await expectOpenAndClose(page, '.PopupBody.TutorialBody', 'tap');
   });
 
+  test('LevelUp notification renders i18n markup as real span elements', async ({ page }) => {
+    await bootGame(page);
+    await page.evaluate(() => {
+      const groot = (window as any).__dd?._app?.game;
+      groot.makeNotifications({ levelup: 2 });
+    });
+    await expect(page.locator('.PopupContainer.lockOn.Tutorial')).toBeVisible({ timeout: 5_000 });
+    const body = page.locator('.PopupBody.TutorialBody').first();
+    await expect(body).toBeVisible({ timeout: 3_000 });
+    // The levelup catalog string embeds `<span class="level">…</span>`
+    // markup.  Rendered correctly it must produce real child <span>
+    // ELEMENTS — not escaped text showing the literal tags.
+    const spans = page.locator('.PopupBody.TutorialBody .NotificationText span');
+    await expect(spans.first()).toBeVisible({ timeout: 3_000 });
+    expect(await spans.count()).toBeGreaterThanOrEqual(1);
+    await expectOpenAndClose(page, '.PopupBody.TutorialBody', 'tap');
+  });
+
   test('Mission briefing (active mission) opens and closes', async ({ page }) => {
     await bootGame(page);
     // Use the first available mission gestalt from the GameRoot's mission set,


### PR DESCRIPTION
## Regression

The tier-2 Preact port (#284) replaced `views/levelup.html` with `LevelUpNotification.tsx`, which rendered the computed message via JSX `{text}`. JSX **escapes** that, but the levelup i18n catalog string embeds markup (`<span class="level">Level 17</span>`, XP / energy spans). Players saw the literal tags as text:

> Wow! Du hast `<span class="level">Level 17</span>` erreicht. Sammle `<span class="xp">1.126 XP</span>` …

The legacy template emitted the same value with `<%= text %>` — raw HTML. The sibling Preact notifications (`TutorialNotification`, `NewItemsNotification`) already match the legacy semantics with `dangerouslySetInnerHTML` + the trusted-i18n `biome-ignore`. This applies the same one-line pattern to `LevelUpNotification` (and renames the local `text` → `textHtml` for consistency).

## Test

New Section B e2e: **"LevelUp notification renders i18n markup as real span elements"** — triggers `makeNotifications({ levelup: 2 })` and asserts `.NotificationText` contains real child `<span>` elements rather than escaped text. Verified failing against the buggy `{text}` render, passing after the fix.

## Validation

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm exec playwright test tests/e2e/dialog-lifecycle.spec.ts` — 43 passed (42 + the new pin)

Independent regression fix, split out from the in-progress tier-3 work so the visible bug lands fast.

https://claude.ai/code/session_017vEmKRFZF7q8yrVGu5tLDJ

---
_Generated by [Claude Code](https://claude.ai/code/session_017vEmKRFZF7q8yrVGu5tLDJ)_