### PR TITLE
Add resource icon between leaderboard title lines

### DIFF
--- a/css/Render.css
+++ b/css/Render.css
@@ -1291,10 +1291,10 @@
   line-height: 26px;
 }
 .TopscoreLabel .TopscoreLabelLine:last-child {
-  margin: 6px 0px 10px 0px;
+  padding: 10px 0px;
 }
 .TopscoreLabelIcon {
-  margin: 26px 0px 10px 0px;
+  margin: 26px 0px 4px 0px;
   text-align: center;
   line-height: 0;
 }

--- a/css/Render.css
+++ b/css/Render.css
@@ -1305,8 +1305,24 @@
 }
 .TopscoreLabelStar {
   display: inline-block;
-  font-size: 38px;
-  line-height: 38px;
+  position: relative;
+  width: 47px;
+  height: 46px;
+  background-image: url(../img/MainSprites.png);
+  background-repeat: no-repeat;
+  background-position: -325px -655px;
+}
+.TopscoreLabelStar span {
+  position: absolute;
+  left: 0px;
+  right: 0px;
+  top: 50%;
+  transform: translateY(-50%);
+  text-align: center;
+  font-size: 15px;
+  line-height: 1;
+  color: #333;
+  font-family: Bowlby;
 }
 
 .small .PopupToken {

--- a/css/Render.css
+++ b/css/Render.css
@@ -1290,8 +1290,11 @@
 .TopscoreLabelLine {
   line-height: 26px;
 }
+.TopscoreLabel .TopscoreLabelLine:last-child {
+  margin: 6px 0px 10px 0px;
+}
 .TopscoreLabelIcon {
-  margin: 26px 0px 14px 0px;
+  margin: 26px 0px 10px 0px;
   text-align: center;
   line-height: 0;
 }

--- a/css/Render.css
+++ b/css/Render.css
@@ -1287,6 +1287,24 @@
   line-height: 26px;
   margin: 8px 0px 4px 0px;
 }
+.TopscoreLabelLine {
+  line-height: 26px;
+}
+.TopscoreLabelIcon {
+  margin: 10px 0px 12px 0px;
+  text-align: center;
+  line-height: 0;
+}
+.TopscoreLabelIcon .Buy.Cash,
+.TopscoreLabelIcon .Buy.Token {
+  transform: scale(1.9);
+  margin: 0px;
+}
+.TopscoreLabelStar {
+  display: inline-block;
+  font-size: 30px;
+  line-height: 30px;
+}
 
 .small .PopupToken {
   width:67px;

--- a/css/Render.css
+++ b/css/Render.css
@@ -1291,7 +1291,7 @@
   line-height: 26px;
 }
 .TopscoreLabel .TopscoreLabelLine:last-child {
-  padding: 4px 0px 10px 0px;
+  padding: 16px 0px 10px 0px;
 }
 .TopscoreLabelIcon {
   margin: 26px 0px 0px 0px;

--- a/css/Render.css
+++ b/css/Render.css
@@ -1285,25 +1285,25 @@
   font-size: 26px;
   text-align: center;
   line-height: 26px;
-  margin: 8px 0px 4px 0px;
+  margin: 20px 0px 4px 0px;
 }
 .TopscoreLabelLine {
   line-height: 26px;
 }
 .TopscoreLabelIcon {
-  margin: 10px 0px 12px 0px;
+  margin: 12px 0px 14px 0px;
   text-align: center;
   line-height: 0;
 }
 .TopscoreLabelIcon .Buy.Cash,
 .TopscoreLabelIcon .Buy.Token {
-  transform: scale(1.9);
+  transform: scale(2.4);
   margin: 0px;
 }
 .TopscoreLabelStar {
   display: inline-block;
-  font-size: 30px;
-  line-height: 30px;
+  font-size: 38px;
+  line-height: 38px;
 }
 
 .small .PopupToken {

--- a/css/Render.css
+++ b/css/Render.css
@@ -1319,7 +1319,7 @@
   top: 20.5px;
   transform: translate(-50%, -50%);
   white-space: nowrap;
-  font-size: 14px;
+  font-size: 12px;
   line-height: 1;
   color: #333;
   font-family: Bowlby;

--- a/css/Render.css
+++ b/css/Render.css
@@ -1291,10 +1291,10 @@
   line-height: 26px;
 }
 .TopscoreLabel .TopscoreLabelLine:last-child {
-  padding: 10px 0px;
+  padding: 4px 0px 10px 0px;
 }
 .TopscoreLabelIcon {
-  margin: 26px 0px 4px 0px;
+  margin: 26px 0px 0px 0px;
   text-align: center;
   line-height: 0;
 }

--- a/css/Render.css
+++ b/css/Render.css
@@ -1311,15 +1311,15 @@
   background-image: url(../img/MainSprites.png);
   background-repeat: no-repeat;
   background-position: -325px -655px;
+  transform: scale(1.35);
 }
 .TopscoreLabelStar span {
   position: absolute;
   left: 0px;
-  right: 0px;
-  top: 50%;
-  transform: translateY(-50%);
+  right: 3px;
+  top: 16px;
   text-align: center;
-  font-size: 15px;
+  font-size: 14px;
   line-height: 1;
   color: #333;
   font-family: Bowlby;

--- a/css/Render.css
+++ b/css/Render.css
@@ -1315,10 +1315,10 @@
 }
 .TopscoreLabelStar span {
   position: absolute;
-  left: 0px;
-  right: 3px;
-  top: 16px;
-  text-align: center;
+  left: 19.5px;
+  top: 20.5px;
+  transform: translate(-50%, -50%);
+  white-space: nowrap;
   font-size: 14px;
   line-height: 1;
   color: #333;

--- a/css/Render.css
+++ b/css/Render.css
@@ -1291,27 +1291,39 @@
   line-height: 26px;
 }
 .TopscoreLabel .TopscoreLabelLine:last-child {
-  padding: 19px 0px 10px 0px;
+  padding: 14px 0px 10px 0px;
 }
 .TopscoreLabelIcon {
-  margin: 26px 0px 0px 0px;
-  text-align: center;
-  line-height: 0;
+  margin: 24px 0px 0px 0px;
+  height: 64px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
-.TopscoreLabelIcon .Buy.Cash,
-.TopscoreLabelIcon .Buy.Token {
-  transform: scale(2.4);
-  margin: 0px;
+.TopscoreLabelCash,
+.TopscoreLabelToken,
+.TopscoreLabelStar {
+  background-image: url(../img/MainSprites.png);
+  background-repeat: no-repeat;
+}
+.TopscoreLabelCash {
+  width: 45px;
+  height: 34px;
+  background-position: -369px -616px;
+  transform: scale(1.3);
+}
+.TopscoreLabelToken {
+  width: 38px;
+  height: 38px;
+  background-position: -331px -616px;
+  transform: scale(1.3);
 }
 .TopscoreLabelStar {
-  display: inline-block;
   position: relative;
   width: 47px;
   height: 46px;
-  background-image: url(../img/MainSprites.png);
-  background-repeat: no-repeat;
   background-position: -325px -655px;
-  transform: scale(1.35);
+  transform: scale(1.38);
 }
 .TopscoreLabelStar span {
   position: absolute;

--- a/css/Render.css
+++ b/css/Render.css
@@ -1285,13 +1285,13 @@
   font-size: 26px;
   text-align: center;
   line-height: 26px;
-  margin: 20px 0px 4px 0px;
+  margin: 8px 0px 4px 0px;
 }
 .TopscoreLabelLine {
   line-height: 26px;
 }
 .TopscoreLabelIcon {
-  margin: 12px 0px 14px 0px;
+  margin: 26px 0px 14px 0px;
   text-align: center;
   line-height: 0;
 }

--- a/css/Render.css
+++ b/css/Render.css
@@ -1291,7 +1291,7 @@
   line-height: 26px;
 }
 .TopscoreLabel .TopscoreLabelLine:last-child {
-  padding: 16px 0px 10px 0px;
+  padding: 19px 0px 10px 0px;
 }
 .TopscoreLabelIcon {
   margin: 26px 0px 0px 0px;

--- a/views/topscore.html
+++ b/views/topscore.html
@@ -6,7 +6,7 @@
   var icon_map = {
     cash: '<div class="Buy Cash"></div>',
     profiles: '<div class="Buy Token"></div>',
-    xp: '<div class="TopscoreLabelStar">★</div>',
+    xp: '<div class="TopscoreLabelStar"><span>XP</span></div>',
     spent: '<div class="Buy Cash"></div>',
   };
   var headline_parts = String(type_headline).split(/<br\s*\/?>/i);

--- a/views/topscore.html
+++ b/views/topscore.html
@@ -3,10 +3,23 @@
   var data = D.gameNode.data || {};
   var type = D.gameNode.scoretype || 'cash';
   var type_headline = data.type_headlines[type];
+  var icon_map = {
+    cash: '<div class="Buy Cash"></div>',
+    profiles: '<div class="Buy Token"></div>',
+    xp: '<div class="TopscoreLabelStar">★</div>',
+    spent: '<div class="Buy Cash"></div>',
+  };
+  var headline_parts = String(type_headline).split(/<br\s*\/?>/i);
+  var headline_top = headline_parts.shift();
+  var headline_bottom = headline_parts.join(' ');
 %>
 
 <div class="TopscoreInline">
-  <div class="TopscoreLabel"><% print(type_headline); %></div>
+  <div class="TopscoreLabel">
+    <div class="TopscoreLabelLine"><% print(headline_top); %></div>
+    <div class="TopscoreLabelIcon"><%= icon_map[type] %></div>
+    <div class="TopscoreLabelLine"><% print(headline_bottom); %></div>
+  </div>
   <div class="LoadingSpinner"></div>
   <div class="TopscoreRank">
     <% print(_.renderView('topscore_rank.html', { data: data, parentdata: parentdata, type:type })); %>

--- a/views/topscore.html
+++ b/views/topscore.html
@@ -4,10 +4,10 @@
   var type = D.gameNode.scoretype || 'cash';
   var type_headline = data.type_headlines[type];
   var icon_map = {
-    cash: '<div class="Buy Cash"></div>',
-    profiles: '<div class="Buy Token"></div>',
+    cash: '<div class="TopscoreLabelCash"></div>',
+    profiles: '<div class="TopscoreLabelToken"></div>',
     xp: '<div class="TopscoreLabelStar"><span>XP</span></div>',
-    spent: '<div class="Buy Cash"></div>',
+    spent: '<div class="TopscoreLabelCash"></div>',
   };
   var headline_parts = String(type_headline).split(/<br\s*\/?>/i);
   var headline_top = headline_parts.shift();


### PR DESCRIPTION
## Summary

- Split the highscore headline at its `<br />` and insert the active tab's resource icon (cash / profiles / token / star) between the two title lines.
- Enlarged the title icon (sprite icons scaled 2.4×, XP star 38px) so it reads as part of the title.
- Tuned the vertical rhythm: largest gap above the icon, the first title line near the panel top, a tightened-then-balanced gap below the icon, and non-collapsing padding so the resource name has real breathing room above the leaderboard rows.

Applies to all four tabs: CASH and INVESTOR show the green money icon, PROFILES the profile icon, XP an orange star.

## Test plan

- [x] Existing `tests/e2e/topscores.spec.ts` and `tests/e2e/highscore-tab.spec.ts` still pass (row markup and testids unchanged).
- [x] Visually verified all four tabs (CASH / PROFILES / XP / INVESTOR) render the icon centered in the widened title gap.

https://claude.ai/code/session_01PRFHnz1SvnVaSL8vgkTiAE

---
_Generated by [Claude Code](https://claude.ai/code/session_01PRFHnz1SvnVaSL8vgkTiAE)_