### PR TITLE
Fix buy_powerup mission goals not completing for already-owned upgrades

### DIFF
--- a/scripts/LocalEngine.ts
+++ b/scripts/LocalEngine.ts
@@ -1716,6 +1716,32 @@ function _autoCompleteBuyPerpGoals(
   return changed ? result : goals;
 }
 
+// buy_powerup analogue of _autoCompleteBuyPerpGoals. Powerups live in each
+// node's instance_data.powerups[] rather than as standalone nodes, so a
+// mission that unlocks after the player already owns the powerup would stay
+// stuck (the goal only advances on a fresh buyPowerup event — which is why
+// re-buying after a sell was the only workaround). Same same-reference
+// contract so callers can detect "nothing changed".
+function _autoCompleteBuyPowerupGoals(
+  goals: MissionGoal[],
+  nodes: GameNode[] | undefined
+): MissionGoal[] {
+  var owned: Record<string, true> = {};
+  (nodes || []).forEach(function (n) {
+    var pus = ((n.instance_data as NodeInstanceData) || {}).powerups || [];
+    pus.forEach(function (pu) {
+      if (pu && pu.gestalt) owned[pu.gestalt] = true;
+    });
+  });
+  var changed = false;
+  var result = goals.map(function (g) {
+    if (g.workflow !== 'buy_powerup' || g.complete || !owned[g.target]) return g;
+    changed = true;
+    return _completeGoal(g);
+  });
+  return changed ? result : goals;
+}
+
 function _eachMissionDef(ruleset: Ruleset, fn: (def: MissionDef) => void): void {
   if (!ruleset.missions) return;
   for (var i = 0; i < ruleset.missions.length; i++) {
@@ -1750,9 +1776,11 @@ function _seedMissionGoals(state: LocalState): LocalState {
     });
   });
 
-  // Repair stuck buy_perp goals for items the player already owns — covers
-  // both newly seeded goals and goals seeded before a prior session ended.
+  // Repair stuck buy_perp / buy_powerup goals for items the player already
+  // owns — covers both newly seeded goals and goals seeded before a prior
+  // session ended.
   var repairedGoals = _autoCompleteBuyPerpGoals(newGoals, state.nodes);
+  repairedGoals = _autoCompleteBuyPowerupGoals(repairedGoals, state.nodes);
   if (!added && repairedGoals === newGoals) return state;
   return Object.assign({}, state, { mission_goals: repairedGoals });
 }
@@ -1897,6 +1925,7 @@ function _completeMissionsIfReady(
       // yet (e.g. the perp just bought this turn), stranding the cascaded
       // mission until a reload replayed the log.
       updatedGoals = _autoCompleteBuyPerpGoals(updatedGoals, nodes);
+      updatedGoals = _autoCompleteBuyPowerupGoals(updatedGoals, nodes);
     }
   }
 

--- a/scripts/LocalEngine.ts
+++ b/scripts/LocalEngine.ts
@@ -1726,6 +1726,10 @@ function _autoCompleteBuyPowerupGoals(
   goals: MissionGoal[],
   nodes: GameNode[] | undefined
 ): MissionGoal[] {
+  var hasCandidate = goals.some(function (g) {
+    return g.workflow === 'buy_powerup' && !g.complete;
+  });
+  if (!hasCandidate) return goals;
   var owned: Record<string, true> = {};
   (nodes || []).forEach(function (n) {
     var pus = ((n.instance_data as NodeInstanceData) || {}).powerups || [];

--- a/tests/handlers/handlers.test.js
+++ b/tests/handlers/handlers.test.js
@@ -1457,6 +1457,72 @@ describe('buyPerp — loadGame repairs stuck buy_perp goal', () => {
   });
 });
 
+// Regression: a buy_powerup goal whose target the player already owns (the
+// powerup sits in a node's instance_data.powerups[]) stayed stuck on load —
+// it only advanced on a fresh buyPowerup event, so the player had to sell and
+// re-buy the upgrade to clear the objective.
+describe('buyPowerup — loadGame repairs stuck buy_powerup goal', () => {
+  const OWNED_PROJECT_NODE = Object.assign({}, PROJECT_NODE, {
+    instance_data: { x: 100, y: 100, powerups: [{ slot: 0, gestalt: 'ad002' }] },
+  });
+
+  it('marks buy_powerup goal complete when the powerup is already owned at load time', async () => {
+    setState(
+      Object.assign(mkBuyPerpState(), {
+        active_missions: ['mission006'],
+        mission_goals: [
+          {
+            mission: 'mission006',
+            workflow: 'buy_powerup',
+            target: 'ad002',
+            amount: null,
+            position: 1,
+            current_amount: 0,
+            complete: false,
+          },
+        ],
+        nodes: mkBuyPerpState().nodes.concat([OWNED_PROJECT_NODE]),
+      })
+    );
+
+    await loadGame();
+
+    const goal = getState().mission_goals.find(
+      (g) => g.mission === 'mission006' && g.workflow === 'buy_powerup'
+    );
+    expect(goal).toBeDefined();
+    expect(goal.complete).toBe(true);
+  });
+
+  it('does not alter buy_powerup goals when the powerup is not yet owned', async () => {
+    setState(
+      Object.assign(mkBuyPerpState(), {
+        active_missions: ['mission006'],
+        mission_goals: [
+          {
+            mission: 'mission006',
+            workflow: 'buy_powerup',
+            target: 'ad002',
+            amount: null,
+            position: 1,
+            current_amount: 0,
+            complete: false,
+          },
+        ],
+        nodes: mkBuyPerpState().nodes.concat([PROJECT_NODE]),
+      })
+    );
+
+    await loadGame();
+
+    const goal = getState().mission_goals.find(
+      (g) => g.mission === 'mission006' && g.workflow === 'buy_powerup'
+    );
+    expect(goal).toBeDefined();
+    expect(goal.complete).toBe(false);
+  });
+});
+
 describe('recheckMissions — recovers stuck goals (current_amount >= amount)', () => {
   it('flips a stuck integrate_profiles goal to complete and finishes the mission', async () => {
     setState(


### PR DESCRIPTION
## Summary

When a mission with `buy_powerup` goals seeded while the player already owned the target upgrades (e.g. "Gewinnspiel erweitern" requiring Logo & Design / Verteilen in Einkaufszentren / Praktikant), the objectives stayed at `0/1` until the player **sold and re-bought** each upgrade — only a fresh `buyPowerup` event advanced them.

The codebase already had `_autoCompleteBuyPerpGoals` to repair the equivalent problem for `buy_perp` goals (whose targets are standalone nodes). There was no sibling for `buy_powerup`, whose targets live in `node.instance_data.powerups[]`.

- Add `_autoCompleteBuyPowerupGoals(goals, nodes)` in `scripts/LocalEngine.ts` — same same-reference contract as the perp helper.
- Wire it into both spots the perp version runs: `_seedMissionGoals` (fresh mission / game load) and the cascade in `_completeMissionsIfReady` (mission unlocked by completing a prereq).
- Regression tests in `tests/handlers/handlers.test.js` covering the owned and not-owned cases. Verified the new test fails on the prior code and passes with the fix.

Existing players with currently-stuck objectives will see them clear automatically on next load, since the repair also runs at load time.

## Audit of other workflow types

Checked all seven workflows for the same class of bug:

| Workflow | Trigger | Repair needed? |
|---|---|---|
| `buy_perp` | event | already repaired |
| `buy_powerup` | event | **fixed here** |
| `integrate_profiles` | event, but computes against absolute state via `Math.max` | self-heals on next integrate event |
| `charge_perp`, `collect_cash`, `collect_profiles`, `upgrade_token` | cumulative event counters / per-collect — no persistent "already done" state | not vulnerable |

## Test plan

- [x] `pnpm test` — 721/721 passing
- [x] `pnpm lint` (biome) clean on changed files
- [x] `pnpm typecheck` clean on `scripts/LocalEngine.ts` (pre-existing unrelated errors elsewhere)
- [x] New regression test fails without the fix, passes with it
- [ ] Manual: load a save where mission006 is active and the upgrades are already owned — objectives should appear checked off

https://claude.ai/code/session_01QSvFUaofsYZZHNAP9xNFiU

---
_Generated by [Claude Code](https://claude.ai/code/session_01QSvFUaofsYZZHNAP9xNFiU)_