### PR TITLE
refactor(ap): tidy reconcileAP follow-up to #298

### DIFF
--- a/scripts/LocalEngine.ts
+++ b/scripts/LocalEngine.ts
@@ -2174,8 +2174,8 @@ export function chargePerp(
   // Return the materialized snapshot so the client can resync its free-running
   // APTicker estimate down to the authoritative value — otherwise the bar stays
   // showing phantom energy the engine has already refused.
-  if ((gv.ap_snapshot || 0) < 1)
-    return Promise.resolve({ result: { error: 1, ap_snapshot: gv.ap_snapshot || 0 } });
+  var apSnap = gv.ap_snapshot || 0;
+  if (apSnap < 1) return Promise.resolve({ result: { error: 1, ap_snapshot: apSnap } });
   if ((gv.cash_value || 0) < chargeCost) return Promise.resolve({ result: { error: 3 } });
 
   // ClientPerps don't carry collect_amount in the ruleset — they ship
@@ -2445,10 +2445,9 @@ export function collectPerp(
   // Each collect costs 1 AP (parity with chargePerp / integrateCollected).
   // The UI pre-checks ap_value < 1 in {Client,Contact,Project,Token}Perp.collect
   // and shows FXNoAP; the engine still guards as defence-in-depth.
-  if (((ms.game_values && ms.game_values.ap_snapshot) || 0) < 1) {
-    return Promise.resolve({
-      result: { error: 4, ap_snapshot: (ms.game_values && ms.game_values.ap_snapshot) || 0 },
-    });
+  var apSnap = (ms.game_values && ms.game_values.ap_snapshot) || 0;
+  if (apSnap < 1) {
+    return Promise.resolve({ result: { error: 4, ap_snapshot: apSnap } });
   }
 
   var collectEntry: { path: string; result?: { amount?: number } } | null = null;
@@ -2689,10 +2688,9 @@ export function integrateCollected(
   var now = clockNow();
   var state = materialize(rawState, now).state;
 
-  if (((state.game_values && state.game_values.ap_snapshot) || 0) < 1) {
-    return Promise.resolve({
-      result: { error: 1, ap_snapshot: (state.game_values && state.game_values.ap_snapshot) || 0 },
-    });
+  var apSnap = (state.game_values && state.game_values.ap_snapshot) || 0;
+  if (apSnap < 1) {
+    return Promise.resolve({ result: { error: 1, ap_snapshot: apSnap } });
   }
 
   var queue = state.db_queue || [];

--- a/scripts/game/GameRoot.ts
+++ b/scripts/game/GameRoot.ts
@@ -1147,7 +1147,9 @@ export class GameRoot extends GameNode {
    *  refused and every retry fails identically. */
   reconcileAP(result: unknown): void {
     const snap = (result as { ap_snapshot?: unknown } | null | undefined)?.ap_snapshot;
-    if (typeof snap === 'number') this.setAP(snap);
+    // Mirror updateGameValues' guard: skip the statusbar re-render when the
+    // authoritative value already matches what's shown.
+    if (typeof snap === 'number' && snap !== this.ap_value) this.setAP(snap);
   }
 
   setCash(num?: number, silent?: boolean): void {

--- a/tests/handlers/chargePerp.test.js
+++ b/tests/handlers/chargePerp.test.js
@@ -371,10 +371,7 @@ describe('chargePerp — failure: insufficient AP', () => {
     expect(getState().nodes_charging).toHaveLength(0);
   });
 
-  // Regression: the AP-rejection must carry the authoritative materialized
-  // ap_snapshot so the client can resync its free-running APTicker estimate
-  // down to the truth. Without it the status bar stays showing phantom
-  // energy the engine has already refused and every retry fails identically.
+  // Regression: rejection must carry ap_snapshot so the client can resync.
   it('returns the authoritative ap_snapshot on AP failure', async () => {
     setOverride(FIXED_NOW);
     setState(mkState({ game_values: { cash_value: 500, ap_snapshot: 0 } }));

--- a/tests/handlers/collect-integrate.test.js
+++ b/tests/handlers/collect-integrate.test.js
@@ -457,10 +457,7 @@ describe('collectPerp — AP cost', () => {
     expect(data.result.error).toBe(4);
   });
 
-  // Regression: the AP-rejection must carry the authoritative materialized
-  // ap_snapshot so the client can resync its free-running APTicker estimate
-  // down to the truth, instead of leaving the bar showing phantom energy
-  // the engine has already refused.
+  // Regression: rejection must carry ap_snapshot so the client can resync.
   it('returns the authoritative ap_snapshot on AP failure', async () => {
     const PATH = 'Imperium.City.Pusher0.client001';
     setState(
@@ -946,10 +943,7 @@ describe('integrateCollected — ap cost', () => {
     expect(data.result.error).toBe(1);
   });
 
-  // Regression: the AP-rejection must carry the authoritative materialized
-  // ap_snapshot so the client can resync its free-running APTicker estimate
-  // down to the truth, instead of leaving the bar showing phantom energy
-  // the engine has already refused.
+  // Regression: rejection must carry ap_snapshot so the client can resync.
   it('returns the authoritative ap_snapshot on AP failure', async () => {
     setState(
       mkState({


### PR DESCRIPTION
## Summary

Post-merge cleanup from a code-review pass on the energy-display fix (#298). **No behavior change** — pure tidy-up.

- **`reconcileAP`**: skip the statusbar re-render when the authoritative snapshot already equals the displayed value, mirroring the guard `updateGameValues` already applies on the success path.
- **`LocalEngine`**: hoist the doubled `ap_snapshot || 0` expression at the three insufficient-AP rejection sites into a local instead of evaluating it twice.
- **Tests**: collapse the repeated four-line regression-test comments to a single line; the `it()` titles already state the contract.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx biome check` — clean on touched files
- [x] `npx vitest run` — 708/708 passing
- [ ] CI green

https://claude.ai/code/session_01VdzcGmSG6CWgXdaKs1ffJt

---
_Generated by [Claude Code](https://claude.ai/code/session_01VdzcGmSG6CWgXdaKs1ffJt)_