### PR TITLE
Popup follow-ups: first-tab reset, hide arrows under subpop, shared PopupHeader, CSS tab visibility

### DIFF
--- a/css/Render.css
+++ b/css/Render.css
@@ -1754,6 +1754,13 @@
 .PopupTab.hidden {
   display: none;
 }
+/* Inactive ProjectPopup per-tab header description.  Legacy hid these
+   `[data-tab]` texts via the RenderTopLevelUI tab-switch JS that was
+   deleted with the engine; the `hidden` class is now CSS-backed (same
+   fix as `.PopupTab.hidden`). */
+.PopupText.TabText.hidden {
+  display: none;
+}
 .PopupTab.hasPopup .PopupPageArrowL,
 .PopupTab.hasPopup .PopupPageArrowR {
   display: none;

--- a/css/Render.css
+++ b/css/Render.css
@@ -1748,6 +1748,12 @@
 .Selector.standalone {
 
 }
+/* Inactive tab — Preact tabs render via display-toggle (not unmount)
+   so the lastTab / getComputedStyle contract holds; the class drives
+   it instead of an inline style. */
+.PopupTab.hidden {
+  display: none;
+}
 .PopupTab.hasPopup .PopupPageArrowL,
 .PopupTab.hasPopup .PopupPageArrowR {
   display: none;

--- a/scripts/components/popups/CityPopup.tsx
+++ b/scripts/components/popups/CityPopup.tsx
@@ -83,7 +83,12 @@ export function CityPopup({ vm, onClose, popup }: CityPopupProps) {
                   />
                 ))}
               </div>
-              <div class="Pagination Selector standalone">
+              {/* Legacy `.Selector.hasPopup { display:none }` — hide
+                  the selector (incl. standalone arrows) under an open
+                  token subpop overlay. */}
+              <div
+                class={`Pagination Selector standalone${containerOpen ? ' hasPopup' : ''}`}
+              >
                 <div class="SubpopHeader">
                   <div class="SubpopHeaderTitle">{t.selectorTitle}</div>
                 </div>

--- a/scripts/components/popups/CityPopup.tsx
+++ b/scripts/components/popups/CityPopup.tsx
@@ -4,9 +4,9 @@
 // provided-perp grids reusing the shared perpShared tiles/subpops.
 // No pagination (popup_city renders a single PerpPage per tab).
 
-import type { JSX } from 'preact';
 import { useState } from 'preact/hooks';
 import type { CityPopupVM } from '../../game/cityView.js';
+import { PopupHeader } from './PopupHeader.js';
 import type { PreactDialogHandle } from './dialogManager.js';
 import { NoItems, PerpProvidedSubpop, PerpProvidedTile, fireAction } from './perpShared.js';
 
@@ -25,10 +25,6 @@ export function CityPopup({ vm, onClose, popup }: CityPopupProps) {
   // active tab is enough.
   const [openKey, setOpenKey] = useState<number | null>(null);
 
-  const closeX = (e: JSX.TargetedMouseEvent<HTMLDivElement>): void => {
-    e.stopPropagation();
-    onClose();
-  };
   const switchTab = (pkey: string): void => {
     if (pkey === activeTab) return;
     setOpenKey(null);
@@ -37,16 +33,13 @@ export function CityPopup({ vm, onClose, popup }: CityPopupProps) {
 
   return (
     <div class="PopupBody">
-      <div class="PopupHeader">
-        {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
-        <div class="PopupClose" onClick={closeX}>
-          X
-        </div>
-        {/* biome-ignore lint/security/noDangerouslySetInnerHtml: locally produced sprite markup */}
-        <div class="PopupLogo" dangerouslySetInnerHTML={{ __html: vm.spriteHtml }} />
-        <div class="PopupTitle">{vm.title}</div>
-        <div class="PopupSubTitle">{vm.subtitle}</div>
-        <div class="PopupText">{vm.description}</div>
+      <PopupHeader
+        onClose={onClose}
+        spriteHtml={vm.spriteHtml}
+        title={vm.title}
+        subtitle={vm.subtitle}
+        description={vm.description}
+      >
         <div class="PopupMenu">
           {vm.tabs.map((t) => (
             // biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass
@@ -60,7 +53,7 @@ export function CityPopup({ vm, onClose, popup }: CityPopupProps) {
             </div>
           ))}
         </div>
-      </div>
+      </PopupHeader>
       <div class="PopupContent">
         {vm.tabs.map((t) => {
           const tabActive = activeTab === t.pkey;
@@ -86,9 +79,7 @@ export function CityPopup({ vm, onClose, popup }: CityPopupProps) {
               {/* Legacy `.Selector.hasPopup { display:none }` — hide
                   the selector (incl. standalone arrows) under an open
                   token subpop overlay. */}
-              <div
-                class={`Pagination Selector standalone${containerOpen ? ' hasPopup' : ''}`}
-              >
+              <div class={`Pagination Selector standalone${containerOpen ? ' hasPopup' : ''}`}>
                 <div class="SubpopHeader">
                   <div class="SubpopHeaderTitle">{t.selectorTitle}</div>
                 </div>

--- a/scripts/components/popups/CityPopup.tsx
+++ b/scripts/components/popups/CityPopup.tsx
@@ -7,6 +7,7 @@
 import { useState } from 'preact/hooks';
 import type { CityPopupVM } from '../../game/cityView.js';
 import { PopupHeader } from './PopupHeader.js';
+import { PopupMenu } from './PopupMenu.js';
 import type { PreactDialogHandle } from './dialogManager.js';
 import { NoItems, PerpProvidedSubpop, PerpProvidedTile, fireAction } from './perpShared.js';
 
@@ -40,19 +41,11 @@ export function CityPopup({ vm, onClose, popup }: CityPopupProps) {
         subtitle={vm.subtitle}
         description={vm.description}
       >
-        <div class="PopupMenu">
-          {vm.tabs.map((t) => (
-            // biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass
-            <div
-              key={t.pkey}
-              class={activeTab === t.pkey ? 'PopupMenuButton active' : 'PopupMenuButton'}
-              data-tab={t.pkey}
-              onClick={() => switchTab(t.pkey)}
-            >
-              {t.menuLabel}
-            </div>
-          ))}
-        </div>
+        <PopupMenu
+          tabs={vm.tabs.map((t) => ({ key: t.pkey, label: t.menuLabel }))}
+          activeKey={activeTab}
+          onSelect={switchTab}
+        />
       </PopupHeader>
       <div class="PopupContent">
         {vm.tabs.map((t) => {

--- a/scripts/components/popups/CityPopup.tsx
+++ b/scripts/components/popups/CityPopup.tsx
@@ -59,12 +59,7 @@ export function CityPopup({ vm, onClose, popup }: CityPopupProps) {
           const tabActive = activeTab === t.pkey;
           const containerOpen = tabActive && openKey !== null;
           return (
-            <div
-              key={t.pkey}
-              class="PopupTab"
-              data-tab={t.pkey}
-              style={tabActive ? undefined : 'display:none'}
-            >
+            <div key={t.pkey} class={tabActive ? 'PopupTab' : 'PopupTab hidden'} data-tab={t.pkey}>
               <div class={containerOpen ? 'SubpopContainer open' : 'SubpopContainer'}>
                 {t.subpops.map((s) => (
                   <PerpProvidedSubpop

--- a/scripts/components/popups/ClientPopup.tsx
+++ b/scripts/components/popups/ClientPopup.tsx
@@ -68,7 +68,7 @@ export function ClientPopup({ vm, onClose, popup }: ClientPopupProps) {
         description={vm.description}
       />
       <div class="PopupContent">
-        <div class="PopupTab">
+        <div class={openToken ? 'PopupTab hasPopup' : 'PopupTab'}>
           {/* SubpopContainer holds the subpops for BOTH token sets
               (legacy profileset_client.html); only `.open` toggles. */}
           <div class={openToken ? 'SubpopContainer open' : 'SubpopContainer'}>

--- a/scripts/components/popups/ClientPopup.tsx
+++ b/scripts/components/popups/ClientPopup.tsx
@@ -5,11 +5,11 @@
 // Charge/Collect button seam as Contact.  Token tile / subpop /
 // arrows / action seam are the shared `perpShared.tsx`.
 
-import type { JSX } from 'preact';
 import { useState } from 'preact/hooks';
 import type { ClientPopupVM } from '../../game/clientView.js';
 import type { TokenVM } from '../../game/tokenView.js';
 import i18n from '../../i18n.js';
+import { PopupHeader } from './PopupHeader.js';
 import type { PreactDialogHandle } from './dialogManager.js';
 import { PageArrows, TokenSubpop, TokenTile, fireAction } from './perpShared.js';
 
@@ -59,23 +59,14 @@ function TokenGrid({
 export function ClientPopup({ vm, onClose, popup }: ClientPopupProps) {
   const [openToken, setOpenToken] = useState<string | null>(null);
 
-  const closeX = (e: JSX.TargetedMouseEvent<HTMLDivElement>): void => {
-    e.stopPropagation();
-    onClose();
-  };
-
   return (
     <div class="PopupBody">
-      <div class="PopupHeader">
-        {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
-        <div class="PopupClose" onClick={closeX}>
-          X
-        </div>
-        {/* biome-ignore lint/security/noDangerouslySetInnerHtml: locally produced sprite markup */}
-        <div class="PopupLogo" dangerouslySetInnerHTML={{ __html: vm.spriteHtml }} />
-        <div class="PopupTitle">{vm.title}</div>
-        <div class="PopupText">{vm.description}</div>
-      </div>
+      <PopupHeader
+        onClose={onClose}
+        spriteHtml={vm.spriteHtml}
+        title={vm.title}
+        description={vm.description}
+      />
       <div class="PopupContent">
         <div class="PopupTab">
           {/* SubpopContainer holds the subpops for BOTH token sets

--- a/scripts/components/popups/ContactPopup.tsx
+++ b/scripts/components/popups/ContactPopup.tsx
@@ -34,7 +34,7 @@ export function ContactPopup({ vm, onClose, popup }: ContactPopupProps) {
         description={vm.description}
       />
       <div class="PopupContent">
-        <div class="PopupTab">
+        <div class={openToken ? 'PopupTab hasPopup' : 'PopupTab'}>
           {/* All token subpops stay mounted (matches legacy
               profileset.html); only `.open` toggles, so the CSS
               scale/opacity transition plays and the grid underneath

--- a/scripts/components/popups/ContactPopup.tsx
+++ b/scripts/components/popups/ContactPopup.tsx
@@ -3,10 +3,10 @@
 // Issue #80 phase 2 tier 5a.  Token tile / subpop / pagination /
 // action-button seam live in `perpShared.tsx` (shared with Client).
 
-import type { JSX } from 'preact';
 import { useState } from 'preact/hooks';
 import type { ContactPopupVM } from '../../game/contactView.js';
 import i18n from '../../i18n.js';
+import { PopupHeader } from './PopupHeader.js';
 import type { PreactDialogHandle } from './dialogManager.js';
 import { PageArrows, TokenSubpop, TokenTile, fireAction } from './perpShared.js';
 
@@ -25,23 +25,14 @@ export function ContactPopup({ vm, onClose, popup }: ContactPopupProps) {
   const pageCount = Math.max(1, Math.ceil(vm.tokens.length / vm.pageSize));
   const pageTokens = vm.tokens.slice(page * vm.pageSize, page * vm.pageSize + vm.pageSize);
 
-  const closeX = (e: JSX.TargetedMouseEvent<HTMLDivElement>): void => {
-    e.stopPropagation();
-    onClose();
-  };
-
   return (
     <div class="PopupBody">
-      <div class="PopupHeader">
-        {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
-        <div class="PopupClose" onClick={closeX}>
-          X
-        </div>
-        {/* biome-ignore lint/security/noDangerouslySetInnerHtml: locally produced sprite markup */}
-        <div class="PopupLogo" dangerouslySetInnerHTML={{ __html: vm.spriteHtml }} />
-        <div class="PopupTitle">{vm.title}</div>
-        <div class="PopupText">{vm.description}</div>
-      </div>
+      <PopupHeader
+        onClose={onClose}
+        spriteHtml={vm.spriteHtml}
+        title={vm.title}
+        description={vm.description}
+      />
       <div class="PopupContent">
         <div class="PopupTab">
           {/* All token subpops stay mounted (matches legacy

--- a/scripts/components/popups/PopupHeader.tsx
+++ b/scripts/components/popups/PopupHeader.tsx
@@ -1,0 +1,76 @@
+// Shared `.PopupHeader` chrome — the close button + logo + title +
+// optional subtitle/description block that every non-trivial dialog
+// (Contact / Client / ProfileSet / City / Token / ProvidedPerp / …)
+// reproduced verbatim, each with its own identical `closeX` handler.
+// One component so the header markup + close behaviour lives in a
+// single place (notably: one spot to restyle for the mobile port).
+//
+// Every field is opt-in so each caller's exact DOM is preserved: a
+// prop that's omitted renders no element (callers that always emitted
+// an empty `.PopupSubTitle` pass `subtitle=""`).  `children` render
+// after the description for headers that carry extra content
+// (City's `.PopupMenu` tab strip, Token's `.PopupButtons`).
+
+import type { ComponentChildren, JSX } from 'preact';
+
+export interface PopupHeaderProps {
+  /** Framework `onClose`; the X stops propagation so the backdrop
+   *  handler doesn't double-fire (mirrors the old per-file `closeX`). */
+  onClose: () => void;
+  /** `MainSpritesPopup` logo class.  Takes precedence over `spriteHtml`.
+   *  `| undefined` so callers can forward an optional VM field directly
+   *  under `exactOptionalPropertyTypes`. */
+  mainspritesClass?: string | undefined;
+  /** Pre-rendered sprite markup for the logo (legacy `<%= sprite %>`). */
+  spriteHtml?: string;
+  title: string;
+  /** Plain-text subtitle. */
+  subtitle?: string;
+  /** Raw-HTML subtitle (legacy `<% print %>`); wins over `subtitle`. */
+  subtitleHtml?: string;
+  /** Plain-text description (`.PopupText`). */
+  description?: string;
+  /** Extra in-header content rendered after the description. */
+  children?: ComponentChildren;
+}
+
+export function PopupHeader({
+  onClose,
+  mainspritesClass,
+  spriteHtml,
+  title,
+  subtitle,
+  subtitleHtml,
+  description,
+  children,
+}: PopupHeaderProps) {
+  const close = (e: JSX.TargetedMouseEvent<HTMLDivElement>): void => {
+    e.stopPropagation();
+    onClose();
+  };
+  return (
+    <div class="PopupHeader">
+      {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
+      <div class="PopupClose" onClick={close}>
+        X
+      </div>
+      {mainspritesClass ? (
+        <div class="PopupLogo">
+          <div class={`MainSpritesPopup ${mainspritesClass}`} />
+        </div>
+      ) : (
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: locally produced sprite markup
+        <div class="PopupLogo" dangerouslySetInnerHTML={{ __html: spriteHtml ?? '' }} />
+      )}
+      <div class="PopupTitle">{title}</div>
+      {subtitleHtml !== undefined ? (
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: raw ruleset HTML (legacy <% print %>)
+        <div class="PopupSubTitle" dangerouslySetInnerHTML={{ __html: subtitleHtml }} />
+      ) : subtitle !== undefined ? (
+        <div class="PopupSubTitle">{subtitle}</div>
+      ) : null}
+      {description !== undefined ? <div class="PopupText">{description}</div> : null}
+      {children}
+    </div>
+  );
+}

--- a/scripts/components/popups/PopupHeader.tsx
+++ b/scripts/components/popups/PopupHeader.tsx
@@ -1,15 +1,16 @@
 // Shared `.PopupHeader` chrome — the close button + logo + title +
-// optional subtitle/description block that every non-trivial dialog
-// (Contact / Client / ProfileSet / City / Token / ProvidedPerp / …)
-// reproduced verbatim, each with its own identical `closeX` handler.
-// One component so the header markup + close behaviour lives in a
-// single place (notably: one spot to restyle for the mobile port).
+// optional subtitle/description block that Contact / Client /
+// ProfileSet / City / Token / ProvidedPerp reproduced verbatim, each
+// with its own identical `closeX` handler.  One component so the
+// header markup + close behaviour lives in a single place (notably:
+// one spot to restyle for the mobile port).  ProjectPopup keeps its
+// own header — its per-tab `.PopupText.TabText` descriptions render
+// between title and menu, which this layout doesn't model.
 //
-// Every field is opt-in so each caller's exact DOM is preserved: a
-// prop that's omitted renders no element (callers that always emitted
-// an empty `.PopupSubTitle` pass `subtitle=""`).  `children` render
-// after the description for headers that carry extra content
-// (City's `.PopupMenu` tab strip, Token's `.PopupButtons`).
+// Every field is opt-in so each caller's exact DOM is preserved: an
+// omitted prop renders no element.  `children` render after the
+// description for headers that carry extra content (City's
+// `.PopupMenu` tab strip, Token's `.PopupButtons`).
 
 import type { ComponentChildren, JSX } from 'preact';
 

--- a/scripts/components/popups/PopupMenu.tsx
+++ b/scripts/components/popups/PopupMenu.tsx
@@ -1,0 +1,38 @@
+// Shared `.PopupMenu` tab strip — the `<div class="PopupMenu">` +
+// N × `<div class="PopupMenuButton[ active]" data-tab onClick>` block
+// that CityPopup and ProjectPopup emitted identically.  Presentational
+// only: the per-dialog `switchTab` *behaviour* (subpop close, bridge,
+// tab_change / lastTab) stays in the caller — just like <PopupHeader>
+// keeps the close handler's callers' concerns out of the markup.
+
+export interface PopupMenuTab {
+  /** `data-tab` value + the key passed to `onSelect`. */
+  key: string;
+  label: string;
+}
+
+export function PopupMenu({
+  tabs,
+  activeKey,
+  onSelect,
+}: {
+  tabs: PopupMenuTab[];
+  activeKey: string;
+  onSelect: (key: string) => void;
+}) {
+  return (
+    <div class="PopupMenu">
+      {tabs.map((t) => (
+        // biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass
+        <div
+          key={t.key}
+          class={activeKey === t.key ? 'PopupMenuButton active' : 'PopupMenuButton'}
+          data-tab={t.key}
+          onClick={() => onSelect(t.key)}
+        >
+          {t.label}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/scripts/components/popups/ProfileSetPopup.tsx
+++ b/scripts/components/popups/ProfileSetPopup.tsx
@@ -36,7 +36,7 @@ export function ProfileSetPopup({ vm, onClose, popup }: ProfileSetPopupProps) {
         description={vm.description}
       />
       <div class="PopupContent">
-        <div class="PopupTab">
+        <div class={openToken ? 'PopupTab hasPopup' : 'PopupTab'}>
           <div class={openToken ? 'SubpopContainer open' : 'SubpopContainer'}>
             {vm.tokens.map((t) => (
               <TokenSubpop

--- a/scripts/components/popups/ProfileSetPopup.tsx
+++ b/scripts/components/popups/ProfileSetPopup.tsx
@@ -5,9 +5,9 @@
 // summary and one Import MainButton (routed through the same
 // `fireAction` seam, wired to `Database.mergeCued`).
 
-import type { JSX } from 'preact';
 import { useState } from 'preact/hooks';
 import type { ProfileSetPopupVM } from '../../game/profilesetView.js';
+import { PopupHeader } from './PopupHeader.js';
 import type { PreactDialogHandle } from './dialogManager.js';
 import { PageArrows, TokenSubpop, TokenTile, fireAction } from './perpShared.js';
 
@@ -26,24 +26,15 @@ export function ProfileSetPopup({ vm, onClose, popup }: ProfileSetPopupProps) {
   const pageCount = Math.max(1, Math.ceil(vm.tokens.length / vm.pageSize));
   const pageTokens = vm.tokens.slice(page * vm.pageSize, page * vm.pageSize + vm.pageSize);
 
-  const closeX = (e: JSX.TargetedMouseEvent<HTMLDivElement>): void => {
-    e.stopPropagation();
-    onClose();
-  };
-
   return (
     <div class="PopupBody">
-      <div class="PopupHeader">
-        {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
-        <div class="PopupClose" onClick={closeX}>
-          X
-        </div>
-        {/* biome-ignore lint/security/noDangerouslySetInnerHtml: locally produced sprite markup */}
-        <div class="PopupLogo" dangerouslySetInnerHTML={{ __html: vm.spriteHtml }} />
-        <div class="PopupTitle">{vm.title}</div>
-        <div class="PopupSubTitle">{vm.subtitle}</div>
-        <div class="PopupText">{vm.description}</div>
-      </div>
+      <PopupHeader
+        onClose={onClose}
+        spriteHtml={vm.spriteHtml}
+        title={vm.title}
+        subtitle={vm.subtitle}
+        description={vm.description}
+      />
       <div class="PopupContent">
         <div class="PopupTab">
           <div class={openToken ? 'SubpopContainer open' : 'SubpopContainer'}>

--- a/scripts/components/popups/ProjectPopup.tsx
+++ b/scripts/components/popups/ProjectPopup.tsx
@@ -555,7 +555,7 @@ export function ProjectPopup({ vm: initialVm, bridge, onClose, popup }: ProjectP
         </div>
       </div>
       <div class="PopupContent">
-        <div class="PopupTab data" data-tab="data" style={dataActive ? undefined : 'display:none'}>
+        <div class={dataActive ? 'PopupTab data' : 'PopupTab data hidden'} data-tab="data">
           <div class={openToken ? 'SubpopContainer open' : 'SubpopContainer'}>
             {vm.tokens.map((t) => (
               <TokenSubpop
@@ -650,13 +650,8 @@ export function ProjectPopup({ vm: initialVm, bridge, onClose, popup }: ProjectP
               return (
                 <div
                   key={cat.pkey}
-                  class={
-                    containerOpen
-                      ? `PopupTab Powerups ${cat.pkey} hasPopup`
-                      : `PopupTab Powerups ${cat.pkey}`
-                  }
+                  class={`PopupTab Powerups ${cat.pkey}${containerOpen ? ' hasPopup' : ''}${tabOpen ? '' : ' hidden'}`}
                   data-tab={cat.pkey}
-                  style={tabOpen ? undefined : 'display:none'}
                 >
                   <div class={containerOpen ? 'SubpopContainer open' : 'SubpopContainer'}>
                     {cat.sellSubpops.map((s) => (

--- a/scripts/components/popups/ProjectPopup.tsx
+++ b/scripts/components/popups/ProjectPopup.tsx
@@ -555,7 +555,10 @@ export function ProjectPopup({ vm: initialVm, bridge, onClose, popup }: ProjectP
         </div>
       </div>
       <div class="PopupContent">
-        <div class={dataActive ? 'PopupTab data' : 'PopupTab data hidden'} data-tab="data">
+        <div
+          class={`PopupTab data${dataActive ? '' : ' hidden'}${openToken ? ' hasPopup' : ''}`}
+          data-tab="data"
+        >
           <div class={openToken ? 'SubpopContainer open' : 'SubpopContainer'}>
             {vm.tokens.map((t) => (
               <TokenSubpop

--- a/scripts/components/popups/ProjectPopup.tsx
+++ b/scripts/components/popups/ProjectPopup.tsx
@@ -21,6 +21,7 @@ import type {
   SellSubpopVM,
 } from '../../game/powerupView.js';
 import i18n from '../../i18n.js';
+import { PopupMenu } from './PopupMenu.js';
 import type { PreactDialogHandle } from './dialogManager.js';
 import { PageArrows, TokenSubpop, TokenTile, fireAction } from './perpShared.js';
 
@@ -530,29 +531,16 @@ export function ProjectPopup({ vm: initialVm, bridge, onClose, popup }: ProjectP
             <div key={c.pkey} class={tcls} data-tab={c.pkey} dangerouslySetInnerHTML={html(tt)} />
           );
         })}
-        <div class="PopupMenu">
-          {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
-          <div
-            class={dataActive ? 'PopupMenuButton active' : 'PopupMenuButton'}
-            data-tab="data"
-            onClick={() => switchTab('data')}
-          >
-            {i18n.gettext('Data')}
-          </div>
-          {vm.categories
-            .filter((c) => c.menuVisible)
-            .map((c) => (
-              // biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass
-              <div
-                key={c.pkey}
-                class={activeTab === c.pkey ? 'PopupMenuButton active' : 'PopupMenuButton'}
-                data-tab={c.pkey}
-                onClick={() => switchTab(c.pkey)}
-              >
-                {c.menuLabel}
-              </div>
-            ))}
-        </div>
+        <PopupMenu
+          tabs={[
+            { key: 'data', label: i18n.gettext('Data') },
+            ...vm.categories
+              .filter((c) => c.menuVisible)
+              .map((c) => ({ key: c.pkey, label: c.menuLabel })),
+          ]}
+          activeKey={activeTab}
+          onSelect={switchTab}
+        />
       </div>
       <div class="PopupContent">
         <div

--- a/scripts/components/popups/ProvidedPerpPopup.tsx
+++ b/scripts/components/popups/ProvidedPerpPopup.tsx
@@ -5,9 +5,9 @@
 // per-perp views resolve the subtitle / selector title / tile kind /
 // button-disabled / empty-state copy into one `ProvidedPopupVM`.
 
-import type { JSX } from 'preact';
 import { useState } from 'preact/hooks';
 import type { ProvidedPopupVM } from '../../game/providedView.js';
+import { PopupHeader } from './PopupHeader.js';
 import type { PreactDialogHandle } from './dialogManager.js';
 import {
   NoItems,
@@ -36,30 +36,16 @@ export function ProvidedPerpPopup({ vm, onClose, popup }: ProvidedPerpPopupProps
   const pageCount = Math.max(1, Math.ceil(vm.tiles.length / vm.pageSize));
   const pageTiles = vm.tiles.slice(page * vm.pageSize, page * vm.pageSize + vm.pageSize);
 
-  const closeX = (e: JSX.TargetedMouseEvent<HTMLDivElement>): void => {
-    e.stopPropagation();
-    onClose();
-  };
-
   return (
     <div class="PopupBody ProvidedPerp">
-      <div class="PopupHeader">
-        {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
-        <div class="PopupClose" onClick={closeX}>
-          X
-        </div>
-        {vm.mainspritesClass ? (
-          <div class="PopupLogo">
-            <div class={`MainSpritesPopup ${vm.mainspritesClass}`} />
-          </div>
-        ) : (
-          // biome-ignore lint/security/noDangerouslySetInnerHtml: locally produced sprite markup
-          <div class="PopupLogo" dangerouslySetInnerHTML={{ __html: vm.spriteHtml }} />
-        )}
-        <div class="PopupTitle">{vm.title}</div>
-        <div class="PopupSubTitle">{vm.subtitle}</div>
-        <div class="PopupText">{vm.description}</div>
-      </div>
+      <PopupHeader
+        onClose={onClose}
+        mainspritesClass={vm.mainspritesClass}
+        spriteHtml={vm.spriteHtml}
+        title={vm.title}
+        subtitle={vm.subtitle}
+        description={vm.description}
+      />
       <div class="PopupContent">
         <div class="PopupTab">
           {/* All subpops stay mounted; only `.open` toggles (matches

--- a/scripts/components/popups/ProvidedPerpPopup.tsx
+++ b/scripts/components/popups/ProvidedPerpPopup.tsx
@@ -75,7 +75,11 @@ export function ProvidedPerpPopup({ vm, onClose, popup }: ProvidedPerpPopupProps
               />
             ))}
           </div>
-          <div class="Pagination Selector standalone">
+          {/* Legacy `.Selector.hasPopup { display:none }` — hide the
+              whole selector (grid + standalone arrows + header) while
+              a token subpop overlays it, so the arrows don't poke out
+              from behind the overlay. */}
+          <div class={`Pagination Selector standalone${openKey !== null ? ' hasPopup' : ''}`}>
             {vm.selectorTitle || vm.karmaChip ? (
               <div class="SubpopHeader">
                 {vm.karmaChip ? (

--- a/scripts/components/popups/TokenPopup.tsx
+++ b/scripts/components/popups/TokenPopup.tsx
@@ -50,7 +50,7 @@ export function TokenPopup({ vm, onClose, popup }: TokenPopupProps) {
       </PopupHeader>
       {vm.isSuper ? (
         <div class="PopupContent">
-          <div class="PopupTab">
+          <div class={openToken ? 'PopupTab hasPopup' : 'PopupTab'}>
             <div class={openToken ? 'SubpopContainer half open' : 'SubpopContainer half'}>
               {vm.upgradeSubpops.map((s) => (
                 <TokenUpgradeSubpop

--- a/scripts/components/popups/TokenPopup.tsx
+++ b/scripts/components/popups/TokenPopup.tsx
@@ -5,9 +5,9 @@
 // SuperToken profileset grid + Compute/Update footer.  Reuses the
 // shared TokenTile/PageArrows/fireAction + the new TokenUpgradeSubpop.
 
-import type { JSX } from 'preact';
 import { useState } from 'preact/hooks';
 import type { TokenPopupVM } from '../../game/tokenPopupView.js';
+import { PopupHeader } from './PopupHeader.js';
 import type { PreactDialogHandle } from './dialogManager.js';
 import { PageArrows, TokenTile, TokenUpgradeSubpop, fireAction } from './perpShared.js';
 
@@ -26,24 +26,15 @@ export function TokenPopup({ vm, onClose, popup }: TokenPopupProps) {
   const pageCount = Math.max(1, Math.ceil(vm.tokens.length / vm.pageSize));
   const pageTokens = vm.tokens.slice(page * vm.pageSize, page * vm.pageSize + vm.pageSize);
 
-  const closeX = (e: JSX.TargetedMouseEvent<HTMLDivElement>): void => {
-    e.stopPropagation();
-    onClose();
-  };
-
   return (
     <div class={vm.isSuper ? 'PopupBody TokenPerp SuperToken' : 'PopupBody TokenPerp'}>
-      <div class="PopupHeader">
-        {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
-        <div class="PopupClose" onClick={closeX}>
-          X
-        </div>
-        {/* biome-ignore lint/security/noDangerouslySetInnerHtml: locally produced sprite markup */}
-        <div class="PopupLogo" dangerouslySetInnerHTML={{ __html: vm.spriteHtml }} />
-        <div class="PopupTitle">{vm.title}</div>
-        {/* biome-ignore lint/security/noDangerouslySetInnerHtml: raw ruleset HTML (legacy <% print %>) */}
-        <div class="PopupSubTitle" dangerouslySetInnerHTML={{ __html: vm.subtitleHtml }} />
-        <div class="PopupText">{vm.description}</div>
+      <PopupHeader
+        onClose={onClose}
+        spriteHtml={vm.spriteHtml}
+        title={vm.title}
+        subtitleHtml={vm.subtitleHtml}
+        description={vm.description}
+      >
         {vm.isSuper ? null : (
           <div class="PopupButtons">
             {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
@@ -56,7 +47,7 @@ export function TokenPopup({ vm, onClose, popup }: TokenPopupProps) {
             </div>
           </div>
         )}
-      </div>
+      </PopupHeader>
       {vm.isSuper ? (
         <div class="PopupContent">
           <div class="PopupTab">

--- a/scripts/game/ProjectPerp.ts
+++ b/scripts/game/ProjectPerp.ts
@@ -81,6 +81,21 @@ export class ProjectPerp extends GamePerp {
   }
 
   override openPopup(): RenderPopupLike {
+    // A genuine open always starts on the first tab.  `lastTab` only
+    // persists *within* an open session so the BuySlots Path-A
+    // re-mount (`updatePopup`) doesn't snap back to Data — it must
+    // not carry across opens.
+    this.lastTab = 'data';
+    return this.mountProjectPopup();
+  }
+
+  // Live-refetch / post-BuySlots re-mount (Path A) — see
+  // PusherPerp.updatePopup.  Rebuilds with the persisted `lastTab`.
+  override updatePopup(): RenderPopupLike {
+    return this.mountProjectPopup();
+  }
+
+  private mountProjectPopup(): RenderPopupLike {
     const vm = buildProjectPopupVM(
       (this.data ?? {}) as Parameters<typeof buildProjectPopupVM>[0],
       this.states,
@@ -95,12 +110,6 @@ export class ProjectPerp extends GamePerp {
       if (typeof tab === 'string') this.lastTab = tab;
     });
     return handle as RenderPopupLike;
-  }
-
-  // Live-refetch / post-BuySlots re-mount (Path A) — see
-  // PusherPerp.updatePopup.  Rebuilds with the persisted `lastTab`.
-  override updatePopup(): RenderPopupLike {
-    return this.openPopup();
   }
 
   constructor(config: GameNodeConfig) {


### PR DESCRIPTION
## Summary

Popup follow-ups on top of the merged phase-2 migration. Grew from the original A/B/C/D into **7 focused commits** as review surfaced two more cases (B only covered one of Data Dealer's two legacy "hide arrows" mechanisms) and two in-theme extensions (a second shared component for C, a second CSS-backing for D).

| Commit | Theme | What |
|---|---|---|
| `7463254` | **A** | **Project (Scheinfirma) always opens on the first tab.** `lastTab` only persisted so the BuySlots Path-A re-mount (`updatePopup`) wouldn't snap back to Data — but `openPopup` reused it too. Split the seam: `openPopup()` resets to `'data'`; `updatePopup()` keeps the tab via a shared `mountProjectPopup()`. |
| `b455547` | **B** | **Hide pagination under a token subpop — provided-grid path.** ProvidedPerp/Karma/Agent/Pusher/Proxy + City use `.Pagination Selector standalone`; its arrows sit outside the subpop overlay. Restored legacy `.Selector.hasPopup { display:none }` by setting `hasPopup` while a subpop is open. |
| `b18952d` | **B** | **…token-grid path too.** Data Dealer has a *second* legacy mechanism — `.PopupTab.hasPopup .PopupPageArrow{L,R}{display:none}` — for the token-detail subpop (Contact/Client/ProfileSet/SuperToken + Project's Data tab). Those dialogs never set `hasPopup` on `.PopupTab`, so arrows stayed visible (e.g. inspecting a token in Scheinfirma → Daten). Added it (Project's Powerups tabs already did this via `containerOpen`). |
| `686b214` | **C** | **Shared `<PopupHeader>`.** 6 dialogs reproduced the same `.PopupHeader { close, logo, title, [subtitle], [text] }` + an identical `closeX`. Hoisted into one component (logo via `mainspritesClass`\|`spriteHtml`, opt-in text/HTML subtitle + description, `children` for in-header extras). Contact/Client/ProfileSet/City/Token/ProvidedPerp share it — one place to restyle for mobile. |
| `3f8e8db` | **C** | **Shared `<PopupMenu>`.** City + Project emitted an identical `.PopupMenu > .PopupMenuButton[.active]` tab strip. Extracted the markup (`tabs`/`activeKey`/`onSelect`); the per-dialog `switchTab` behaviour (subpop close, ProjectBridge, `tab_change`/`lastTab`) stays in the callers — same presentational/behavioural split as `<PopupHeader>`. (Tab *state*/logic deliberately **not** unified — a shared hook would just take an `onSwitch` callback ≈ `switchTab`, adding indirection without removing meaningful code.) |
| `8b5b4e1` | **D** | **CSS-driven tab visibility.** Dialog *centering* was already pure CSS (flexbox `.PopupContainer.lockOn.PopupPreact`; the JS centering died with `RenderPopup`). The remaining inline-style magic — City/Project tab show/hide via `style={…'display:none'}` — became a scoped `.PopupTab.hidden { display:none }` class toggle (same display-toggle, `lastTab`/`getComputedStyle` contract intact). |
| `b311d83` | **D** | **CSS-back the ProjectPopup inactive tab-description hide.** `.PopupText.TabText.hidden` had no CSS rule — legacy hid those per-tab header texts via the deleted `RenderTopLevelUI` tab-switch JS, so inactive descriptions were no longer hidden (only masked by `.PopupText` overlap). Added the rule, mirroring `.PopupTab.hidden`. |

### Scope note (the mobile-porting ask)

The largest remaining duplication is the **token-grid + subpop + pagination** pattern (Contact/Client/ProfileSet/ProvidedPerp/City each re-implement `openToken`/`openKey` + `.SubpopContainer` + `.PopupPageWrap` + `PageArrows`). Unifying *that* is high-value for mobile but stateful across 5 components with real behavioural differences (page sizes, dual token sets, tab-scoped keys) — a risky single-PR rewrite, called out here as a dedicated follow-up. This PR takes the safe, high-leverage presentational slices (`<PopupHeader>`, `<PopupMenu>`) + the inline-style/inert-class removals.

## Validation

- [x] `typecheck` (both tsconfigs) + `lint` (Biome) — clean
- [x] **715 unit** (vitest)
- [x] `dialog-lifecycle` e2e — **49/49** (both shared components are DOM-equivalent — every `.PopupClose`/`.PopupTitle`/`.PopupSubTitle`/`.PopupText`/`.PopupLogo`/`.PopupMenu`/`.PopupMenuButton` selector still resolves; A/B/D behaviour changes regress nothing)
- [ ] Reviewer / manual smoke: reopen Scheinfirma → Data tab; open a token detail in Karma/City/Scheinfirma-Daten → next/prev arrows gone; Project/City tab switching + active highlight unaffected; Project header shows only the active tab's description

https://claude.ai/code/session_01QA3qjy8ieFMmcGAsYG7Mnb

---
_Generated by [Claude Code](https://claude.ai/code/session_01QA3qjy8ieFMmcGAsYG7Mnb)_