### PR TITLE
Fix sellPowerup to disambiguate powerups by category at same slot

### DIFF
--- a/scripts/LocalEngine.ts
+++ b/scripts/LocalEngine.ts
@@ -1302,10 +1302,28 @@ export function sellPowerup(
 
   var idata: NodeInstanceData = node.instance_data || {};
   var powerups: PowerupDef[] = idata.powerups || [];
+
+  // Slot indices are per-category (Upgrade / Ad / TeamMember each keep
+  // their own 0-based slot grid) but `powerups` is one flat array, so a
+  // bare `p.slot === slot` match resolves the wrong category's entry and
+  // the removal filter drops every entry sharing that slot index.  Scope
+  // the match to the sold powerup's game type — mirrors the buyPowerup
+  // slot-occupied guard above.
+  var soldDef = _findPowerupDef(perpTypeData, gestalt);
+  var soldGameType = soldDef ? _gameTypeFrom(soldDef.full_type) : '';
+  var _entryGameType = function (p: PowerupDef): string {
+    if (p.full_type) return _gameTypeFrom(p.full_type);
+    var d = p.gestalt ? _findPowerupDef(perpTypeData, p.gestalt) : null;
+    return d ? _gameTypeFrom(d.full_type) : '';
+  };
+  var _isSold = function (p: PowerupDef | null | undefined): boolean {
+    return !!p && p.slot === slot && _entryGameType(p) === soldGameType;
+  };
+
   var puEntry: PowerupDef | null = null;
   for (var i = 0; i < powerups.length; i++) {
     var p0 = powerups[i];
-    if (p0 && p0.slot === slot) {
+    if (p0 && _isSold(p0)) {
       puEntry = p0;
       break;
     }
@@ -1317,7 +1335,7 @@ export function sellPowerup(
   var refund = Math.floor(price * 0.75);
 
   var newPowerups: PowerupDef[] = powerups.filter(function (p) {
-    return p && p.slot !== slot;
+    return p && !_isSold(p);
   });
   var mods = _computeModifiers(perpTypeData, newPowerups);
 

--- a/scripts/LocalEngine.ts
+++ b/scripts/LocalEngine.ts
@@ -1307,23 +1307,18 @@ export function sellPowerup(
   // their own 0-based slot grid) but `powerups` is one flat array, so a
   // bare `p.slot === slot` match resolves the wrong category's entry and
   // the removal filter drops every entry sharing that slot index.  Scope
-  // the match to the sold powerup's game type — mirrors the buyPowerup
-  // slot-occupied guard above.
+  // the match to the sold powerup's game type — same `full_type`-derived
+  // guard buyPowerup uses for its slot-occupied check above.
   var soldDef = _findPowerupDef(perpTypeData, gestalt);
   var soldGameType = soldDef ? _gameTypeFrom(soldDef.full_type) : '';
-  var _entryGameType = function (p: PowerupDef): string {
-    if (p.full_type) return _gameTypeFrom(p.full_type);
-    var d = p.gestalt ? _findPowerupDef(perpTypeData, p.gestalt) : null;
-    return d ? _gameTypeFrom(d.full_type) : '';
-  };
-  var _isSold = function (p: PowerupDef | null | undefined): boolean {
-    return !!p && p.slot === slot && _entryGameType(p) === soldGameType;
+  var isSold = function (p: PowerupDef | null | undefined): boolean {
+    return !!p && p.slot === slot && _gameTypeFrom(p.full_type) === soldGameType;
   };
 
   var puEntry: PowerupDef | null = null;
   for (var i = 0; i < powerups.length; i++) {
     var p0 = powerups[i];
-    if (p0 && _isSold(p0)) {
+    if (p0 && isSold(p0)) {
       puEntry = p0;
       break;
     }
@@ -1335,7 +1330,7 @@ export function sellPowerup(
   var refund = Math.floor(price * 0.75);
 
   var newPowerups: PowerupDef[] = powerups.filter(function (p) {
-    return p && !_isSold(p);
+    return p && !isSold(p);
   });
   var mods = _computeModifiers(perpTypeData, newPowerups);
 

--- a/scripts/game/ProjectPerp.ts
+++ b/scripts/game/ProjectPerp.ts
@@ -352,7 +352,12 @@ export class ProjectPerp extends GamePerp {
           return;
         }
         groot.updateGameValues(r.game_values || {}, r.levelup === true, r.missions);
-        gnode.data = mergeData(groot.getTypeData(gnode.gestalt), r.node?.instance_data);
+        // Merge into the live `gnode.data` (like BuyPowerup/BuySlots) —
+        // rebuilding from `getTypeData` drops runtime flags such as
+        // `powerupsCached`, which leaves the rebuilt VM stuck on the
+        // loading spinner.  `instance_data` wins in mergeData, so the
+        // post-sell (shorter) powerups array still replaces cleanly.
+        gnode.data = mergeData(gnode.data, r.node?.instance_data);
         gnode.addProvidedPowerup(bgestalt);
         gnode.compilePowerups();
         gnode.compileProfileSet();

--- a/tests/e2e/dialog-lifecycle.spec.ts
+++ b/tests/e2e/dialog-lifecycle.spec.ts
@@ -1050,6 +1050,24 @@ test.describe('Section J — in-popup action handlers', () => {
       bodySelector: '.PopupContainer.lockOn .PopupMenu',
       boost: { cash: 5_000, xp_level: 2, xp_value: 20 },
     });
+    // Drive fetchPowerups so `powerupsCached` is set and the powerup
+    // grid renders (real open path).  Without this the harness opens via
+    // bare openPopup(), the grid is never fetched, and the spinner is
+    // present regardless of Bug B — the regression guard below needs the
+    // non-spinner baseline to be meaningful.
+    await page.evaluate(() => {
+      const game = (window as any).__dd?._app?.game;
+      const gnode = game.getById('project001');
+      gnode.fetchPowerups(function () {
+        gnode.compilePowerups();
+        gnode.compileProfileSet?.();
+        if (gnode.renderPopup) gnode.updatePopup();
+      });
+    });
+    await expect(page.locator('.PopupContainer.lockOn .PopupTab.Powerups').first()).toBeAttached({
+      timeout: 3_000,
+    });
+    await expect(page.locator('.PopupContainer.lockOn .PopupContentLoading')).toHaveCount(0);
     // Buy through the popup's button_click first so the rest of the flow
     // (compilePowerups, slot taken) goes through the same wiring.  Use a
     // numeric slot so the engine's strict-equals slot match in
@@ -1107,6 +1125,18 @@ test.describe('Section J — in-popup action handlers', () => {
       return (state.nodes || []).find((n: any) => n.full_path === 'Imperium.project001');
     });
     expect(node?.instance_data?.powerups || []).toHaveLength(0);
+
+    // Regression (Bug B): SellPowerup rebuilt gnode.data from
+    // `getTypeData`, dropping the runtime `powerupsCached` flag, so the
+    // post-sell VM fell back to `cached:false` — the popup hung forever
+    // on the loading spinner with no powerup tabs (unresponsive dialog).
+    // The graceful slot-swap is `close_powerup` (400ms) → out (400ms) →
+    // setVm → in (400ms); settle well past that, then assert the dialog
+    // rebuilt into the *grid* (not the permanent spinner).  Verified to
+    // fail (`spinner:1, cat:0`) when the fix is reverted.
+    await page.waitForTimeout(2_000);
+    await expect(page.locator('.PopupContainer.lockOn .PopupContentLoading')).toHaveCount(0);
+    await expect(page.locator('.PopupContainer.lockOn .PopupTab.Powerups').first()).toBeAttached();
 
     await expectOpenAndClose(page, '.PopupContainer.lockOn .PopupMenu', 'x');
   });

--- a/tests/e2e/dialog-lifecycle.spec.ts
+++ b/tests/e2e/dialog-lifecycle.spec.ts
@@ -1126,14 +1126,14 @@ test.describe('Section J — in-popup action handlers', () => {
     });
     expect(node?.instance_data?.powerups || []).toHaveLength(0);
 
-    // Regression (Bug B): SellPowerup rebuilt gnode.data from
-    // `getTypeData`, dropping the runtime `powerupsCached` flag, so the
-    // post-sell VM fell back to `cached:false` — the popup hung forever
-    // on the loading spinner with no powerup tabs (unresponsive dialog).
-    // The graceful slot-swap is `close_powerup` (400ms) → out (400ms) →
-    // setVm → in (400ms); settle well past that, then assert the dialog
-    // rebuilt into the *grid* (not the permanent spinner).  Verified to
-    // fail (`spinner:1, cat:0`) when the fix is reverted.
+    // Regression: a post-sell perp-data rebuild that drops the runtime
+    // `powerupsCached` flag makes the rebuilt VM fall back to
+    // `cached:false`, hanging the dialog forever on the loading spinner.
+    // The buggy spinner only appears *after* the graceful slot-swap
+    // (`close_powerup` 400ms → out 400ms → setVm → in 400ms) and is then
+    // permanent, so an auto-retrying assertion would pass on the
+    // pre-rebuild DOM and miss it — a fixed settle past that ~1.2s chain
+    // is required before asserting the dialog rebuilt into the grid.
     await page.waitForTimeout(2_000);
     await expect(page.locator('.PopupContainer.lockOn .PopupContentLoading')).toHaveCount(0);
     await expect(page.locator('.PopupContainer.lockOn .PopupTab.Powerups').first()).toBeAttached();

--- a/tests/handlers/handlers.test.js
+++ b/tests/handlers/handlers.test.js
@@ -939,6 +939,77 @@ describe('sellPowerup — failure: slot empty', () => {
   });
 });
 
+// Regression: slot indices are per-category (Upgrade / Ad / TeamMember
+// each keep their own 0-based grid), so all three can occupy slot 0 at
+// once.  sellPowerup must disambiguate by the sold gestalt's game type —
+// a bare slot match would remove the wrong category's entry (and the
+// removal filter would drop every entry at that slot index).
+describe('sellPowerup — cross-category slot-0 collision', () => {
+  // upgrade001 price 160, ad002 price 90, teammember020 price 110 —
+  // all valid project001 provided powerups, all seeded at slot 0.
+  function mkCollisionState() {
+    const nodeWithPus = Object.assign({}, PROJECT_NODE, {
+      instance_data: {
+        x: 100,
+        y: 100,
+        powerups: [
+          { slot: 0, gestalt: 'teammember020', full_type: 'TeamMemberPowerup:teammember020' },
+          { slot: 0, gestalt: 'upgrade001', full_type: 'UpgradePowerup:upgrade001' },
+          { slot: 0, gestalt: 'ad002', full_type: 'AdPowerup:ad002' },
+        ],
+      },
+    });
+    return Object.assign({}, freshState('test@local'), { nodes: [nodeWithPus] });
+  }
+
+  const remaining = (result) => result.node.instance_data.powerups.map((p) => p.gestalt).sort();
+
+  it('selling the upgrade removes ONLY the upgrade (ad + team stay)', async () => {
+    setState(mkCollisionState());
+    const before = getState().game_values.cash_value;
+    const { result } = await sellPowerup(PROJECT_NODE.full_path, 0, 'upgrade001');
+    expect(result).not.toHaveProperty('error');
+    expect(remaining(result)).toEqual(['ad002', 'teammember020']);
+    expect(result.game_values.cash_value).toBe(before + Math.floor(160 * 0.75));
+  });
+
+  it('selling the ad removes ONLY the ad (upgrade + team stay)', async () => {
+    setState(mkCollisionState());
+    const before = getState().game_values.cash_value;
+    const { result } = await sellPowerup(PROJECT_NODE.full_path, 0, 'ad002');
+    expect(result).not.toHaveProperty('error');
+    expect(remaining(result)).toEqual(['teammember020', 'upgrade001']);
+    expect(result.game_values.cash_value).toBe(before + Math.floor(90 * 0.75));
+  });
+
+  it('selling the team member removes ONLY the team member (upgrade + ad stay)', async () => {
+    setState(mkCollisionState());
+    const before = getState().game_values.cash_value;
+    const { result } = await sellPowerup(PROJECT_NODE.full_path, 0, 'teammember020');
+    expect(result).not.toHaveProperty('error');
+    expect(remaining(result)).toEqual(['ad002', 'upgrade001']);
+    expect(result.game_values.cash_value).toBe(before + Math.floor(110 * 0.75));
+  });
+
+  it('returns error:1 when (slot, gestalt) names a category not at that slot', async () => {
+    // Only team member sits at slot 1; selling an ad at slot 1 must not
+    // fall back to a bare slot match and wipe the team member.
+    const node = Object.assign({}, PROJECT_NODE, {
+      instance_data: {
+        x: 100,
+        y: 100,
+        powerups: [
+          { slot: 1, gestalt: 'teammember020', full_type: 'TeamMemberPowerup:teammember020' },
+        ],
+      },
+    });
+    setState(Object.assign({}, freshState('test@local'), { nodes: [node] }));
+    const { result } = await sellPowerup(PROJECT_NODE.full_path, 1, 'ad002');
+    expect(result.error).toBe(1);
+    expect(getState().nodes[0].instance_data.powerups).toHaveLength(1);
+  });
+});
+
 // ── buyPerp ───────────────────────────────────────────────────────────────────
 //
 // Ruleset fixtures used:


### PR DESCRIPTION
## Summary
Fixed a critical bug in `sellPowerup` where powerups from different categories (Upgrade, Ad, TeamMember) could occupy the same slot index, causing the wrong powerup to be removed. Also fixed a regression where the powerup grid would hang on a loading spinner after selling a powerup.

## Key Changes

**LocalEngine.ts (sellPowerup function):**
- Added logic to extract the game type from a powerup's `full_type` field to disambiguate powerups by category
- Changed the powerup lookup and removal filters from matching only `slot` to matching both `slot` AND `game_type`
- This ensures that when multiple powerups occupy slot 0 (one from each category), only the intended category's powerup is removed

**ProjectPerp.ts (SellPowerup handler):**
- Changed `gnode.data` reconstruction from `mergeData(groot.getTypeData(...), r.node?.instance_data)` to `mergeData(gnode.data, r.node?.instance_data)`
- This preserves runtime flags like `powerupsCached` that were being lost when rebuilding from type data
- Prevents the post-sell popup from getting stuck on the loading spinner with no powerup tabs

**Test Coverage:**
- Added comprehensive regression tests for cross-category slot-0 collisions, verifying that selling each category removes only the intended powerup
- Added test for error handling when attempting to sell a powerup category that doesn't exist at the specified slot
- Added e2e test to verify the popup grid renders correctly after selling a powerup (not stuck on spinner)

## Implementation Details
- Slot indices are per-category, so each category maintains its own 0-based grid
- The `_gameTypeFrom()` helper extracts the category from a powerup's `full_type` field (e.g., "UpgradePowerup:upgrade001" → "UpgradePowerup")
- The fix mirrors the existing slot-occupied guard in `buyPowerup` for consistency

https://claude.ai/code/session_01WHvLGLMAcajcjLp11vhuxp