### PR TITLE
Popup dedup: shared TokenGrid + stopAndClose close handler

### DIFF
--- a/scripts/components/popups/ClientPopup.tsx
+++ b/scripts/components/popups/ClientPopup.tsx
@@ -7,11 +7,10 @@
 
 import { useState } from 'preact/hooks';
 import type { ClientPopupVM } from '../../game/clientView.js';
-import type { TokenVM } from '../../game/tokenView.js';
 import i18n from '../../i18n.js';
 import { PopupHeader } from './PopupHeader.js';
 import type { PreactDialogHandle } from './dialogManager.js';
-import { PageArrows, TokenSubpop, TokenTile, fireAction } from './perpShared.js';
+import { TokenGrid, TokenSubpop, fireAction } from './perpShared.js';
 
 export interface ClientPopupProps {
   vm: ClientPopupVM;
@@ -19,41 +18,6 @@ export interface ClientPopupProps {
   onClose: () => void;
   /** Framework-injected — the live perp popup handle. */
   popup: PreactDialogHandle;
-}
-
-/** One paged token grid — `profileset_client.html` renders the blue
- *  "provided" set and the orange "consumed" set with the same markup,
- *  differing only in the wrapper classes and page size. */
-function TokenGrid({
-  tokens,
-  pageSize,
-  paginationClass,
-  tokensClass,
-  onOpen,
-}: {
-  tokens: TokenVM[];
-  pageSize: number;
-  paginationClass: string;
-  tokensClass: string;
-  onOpen: (gestalt: string) => void;
-}) {
-  const [page, setPage] = useState(0);
-  const pageCount = Math.max(1, Math.ceil(tokens.length / pageSize));
-  const pageTokens = tokens.slice(page * pageSize, page * pageSize + pageSize);
-  return (
-    <div class={paginationClass}>
-      <div class={tokensClass}>
-        <div class="PopupPageWrap">
-          <div class="PopupPage" data-page-id={page}>
-            {pageTokens.map((t) => (
-              <TokenTile key={t.gestalt} token={t} onOpen={onOpen} />
-            ))}
-          </div>
-        </div>
-      </div>
-      <PageArrows page={page} pageCount={pageCount} setPage={setPage} />
-    </div>
-  );
 }
 
 export function ClientPopup({ vm, onClose, popup }: ClientPopupProps) {

--- a/scripts/components/popups/ContactPopup.tsx
+++ b/scripts/components/popups/ContactPopup.tsx
@@ -8,7 +8,7 @@ import type { ContactPopupVM } from '../../game/contactView.js';
 import i18n from '../../i18n.js';
 import { PopupHeader } from './PopupHeader.js';
 import type { PreactDialogHandle } from './dialogManager.js';
-import { PageArrows, TokenSubpop, TokenTile, fireAction } from './perpShared.js';
+import { TokenGrid, TokenSubpop, fireAction } from './perpShared.js';
 
 export interface ContactPopupProps {
   vm: ContactPopupVM;
@@ -19,11 +19,7 @@ export interface ContactPopupProps {
 }
 
 export function ContactPopup({ vm, onClose, popup }: ContactPopupProps) {
-  const [page, setPage] = useState(0);
   const [openToken, setOpenToken] = useState<string | null>(null);
-
-  const pageCount = Math.max(1, Math.ceil(vm.tokens.length / vm.pageSize));
-  const pageTokens = vm.tokens.slice(page * vm.pageSize, page * vm.pageSize + vm.pageSize);
 
   return (
     <div class="PopupBody">
@@ -49,18 +45,13 @@ export function ContactPopup({ vm, onClose, popup }: ContactPopupProps) {
               />
             ))}
           </div>
-          <div class="Pagination">
-            <div class="PopupTokens">
-              <div class="PopupPageWrap">
-                <div class="PopupPage" data-page-id={page}>
-                  {pageTokens.map((t) => (
-                    <TokenTile key={t.gestalt} token={t} onOpen={setOpenToken} />
-                  ))}
-                </div>
-              </div>
-            </div>
-            <PageArrows page={page} pageCount={pageCount} setPage={setPage} />
-          </div>
+          <TokenGrid
+            tokens={vm.tokens}
+            pageSize={vm.pageSize}
+            paginationClass="Pagination"
+            tokensClass="PopupTokens"
+            onOpen={setOpenToken}
+          />
           <div class="PopupSummary">
             <div class="PopupSummaryItem Profiles">
               <div class="RenderSprite Tobi" />

--- a/scripts/components/popups/PopupHeader.tsx
+++ b/scripts/components/popups/PopupHeader.tsx
@@ -12,7 +12,8 @@
 // description for headers that carry extra content (City's
 // `.PopupMenu` tab strip, Token's `.PopupButtons`).
 
-import type { ComponentChildren, JSX } from 'preact';
+import type { ComponentChildren } from 'preact';
+import { stopAndClose } from './dialogManager.js';
 
 export interface PopupHeaderProps {
   /** Framework `onClose`; the X stops propagation so the backdrop
@@ -45,10 +46,7 @@ export function PopupHeader({
   description,
   children,
 }: PopupHeaderProps) {
-  const close = (e: JSX.TargetedMouseEvent<HTMLDivElement>): void => {
-    e.stopPropagation();
-    onClose();
-  };
+  const close = stopAndClose(onClose);
   return (
     <div class="PopupHeader">
       {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}

--- a/scripts/components/popups/PopupShell.tsx
+++ b/scripts/components/popups/PopupShell.tsx
@@ -7,7 +7,8 @@
 // framework-injected prop) and call `stopPropagation` so the
 // dialog-manager backdrop click handler doesn't double-fire.
 
-import type { ComponentChildren, JSX } from 'preact';
+import type { ComponentChildren } from 'preact';
+import { stopAndClose } from './dialogManager.js';
 
 export interface PopupShellProps {
   /**
@@ -36,10 +37,7 @@ export function PopupShell({
   children,
   onClose,
 }: PopupShellProps) {
-  const close = (e: JSX.TargetedMouseEvent<HTMLDivElement>): void => {
-    e.stopPropagation();
-    onClose();
-  };
+  const close = stopAndClose(onClose);
   return (
     <div class={bodyClass ? `PopupBody ${bodyClass}` : 'PopupBody'}>
       <div class="PopupHeader">

--- a/scripts/components/popups/ProfileSetPopup.tsx
+++ b/scripts/components/popups/ProfileSetPopup.tsx
@@ -9,7 +9,7 @@ import { useState } from 'preact/hooks';
 import type { ProfileSetPopupVM } from '../../game/profilesetView.js';
 import { PopupHeader } from './PopupHeader.js';
 import type { PreactDialogHandle } from './dialogManager.js';
-import { PageArrows, TokenSubpop, TokenTile, fireAction } from './perpShared.js';
+import { TokenGrid, TokenSubpop, fireAction } from './perpShared.js';
 
 export interface ProfileSetPopupProps {
   vm: ProfileSetPopupVM;
@@ -20,11 +20,7 @@ export interface ProfileSetPopupProps {
 }
 
 export function ProfileSetPopup({ vm, onClose, popup }: ProfileSetPopupProps) {
-  const [page, setPage] = useState(0);
   const [openToken, setOpenToken] = useState<string | null>(null);
-
-  const pageCount = Math.max(1, Math.ceil(vm.tokens.length / vm.pageSize));
-  const pageTokens = vm.tokens.slice(page * vm.pageSize, page * vm.pageSize + vm.pageSize);
 
   return (
     <div class="PopupBody">
@@ -47,18 +43,13 @@ export function ProfileSetPopup({ vm, onClose, popup }: ProfileSetPopupProps) {
               />
             ))}
           </div>
-          <div class="Pagination">
-            <div class="PopupTokens">
-              <div class="PopupPageWrap">
-                <div class="PopupPage" data-page-id={page}>
-                  {pageTokens.map((t) => (
-                    <TokenTile key={t.gestalt} token={t} onOpen={setOpenToken} />
-                  ))}
-                </div>
-              </div>
-            </div>
-            <PageArrows page={page} pageCount={pageCount} setPage={setPage} />
-          </div>
+          <TokenGrid
+            tokens={vm.tokens}
+            pageSize={vm.pageSize}
+            paginationClass="Pagination"
+            tokensClass="PopupTokens"
+            onOpen={setOpenToken}
+          />
           <div class="PopupSummary">
             <div class="PopupSummaryItem Profiles">
               <div class="RenderSprite Tobi" />

--- a/scripts/components/popups/TokenPopup.tsx
+++ b/scripts/components/popups/TokenPopup.tsx
@@ -9,7 +9,7 @@ import { useState } from 'preact/hooks';
 import type { TokenPopupVM } from '../../game/tokenPopupView.js';
 import { PopupHeader } from './PopupHeader.js';
 import type { PreactDialogHandle } from './dialogManager.js';
-import { PageArrows, TokenTile, TokenUpgradeSubpop, fireAction } from './perpShared.js';
+import { TokenGrid, TokenUpgradeSubpop, fireAction } from './perpShared.js';
 
 export interface TokenPopupProps {
   vm: TokenPopupVM;
@@ -20,11 +20,7 @@ export interface TokenPopupProps {
 }
 
 export function TokenPopup({ vm, onClose, popup }: TokenPopupProps) {
-  const [page, setPage] = useState(0);
   const [openToken, setOpenToken] = useState<string | null>(null);
-
-  const pageCount = Math.max(1, Math.ceil(vm.tokens.length / vm.pageSize));
-  const pageTokens = vm.tokens.slice(page * vm.pageSize, page * vm.pageSize + vm.pageSize);
 
   return (
     <div class={vm.isSuper ? 'PopupBody TokenPerp SuperToken' : 'PopupBody TokenPerp'}>
@@ -61,18 +57,13 @@ export function TokenPopup({ vm, onClose, popup }: TokenPopupProps) {
                 />
               ))}
             </div>
-            <div class="Pagination half">
-              <div class="PopupTokens">
-                <div class="PopupPageWrap">
-                  <div class="PopupPage" data-page-id={page}>
-                    {pageTokens.map((t) => (
-                      <TokenTile key={t.gestalt} token={t} onOpen={setOpenToken} />
-                    ))}
-                  </div>
-                </div>
-              </div>
-              <PageArrows page={page} pageCount={pageCount} setPage={setPage} />
-            </div>
+            <TokenGrid
+              tokens={vm.tokens}
+              pageSize={vm.pageSize}
+              paginationClass="Pagination half"
+              tokensClass="PopupTokens"
+              onOpen={setOpenToken}
+            />
             <div class="PopupSummary half">
               <div class="PopupSummaryItem Profiles">
                 <div class="RenderSprite Tobi" />

--- a/scripts/components/popups/dialogManager.ts
+++ b/scripts/components/popups/dialogManager.ts
@@ -6,7 +6,7 @@
 // transition: opening a new Preact dialog while another (legacy or
 // Preact) is already active closes the existing one first.
 
-import { type ComponentChildren, type ComponentType, h, render } from 'preact';
+import { type ComponentChildren, type ComponentType, type JSX, h, render } from 'preact';
 import setup from '../../setup.js';
 
 // MainSprites.png window (x y, 65x65) for the legacy FX bling icons.
@@ -84,6 +84,19 @@ export type ExtendClass = 'Tutorial' | 'Alert' | 'NewItems' | 'LevelUp' | 'Missi
 export interface FXClassTarget {
   addClass(s: string): unknown;
   removeClass(s: string): unknown;
+}
+
+/** Popup close click handler — `stopPropagation` so the dialog
+ *  manager's backdrop click (which also closes) doesn't double-fire,
+ *  then `onClose`.  Every `.PopupClose` / `.SubpopClose` reproduced
+ *  this 3-liner verbatim. */
+export function stopAndClose(
+  onClose: () => void
+): (e: JSX.TargetedMouseEvent<HTMLDivElement>) => void {
+  return (e) => {
+    e.stopPropagation();
+    onClose();
+  };
 }
 
 /** Wrap a button element as an `FXClassTarget` so `no_cash`/`no_AP`/

--- a/scripts/components/popups/perpShared.tsx
+++ b/scripts/components/popups/perpShared.tsx
@@ -6,6 +6,7 @@
 // once here instead of being duplicated per perp component.
 
 import type { JSX } from 'preact';
+import { useState } from 'preact/hooks';
 import type { ProvidedSubpopVM, ProvidedTileVM } from '../../game/providedView.js';
 import type { TokenUpgradeSubpopVM } from '../../game/tokenPopupView.js';
 import type { TokenVM } from '../../game/tokenView.js';
@@ -129,6 +130,43 @@ export function PageArrows({
         onClick={() => setPage((p) => Math.max(p - 1, 0))}
       />
     </>
+  );
+}
+
+/** One paged token grid — `token.html` inside `profileset*.html`.
+ *  Owns its own page state; the wrapper classes + page size vary per
+ *  caller (Contact/ProfileSet `Pagination`/`PopupTokens`, Client's
+ *  provided/consumed halves, TokenPopup's SuperToken `Pagination
+ *  half`).  The subpop overlay + open-state stay with the caller. */
+export function TokenGrid({
+  tokens,
+  pageSize,
+  paginationClass,
+  tokensClass,
+  onOpen,
+}: {
+  tokens: TokenVM[];
+  pageSize: number;
+  paginationClass: string;
+  tokensClass: string;
+  onOpen: (gestalt: string) => void;
+}) {
+  const [page, setPage] = useState(0);
+  const pageCount = Math.max(1, Math.ceil(tokens.length / pageSize));
+  const pageTokens = tokens.slice(page * pageSize, page * pageSize + pageSize);
+  return (
+    <div class={paginationClass}>
+      <div class={tokensClass}>
+        <div class="PopupPageWrap">
+          <div class="PopupPage" data-page-id={page}>
+            {pageTokens.map((t) => (
+              <TokenTile key={t.gestalt} token={t} onOpen={onOpen} />
+            ))}
+          </div>
+        </div>
+      </div>
+      <PageArrows page={page} pageCount={pageCount} setPage={setPage} />
+    </div>
   );
 }
 

--- a/scripts/components/popups/perpShared.tsx
+++ b/scripts/components/popups/perpShared.tsx
@@ -11,7 +11,7 @@ import type { ProvidedSubpopVM, ProvidedTileVM } from '../../game/providedView.j
 import type { TokenUpgradeSubpopVM } from '../../game/tokenPopupView.js';
 import type { TokenVM } from '../../game/tokenView.js';
 import i18n from '../../i18n.js';
-import { type PreactDialogHandle, toFXTarget } from './dialogManager.js';
+import { type PreactDialogHandle, stopAndClose, toFXTarget } from './dialogManager.js';
 
 /** Fire the legacy `.Button` seam: park the clicked element +
  *  click point on the handle, then `popup.trigger('button_click.X')`
@@ -72,10 +72,7 @@ export function TokenSubpop({
   isOpen: boolean;
   onClose: () => void;
 }) {
-  const close = (e: JSX.TargetedMouseEvent<HTMLDivElement>): void => {
-    e.stopPropagation();
-    onClose();
-  };
+  const close = stopAndClose(onClose);
   const sub = token.subpop.subTitleHtml;
   return (
     <div class={isOpen ? 'Subpop open' : 'Subpop'} data-subpop-id={`token${token.gestalt}`}>
@@ -220,10 +217,7 @@ export function PerpProvidedSubpop({
   onClose: () => void;
   popup: PreactDialogHandle;
 }) {
-  const close = (e: JSX.TargetedMouseEvent<HTMLDivElement>): void => {
-    e.stopPropagation();
-    onClose();
-  };
+  const close = stopAndClose(onClose);
   const vd = subpop.valuesDetailsHtml;
   return (
     <div class={isOpen ? 'Subpop open' : 'Subpop'} data-subpop-id={subpop.key}>
@@ -292,10 +286,7 @@ export function TokenUpgradeSubpop({
   isOpen: boolean;
   onClose: () => void;
 }) {
-  const close = (e: JSX.TargetedMouseEvent<HTMLDivElement>): void => {
-    e.stopPropagation();
-    onClose();
-  };
+  const close = stopAndClose(onClose);
   return (
     <div
       class={isOpen ? 'Subpop TokenUpgrade open' : 'Subpop TokenUpgrade'}


### PR DESCRIPTION
## Summary

Finishes the popup dedup flagged during the mobile-readiness review. Two focused commits.

| Commit | What |
|---|---|
| `2f2635e` | **Promote shared `<TokenGrid>`.** ClientPopup already had a local `TokenGrid` (paged tile grid + arrows); Contact/ProfileSet inlined the **byte-identical** block and TokenPopup's SuperToken branch a `Pagination half` variant. Hoisted into `perpShared` and reused in all **4** — the paged-grid layout (the main mobile-port restyle surface) now lives once. Callers drop their now-encapsulated `page`/`pageCount`/`pageTokens` state; open-state + subpop overlay stay in callers (the share-markup / keep-behaviour split established by `<PopupHeader>`/`<PopupMenu>`). |
| `6465e0e` | **Dedupe the close handler into `dialogManager.stopAndClose`.** The byte-identical `(e) => { e.stopPropagation(); onClose(); }` was reproduced 5× (`PopupHeader`, `PopupShell`, 3 `perpShared` subpops). Hoisted to one factory — its home is `dialogManager` since the `stopPropagation` exists only to stop the dialog-manager backdrop click double-firing. |

### Deliberately **not** done: a shared `<ProvidedGrid>` (ProvidedPerp + City)

These two are the only consumers of the provided-perp grid and they diverge in **5 material ways**: ProvidedPerp paginates (`page` state, `<PageArrows standalone>`, `.PopupPage PerpPage data-page-id`), City doesn't (single PerpPage per tab, no arrows, no `data-page-id`); ProvidedPerp's SubpopHeader is conditional on `selectorTitle || karmaChip` and renders a karma chip, City's is an always-plain title; City's open-state is parent-controlled + tab-scoped, ProvidedPerp's is local. A shared component would need a `paginate` flag + conditional header slots for just 2 callers — the flag-sprawl / premature-abstraction pattern. `<TokenGrid>` earned extraction (4 byte-identical consumers); this doesn't. The ~5 shared wrapper-div lines aren't worth a flagged component. Noted here so it's a recorded decision, not an oversight.

## Validation

- [x] `typecheck` (both tsconfigs) + `lint` (Biome) — clean
- [x] **715 unit** (vitest)
- [x] `dialog-lifecycle` e2e — **49/49**, gated **per commit** (TokenGrid promotion DOM-equivalent for Contact/Client/ProfileSet/SuperToken; close-handler dedup behaviour-equivalent incl. the 4 `PopupShell` status popups)
- [ ] Reviewer / manual smoke: token grids paginate + open/close subpops in Contact/Client/ProfileSet/SuperToken; every `.PopupClose`/`.SubpopClose` still dismisses

## Why this matters for the mobile port

`<TokenGrid>` collapses the most layout-heavy, most-duplicated block (paged token grid + pagination) from 4 hand-rolled copies to one — that grid is the primary thing the mobile reflow/scale work will need to restyle, now done in a single place. Combined with the earlier `<PopupHeader>`/`<PopupMenu>`, the dialog chrome + grids are now centralized; the remaining mobile work is the layout strategy itself (scale vs reflow), not chasing duplicated markup.

https://claude.ai/code/session_01QA3qjy8ieFMmcGAsYG7Mnb

---
_Generated by [Claude Code](https://claude.ai/code/session_01QA3qjy8ieFMmcGAsYG7Mnb)_