### PR TITLE
Fix dev-simulator storage-quota crash: IndexedDB persistence + canonical async webxdc API

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^3.0.0",
     "@webxdc/types": "^2.1.2",
-    "@webxdc/vite-plugins": "^1.6.0",
+    "@webxdc/vite-plugins": "github:experintellia/vite-plugins#claude/indexeddb-webxdc-simulator-Oy3ii",
     "lefthook": "^2.1.6",
     "typescript": "^5.3.0",
     "vite": "^8.0.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ importers:
         specifier: ^2.1.2
         version: 2.1.2
       '@webxdc/vite-plugins':
-        specifier: ^1.6.0
-        version: 1.6.0(terser@5.46.2)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(terser@5.46.2)(yaml@2.8.3))
+        specifier: github:experintellia/vite-plugins#claude/indexeddb-webxdc-simulator-Oy3ii
+        version: https://codeload.github.com/experintellia/vite-plugins/tar.gz/ae3978e30fa35569083bfc16dac3746209eeeb96(terser@5.46.2)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(terser@5.46.2)(yaml@2.8.3))
       lefthook:
         specifier: ^2.1.6
         version: 2.1.6
@@ -56,8 +56,8 @@ packages:
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/compat-data@7.29.0':
-    resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
+  '@babel/compat-data@7.29.3':
+    resolution: {integrity: sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/core@7.29.0':
@@ -76,8 +76,8 @@ packages:
     resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-create-class-features-plugin@7.28.6':
-    resolution: {integrity: sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==}
+  '@babel/helper-create-class-features-plugin@7.29.3':
+    resolution: {integrity: sha512-RpLYy2sb51oNLjuu1iD3bwBqCBWUzjO0ocp+iaCP/lJtb2CPLcnC2Fftw+4sAzaMELGeWTgExSKADbdo0GFVzA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -160,6 +160,11 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/parser@7.29.3':
+    resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5':
     resolution: {integrity: sha512-87GDMS3tsmMSi/3bWOte1UblL+YUTFMV8SZPZ2eSEL17s74Cw/l63rR6NmGVKMYW2GYi85nE+/d6Hw5N0bEk2Q==}
     engines: {node: '>=6.9.0'}
@@ -174,6 +179,12 @@ packages:
 
   '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1':
     resolution: {integrity: sha512-g4L7OYun04N1WyqMNjldFwlfPCLVkgB54A/YCXICZYBsvJJE3kByKv9c9+R/nAfmIfjl2rKYLNyMHboYbZaWaA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@7.29.3':
+    resolution: {integrity: sha512-SRS46DFR4HqzUzCVgi90/xMoL+zeBDBvWdKYXSEzh79kXswNFEglUpMKxR04//dPqwYXWUBJ3mpUd933ru9Kmg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -364,8 +375,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-modules-systemjs@7.29.0':
-    resolution: {integrity: sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==}
+  '@babel/plugin-transform-modules-systemjs@7.29.4':
+    resolution: {integrity: sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -520,8 +531,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/preset-env@7.29.2':
-    resolution: {integrity: sha512-DYD23veRYGvBFhcTY1iUvJnDNpuqNd/BzBwCvzOTKUnJjKg5kpUBh3/u9585Agdkgj+QuygG7jLfOPWMa2KVNw==}
+  '@babel/preset-env@7.29.5':
+    resolution: {integrity: sha512-/69t2aEzGKHD76DyLbHysF/QH2LJOB8iFnYO37unDTKBTubzcMRv0f3H5EiN1Q6ajOd/eB7dAInF0qdFVS06kA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1071,8 +1082,8 @@ packages:
     peerDependencies:
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  '@vitejs/plugin-legacy@8.0.1':
-    resolution: {integrity: sha512-8zeDeuNPqXd49rIVgFgluQYB8vQICHR7l+W2I3CxYK4gTjTorajVr0wLvSjALIwEwLRxBn68EgNVyGP4j6hP7w==}
+  '@vitejs/plugin-legacy@8.0.2':
+    resolution: {integrity: sha512-+n6znc/hTsuD2v/qWX3nfR6UFWFKwpL+XS+SPyiPuEwAvR24iRvLkJQDh18u0XrHPEwuwxPmw0VopvlmLSg66Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       terser: ^5.16.0
@@ -1119,8 +1130,9 @@ packages:
   '@webxdc/types@2.1.2':
     resolution: {integrity: sha512-oklcyHvUXqCS5JwbPVaN8tt7nSB8ffRmyrUlVt0HeSn4kDyNE46oKSbw3KtrDzl530KHnm67LfcK/AjWbBoXUA==}
 
-  '@webxdc/vite-plugins@1.6.0':
-    resolution: {integrity: sha512-mjh2M2JGUJmYJrr789mhwgKEWhYcFcz0T3EKZ8VBesDlWmm2KCw8j063stVTb3riRDVLM+0m+UCBWuV8S2+7qg==}
+  '@webxdc/vite-plugins@https://codeload.github.com/experintellia/vite-plugins/tar.gz/ae3978e30fa35569083bfc16dac3746209eeeb96':
+    resolution: {tarball: https://codeload.github.com/experintellia/vite-plugins/tar.gz/ae3978e30fa35569083bfc16dac3746209eeeb96}
+    version: 1.6.1-fork.4
 
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
@@ -1176,8 +1188,8 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  baseline-browser-mapping@2.10.24:
-    resolution: {integrity: sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA==}
+  baseline-browser-mapping@2.10.30:
+    resolution: {integrity: sha512-xjOFN16Ha1+Rz4nFYKqHU/LSB+gx/Vi3yQLX7r7sAW+Wa+8hhF2h4pvqTrTMc8+WcDBEunnUurr46Jvv0jk3Vg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -1215,8 +1227,8 @@ packages:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
 
-  caniuse-lite@1.0.30001791:
-    resolution: {integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==}
+  caniuse-lite@1.0.30001793:
+    resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
 
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
@@ -1276,8 +1288,8 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
-  electron-to-chromium@1.5.344:
-    resolution: {integrity: sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==}
+  electron-to-chromium@1.5.357:
+    resolution: {integrity: sha512-NHlTIQDK8fmVwHwuIzmXYEJ1Ewq3D9wDNc0cWXxDGysP6Pb21giwGNkxiTifyKy/4SoPuN5l6GLP1W9Sv7zB2g==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -1379,8 +1391,8 @@ packages:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
     engines: {node: '>=8'}
 
-  is-core-module@2.16.1:
-    resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
+  is-core-module@2.16.2:
+    resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
     engines: {node: '>= 0.4'}
 
   is-extglob@2.1.1:
@@ -1623,8 +1635,8 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  node-releases@2.0.38:
-    resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
+  node-releases@2.0.44:
+    resolution: {integrity: sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==}
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -2049,7 +2061,7 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@babel/compat-data@7.29.0': {}
+  '@babel/compat-data@7.29.3': {}
 
   '@babel/core@7.29.0':
     dependencies:
@@ -2058,7 +2070,7 @@ snapshots:
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
       '@babel/helpers': 7.29.2
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       '@babel/template': 7.28.6
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
@@ -2073,7 +2085,7 @@ snapshots:
 
   '@babel/generator@7.29.1':
     dependencies:
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       '@babel/types': 7.29.0
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
@@ -2085,13 +2097,13 @@ snapshots:
 
   '@babel/helper-compilation-targets@7.28.6':
     dependencies:
-      '@babel/compat-data': 7.29.0
+      '@babel/compat-data': 7.29.3
       '@babel/helper-validator-option': 7.27.1
       browserslist: 4.28.2
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.28.6(@babel/core@7.29.0)':
+  '@babel/helper-create-class-features-plugin@7.29.3(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-annotate-as-pure': 7.27.3
@@ -2201,6 +2213,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@babel/parser@7.29.3':
+    dependencies:
+      '@babel/types': 7.29.0
+
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -2218,6 +2234,14 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@7.29.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.29.0)':
     dependencies:
@@ -2292,7 +2316,7 @@ snapshots:
   '@babel/plugin-transform-class-properties@7.28.6(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
@@ -2300,7 +2324,7 @@ snapshots:
   '@babel/plugin-transform-class-static-block@7.28.6(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
@@ -2424,7 +2448,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-systemjs@7.29.0(@babel/core@7.29.0)':
+  '@babel/plugin-transform-modules-systemjs@7.29.4(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
@@ -2503,7 +2527,7 @@ snapshots:
   '@babel/plugin-transform-private-methods@7.28.6(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
@@ -2512,7 +2536,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
@@ -2589,9 +2613,9 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/preset-env@7.29.2(@babel/core@7.29.0)':
+  '@babel/preset-env@7.29.5(@babel/core@7.29.0)':
     dependencies:
-      '@babel/compat-data': 7.29.0
+      '@babel/compat-data': 7.29.3
       '@babel/core': 7.29.0
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
@@ -2599,6 +2623,7 @@ snapshots:
       '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.28.5(@babel/core@7.29.0)
       '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-bugfix-safari-rest-destructuring-rhs-array': 7.29.3(@babel/core@7.29.0)
       '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.6(@babel/core@7.29.0)
       '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.0)
@@ -2630,7 +2655,7 @@ snapshots:
       '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-systemjs': 7.29.0(@babel/core@7.29.0)
+      '@babel/plugin-transform-modules-systemjs': 7.29.4(@babel/core@7.29.0)
       '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-transform-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.0)
       '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.29.0)
@@ -2675,7 +2700,7 @@ snapshots:
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       '@babel/types': 7.29.0
 
   '@babel/traverse@7.29.0':
@@ -2683,7 +2708,7 @@ snapshots:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
       '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
       debug: 4.4.3
@@ -3025,12 +3050,12 @@ snapshots:
     dependencies:
       vite: 8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(terser@5.46.2)(yaml@2.8.3)
 
-  '@vitejs/plugin-legacy@8.0.1(terser@5.46.2)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(terser@5.46.2)(yaml@2.8.3))':
+  '@vitejs/plugin-legacy@8.0.2(terser@5.46.2)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(terser@5.46.2)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-dynamic-import': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-systemjs': 7.29.0(@babel/core@7.29.0)
-      '@babel/preset-env': 7.29.2(@babel/core@7.29.0)
+      '@babel/plugin-transform-modules-systemjs': 7.29.4(@babel/core@7.29.0)
+      '@babel/preset-env': 7.29.5(@babel/core@7.29.0)
       babel-plugin-polyfill-corejs3: 0.14.2(@babel/core@7.29.0)
       babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.29.0)
       browserslist: 4.28.2
@@ -3107,10 +3132,10 @@ snapshots:
 
   '@webxdc/types@2.1.2': {}
 
-  '@webxdc/vite-plugins@1.6.0(terser@5.46.2)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(terser@5.46.2)(yaml@2.8.3))':
+  '@webxdc/vite-plugins@https://codeload.github.com/experintellia/vite-plugins/tar.gz/ae3978e30fa35569083bfc16dac3746209eeeb96(terser@5.46.2)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(terser@5.46.2)(yaml@2.8.3))':
     dependencies:
       '@vitejs/plugin-basic-ssl': 2.3.0(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(terser@5.46.2)(yaml@2.8.3))
-      '@vitejs/plugin-legacy': 8.0.1(terser@5.46.2)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(terser@5.46.2)(yaml@2.8.3))
+      '@vitejs/plugin-legacy': 8.0.2(terser@5.46.2)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(terser@5.46.2)(yaml@2.8.3))
       eruda: 3.4.3
       vite-plugin-zip-pack: 1.2.4(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(terser@5.46.2)(yaml@2.8.3))
     transitivePeerDependencies:
@@ -3145,7 +3170,7 @@ snapshots:
 
   babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.0):
     dependencies:
-      '@babel/compat-data': 7.29.0
+      '@babel/compat-data': 7.29.3
       '@babel/core': 7.29.0
       '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)
       semver: 6.3.1
@@ -3171,7 +3196,7 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  baseline-browser-mapping@2.10.24: {}
+  baseline-browser-mapping@2.10.30: {}
 
   binary-extensions@2.3.0: {}
 
@@ -3194,17 +3219,17 @@ snapshots:
 
   browserslist@4.28.2:
     dependencies:
-      baseline-browser-mapping: 2.10.24
-      caniuse-lite: 1.0.30001791
-      electron-to-chromium: 1.5.344
-      node-releases: 2.0.38
+      baseline-browser-mapping: 2.10.30
+      caniuse-lite: 1.0.30001793
+      electron-to-chromium: 1.5.357
+      node-releases: 2.0.44
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
   buffer-from@1.1.2: {}
 
   cac@6.7.14: {}
 
-  caniuse-lite@1.0.30001791: {}
+  caniuse-lite@1.0.30001793: {}
 
   chai@5.3.3:
     dependencies:
@@ -3262,7 +3287,7 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
-  electron-to-chromium@1.5.344: {}
+  electron-to-chromium@1.5.357: {}
 
   emoji-regex@8.0.0: {}
 
@@ -3365,7 +3390,7 @@ snapshots:
     dependencies:
       binary-extensions: 2.3.0
 
-  is-core-module@2.16.1:
+  is-core-module@2.16.2:
     dependencies:
       hasown: 2.0.3
 
@@ -3563,7 +3588,7 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  node-releases@2.0.38: {}
+  node-releases@2.0.44: {}
 
   normalize-path@3.0.0: {}
 
@@ -3650,7 +3675,7 @@ snapshots:
   resolve@1.22.12:
     dependencies:
       es-errors: 1.3.0
-      is-core-module: 2.16.1
+      is-core-module: 2.16.2
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 

--- a/scripts/LocalEngine.ts
+++ b/scripts/LocalEngine.ts
@@ -211,7 +211,6 @@ interface AchievementPayload {
 }
 
 type Emitter = (ev: string, pl: unknown) => void;
-type DeltaSender = (delta: Delta) => void;
 type AchievementSender = (msg: { info: string; payload: AchievementPayload }) => void;
 
 interface MissionUpdate {
@@ -315,19 +314,8 @@ function _isProvidable(
 }
 
 // ---------------------------------------------------------------------------
-// Delta persistence — injected by production boot so webxdc.sendUpdate is
-// not imported here.  Tests override with setSendDelta to capture deltas.
+// Delta persistence
 // ---------------------------------------------------------------------------
-let _sendDelta: DeltaSender | null = null;
-
-/**
- * Inject the test-only delta sink. When set, `_persistDelta` short-circuits
- * and does NOT call `webxdc.sendUpdate`, so tests asserting the real
- * listener round-trip must leave the spy unset.
- */
-export function setSendDelta(fn: DeltaSender): void {
-  _sendDelta = fn;
-}
 
 // ---------------------------------------------------------------------------
 // Achievement emit — fires info messages at action sites only.
@@ -380,24 +368,14 @@ function triggerAchievement(
   }
 }
 
-// Single persistence path: capture for tests, then either fire the production
-// webxdc.sendUpdate (listener will echo and apply via applyDelta) or, in
-// Node/no-webxdc environments, emulate the listener echo synchronously.
-// This is the only place outside the listener that calls setState — it IS the
-// listener-equivalent for environments without webxdc.
+// Canonical webxdc: handlers only SEND. State mutation happens solely in the
+// setUpdateListener callback (scripts/boot.ts) when the messenger delivers the
+// update back — including our own. Nothing here mutates state or reads it back;
+// the real Delta Chat messenger delivers asynchronously, so any synchronous
+// post-send read would observe stale state.
 function _persistDelta(delta: Delta): void {
-  // Test sink and webxdc.sendUpdate are mutually exclusive (otherwise the
-  // shim's listener echo double-mutates state). We still advance state
-  // synchronously so handlers see the post-mutation view.
-  if (_sendDelta) {
-    _sendDelta(delta);
-    setState(applyDelta(getState(), delta));
-    return;
-  }
   if (typeof webxdc !== 'undefined' && webxdc) {
     webxdc.sendUpdate({ payload: delta }, '');
-  } else {
-    setState(applyDelta(getState(), delta));
   }
 }
 
@@ -515,13 +493,16 @@ export function loadGame(): Promise<{ result: ReturnType<typeof _buildLoadGameRe
   var startupRepair = _repairStuckMissionGoals(seededState);
   if (startupRepair && startupRepair.missions) {
     var startupGv = _applyRewardsToGv(seededState.game_values || {}, startupRepair.rewards);
-    _persistDelta(
-      _mkDelta(seededState.addr, 'recheckMissions', [], {
-        game_values: startupGv,
-        missions: startupRepair.missions,
-      })
-    );
-    seededState = getState();
+    var recheckDelta = _mkDelta(seededState.addr, 'recheckMissions', [], {
+      game_values: startupGv,
+      missions: startupRepair.missions,
+    });
+    _persistDelta(recheckDelta);
+    // State mutates only in the setUpdateListener (canonical webxdc), which the
+    // async messenger has not invoked yet. Project the same delta locally —
+    // applyDelta is pure — to build this call's response without reading back
+    // global state. The listener independently commits the durable mutation.
+    seededState = applyDelta(seededState, recheckDelta);
   }
 
   // Re-arm one-shot materializers for any charges still in flight. Clear
@@ -2993,7 +2974,6 @@ var LocalEngine = Object.assign(
     markTokenSeen: markTokenSeen,
     recheckMissions: recheckMissions,
     setEmitter: setEmitter,
-    setSendDelta: setSendDelta,
     setSendAchievement: setSendAchievement,
     setPrngSeed: setPrngSeed,
   },

--- a/scripts/app.ts
+++ b/scripts/app.ts
@@ -149,7 +149,6 @@ const Application = function (): ApplicationApi {
   // start() don't need per-call casts on the chained .then() / .fail().
   const INTERNAL_API: Record<string, true> = {
     setEmitter: true,
-    setSendDelta: true,
     setSendAchievement: true,
     setPrngSeed: true,
   };

--- a/scripts/boot.ts
+++ b/scripts/boot.ts
@@ -160,6 +160,22 @@ export function getState(): LocalState {
 }
 
 /**
+ * Test-only: clear the boot singletons so the next boot() re-runs and
+ * re-registers the setUpdateListener against a fresh messenger. boot() is
+ * idempotent in production (one boot per page load) but unit tests boot once
+ * per test against a new fake-webxdc; without this reset the cached
+ * _bootPromise would skip listener registration on the new messenger.
+ */
+export function __resetBootForTest(): void {
+  _bootPromise = null;
+  _currentState = null;
+  _replayProgress.serial = 0;
+  _replayProgress.max_serial = 0;
+  _replayProgress.done = false;
+  _peersChangedSubs.length = 0;
+}
+
+/**
  * Replace the in-memory state.  Called by LocalEngine after materializer
  * runs to persist the advanced state.  Also useful in tests to seed state
  * before exercising handlers.

--- a/tests/e2e/_helpers.ts
+++ b/tests/e2e/_helpers.ts
@@ -1,0 +1,47 @@
+import type { Page } from '@playwright/test';
+
+/**
+ * Install `window.__ddSettle` — an in-page async poll that resolves once the
+ * canonical setUpdateListener (scripts/boot.ts) has applied enough deltas for
+ * the predicate to hold.
+ *
+ * Canonical webxdc: a handler call only SENDS; real Delta Chat (and the
+ * IndexedDB simulator) deliver the update — including the sender's own — back
+ * to the listener asynchronously, and the listener is the sole state mutator.
+ * So any dependent follow-up (another handler that reads state, a reload that
+ * replays history, or a direct state assertion) must wait for the listener to
+ * apply the prior delta instead of assuming it landed synchronously.
+ *
+ * Must be called before `page.goto` / the first navigation so the init script
+ * is present on the page and survives reloads.
+ */
+export async function installSettle(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    (window as { __ddSettle?: unknown }).__ddSettle = async (
+      pred: (s: Record<string, unknown>) => boolean,
+      timeoutMs = 5000,
+      stepMs = 15
+    ): Promise<Record<string, unknown>> => {
+      const w = window as unknown as {
+        require: (deps: string[], res: (m: unknown) => void, rej: (e: unknown) => void) => void;
+      };
+      const boot = (await new Promise<unknown>((res, rej) => w.require(['boot'], res, rej))) as {
+        getState: () => Record<string, unknown>;
+      };
+      const t0 = Date.now();
+      for (;;) {
+        let s: Record<string, unknown> | null = null;
+        try {
+          s = boot.getState();
+        } catch {
+          s = null;
+        }
+        if (s && pred(s)) return s;
+        if (Date.now() - t0 > timeoutMs) {
+          throw new Error('__ddSettle: timed out waiting for listener-applied state');
+        }
+        await new Promise((r) => setTimeout(r, stepMs));
+      }
+    };
+  });
+}

--- a/tests/e2e/ap-bar.spec.ts
+++ b/tests/e2e/ap-bar.spec.ts
@@ -16,11 +16,13 @@
  */
 
 import { expect, test } from '@playwright/test';
+import { installSettle } from './_helpers';
 
 const GESTALT = 'contact035';
 const PATH = `Imperium.${GESTALT}`;
 
 test('energy bar: charge action decrements visual AP value and bar width', async ({ page }) => {
+  await installSettle(page);
   await page.goto('/?devtools=1');
   await expect(page.locator('[data-testid="game-container"]')).toBeVisible({
     timeout: 50_000,
@@ -56,6 +58,13 @@ test('energy bar: charge action decrements visual AP value and bar width', async
         (window as any).require(['LocalEngine'], res, rej)
       );
       await eng.buyPerp('Imperium', args.gestalt);
+      // buyPerp only SENDS; wait for the listener to apply it so chargePerp
+      // (which reads current state to find the node) sees the bought perp.
+      await (
+        window as unknown as {
+          __ddSettle: (p: (s: { nodes?: { full_path: string }[] }) => boolean) => Promise<unknown>;
+        }
+      ).__ddSettle((s) => !!s.nodes?.some((n) => n.full_path === args.path));
       return eng.chargePerp(args.path);
     },
     { gestalt: GESTALT, path: PATH }

--- a/tests/e2e/collect-icon-after-charge.spec.ts
+++ b/tests/e2e/collect-icon-after-charge.spec.ts
@@ -48,6 +48,7 @@
  */
 
 import { expect, test } from '@playwright/test';
+import { installSettle } from './_helpers';
 
 const GESTALT = 'contact035';
 const PATH = `Imperium.${GESTALT}`;
@@ -61,6 +62,7 @@ async function waitForGameReady(page: import('@playwright/test').Page) {
 test('collect-icon: DecoratorReady appears after node_ready emit (no stuck clock)', async ({
   page,
 }) => {
+  await installSettle(page);
   await page.goto('/?devtools=1');
   await waitForGameReady(page);
 
@@ -72,8 +74,15 @@ test('collect-icon: DecoratorReady appears after node_ready emit (no stuck clock
     const eng = await new Promise<any>((res, rej) =>
       (window as any).require(['LocalEngine'], res, rej)
     );
+    const path = `Imperium.${gestalt}`;
+    const settle = (window as any).__ddSettle as (p: (s: any) => boolean) => Promise<unknown>;
     await eng.buyPerp('Imperium', gestalt);
-    await eng.chargePerp(`Imperium.${gestalt}`);
+    // Each handler only SENDS; wait for the listener to apply before the
+    // dependent step. chargePerp needs the bought node; the reload below
+    // replays webxdc history so the charge must be applied/persisted first.
+    await settle((s) => !!(s.nodes ?? []).some((n: any) => n.full_path === path));
+    await eng.chargePerp(path);
+    await settle((s) => !!(s.nodes_charging ?? []).some((c: any) => c.path === path));
   }, GESTALT);
 
   // ── 2. Reload — boot.js replays the delta log, the engine's

--- a/tests/e2e/dialog-lifecycle.spec.ts
+++ b/tests/e2e/dialog-lifecycle.spec.ts
@@ -90,7 +90,19 @@ async function bootGame(page: Page): Promise<void> {
     }
   });
 
-  for (let attempt = 0; attempt < 12; attempt++) {
+  // RenderPopup.close() schedules DOM removal + the next queued open through a
+  // 250–500ms setTimeout that captured the popup ref, so a single momentarily
+  // empty poll is not proof the system is quiescent: a re-mount timer can still
+  // be in flight and fire *after* bootGame returns, landing a stray popup in
+  // the middle of the test (under 2-worker CPU contention this is when the
+  // dialog-lifecycle flakes — a different test each run depending on when the
+  // timer lands). Keep actively draining, but only return once "empty" has
+  // held across consecutive polls spanning longer than that timer window, so
+  // any pending re-mount has had time to fire and be drained first.
+  const STABLE_POLLS_REQUIRED = 3; // 3 × 300ms ≈ 900ms > the 500ms timer ceiling
+  const MAX_ATTEMPTS = 40; // ~12s ceiling for slow/contended CI
+  let consecutiveSettled = 0;
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
     const settled = await page.evaluate(() => {
       const groot = (window as any).__dd?._app?.game;
       if (!groot) return false;
@@ -125,14 +137,14 @@ async function bootGame(page: Page): Promise<void> {
         document.querySelectorAll('.PopupContainer.lockOn').length === 0
       );
     });
-    if (settled) return;
-    // RenderPopup.close() schedules its DOM removal + callback via 250–500ms
-    // setTimeout.  Wait above that floor before re-checking so the queue's
-    // openNotification chain has time to finish or to dispatch the next
-    // item we then drain on the next iteration.
+    consecutiveSettled = settled ? consecutiveSettled + 1 : 0;
+    if (consecutiveSettled >= STABLE_POLLS_REQUIRED) return;
+    // Wait above the 250–500ms close/re-mount timer floor before re-checking
+    // so an in-flight openNotification chain either finishes or dispatches the
+    // next item we then drain on the following iteration.
     await page.waitForTimeout(300);
   }
-  throw new Error('bootGame: could not drain notification queue after 12 attempts');
+  throw new Error('bootGame: notification queue did not stay drained after 40 attempts');
 }
 
 /** Open a popup-status dialog by firing the same `click_status.<id>` event

--- a/tests/e2e/dialog-lifecycle.spec.ts
+++ b/tests/e2e/dialog-lifecycle.spec.ts
@@ -45,6 +45,7 @@
  */
 
 import { type Page, expect, test } from '@playwright/test';
+import { installSettle } from './_helpers';
 
 // ── Shared helpers ────────────────────────────────────────────────────────
 
@@ -641,12 +642,18 @@ test.describe('Section H — profileset import & sub-popups', () => {
     // click path, but driving the engine directly bypasses that wiring).
     // Then the Database.openProfileSetPopup helper opens the popup_profileset
     // template with the right ProfileSet templateData.
+    await installSettle(page);
     await bootGame(page);
     await page.evaluate(async () => {
       const eng = await new Promise<any>((res, rej) =>
         (window as any).require(['LocalEngine'], res, rej)
       );
       await eng.buyPerp('Imperium', 'contact035');
+      // Only SENDS; wait for the listener to apply before reload replays
+      // webxdc history (otherwise contact035 is missing post-reload).
+      await ((window as any).__ddSettle as (p: (s: any) => boolean) => Promise<unknown>)(
+        (s) => !!(s.nodes ?? []).some((n: any) => n.full_path === 'Imperium.contact035')
+      );
     });
     await page.reload();
     await bootGame(page);
@@ -656,6 +663,11 @@ test.describe('Section H — profileset import & sub-popups', () => {
         (window as any).require(['LocalEngine'], res, rej)
       );
       await eng.chargePerp('Imperium.contact035');
+      // chargePerp only SENDS; collectPerp reads current state, so wait for
+      // the listener to apply the charge first.
+      await ((window as any).__ddSettle as (p: (s: any) => boolean) => Promise<unknown>)(
+        (s) => !!(s.nodes_charging ?? []).some((c: any) => c.path === 'Imperium.contact035')
+      );
       // contact035.charge_time is 30s in the ruleset — advance the
       // injectable clock past it so collectPerp doesn't return error 0.
       (window as any).__dd.advanceNow(31_000);
@@ -1171,12 +1183,16 @@ test.describe('Section J — in-popup action handlers', () => {
     // MainButton click handler (the popup wires it via popup.on(
     // 'button_click.MainButton') → gnode.mergeCued in
     // scripts/game/Database.ts:675).
+    await installSettle(page);
     await bootGame(page);
     await page.evaluate(async () => {
       const eng = await new Promise<any>((res, rej) =>
         (window as any).require(['LocalEngine'], res, rej)
       );
       await eng.buyPerp('Imperium', 'contact035');
+      await ((window as any).__ddSettle as (p: (s: any) => boolean) => Promise<unknown>)(
+        (s) => !!(s.nodes ?? []).some((n: any) => n.full_path === 'Imperium.contact035')
+      );
     });
     await page.reload();
     await bootGame(page);
@@ -1186,6 +1202,9 @@ test.describe('Section J — in-popup action handlers', () => {
         (window as any).require(['LocalEngine'], res, rej)
       );
       await eng.chargePerp('Imperium.contact035');
+      await ((window as any).__ddSettle as (p: (s: any) => boolean) => Promise<unknown>)(
+        (s) => !!(s.nodes_charging ?? []).some((c: any) => c.path === 'Imperium.contact035')
+      );
       (window as any).__dd.advanceNow(31_000);
       const cr = await eng.collectPerp('Imperium.contact035');
       const inner = cr?.result?.result;

--- a/tests/e2e/share-merge.spec.ts
+++ b/tests/e2e/share-merge.spec.ts
@@ -18,8 +18,10 @@
  */
 
 import { expect, test } from '@playwright/test';
+import { installSettle } from './_helpers';
 
 test.beforeEach(async ({ page }) => {
+  await installSettle(page);
   await page.goto('/?devtools=1');
   await expect(page.locator('[data-testid="game-container"]')).toBeVisible({
     timeout: 50_000,
@@ -66,8 +68,14 @@ test('integrate dilutes untouched token shares + crosssum stays under 100', asyn
     state.integrated_ids = {};
     boot.setState(state);
 
+    const settle = (window as any).__ddSettle as (p: (s: any) => boolean) => Promise<unknown>;
+    // Each integrate only SENDS; the listener applies it asynchronously and is
+    // the sole mutator. The second merge must run on the post-first state, and
+    // the final read must see both applied.
     await eng.integrateCollected('cq_test_a');
+    await settle((s) => !!(s.integrated_ids && s.integrated_ids.cq_test_a));
     await eng.integrateCollected('cq_test_b');
+    await settle((s) => !!(s.integrated_ids && s.integrated_ids.cq_test_b));
 
     const finalNodes = boot.getState().nodes.filter((n: any) => n.game_type === 'TokenPerp');
     const byGestalt: Record<string, number> = {};
@@ -132,7 +140,9 @@ test('integrating the same profileset twice does not change shares (N = 0 dup re
     state.integrated_ids = {};
     boot.setState(state);
 
+    const settle = (window as any).__ddSettle as (p: (s: any) => boolean) => Promise<unknown>;
     await eng.integrateCollected('cq_dup_test');
+    await settle((s) => !!(s.integrated_ids && s.integrated_ids.cq_dup_test));
     const afterFirst = boot.getState();
     const shareAfterFirst =
       afterFirst.nodes.find((n: any) => n.gestalt === 'token008')?.instance_data?.amount ?? null;

--- a/tests/handlers/_webxdc-harness.js
+++ b/tests/handlers/_webxdc-harness.js
@@ -1,0 +1,103 @@
+// @ts-nocheck — strict-TS quarantine; remove when this file is migrated to TS (issue #147)
+/**
+ * Synchronous fake-webxdc harness for handler unit tests.
+ *
+ * Canonical webxdc (post #120 follow-up): handlers only `webxdc.sendUpdate`;
+ * the SOLE state mutation site is the `setUpdateListener` callback registered
+ * by scripts/boot.ts. The real messenger delivers updates asynchronously, but
+ * for deterministic unit tests this fake delivers the update to the registered
+ * listener SYNCHRONOUSLY inside `sendUpdate`. State still mutates only in the
+ * listener (via applyDelta) — exactly the production path — just without the
+ * messenger's async hop.
+ *
+ * Usage in a handler test file:
+ *
+ *   import { installWebxdc, uninstallWebxdc, setSendDelta } from './_webxdc-harness.js';
+ *   beforeEach(async () => { await installWebxdc(); });
+ *   afterEach(() => uninstallWebxdc());
+ *
+ * `setSendDelta` is a capture-only spy (it does NOT mutate state and is NOT in
+ * production code) kept so the pre-existing delta-capture/idempotence tests
+ * migrate with only an import-path change. It receives the VERBOSE delta
+ * payload, identical to what the old LocalEngine `_sendDelta` sink received.
+ */
+import { __resetBootForTest, boot } from '../../scripts/boot.js';
+
+const SELF_ADDR = 'test@local';
+
+let _savedWebxdc;
+let _captureCb = null;
+let _sent = []; // raw on-the-wire payloads, in send order
+
+function _makeFakeWebxdc() {
+  const updates = [];
+  let listener = null;
+  return {
+    selfAddr: SELF_ADDR,
+    selfName: 'Test',
+    sendUpdate(update, _descr) {
+      const serial = updates.length + 1;
+      const entry = Object.assign({}, update, { serial, max_serial: serial });
+      updates.push(entry);
+      _sent.push(update && update.payload);
+      const decoded = update && update.payload;
+      if (_captureCb && decoded && decoded.kind === 'delta') {
+        _captureCb(decoded);
+      }
+      // Canonical mutation site: deliver to the listener boot() registered.
+      if (listener) listener(entry);
+    },
+    setUpdateListener(cb, serial) {
+      const after = typeof serial === 'number' ? serial : 0;
+      for (const u of updates) {
+        if (u.serial > after) cb(u);
+      }
+      listener = cb; // last registration wins — matches real webxdc
+      return Promise.resolve();
+    },
+  };
+}
+
+/**
+ * Install a fresh synchronous fake-webxdc on globalThis and re-run boot() so
+ * the canonical listener is registered against it. Call in `beforeEach`.
+ */
+export async function installWebxdc() {
+  _savedWebxdc = globalThis.webxdc;
+  _captureCb = null;
+  _sent = [];
+  globalThis.webxdc = _makeFakeWebxdc();
+  __resetBootForTest();
+  await boot({ selfAddr: SELF_ADDR });
+}
+
+/** Restore the previous global and clear boot/capture state. Call in `afterEach`. */
+export function uninstallWebxdc() {
+  _captureCb = null;
+  _sent = [];
+  __resetBootForTest();
+  if (_savedWebxdc === undefined) {
+    delete globalThis.webxdc;
+  } else {
+    globalThis.webxdc = _savedWebxdc;
+  }
+}
+
+/**
+ * Capture-only spy. `setSendDelta(fn)` registers fn(verboseDelta); the fake
+ * messenger calls it for every delta-kind update sent. `setSendDelta(null)`
+ * clears it. Does not affect state — the listener is still the only mutator.
+ */
+export function setSendDelta(fn) {
+  _captureCb = typeof fn === 'function' ? fn : null;
+}
+
+/** All delta-kind payloads sent so far, decoded to verbose form (send order). */
+export function sentDeltas() {
+  return _sent.filter((d) => d && d.kind === 'delta');
+}
+
+/** Raw on-the-wire payloads sent so far (send order), including achievements. */
+export function sentPayloads() {
+  return _sent.slice();
+}

--- a/tests/handlers/achievements.test.js
+++ b/tests/handlers/achievements.test.js
@@ -18,9 +18,16 @@ import {
   integrateCollected,
   setEmitter,
   setSendAchievement,
-  setSendDelta,
 } from '../../scripts/LocalEngine.js';
 import { getState, setState } from '../../scripts/boot.js';
+import { installWebxdc, setSendDelta, uninstallWebxdc } from './_webxdc-harness.js';
+
+beforeEach(async () => {
+  await installWebxdc();
+});
+afterEach(() => {
+  uninstallWebxdc();
+});
 import { clearOverride, setOverride } from '../../scripts/clock.js';
 import { applyDelta, freshState } from '../../scripts/state.js';
 import { FIXED_NOW, mkGv, mkState } from './_fixtures.js';

--- a/tests/handlers/chargePerp.test.js
+++ b/tests/handlers/chargePerp.test.js
@@ -1,11 +1,19 @@
 // @ts-nocheck — strict-TS quarantine; remove when this file is migrated to TS (issue #147)
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { chargePerp, loadGame, setEmitter, setSendDelta } from '../../scripts/LocalEngine.js';
+import { chargePerp, loadGame, setEmitter } from '../../scripts/LocalEngine.js';
 import { getState, setState } from '../../scripts/boot.js';
 import { clearOverride, setOverride } from '../../scripts/clock.js';
 import { materialize } from '../../scripts/materializer.js';
 import { applyDelta, freshState } from '../../scripts/state.js';
 import { FIXED_NOW, mkState as _mkBaseState, mkNode as _mkNode } from './_fixtures.js';
+import { installWebxdc, setSendDelta, uninstallWebxdc } from './_webxdc-harness.js';
+
+beforeEach(async () => {
+  await installWebxdc();
+});
+afterEach(() => {
+  uninstallWebxdc();
+});
 
 // ── fixtures ─────────────────────────────────────────────────────────────────
 

--- a/tests/handlers/collect-integrate.test.js
+++ b/tests/handlers/collect-integrate.test.js
@@ -16,9 +16,16 @@ import {
   loadGame,
   setEmitter,
   setPrngSeed,
-  setSendDelta,
 } from '../../scripts/LocalEngine.js';
 import { getState, setState } from '../../scripts/boot.js';
+import { installWebxdc, setSendDelta, uninstallWebxdc } from './_webxdc-harness.js';
+
+beforeEach(async () => {
+  await installWebxdc();
+});
+afterEach(() => {
+  uninstallWebxdc();
+});
 import { advance, clearOverride, setOverride } from '../../scripts/clock.js';
 import { materialize } from '../../scripts/materializer.js';
 import { applyDelta } from '../../scripts/state.js';

--- a/tests/handlers/handlers.test.js
+++ b/tests/handlers/handlers.test.js
@@ -24,6 +24,14 @@ import { clearOverride, setOverride } from '../../scripts/clock.js';
 import { materialize } from '../../scripts/materializer.js';
 import { applyDelta, freshState } from '../../scripts/state.js';
 import { FIXED_NOW, mkState } from './_fixtures.js';
+import { installWebxdc, uninstallWebxdc } from './_webxdc-harness.js';
+
+beforeEach(async () => {
+  await installWebxdc();
+});
+afterEach(() => {
+  uninstallWebxdc();
+});
 
 // ── getRanking ───────────────────────────────────────────────────────────────
 

--- a/tests/handlers/levelup-xp-max.test.js
+++ b/tests/handlers/levelup-xp-max.test.js
@@ -18,13 +18,16 @@
  * the next level.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import {
-  buyPerp,
-  setEmitter,
-  setSendAchievement,
-  setSendDelta,
-} from '../../scripts/LocalEngine.js';
+import { buyPerp, setEmitter, setSendAchievement } from '../../scripts/LocalEngine.js';
 import { getState, setState } from '../../scripts/boot.js';
+import { installWebxdc, setSendDelta, uninstallWebxdc } from './_webxdc-harness.js';
+
+beforeEach(async () => {
+  await installWebxdc();
+});
+afterEach(() => {
+  uninstallWebxdc();
+});
 import { clearOverride, setOverride } from '../../scripts/clock.js';
 import { FIXED_NOW, mkGv, mkState } from './_fixtures.js';
 

--- a/tests/handlers/listener-echo.test.js
+++ b/tests/handlers/listener-echo.test.js
@@ -1,22 +1,25 @@
 // @ts-nocheck — strict-TS quarantine; remove when this file is migrated to TS (issue #147)
 /**
- * Listener-echo idempotence tests (issue #119 bug class).
+ * Reducer idempotence tests (issue #119 bug class).
  *
- * In production webxdc, the realtime channel echoes a sender's own update
- * back into the listener registered by boot.js. The listener applies the
- * delta through the reducer in scripts/state.js. Handlers that have already
- * called setState(newState) directly will then see the SAME mutation applied
- * a second time on top of the post-handler state.
+ * Canonical webxdc (post #120 follow-up): handlers NEVER call setState — the
+ * sole mutation site is the setUpdateListener callback in boot.js, which
+ * applies each delta through the reducer in scripts/state.js exactly once.
+ * The old "handler setState + echo double-apply" path no longer exists by
+ * construction. These tests remain the regression guard for the snapshot
+ * convention that keeps that single application correct: applying a delta to
+ * its own post-state must be a no-op, so cold-start replay (and any redelivery
+ * across sessions) reconstructs identical state regardless of starting point.
  *
  * Reducers using INCREMENTAL math (e.g. cash_value: gv.cash_value - cashDelta)
- * double-deduct on self-echo. Reducers that apply a full snapshot via
- * Object.assign({}, state.game_values, r.game_values) are idempotent — the
+ * drift if applied more than once. Reducers that apply a full snapshot via
+ * Object.assign({}, state.game_values, r.game_values) are idempotent — a
  * second application overwrites identical values with the same numbers.
  *
- * Status of each reducer in scripts/state.js (as of this commit):
+ * Status of each reducer in scripts/state.js:
  *
- *   chargePerp         — INCREMENTAL math on cash_value/cash_spent/xp/ap.
- *                         BUGGY: double-deducts on echo. (PR #119 reproduces this.)
+ *   chargePerp         — Snapshot-style: emits post-mutation game_values in
+ *                         result; Object.assign is idempotent. Regression guard.
  *
  *   buyKarma           — Snapshot-style: Object.assign(gv, r.game_values).
  *                         Echo-safe IFF the delta carries the full post-handler
@@ -54,9 +57,16 @@ import {
   integrateCollected,
   sellPowerup,
   setEmitter,
-  setSendDelta,
 } from '../../scripts/LocalEngine.js';
 import { getState, setState } from '../../scripts/boot.js';
+import { installWebxdc, setSendDelta, uninstallWebxdc } from './_webxdc-harness.js';
+
+beforeEach(async () => {
+  await installWebxdc();
+});
+afterEach(() => {
+  uninstallWebxdc();
+});
 import { clearOverride, setOverride } from '../../scripts/clock.js';
 import { materialize } from '../../scripts/materializer.js';
 import { applyDelta, freshState } from '../../scripts/state.js';

--- a/tests/handlers/persist-delta.test.js
+++ b/tests/handlers/persist-delta.test.js
@@ -1,20 +1,28 @@
 // @ts-nocheck — strict-TS quarantine; remove when this file is migrated to TS (issue #147)
 /**
- * _persistDelta dual-path mutual-exclusion regression.
+ * _persistDelta send-only contract (canonical webxdc).
  *
- * `_persistDelta` historically called both the test `_sendDelta` spy AND
- * `webxdc.sendUpdate` when both were set. In tests that install a real
- * webxdc shim, the shim's listener echoes the update back through
- * applyDelta a second time — double-mutating state.
- *
- * Contract: when `_sendDelta` is set, treat it as the test sink and skip
- * `webxdc.sendUpdate`. Production callers don't call setSendDelta, so the
- * webxdc.sendUpdate path remains the only one in real builds.
+ * Post #120 follow-up: handlers NEVER mutate state. `_persistDelta` only calls
+ * `webxdc.sendUpdate` with the compact wire payload; the SOLE state-mutation
+ * site is the setUpdateListener callback registered by scripts/boot.ts. This
+ * matches real Delta Chat, where the messenger delivers updates (including the
+ * sender's own) asynchronously. The previous dual spy/webxdc sink — which
+ * mutated state synchronously and only worked because the old localStorage
+ * simulator echoed synchronously — has been removed.
  */
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { buyKarma, setSendDelta } from '../../scripts/LocalEngine.js';
-import { setState } from '../../scripts/boot.js';
-import { freshState } from '../../scripts/state.js';
+import { buyKarma } from '../../scripts/LocalEngine.js';
+import { getState, setState } from '../../scripts/boot.js';
+import { clearOverride, setOverride } from '../../scripts/clock.js';
+import { applyDelta, freshState } from '../../scripts/state.js';
+import { FIXED_NOW } from './_fixtures.js';
+import {
+  installWebxdc,
+  sentDeltas,
+  sentPayloads,
+  setSendDelta,
+  uninstallWebxdc,
+} from './_webxdc-harness.js';
 
 function mkKarmaState() {
   const base = freshState('test@local');
@@ -33,46 +41,54 @@ function mkKarmaState() {
   });
 }
 
-describe('_persistDelta — spy/webxdc mutual exclusion', () => {
-  let savedWebxdc;
-  let sendUpdateCalls;
-
-  beforeEach(() => {
-    savedWebxdc = globalThis.webxdc;
-    sendUpdateCalls = [];
-    globalThis.webxdc = {
-      selfAddr: 'test@local',
-      selfName: 'Test',
-      sendUpdate(u) {
-        sendUpdateCalls.push(u);
-      },
-      setUpdateListener() {
-        return Promise.resolve();
-      },
-    };
+describe('_persistDelta — send-only, listener is the sole mutator', () => {
+  beforeEach(async () => {
+    await installWebxdc();
+    setOverride(FIXED_NOW); // pin clock so applyDelta's skew guard is deterministic
   });
-
   afterEach(() => {
-    setSendDelta(null);
-    globalThis.webxdc = savedWebxdc;
+    clearOverride();
+    uninstallWebxdc();
   });
 
-  it('does NOT call webxdc.sendUpdate when _sendDelta spy is set', async () => {
+  it('sends exactly one compact delta over webxdc.sendUpdate', async () => {
+    setState(mkKarmaState());
+
+    await buyKarma('karma001');
+
+    const payloads = sentPayloads();
+    expect(payloads).toHaveLength(1);
+    // Raw verbose delta is persisted (no wire codec in this PR).
+    const decoded = payloads[0];
+    expect(decoded.kind).toBe('delta');
+    expect(decoded.op).toBe('buyKarma');
+  });
+
+  it('mutates state ONLY via the listener applying the sent delta', async () => {
+    setState(mkKarmaState());
+    const pre = getState();
+
+    await buyKarma('karma001');
+
+    // Post-state must equal the pre-state with exactly the sent delta applied
+    // once — i.e. nothing mutated state except the listener. (applyDelta is
+    // pure; the codec round-trips losslessly.)
+    const expected = applyDelta(pre, sentPayloads()[0]);
+    expect(getState()).toEqual(expected);
+    expect(getState().game_values.karma_value).not.toBe(pre.game_values.karma_value);
+  });
+
+  it('setSendDelta capture spy still receives the verbose delta', async () => {
     const captured = [];
     setSendDelta((d) => captured.push(d));
     setState(mkKarmaState());
 
     await buyKarma('karma001');
 
-    expect(captured.length).toBeGreaterThan(0);
-    expect(sendUpdateCalls.length).toBe(0);
-  });
-
-  it('DOES call webxdc.sendUpdate when no _sendDelta spy is set', async () => {
-    setState(mkKarmaState());
-
-    await buyKarma('karma001');
-
-    expect(sendUpdateCalls.length).toBeGreaterThan(0);
+    expect(captured).toHaveLength(1);
+    expect(captured[0].kind).toBe('delta');
+    expect(captured[0].op).toBe('buyKarma');
+    // The spy sees the same delta the wire carries, decoded.
+    expect(captured[0]).toEqual(sentDeltas()[0]);
   });
 });

--- a/tests/handlers/upgradeTokens.test.js
+++ b/tests/handlers/upgradeTokens.test.js
@@ -23,6 +23,7 @@ import { getState, setState } from '../../scripts/boot.js';
 import { clearOverride, setOverride } from '../../scripts/clock.js';
 import { applyDelta } from '../../scripts/state.js';
 import { FIXED_NOW, mkState } from './_fixtures.js';
+import { installWebxdc, uninstallWebxdc } from './_webxdc-harness.js';
 
 // project009 = "Preventive checkup" (ruleset_3.en.json:7531)
 const PROJECT_PATH = 'Imperium.CityVienna.project009';
@@ -52,12 +53,14 @@ function projectState(overrides) {
   );
 }
 
-beforeEach(() => {
+beforeEach(async () => {
+  await installWebxdc();
   setOverride(FIXED_NOW);
 });
 
 afterEach(() => {
   clearOverride();
+  uninstallWebxdc();
 });
 
 describe('buyPowerup — upgrade tokens unlock venture data points', () => {


### PR DESCRIPTION
## Summary

Long dev/test sessions crashed with `QuotaExceededError`: the webxdc
simulator serialized the *entire* `sendUpdate` history into one localStorage
key on every update, eventually exceeding the ~5 MB string quota. This PR
removes that ceiling and aligns the engine with the real webxdc contract.

**The persisted-log size optimization (a compact wire codec) is split into its
own stacked PR (#294)** so this PR is purely the quota fix + the contract
refactor. #292 alone persists raw verbose deltas — the quota crash is fixed by
moving off localStorage, not by shrinking records.

## Commits (single-topic)

| Commit | Topic |
|---|---|
| `refactor(engine): move persistence to the canonical async webxdc API` | `_persistDelta` is send-only and persists the **raw delta**; all state mutation happens in the `setUpdateListener` echo on a later turn, exactly as real Delta Chat delivers (including the sender's own updates). Handler tests drive a synchronous fake-webxdc; e2e specs await the listener instead of assuming a synchronous echo. |
| `chore(deps): use IndexedDB-backed webxdc dev simulator` | Pin `@webxdc/vite-plugins` to **`1.6.1-fork.4` (`ae3978e`)**, whose dev mock persists each update as its own IndexedDB record instead of one re-serialized localStorage blob — O(1) writes, no string-quota ceiling, with automatic one-time localStorage→IndexedDB migration. |
| `test(e2e): fix dialog-lifecycle parallel-load flake at the source` | `bootGame` waits until the popup queue stays drained past the re-mount timer ceiling, so a throttled `setTimeout` can't leak a stray popup into a later test under 2-worker CI contention. |

## Fork-pin note (important for reviewers)

The simulator fork briefly carried `232aef53` *"Allocate serials in the shared
IndexedDB write transaction"*, which coupled serial allocation to the write tx
**and** made `flushDelivery` strictly contiguous — any transient serial gap
then became *permanent* non-delivery, regressing persistence (`chargePerp`'s
echo never reached state; `persistence.spec` failed). `fork-4` (`ae3978e`) is
the upstream **revert** of that commit (byte-identical simulator code to the
validated gap-tolerant `457c285f`); the broken revision is intentionally not
adopted.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Unit: **702/702**
- [x] e2e regression cluster on the `fork-4` pin: `persistence` (the `232aef53` failure) green, `dialog-lifecycle` 46/46, `share-merge`, `collect-after-reload` green
- [x] History rebuilt as 3 single-topic commits; codec-free tree verified by hash equality against the validated working state

Follow-up: **#294** (stacked) adds the compact delta-log codec + `game_values`
key migration + a shorter-key exploration benchmark.

https://claude.ai/code/session_016AEP6a1aBKiiBAMNnxvfmH