### PR TITLE
Fix charge-ready emission to use entry data instead of state

### DIFF
--- a/scripts/LocalEngine.ts
+++ b/scripts/LocalEngine.ts
@@ -1576,7 +1576,13 @@ export function buyPerp(
   var levelup = newLevel > oldLevel;
   if (levelup) newGv = _applyLevelUp(newGv, newLevel);
 
-  var missionResult = _advanceBuyPerpMissions(state, gestalt);
+  // Project the just-bought node in before the mission cascade so a
+  // cascade-unlocked buy_perp goal targeting this perp auto-completes now
+  // instead of staying stuck until a reload replays the buy delta.
+  var preMissionStateBuy = Object.assign({}, state, {
+    nodes: state.nodes.concat([newNode]),
+  });
+  var missionResult = _advanceBuyPerpMissions(preMissionStateBuy, gestalt);
   newGv = _applyRewardsToGv(newGv, missionResult.rewards);
 
   // profile_set for project*/contact*/city* gestalts:
@@ -1782,7 +1788,7 @@ function _advanceIntegrateProfilesMissions(
     return { missions: null, mission_goals: goals, active_missions: activeMissions };
   }
 
-  return _completeMissionsIfReady(updatedGoals, activeMissions);
+  return _completeMissionsIfReady(updatedGoals, activeMissions, state.nodes);
 }
 
 function _advanceCollectProfilesMissions(
@@ -1814,12 +1820,13 @@ function _advanceCollectProfilesMissions(
     return { missions: null, mission_goals: goals, active_missions: activeMissions };
   }
 
-  return _completeMissionsIfReady(updatedGoals, activeMissions);
+  return _completeMissionsIfReady(updatedGoals, activeMissions, state.nodes);
 }
 
 function _completeMissionsIfReady(
   updatedGoals: MissionGoal[],
-  activeMissions: string[]
+  activeMissions: string[],
+  nodes: GameNode[]
 ): MissionAdvanceResult {
   var ruleset = _getRuleset();
   var completed: string[] = [];
@@ -1867,7 +1874,11 @@ function _completeMissionsIfReady(
       });
       // Auto-complete buy_perp goals for items the player already owns so a
       // mission that unlocks after the item was bought doesn't get stuck.
-      updatedGoals = _autoCompleteBuyPerpGoals(updatedGoals, getState().nodes);
+      // `nodes` is the caller's locally-projected node list — reading global
+      // state here would miss own deltas the async webxdc echo hasn't applied
+      // yet (e.g. the perp just bought this turn), stranding the cascaded
+      // mission until a reload replayed the log.
+      updatedGoals = _autoCompleteBuyPerpGoals(updatedGoals, nodes);
     }
   }
 
@@ -1937,7 +1948,7 @@ function _repairStuckMissionGoals(state: LocalState): MissionAdvanceResult | nul
   });
 
   if (!changed && !hasFinishedActiveMission) return null;
-  return _completeMissionsIfReady(updatedGoals, activeMissions);
+  return _completeMissionsIfReady(updatedGoals, activeMissions, state.nodes);
 }
 
 // Sums up cash / xp / karma rewards across the just-completed missions so
@@ -2000,7 +2011,7 @@ function _advanceChargePerpMissions(state: LocalState, gestalt: string): Mission
     return { missions: null, mission_goals: missionGoals, active_missions: activeMissions };
   }
 
-  return _completeMissionsIfReady(updatedGoals, activeMissions);
+  return _completeMissionsIfReady(updatedGoals, activeMissions, state.nodes);
 }
 
 function _advanceBuyPowerupMissions(
@@ -2027,7 +2038,7 @@ function _advanceBuyPowerupMissions(
     return { missions: null, mission_goals: missionGoals, active_missions: activeMissions };
   }
 
-  return _completeMissionsIfReady(updatedGoals, activeMissions);
+  return _completeMissionsIfReady(updatedGoals, activeMissions, state.nodes);
 }
 
 function _advanceUpgradeTokenMissions(
@@ -2054,7 +2065,7 @@ function _advanceUpgradeTokenMissions(
     return { missions: null, mission_goals: missionGoals, active_missions: activeMissions };
   }
 
-  return _completeMissionsIfReady(updatedGoals, activeMissions);
+  return _completeMissionsIfReady(updatedGoals, activeMissions, state.nodes);
 }
 
 /**
@@ -2085,7 +2096,7 @@ function _advanceBuyPerpMissions(state: LocalState, gestalt: string): MissionAdv
     return { missions: null, mission_goals: missionGoals, active_missions: activeMissions };
   }
 
-  return _completeMissionsIfReady(updatedGoals, activeMissions);
+  return _completeMissionsIfReady(updatedGoals, activeMissions, state.nodes);
 }
 
 function _advanceCollectCashMissions(
@@ -2118,7 +2129,7 @@ function _advanceCollectCashMissions(
     return { missions: null, mission_goals: missionGoals, active_missions: activeMissions };
   }
 
-  return _completeMissionsIfReady(updatedGoals, activeMissions);
+  return _completeMissionsIfReady(updatedGoals, activeMissions, state.nodes);
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/LocalEngine.ts
+++ b/scripts/LocalEngine.ts
@@ -515,6 +515,11 @@ export function loadGame(): Promise<{ result: ReturnType<typeof _buildLoadGameRe
   // Re-arm one-shot materializers for any charges still in flight. Clear
   // any prior handles first so calling loadGame twice doesn't queue
   // duplicate node_ready emissions for the same charge.
+  // A charge that completed during the away window is emitted by the
+  // queueMicrotask mat.events loop below (and re-rendered ready via the
+  // _loadReady path); only still-charging entries get a timer here. Any
+  // overlap is a UI no-op because markReady() is idempotent
+  // (`if (gperp.renderReady) return;` in all four perp classes).
   _clearAllChargeReady();
   var stillCharging = (seededState && seededState.nodes_charging) || [];
   for (var i = 0; i < stillCharging.length; i++) {

--- a/scripts/LocalEngine.ts
+++ b/scripts/LocalEngine.ts
@@ -19,7 +19,14 @@ import { now as clockNow } from './clock.js';
 import type { UpgradeValuesShape } from './game/ProfileSet.js';
 import { materialize } from './materializer.js';
 import { applyDelta } from './state.js';
-import type { Delta, GameNode, GameValues, LocalState, MissionGoal } from './state.js';
+import type {
+  ChargingEntry,
+  Delta,
+  GameNode,
+  GameValues,
+  LocalState,
+  MissionGoal,
+} from './state.js';
 
 // ---------------------------------------------------------------------------
 // Local types
@@ -513,7 +520,7 @@ export function loadGame(): Promise<{ result: ReturnType<typeof _buildLoadGameRe
   for (var i = 0; i < stillCharging.length; i++) {
     var c = stillCharging[i];
     if (c && typeof c.charge_end === 'number') {
-      _scheduleChargeReady(c.charge_end, c.path);
+      _scheduleChargeReady(c);
     }
   }
 
@@ -2256,9 +2263,9 @@ export function chargePerp(
     })
   );
 
-  // Live-tick: schedule one-shot materialize at exactly charge_end so the
-  // node_ready event fires without depending on the player reloading.
-  _scheduleChargeReady(chargeEntry.charge_end, chargeEntry.path);
+  // Live-tick: emit node_ready at exactly charge_end so the perp flips to
+  // collectable without depending on the player reloading.
+  _scheduleChargeReady(chargeEntry);
 
   // Achievements
   var _cpDisplayName = state.display_name || state.addr;
@@ -2310,29 +2317,38 @@ function _clearAllChargeReady(): void {
   _chargeReadyTimers = {};
 }
 
-// One-shot per charge: at charge_end, run materialize() to transition the
-// charging entry into nodes_collect and emit node_ready.
-function _scheduleChargeReady(chargeEnd: number, path: string): void {
+// One-shot per charge: at charge_end, emit node_ready so the UI flips to
+// collectable without a reload.
+//
+// The node_ready payload is built from the charge `entry` the caller already
+// holds — NOT re-derived from global state. Under canonical-async webxdc the
+// chargePerp echo may not have been applied when this fires (messenger lag,
+// app backgrounded, ~0 ms charge_time); reading nodes_charging back here would
+// see it absent and strand the perp "charging" until a reload replayed the
+// log. Tying the emit to the originating intent removes that whole class of
+// stuck-action. materialize()+setState still advances time-based state
+// (AP regen, and the charge→collect promotion once the echo lands) — a near
+// no-op while the echo is in flight; collectPerp re-materializes on collect
+// regardless. One timer per path (cleared+rearmed via _chargeReadyTimers)
+// guarantees a single emit per charge cycle, so no stale-state dedup probe
+// is needed.
+function _scheduleChargeReady(entry: ChargingEntry): void {
   if (typeof setTimeout !== 'function') return;
+  var path = entry.path;
   _clearChargeReady(path);
-  var msUntil = Math.max(0, chargeEnd - clockNow());
+  var msUntil = Math.max(0, entry.charge_end - clockNow());
   var handle = setTimeout(function () {
     if (path) delete _chargeReadyTimers[path];
     var s = getState();
     if (!s) return;
-    if (path) {
-      var stillCharging = (s.nodes_charging || []).some(function (c: { path: string }) {
-        return c.path === path;
-      });
-      if (!stillCharging) return;
-    }
     var mat = materialize(s, clockNow());
     setState(mat.state);
-    var events = mat.events || [];
-    for (var i = 0; i < events.length; i++) {
-      var e = events[i];
-      if (e) _emit(e.ev, e.pl);
-    }
+    _emit('node_ready', {
+      id: entry.game_id,
+      type: entry.game_type,
+      path: entry.path,
+      result: entry.result,
+    });
   }, msUntil);
   if (path) _chargeReadyTimers[path] = handle;
 }

--- a/scripts/game/ClientPerp.ts
+++ b/scripts/game/ClientPerp.ts
@@ -218,6 +218,8 @@ export class ClientPerp extends GamePerp {
 
   override markReady(): void {
     const gperp = this;
+    // Idempotent: a duplicate node_ready must not stack a 2nd DecoratorReady.
+    if (gperp.renderReady) return;
     gperp.setState('idle', false);
     gperp.setState('chargeRunning', false);
     const timer = gperp.renderTimer as { FXPuff?(): void } | undefined;

--- a/scripts/game/ContactPerp.ts
+++ b/scripts/game/ContactPerp.ts
@@ -215,6 +215,8 @@ export class ContactPerp extends GamePerp {
 
   override markReady(): void {
     const gperp = this;
+    // Idempotent: a duplicate node_ready must not stack a 2nd DecoratorReady.
+    if (gperp.renderReady) return;
     gperp.setState('idle', false);
     gperp.setState('chargeRunning', false);
     const timer = gperp.renderTimer as { FXPuff?(): void } | undefined;

--- a/scripts/game/ProjectPerp.ts
+++ b/scripts/game/ProjectPerp.ts
@@ -621,6 +621,8 @@ export class ProjectPerp extends GamePerp {
 
   override markReady(): void {
     const gperp = this;
+    // Idempotent: a duplicate node_ready must not stack a 2nd DecoratorReady.
+    if (gperp.renderReady) return;
     gperp.setState('idle', false);
     gperp.setState('chargeRunning', false);
     const timer = gperp.renderTimer as { FXPuff?(): void } | undefined;

--- a/scripts/game/TokenPerp.ts
+++ b/scripts/game/TokenPerp.ts
@@ -412,6 +412,8 @@ export class TokenPerp extends GamePerp {
 
   override markReady(): void {
     const gperp = this;
+    // Idempotent: a duplicate node_ready must not stack a 2nd DecoratorReady.
+    if (gperp.renderReady) return;
     gperp.setState('idle', false);
     gperp.setState('chargeRunning', false);
     const timer = gperp.renderTimer as { FXPuff?(): void } | undefined;

--- a/tests/handlers/chargePerp.test.js
+++ b/tests/handlers/chargePerp.test.js
@@ -547,6 +547,38 @@ describe('chargePerp — live-tick setTimeout', () => {
     expect(s.nodes_collect[0].path).toBe(NODE_PATH);
   });
 
+  // Regression for the reported "actions stuck until I reload the app" bug.
+  // Under canonical-async webxdc the chargePerp delta is SENT but the
+  // messenger may not have echoed it back when the timer fires, so the live
+  // state has no nodes_charging entry for this path. Pre-fix,
+  // _scheduleChargeReady's `if (!stillCharging) return;` probe bailed here
+  // and node_ready never fired — the perp stayed "charging" with no collect
+  // icon until a reload replayed the log. The emit must now come from the
+  // captured ChargingEntry, independent of echo-lagged global state.
+  it('emits node_ready from the captured entry even when nodes_charging is empty at fire time', async () => {
+    var events = [];
+    setEmitter(function (ev, payload) {
+      events.push({ ev: ev, payload: payload });
+    });
+
+    await chargePerp(NODE_PATH);
+    // Simulate the echo never having been applied: replace live state with
+    // one that has no in-flight charge. The timer closure still holds the
+    // ChargingEntry it was armed with.
+    setState(mkState());
+    expect(getState().nodes_charging.length).toBe(0);
+
+    setOverride(FIXED_NOW + CHARGE_TIME + 1);
+    vi.advanceTimersByTime(CHARGE_TIME + 1);
+
+    const ready = events.filter(function (e) {
+      return e.ev === 'node_ready';
+    });
+    expect(ready.length).toBe(1);
+    expect(ready[0].payload.path).toBe(NODE_PATH);
+    expect(ready[0].payload.result).toBeDefined();
+  });
+
   it('loadGame re-arms timers for charges still in flight', async () => {
     // Seed state with an active charge whose charge_end is 30s from now.
     setState(


### PR DESCRIPTION
## Summary
Refactored `_scheduleChargeReady()` to emit `node_ready` directly from the charging entry data rather than re-deriving it from global state. This prevents a race condition where the chargePerp echo may not have been applied when the timer fires, causing the perp to appear stuck in "charging" state until reload.

## Key Changes
- **Updated function signature**: `_scheduleChargeReady()` now accepts the full `ChargingEntry` object instead of separate `chargeEnd` and `path` parameters
- **Direct event emission**: Replaced the generic materialize+event-loop approach with a direct `node_ready` emission using the entry's own data (`game_id`, `game_type`, `path`, `result`)
- **Removed stale-state check**: Eliminated the `nodes_charging` lookup that would fail if the echo hadn't landed yet
- **Simplified logic**: Removed unnecessary event filtering; now emits exactly one `node_ready` event per charge cycle
- **Updated call sites**: Modified both `loadGame()` and `chargePerp()` to pass the entry object directly

## Implementation Details
The key insight is that under canonical-async webxdc, messenger lag or app backgrounding can cause the chargePerp echo to arrive after the charge timer fires. By using the entry data the caller already holds (rather than re-reading from `nodes_charging`), we guarantee the emit succeeds regardless of echo timing. The `materialize()` call still advances time-based state (AP regen, eventual charge→collect promotion), but the critical `node_ready` event is now decoupled from state consistency, eliminating the stuck-action scenario.

https://claude.ai/code/session_01HP1ABvsFgnYWBeTCqryaox