### PR TITLE
Sync authoritative AP snapshot on insufficient AP rejection

### DIFF
--- a/scripts/LocalEngine.ts
+++ b/scripts/LocalEngine.ts
@@ -2171,7 +2171,11 @@ export function chargePerp(
         : 0;
 
   // Distinct codes (1=AP, 3=cash) let Game.js show the correct feedback animation.
-  if ((gv.ap_snapshot || 0) < 1) return Promise.resolve({ result: { error: 1 } });
+  // Return the materialized snapshot so the client can resync its free-running
+  // APTicker estimate down to the authoritative value — otherwise the bar stays
+  // showing phantom energy the engine has already refused.
+  if ((gv.ap_snapshot || 0) < 1)
+    return Promise.resolve({ result: { error: 1, ap_snapshot: gv.ap_snapshot || 0 } });
   if ((gv.cash_value || 0) < chargeCost) return Promise.resolve({ result: { error: 3 } });
 
   // ClientPerps don't carry collect_amount in the ruleset — they ship
@@ -2442,7 +2446,9 @@ export function collectPerp(
   // The UI pre-checks ap_value < 1 in {Client,Contact,Project,Token}Perp.collect
   // and shows FXNoAP; the engine still guards as defence-in-depth.
   if (((ms.game_values && ms.game_values.ap_snapshot) || 0) < 1) {
-    return Promise.resolve({ result: { error: 4 } });
+    return Promise.resolve({
+      result: { error: 4, ap_snapshot: (ms.game_values && ms.game_values.ap_snapshot) || 0 },
+    });
   }
 
   var collectEntry: { path: string; result?: { amount?: number } } | null = null;
@@ -2684,7 +2690,9 @@ export function integrateCollected(
   var state = materialize(rawState, now).state;
 
   if (((state.game_values && state.game_values.ap_snapshot) || 0) < 1) {
-    return Promise.resolve({ result: { error: 1 } });
+    return Promise.resolve({
+      result: { error: 1, ap_snapshot: (state.game_values && state.game_values.ap_snapshot) || 0 },
+    });
   }
 
   var queue = state.db_queue || [];

--- a/scripts/game/ClientPerp.ts
+++ b/scripts/game/ClientPerp.ts
@@ -197,6 +197,7 @@ export class ClientPerp extends GamePerp {
           });
           gperp.setState('idle', true);
         } else if (data.result?.error) {
+          groot.reconcileAP(data.result);
           if (popup) popup.trigger('error');
           else deco.FXError();
           deco.FXStop();
@@ -258,6 +259,7 @@ export class ClientPerp extends GamePerp {
         }
         const r = data.result;
         if (r.error) {
+          groot.reconcileAP(r);
           if (gnode.renderPopup && (gnode.renderPopup as RenderPopupLike).open) {
             (gnode.renderPopup as RenderPopupLike).trigger('no_AP');
           } else {

--- a/scripts/game/ContactPerp.ts
+++ b/scripts/game/ContactPerp.ts
@@ -116,6 +116,7 @@ export class ContactPerp extends GamePerp {
         const r = data.result;
         if (r.error) {
           if (r.error === 1) {
+            groot.reconcileAP(r);
             if (gnode.renderPopup && (gnode.renderPopup as RenderPopupLike).open) {
               (gnode.renderPopup as RenderPopupLike).trigger('no_AP');
             } else {
@@ -193,6 +194,7 @@ export class ContactPerp extends GamePerp {
           groot.getDatabase().cue(inner.profile_set, inner.origin, inner.collect_id);
           gperp.setState('idle', true);
         } else if (data.result?.error) {
+          groot.reconcileAP(data.result);
           if (popup) popup.trigger('no_AP');
           else deco.FXNoAP();
           deco.FXStop();

--- a/scripts/game/Database.ts
+++ b/scripts/game/Database.ts
@@ -467,6 +467,7 @@ export class Database extends GameNode {
       // FIXME returned error 0
       if (r.error !== undefined) {
         // No AP
+        groot.reconcileAP(r);
         if (gnode.renderPopup && gnode.renderPopup.open) {
           gnode.renderPopup.trigger('no_AP');
         } else {

--- a/scripts/game/GamePerp.ts
+++ b/scripts/game/GamePerp.ts
@@ -71,6 +71,7 @@ export interface GameRootForPerp {
     missions?: unknown,
     quiet?: boolean
   ): void;
+  reconcileAP(result: unknown): void;
   getType(
     gestalt?: string
   ):

--- a/scripts/game/GameRoot.ts
+++ b/scripts/game/GameRoot.ts
@@ -1138,6 +1138,18 @@ export class GameRoot extends GameNode {
     this.renderStatusbar?.FXUpdateAP?.(silent);
   }
 
+  /** Snap the displayed AP back down to an authoritative engine
+   *  snapshot.  Spend handlers call this on an insufficient-AP
+   *  rejection: the free-running APTicker estimate (`ap_value += inc`)
+   *  can drift above the engine's materialized `ap_snapshot`, and the
+   *  rejection path never went through `updateGameValues`, so without
+   *  this the bar stays showing phantom energy the engine has already
+   *  refused and every retry fails identically. */
+  reconcileAP(result: unknown): void {
+    const snap = (result as { ap_snapshot?: unknown } | null | undefined)?.ap_snapshot;
+    if (typeof snap === 'number') this.setAP(snap);
+  }
+
   setCash(num?: number, silent?: boolean): void {
     if (num !== undefined) this.cash_value = num;
     const sb = this.data.status_bar;

--- a/scripts/game/ProjectPerp.ts
+++ b/scripts/game/ProjectPerp.ts
@@ -533,6 +533,7 @@ export class ProjectPerp extends GamePerp {
             if (popup?.open) popup.trigger('no_cash');
             else rn?.FXNoCash?.();
           } else if (r.error === 1) {
+            groot.reconcileAP(r);
             gnode.NoAP?.();
           }
           return;
@@ -600,6 +601,7 @@ export class ProjectPerp extends GamePerp {
           groot.getDatabase()?.cue(inner.profile_set, inner.origin, inner.collect_id);
           gperp.setState('idle', true);
         } else if (data.result?.error) {
+          groot.reconcileAP(data.result);
           if (popup) popup.trigger('no_AP');
           else deco.FXNoAP();
           deco.FXStop();

--- a/tests/handlers/chargePerp.test.js
+++ b/tests/handlers/chargePerp.test.js
@@ -370,6 +370,19 @@ describe('chargePerp — failure: insufficient AP', () => {
     await chargePerp(NODE_PATH);
     expect(getState().nodes_charging).toHaveLength(0);
   });
+
+  // Regression: the AP-rejection must carry the authoritative materialized
+  // ap_snapshot so the client can resync its free-running APTicker estimate
+  // down to the truth. Without it the status bar stays showing phantom
+  // energy the engine has already refused and every retry fails identically.
+  it('returns the authoritative ap_snapshot on AP failure', async () => {
+    setOverride(FIXED_NOW);
+    setState(mkState({ game_values: { cash_value: 500, ap_snapshot: 0 } }));
+
+    const { result } = await chargePerp(NODE_PATH);
+    expect(result.error).toBe(1);
+    expect(result.ap_snapshot).toBe(0);
+  });
 });
 
 describe('chargePerp — failure: perp already charging', () => {

--- a/tests/handlers/collect-integrate.test.js
+++ b/tests/handlers/collect-integrate.test.js
@@ -457,6 +457,25 @@ describe('collectPerp — AP cost', () => {
     expect(data.result.error).toBe(4);
   });
 
+  // Regression: the AP-rejection must carry the authoritative materialized
+  // ap_snapshot so the client can resync its free-running APTicker estimate
+  // down to the truth, instead of leaving the bar showing phantom energy
+  // the engine has already refused.
+  it('returns the authoritative ap_snapshot on AP failure', async () => {
+    const PATH = 'Imperium.City.Pusher0.client001';
+    setState(
+      mkState({
+        nodes: [mkNode('ClientPerp', PATH)],
+        nodes_collect: [{ path: PATH, result: { amount: 100 } }],
+        game_values: mkGv({ ap_snapshot: 0, ap_max: 6 }),
+      })
+    );
+
+    const { result } = await collectPerp(PATH);
+    expect(result.error).toBe(4);
+    expect(result.ap_snapshot).toBe(0);
+  });
+
   it('error path: state is untouched when AP is insufficient', async () => {
     const PATH = 'Imperium.City.Pusher0.client001';
     setState(
@@ -925,6 +944,30 @@ describe('integrateCollected — ap cost', () => {
 
     const data = await integrateCollected(COLLECT_ID);
     expect(data.result.error).toBe(1);
+  });
+
+  // Regression: the AP-rejection must carry the authoritative materialized
+  // ap_snapshot so the client can resync its free-running APTicker estimate
+  // down to the truth, instead of leaving the bar showing phantom energy
+  // the engine has already refused.
+  it('returns the authoritative ap_snapshot on AP failure', async () => {
+    setState(
+      mkState({
+        game_values: Object.assign({}, mkGv(), { ap_snapshot: 0, ap_max: 6 }),
+        db_queue: [
+          {
+            origin: 'Imperium.City.contact001',
+            collect_id: COLLECT_ID,
+            profile_set: { profiles_value: 1, tokens_map: {} },
+            collect_dt: FIXED_NOW,
+          },
+        ],
+      })
+    );
+
+    const { result } = await integrateCollected(COLLECT_ID);
+    expect(result.error).toBe(1);
+    expect(result.ap_snapshot).toBe(0);
   });
 
   it('level-up refill overrides the AP cost — full ap_max after crossing threshold', async () => {


### PR DESCRIPTION
## Summary
This PR fixes a UI desynchronization issue where the AP status bar would display phantom energy after the engine rejected a spend action due to insufficient AP. The client's free-running APTicker estimate could drift above the engine's materialized `ap_snapshot`, and rejection responses weren't providing the authoritative value needed to resync the UI.

## Key Changes
- **Engine handlers** (`chargePerp`, `collectPerp`, `integrateCollected`): Modified to include `ap_snapshot` in error responses when AP is insufficient, providing the authoritative materialized value to clients
- **GameRoot**: Added `reconcileAP()` method to snap the displayed AP back down to an engine-provided authoritative snapshot
- **Perp handlers** (ClientPerp, ContactPerp, ProjectPerp, Database): Updated all spend/collect error paths to call `groot.reconcileAP()` when receiving insufficient AP rejections, ensuring the UI syncs to the engine's truth
- **Tests**: Added regression test cases for all three handler types to verify `ap_snapshot` is returned on AP failure

## Implementation Details
The fix addresses a fundamental issue where the client maintains a free-running AP estimate (`ap_value += increment`) that can drift ahead of the engine's materialized `ap_snapshot`. When a spend is rejected due to insufficient AP, the rejection response now carries the authoritative snapshot value. The client immediately reconciles its displayed AP to this value, preventing the bar from showing energy the engine has already refused and ensuring subsequent retries don't fail identically due to stale UI state.

https://claude.ai/code/session_01VdzcGmSG6CWgXdaKs1ffJt