### PR TITLE
Fix infinite setXP/setLevel recursion on XP level boundary

### DIFF
--- a/scripts/game/GameRoot.ts
+++ b/scripts/game/GameRoot.ts
@@ -149,6 +149,15 @@ interface Level {
   [key: string]: unknown;
 }
 
+/** Level-shaped zero sentinel.  Used where a real level isn't available
+ *  yet (pre-bootstrap `xp_level`, out-of-range `getLevel`/`getLevelByXP`
+ *  lookups) so the strict-TS shape stays satisfied without a legacy
+ *  `undefined.xp_min` TypeError.  Returns a fresh object each call —
+ *  callers assign it to `xp_level`, which other code may overwrite. */
+function emptyLevel(): Level {
+  return { number: 0, xp_min: 0, xp_max: 0, ap_max: 0, ap_inc_value: 0, ap_inc_interval: 0 };
+}
+
 // Render Popup surface used by `openNotification` — re-imports the
 // canonical `RenderPopupLike` from GamePerp.ts (was duplicated across
 // GameRoot / GameNode / GamePerp / Database / ProjectPerp before this
@@ -514,14 +523,7 @@ export class GameRoot extends GameNode {
   karma_value = 0;
   karma_max = 100;
   xp_value = 0;
-  xp_level: Level = {
-    number: 0,
-    xp_min: 0,
-    xp_max: 0,
-    ap_max: 0,
-    ap_inc_value: 0,
-    ap_inc_interval: 0,
-  };
+  xp_level: Level = emptyLevel();
   /** Set by `loadGame` (still in Game.js) once the Missions singleton
    *  is constructed.  Forward-ref optional until Missions extracts. */
   Missions?: Missions;
@@ -980,16 +982,7 @@ export class GameRoot extends GameNode {
   getLevel(level?: number): Level {
     const levels = this.data.levels ?? [];
     const idx = level ? level - 1 : (this.data.game_values?.xp_level ?? 1) - 1;
-    return (
-      levels[idx] ?? {
-        number: 0,
-        xp_min: 0,
-        xp_max: 0,
-        ap_max: 0,
-        ap_inc_value: 0,
-        ap_inc_interval: 0,
-      }
-    );
+    return levels[idx] ?? emptyLevel();
   }
 
   /** Returns the Level `xp` resolves to, or an empty Level-shape when
@@ -1007,7 +1000,7 @@ export class GameRoot extends GameNode {
    *  (RangeError / stack overflow surfacing in `FXSimpleCue`). */
   getLevelByXP(xp?: number): Level {
     if (!xp) {
-      return { number: 0, xp_min: 0, xp_max: 0, ap_max: 0, ap_inc_value: 0, ap_inc_interval: 0 };
+      return emptyLevel();
     }
     const levels = this.data.levels ?? [];
     for (let i = levels.length - 1; i >= 0; i--) {
@@ -1018,7 +1011,7 @@ export class GameRoot extends GameNode {
         return lvl;
       }
     }
-    return { number: 0, xp_min: 0, xp_max: 0, ap_max: 0, ap_inc_value: 0, ap_inc_interval: 0 };
+    return emptyLevel();
   }
 
   override APTick(): void {

--- a/scripts/game/GameRoot.ts
+++ b/scripts/game/GameRoot.ts
@@ -992,19 +992,33 @@ export class GameRoot extends GameNode {
     );
   }
 
-  /** Returns the Level whose `xp_min..xp_max` window contains `xp`,
-   *  or an empty Level-shape when `xp` is falsy.  Legacy returned
-   *  `{}` for the falsy branch — flattened to a Level-shaped sentinel
-   *  to keep the strict-TS signature clean (callers pass it to
-   *  `setLevel`'s identity check, never read fields off it). */
+  /** Returns the Level `xp` resolves to, or an empty Level-shape when
+   *  `xp` is falsy.  Legacy returned `{}` for the falsy branch —
+   *  flattened to a Level-shaped sentinel to keep the strict-TS
+   *  signature clean (callers pass it to `setLevel`'s identity check,
+   *  never read fields off it).
+   *
+   *  Ruleset levels leave a one-XP gap between consecutive ranges
+   *  (L1: 0–10, L2: 11–30, …).  `xp_max` is the promotion threshold:
+   *  xp landing exactly on a level's `xp_max` resolves to the *next*
+   *  level, mirroring the engine's `_getLevelByXP`.  The old inclusive
+   *  `xp <= xp_max` match kept it on the lower level, which made
+   *  `setXP` and `setLevel` recurse forever on the boundary value
+   *  (RangeError / stack overflow surfacing in `FXSimpleCue`). */
   getLevelByXP(xp?: number): Level {
     if (!xp) {
       return { number: 0, xp_min: 0, xp_max: 0, ap_max: 0, ap_inc_value: 0, ap_inc_interval: 0 };
     }
-    const found = (this.data.levels ?? []).find((lvl) => xp >= lvl.xp_min && xp <= lvl.xp_max);
-    return (
-      found ?? { number: 0, xp_min: 0, xp_max: 0, ap_max: 0, ap_inc_value: 0, ap_inc_interval: 0 }
-    );
+    const levels = this.data.levels ?? [];
+    for (let i = levels.length - 1; i >= 0; i--) {
+      const lvl = levels[i];
+      if (lvl && xp >= lvl.xp_min) {
+        const next = levels[i + 1];
+        if (next && xp >= lvl.xp_max) return next;
+        return lvl;
+      }
+    }
+    return { number: 0, xp_min: 0, xp_max: 0, ap_max: 0, ap_inc_value: 0, ap_inc_interval: 0 };
   }
 
   override APTick(): void {
@@ -1208,11 +1222,18 @@ export class GameRoot extends GameNode {
     if (num !== undefined && num > this.xp_value) {
       this.xp_value = num;
     }
-    if (this.xp_value >= this.xp_level.xp_max) {
-      this.setLevel(this.getLevelByXP(this.xp_value).number);
-    }
-    if (this.xp_value < this.xp_level.xp_min) {
-      this.setLevel(this.getLevelByXP(this.xp_value).number);
+    // `setLevel` calls back into `setXP`, so only re-enter it when the
+    // XP actually resolves to a *different* level.  Without the
+    // `resolved.number !== this.xp_level.number` guard, an `xp_value`
+    // sitting on a level boundary (e.g. exactly L1.xp_max) keeps
+    // resolving to the level we're already on and the two methods
+    // recurse until the stack overflows.
+    const resolved = this.getLevelByXP(this.xp_value);
+    if (
+      resolved.number !== this.xp_level.number &&
+      (this.xp_value >= this.xp_level.xp_max || this.xp_value < this.xp_level.xp_min)
+    ) {
+      this.setLevel(resolved.number);
     }
     const sb = this.data.status_bar;
     if (!sb) return;

--- a/tests/game/levelxp-recursion.test.js
+++ b/tests/game/levelxp-recursion.test.js
@@ -1,0 +1,102 @@
+// Regression: GameRoot.setXP / setLevel must not recurse forever when
+// xp_value lands exactly on a level's xp_max (issue: collect action
+// stuck loading, "RangeError: Maximum call stack size exceeded" in
+// FXSimpleCue, stack alternating setXP -> setLevel -> setXP ...).
+//
+// Ruleset levels leave a one-XP gap between ranges (L1: 0-10,
+// L2: 11-30, ...). The pre-fix client `getLevelByXP` matched the
+// inclusive upper bound (`xp <= xp_max`), so xp=10 kept resolving to
+// L1 while `setXP`'s `xp_value >= xp_level.xp_max` guard tried to
+// level up — `setXP` -> `setLevel` -> `setXP` ping-ponged forever.
+//
+// We invoke the prototype methods via Function.prototype.bind against
+// a stubbed `this`, sidestepping the full GameRoot/jQuery/Render
+// bootstrap (same approach as origin-token-lookup.test.js).
+
+import { describe, expect, it } from 'vitest';
+import { GameRoot } from '../../scripts/game/GameRoot.ts';
+
+const LEVELS = [
+  { number: 1, xp_min: 0, xp_max: 10, ap_max: 100, ap_inc_value: 1, ap_inc_interval: 1 },
+  { number: 2, xp_min: 11, xp_max: 30, ap_max: 200, ap_inc_value: 1, ap_inc_interval: 1 },
+  { number: 3, xp_min: 31, xp_max: 54, ap_max: 300, ap_inc_value: 1, ap_inc_interval: 1 },
+];
+
+function mkNode(xpValue, levelObj) {
+  const node = {
+    data: {
+      levels: LEVELS,
+      game_values: { xp_level: levelObj.number },
+      status_bar: { XP: {}, AP: {} },
+    },
+    xp_value: xpValue,
+    xp_level: levelObj,
+    ap_value: 0,
+    renderStatusbar: { FXUpdateXP() {}, FXUpdateAP() {} },
+  };
+  node.getLevel = GameRoot.prototype.getLevel.bind(node);
+  node.getLevelByXP = GameRoot.prototype.getLevelByXP.bind(node);
+  node.setLevel = GameRoot.prototype.setLevel.bind(node);
+  node.setXP = GameRoot.prototype.setXP.bind(node);
+  node.setAP = GameRoot.prototype.setAP.bind(node);
+  return node;
+}
+
+describe('GameRoot.getLevelByXP — xp_max is the promotion threshold', () => {
+  const fn = GameRoot.prototype.getLevelByXP;
+  const stub = { data: { levels: LEVELS } };
+
+  it('resolves a mid-band xp to its own level', () => {
+    expect(fn.call(stub, 5).number).toBe(1);
+    expect(fn.call(stub, 20).number).toBe(2);
+  });
+
+  it('promotes to the next level when xp lands exactly on xp_max', () => {
+    expect(fn.call(stub, 10).number).toBe(2);
+    expect(fn.call(stub, 30).number).toBe(3);
+  });
+
+  it('resolves the next level once xp reaches its xp_min', () => {
+    expect(fn.call(stub, 11).number).toBe(2);
+    expect(fn.call(stub, 31).number).toBe(3);
+  });
+
+  it('returns the empty Level-shape sentinel for falsy xp', () => {
+    expect(fn.call(stub, 0).number).toBe(0);
+    expect(fn.call(stub, undefined).number).toBe(0);
+  });
+});
+
+describe('GameRoot.setXP — no infinite recursion on a level boundary', () => {
+  it('does not overflow the stack when xp_value equals xp_max', () => {
+    const node = mkNode(10, LEVELS[0]);
+    expect(() => node.setXP()).not.toThrow();
+    expect(node.xp_level.number).toBe(2);
+  });
+
+  it('promotes via the engine entry path (setXP with a new value)', () => {
+    const node = mkNode(9, LEVELS[0]);
+    expect(() => node.setXP(10, true)).not.toThrow();
+    expect(node.xp_value).toBe(10);
+    expect(node.xp_level.number).toBe(2);
+  });
+
+  it('promotes across the top of L2 (xp_value === L2.xp_max)', () => {
+    const node = mkNode(30, LEVELS[1]);
+    expect(() => node.setXP()).not.toThrow();
+    expect(node.xp_level.number).toBe(3);
+  });
+
+  it('stays on the current level for a mid-band xp_value', () => {
+    const node = mkNode(5, LEVELS[0]);
+    expect(() => node.setXP()).not.toThrow();
+    expect(node.xp_level.number).toBe(1);
+    expect(node.data.status_bar.XP.level).toBe(1);
+  });
+
+  it('handles a multi-level jump in a single call', () => {
+    const node = mkNode(40, LEVELS[0]);
+    expect(() => node.setXP()).not.toThrow();
+    expect(node.xp_level.number).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary

A collect action that awarded XP landing **exactly on a level's `xp_max`** (10, 30, 54, …) hung with the action stuck loading and `RangeError: Maximum call stack size exceeded` thrown in `FXSimpleCue`. The console stack alternated `setXP → setLevel → setXP …`.

Root cause: `GameRoot.getLevelByXP` matched the inclusive upper bound (`xp <= xp_max`), so a boundary `xp_value` kept resolving to the level `setXP` was already trying to leave, while `setLevel` called back into `setXP` — the two recursed until the stack overflowed (surfacing at the bottom of the chain, `setAP → FXUpdateAP → FXSimpleCue`). The client level also drifted out of sync with the engine, whose `_getLevelByXP` already treats `xp_max` as a promotion threshold.

## Changes

- **`getLevelByXP`** now treats `xp_max` as the promotion threshold (walks levels high→low, returns the next level when `xp >= xp_max`), mirroring the engine's `_getLevelByXP`. The displayed level now matches engine state.
- **`setXP`** resolves the level once and only re-enters `setLevel` when the resolved level differs from the current `xp_level`, so the mutual recursion converges in a single step instead of ping-ponging on the boundary.
- **Cleanup:** extracted the 4×-duplicated zero-`Level` sentinel into a single `emptyLevel()` factory (no behavior change).
- Added `tests/game/levelxp-recursion.test.js` (9 cases) covering the boundary, promotion, multi-level jump, and mid-band cases.

## Test plan

- [x] `tests/game/levelxp-recursion.test.js` — verified it fails on 4 boundary/recursion cases without the fix, passes with it
- [x] Full unit suite: 718/718 passing (32 files)
- [x] `tsc --noEmit` clean
- [x] `biome check` clean
- [ ] Manual: trigger a collect that lands XP exactly on a level boundary (e.g. reach 10 XP at level 1) and confirm the action completes and the level/XP bar advances correctly

https://claude.ai/code/session_012rXLs9d2szyzJkWTKhLq98

---
_Generated by [Claude Code](https://claude.ai/code/session_012rXLs9d2szyzJkWTKhLq98)_