### PR TITLE
Simplify AboutPopup: remove debug tab, extract links to i18n

### DIFF
--- a/i18n/de_AT.json
+++ b/i18n/de_AT.json
@@ -693,6 +693,30 @@
     null,
     "Über"
   ],
+  "about fork headline": [
+    null,
+    "Über diesen Fork"
+  ],
+  "about fork text": [
+    null,
+    "Dies ist eine webxdc-Portierung des originalen Data-Dealer-Browserspiels, neu verpackt, damit es ohne Server in einer Delta-Chat-Gruppe läuft. Quellcode, Fehlerberichte und Beiträge: %s."
+  ],
+  "about displayname text": [
+    null,
+    "Dein Anzeigename wird über dein Delta-Chat-Profil festgelegt — ändere ihn dort, und das Spiel übernimmt ihn automatisch."
+  ],
+  "about original headline": [
+    null,
+    "Das Originalspiel"
+  ],
+  "about original text": [
+    null,
+    "Data Dealer wurde zwischen 2011 und 2014 in Wien von Cuteacute Media OG entwickelt (Ivan Averintsev, Wolfie Christl, Pascale Osterwalder, Tobi Schäfer, Ralf Traunsteiner). Es war ein satirisches Browserspiel über den Handel mit persönlichen Daten, das als öffentliche Beta auf datadealer.com veröffentlicht und als %s, %s und %s quelloffen gemacht wurde."
+  ],
+  "about original faq": [
+    null,
+    "Hintergrundinfos und die ursprüngliche FAQ: %s."
+  ],
   "agent_popup selector title": [
     null,
     "Kontakte anwerben"

--- a/i18n/en_US.json
+++ b/i18n/en_US.json
@@ -693,6 +693,30 @@
     null,
     "About"
   ],
+  "about fork headline": [
+    null,
+    "About this fork"
+  ],
+  "about fork text": [
+    null,
+    "This is a webxdc port of the original Data Dealer browser game, repackaged so it can run inside a Delta Chat group with no server. Source, issues and contributions: %s."
+  ],
+  "about displayname text": [
+    null,
+    "Your display name is set through your Delta Chat profile — change it there and the game picks it up automatically."
+  ],
+  "about original headline": [
+    null,
+    "The original game"
+  ],
+  "about original text": [
+    null,
+    "Data Dealer was created in Vienna by Cuteacute Media OG between 2011 and 2014 (Ivan Averintsev, Wolfie Christl, Pascale Osterwalder, Tobi Schäfer, Ralf Traunsteiner). It was a satirical browser game about the personal-data trade, released as a public beta on datadealer.com and open-sourced as %s, %s and %s."
+  ],
+  "about original faq": [
+    null,
+    "Background info and the original FAQ: %s."
+  ],
   "agent_popup selector title": [
     null,
     "Acquire contact"

--- a/scripts/components/Link.tsx
+++ b/scripts/components/Link.tsx
@@ -1,0 +1,18 @@
+// External link.  Centralises the `class="mln"` styling hook and the
+// `target="_blank" rel="noreferrer noopener"` safety boilerplate so
+// callers just give an href + label.
+
+import type { ComponentChildren } from 'preact';
+
+export interface LinkProps {
+  href: string;
+  children: ComponentChildren;
+}
+
+export function Link({ href, children }: LinkProps) {
+  return (
+    <a href={href} class="mln" target="_blank" rel="noreferrer noopener">
+      {children}
+    </a>
+  );
+}

--- a/scripts/components/popups/AboutPopup.tsx
+++ b/scripts/components/popups/AboutPopup.tsx
@@ -1,140 +1,82 @@
 // About dialog — Preact port of `views/popup_user_data.html`
-// (issue #80 phase 2 tier 4).  Informational; the only interactive
-// surface is the dev-only Debug tab (gated on `userdebug`).  First
-// multi-tab dialog: the active tab
-// is a `useState` value and the DOM is derived from it, so the
-// "tab description sometimes not shown" desync the legacy
-// jQuery-`.show()/.hide()` flow could produce is structurally
-// impossible here.
-//
-// The `.PopupMenu` tab strip + the Debug tab only render when
-// `userdebug` is on (matches the legacy `game.setup.userdebug`
-// gate).  About copy is intentionally literal (not i18n) — it was
-// hardcoded in the template too.
+// (issue #80).  Purely informational: a blurb about this webxdc
+// fork and the original game, plus a Close button.  The legacy
+// template carried a dev-only "Debug" reset tab, but webxdc has no
+// resetGame (reset = re-share the .xdc), so there is no second tab —
+// the dialog is single-purpose and stateless.
 
 import type { JSX } from 'preact';
-import { useState } from 'preact/hooks';
 import i18n from '../../i18n.js';
+import { Link } from '../Link.js';
 
 export interface AboutPopupProps {
-  /** `game.setup.userdebug` — gates the tab strip + Debug tab. */
-  userdebug: boolean;
   /** `game.setup.locale` — MainMenuLogo sprite locale class. */
   locale: string;
   buttonLabel: string;
   onClose: () => void;
 }
 
-type Tab = 'settings' | 'debug';
+// Translatable prose carries `%s` markers where external links sit;
+// the link labels are URLs / repo names and stay literal, so we
+// splice the <Link> nodes into the split string here.
+function withLinks(template: string, links: JSX.Element[]): (string | JSX.Element)[] {
+  const parts = template.split('%s');
+  const out: (string | JSX.Element)[] = [];
+  parts.forEach((part, i) => {
+    if (part) out.push(part);
+    const link = links[i];
+    if (link) out.push(link);
+  });
+  return out;
+}
 
-export function AboutPopup({ userdebug, locale, buttonLabel, onClose }: AboutPopupProps) {
-  const [tab, setTab] = useState<Tab>('settings');
+export function AboutPopup({ locale, buttonLabel, onClose }: AboutPopupProps) {
   const close = (e: JSX.TargetedMouseEvent<HTMLDivElement>): void => {
     e.stopPropagation();
     onClose();
   };
-  // Mirror the legacy jQuery `.show()/.hide()` (inline display) so the
-  // phase-1 contract's toBeVisible / toBeHidden assertions hold while
-  // keeping both panels in the DOM.
-  const tabStyle = (t: Tab): { display: string } => ({
-    display: tab === t ? '' : 'none',
-  });
   return (
     <div class="PopupBody About">
       {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
       <div class="PopupClose" onClick={close}>
         X
       </div>
-      {userdebug ? (
-        <div class="PopupMenu">
-          {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
-          <div
-            class={tab === 'settings' ? 'PopupMenuButton active' : 'PopupMenuButton'}
-            data-tab="settings"
-            onClick={() => setTab('settings')}
-          >
-            About
-          </div>
-          {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
-          <div
-            class={tab === 'debug' ? 'PopupMenuButton active' : 'PopupMenuButton'}
-            data-tab="debug"
-            onClick={() => setTab('debug')}
-          >
-            {i18n.gettext('userdebug tab')}
-          </div>
-        </div>
-      ) : null}
       <div class="PopupContent">
-        <div class="PopupTab" data-tab="settings" style={tabStyle('settings')}>
+        <div class="PopupTab">
           <div class="SubpopContainer" />
           <div class={`RenderSprite MainMenuLogo ${locale}`} />
           <div class="PopupContentText">
-            <div class="PopupTitle">About this fork</div>
+            <div class="PopupTitle">{i18n.gettext('about fork headline')}</div>
             <div class="PopupParagraph">
-              This is a webxdc port of the original Data Dealer browser game, repackaged so it can
-              run inside a Delta Chat group with no server. Source, issues and contributions:{' '}
-              <a
-                href="https://github.com/experintellia/data_dealer"
-                class="mln"
-                target="_blank"
-                rel="noreferrer noopener"
-              >
-                github.com/experintellia/data_dealer
-              </a>
-              .
+              {withLinks(i18n.gettext('about fork text'), [
+                <Link key="repo" href="https://github.com/experintellia/data_dealer">
+                  github.com/experintellia/data_dealer
+                </Link>,
+              ])}
             </div>
-            <div class="PopupParagraph">
-              Your display name is set through your Delta Chat profile &mdash; change it there and
-              the game picks it up automatically.
-            </div>
+            <div class="PopupParagraph">{i18n.gettext('about displayname text')}</div>
           </div>
           <div class="PopupContentText">
-            <div class="PopupTitle">The original game</div>
+            <div class="PopupTitle">{i18n.gettext('about original headline')}</div>
             <div class="PopupParagraph">
-              Data Dealer was created in Vienna by Cuteacute Media OG between 2011 and 2014 (Ivan
-              Averintsev, Wolfie Christl, Pascale Osterwalder, Tobi Sch&auml;fer, Ralf
-              Traunsteiner). It was a satirical browser game about the personal-data trade, released
-              as a public beta on datadealer.com and open-sourced as{' '}
-              <a
-                href="https://github.com/datadealer/dd_js"
-                class="mln"
-                target="_blank"
-                rel="noreferrer noopener"
-              >
-                dd_js
-              </a>
-              ,{' '}
-              <a
-                href="https://github.com/datadealer/dd_rules"
-                class="mln"
-                target="_blank"
-                rel="noreferrer noopener"
-              >
-                dd_rules
-              </a>{' '}
-              and{' '}
-              <a
-                href="https://github.com/datadealer/dd_app"
-                class="mln"
-                target="_blank"
-                rel="noreferrer noopener"
-              >
-                dd_app
-              </a>
-              .
+              {withLinks(i18n.gettext('about original text'), [
+                <Link key="dd_js" href="https://github.com/datadealer/dd_js">
+                  dd_js
+                </Link>,
+                <Link key="dd_rules" href="https://github.com/datadealer/dd_rules">
+                  dd_rules
+                </Link>,
+                <Link key="dd_app" href="https://github.com/datadealer/dd_app">
+                  dd_app
+                </Link>,
+              ])}
             </div>
             <div class="PopupParagraph">
-              Background info and the original FAQ:{' '}
-              <a
-                href="https://datadealer.com/beta"
-                class="mln"
-                target="_blank"
-                rel="noreferrer noopener"
-              >
-                datadealer.com/beta
-              </a>
-              .
+              {withLinks(i18n.gettext('about original faq'), [
+                <Link key="beta" href="https://datadealer.com/beta">
+                  datadealer.com/beta
+                </Link>,
+              ])}
             </div>
           </div>
           <div class="PopupButtons">
@@ -144,27 +86,6 @@ export function AboutPopup({ userdebug, locale, buttonLabel, onClose }: AboutPop
             </div>
           </div>
         </div>
-        {userdebug ? (
-          <div class="PopupTab" data-tab="debug" style={tabStyle('debug')}>
-            <div class="SubpopContainer" />
-            <div class="PopupContentText">
-              <div class="PopupTitle">{i18n.gettext('userdebug reset game headline')}</div>
-              <div class="PopupParagraph">{i18n.gettext('userdebug reset game text')}</div>
-            </div>
-            <div class="PopupButtons">
-              {/* Dead button (phase-1 spec Section N): webxdc has no
-                  resetGame — reset = re-share the .xdc.  DOM kept for
-                  the contract / future wiring. */}
-              <div
-                class="Button sell"
-                data-button-id="ResetButton"
-                data-testid="dd-reset-game-button"
-              >
-                {i18n.gettext('Reset Game')}
-              </div>
-            </div>
-          </div>
-        ) : null}
       </div>
     </div>
   );

--- a/scripts/game/GameRoot.ts
+++ b/scripts/game/GameRoot.ts
@@ -2076,7 +2076,6 @@ export class GameRoot extends GameNode {
     this.on('user_data', (e: unknown) => {
       _stopPropFile(e);
       this.openPreactDialog(AboutPopup, {
-        userdebug: (setup as { userdebug?: boolean }).userdebug === true,
         locale: setup.locale ?? '',
         buttonLabel: i18n.gettext('Close'),
       });

--- a/tests/e2e/dialog-lifecycle.spec.ts
+++ b/tests/e2e/dialog-lifecycle.spec.ts
@@ -959,49 +959,6 @@ test.describe('Section I — popup tab strip navigation', () => {
     }
     await expectOpenAndClose(page, '.PopupContainer.lockOn .PopupMenu', 'x');
   });
-
-  test('UserData tab strip switches between Settings and Debug when userdebug is on', async ({
-    page,
-  }) => {
-    await bootGame(page);
-    // popup_user_data.html only renders the .PopupMenu when
-    // game.setup.userdebug is truthy — the live setup module is mutable
-    // (groot.setup is the same singleton) so flipping the flag before
-    // opening the popup activates the Settings/Debug tabs.
-    await page.evaluate(() => {
-      const groot = (window as any).__dd?._app?.game;
-      groot.setup.userdebug = true;
-      groot.trigger('user_data');
-    });
-    await expect(page.locator('.PopupBody.About .PopupMenu')).toBeVisible({ timeout: 3_000 });
-
-    // Click Debug → debug body shown, settings body hidden.
-    await page
-      .locator('.PopupBody.About .PopupMenuButton[data-tab="debug"]')
-      .first()
-      .click({ force: true });
-    await expect(
-      page.locator('.PopupBody.About .PopupMenuButton[data-tab="debug"].active').first()
-    ).toBeVisible();
-    await expect(
-      page.locator('.PopupBody.About .PopupTab[data-tab="debug"]').first()
-    ).toBeVisible();
-    await expect(
-      page.locator('.PopupBody.About .PopupTab[data-tab="settings"]').first()
-    ).toBeHidden();
-
-    // Click Settings → flip back.
-    await page
-      .locator('.PopupBody.About .PopupMenuButton[data-tab="settings"]')
-      .first()
-      .click({ force: true });
-    await expect(
-      page.locator('.PopupBody.About .PopupTab[data-tab="settings"]').first()
-    ).toBeVisible();
-    await expect(page.locator('.PopupBody.About .PopupTab[data-tab="debug"]').first()).toBeHidden();
-
-    await expectOpenAndClose(page, '.PopupBody.About', 'x');
-  });
 });
 
 // ── Section J: in-popup action handlers (buy / sell / integrate) ────────
@@ -1647,10 +1604,11 @@ test.describe('Section M — Subpop close + simple TokenPerp', () => {
 // without verifying they're actually fired.
 //
 // - ResetButton (data-button-id="ResetButton", data-testid="dd-reset-game-button")
-//   appears in popup_user_data.html's Debug tab.  No listener anywhere in
-//   scripts/.  Engine has no resetGame export by design (the webxdc-native
-//   reset is to re-share the .xdc; see scripts/LocalEngine.ts:10).  No
-//   test added because there is nothing to assert beyond DOM presence.
+//   was in popup_user_data.html's Debug tab.  No listener anywhere in
+//   scripts/; the engine has no resetGame export by design (the
+//   webxdc-native reset is to re-share the .xdc; see
+//   scripts/LocalEngine.ts:10).  The AboutPopup Preact port dropped the
+//   Debug tab entirely, so this affordance no longer exists.
 //
 // - button_click.RefreshButton listener exists at GameNode.ts:807 but no
 //   template uses data-button-id="RefreshButton".  Dead handler.


### PR DESCRIPTION
## Summary
Simplifies the AboutPopup component by removing the debug tab functionality and extracting hardcoded links and text into i18n strings. The dialog is now single-purpose and stateless, reflecting that webxdc has no reset functionality.

## Key Changes
- **Removed debug tab**: Eliminated the conditional tab strip and Debug tab that was gated on `userdebug`. The legacy reset functionality doesn't apply to webxdc (reset = re-share the .xdc file).
- **Extracted text to i18n**: Converted all hardcoded English prose into translatable i18n strings with `%s` placeholders for external links.
- **Created Link component**: New `Link.tsx` component centralizes external link styling (`class="mln"`) and security attributes (`target="_blank" rel="noreferrer noopener"`).
- **Implemented link splicing**: Added `withLinks()` helper function to splice `<Link>` components into i18n template strings at `%s` markers.
- **Updated props**: Removed `userdebug` prop from `AboutPopupProps` since it's no longer needed.
- **Removed useState**: Eliminated tab state management since there's now only one tab.
- **Updated tests**: Removed e2e test for tab switching behavior and updated comments about the dead ResetButton.
- **Added i18n strings**: Added German and English translations for all About dialog content (fork headline/text, displayname text, original game headline/text, FAQ link).

## Implementation Details
- The `withLinks()` function splits i18n strings on `%s` markers and interleaves them with corresponding `<Link>` components, maintaining proper ordering.
- The dialog remains purely informational with only a Close button, matching the webxdc use case.
- All external links now use the centralized `Link` component for consistency.

https://claude.ai/code/session_015JLEWuccHojZTkMVsJLyUR