### PR TITLE
Fix level-up handling to apply full effects and check post-reward

### DIFF
--- a/scripts/LocalEngine.ts
+++ b/scripts/LocalEngine.ts
@@ -1232,10 +1232,9 @@ export function buyPowerup(
   var puMissionResult = _advanceBuyPowerupMissions(preMissionStatePu, gestalt);
   newGameValues = _applyRewardsToGv(newGameValues, puMissionResult.rewards);
   // Mission rewards may add XP that crosses another level threshold — check again.
-  var postRewardLevel = _getLevelByXP(newGameValues.xp_value || 0);
-  if (postRewardLevel > (newGameValues.xp_level || 1)) {
+  if (_checkLevelup(newGameValues.xp_level || 1, newGameValues.xp_value || 0)) {
     levelup = true;
-    newGameValues = _applyLevelUp(newGameValues, postRewardLevel);
+    newGameValues = _applyLevelUp(newGameValues, _getLevelByXP(newGameValues.xp_value || 0));
   }
 
   var responseNode = {
@@ -3010,6 +3009,10 @@ export function recheckMissions(): Promise<{
   // Reward XP may push the player into a new level — apply energy refill if so.
   var rewardLevelup = _checkLevelup(state.game_values.xp_level || 1, newGv.xp_value || 0);
   if (rewardLevelup) newGv = _applyLevelUp(newGv, _getLevelByXP(newGv.xp_value || 0));
+  // `levelup` is intentionally not included in the persisted delta payload:
+  // game_values (which already carries the updated ap_max/ap_snapshot/xp_level)
+  // is the authoritative source for replay. Callers that need to show a
+  // level-up notification should read it from the returned result, not replay.
   _persistDelta(
     _mkDelta(state.addr, 'recheckMissions', [], {
       game_values: newGv,

--- a/scripts/LocalEngine.ts
+++ b/scripts/LocalEngine.ts
@@ -1223,7 +1223,7 @@ export function buyPowerup(
     xp_value: newXp,
     karma_value: (state.game_values.karma_value || 0) + 1,
   });
-  if (levelup) newGameValues.xp_level = _getLevelByXP(newXp);
+  if (levelup) newGameValues = _applyLevelUp(newGameValues, _getLevelByXP(newXp));
 
   var newNodes = state.nodes.slice();
   newNodes[nodeIdx] = Object.assign({}, node, { instance_data: newInstanceData });
@@ -1231,6 +1231,12 @@ export function buyPowerup(
   var preMissionStatePu = Object.assign({}, state, { nodes: newNodes, game_values: newGameValues });
   var puMissionResult = _advanceBuyPowerupMissions(preMissionStatePu, gestalt);
   newGameValues = _applyRewardsToGv(newGameValues, puMissionResult.rewards);
+  // Mission rewards may add XP that crosses another level threshold — check again.
+  var postRewardLevel = _getLevelByXP(newGameValues.xp_value || 0);
+  if (postRewardLevel > (newGameValues.xp_level || 1)) {
+    levelup = true;
+    newGameValues = _applyLevelUp(newGameValues, postRewardLevel);
+  }
 
   var responseNode = {
     game_id: node.game_id,
@@ -1349,7 +1355,7 @@ export function sellPowerup(
     cash_value: (state.game_values.cash_value || 0) + refund,
     xp_value: newXp,
   });
-  if (levelup) newGameValues.xp_level = _getLevelByXP(newXp);
+  if (levelup) newGameValues = _applyLevelUp(newGameValues, _getLevelByXP(newXp));
 
   var newNodes = state.nodes.slice();
   newNodes[nodeIdx] = Object.assign({}, node, { instance_data: newInstanceData });
@@ -1434,7 +1440,7 @@ export function buySlots(
     cash_spent: (state.game_values.cash_spent || 0) + totalCost,
     xp_value: newXp,
   });
-  if (levelup) newGameValues.xp_level = _getLevelByXP(newXp);
+  if (levelup) newGameValues = _applyLevelUp(newGameValues, _getLevelByXP(newXp));
 
   var newNodes = state.nodes.slice();
   newNodes[nodeIdx] = Object.assign({}, node, { instance_data: newInstanceData });
@@ -2993,7 +2999,7 @@ export function dismissMissionBriefing(
 export function recheckMissions(): Promise<{
   result:
     | { repaired: false }
-    | { repaired: true; missions: MissionUpdate; game_values: GameValues; levelup: false };
+    | { repaired: true; missions: MissionUpdate; game_values: GameValues; levelup: boolean };
 }> {
   var state = getState();
   var repair = _repairStuckMissionGoals(state);
@@ -3001,6 +3007,9 @@ export function recheckMissions(): Promise<{
     return Promise.resolve({ result: { repaired: false } });
   }
   var newGv = _applyRewardsToGv(state.game_values || {}, repair.rewards);
+  // Reward XP may push the player into a new level — apply energy refill if so.
+  var rewardLevelup = _checkLevelup(state.game_values.xp_level || 1, newGv.xp_value || 0);
+  if (rewardLevelup) newGv = _applyLevelUp(newGv, _getLevelByXP(newGv.xp_value || 0));
   _persistDelta(
     _mkDelta(state.addr, 'recheckMissions', [], {
       game_values: newGv,
@@ -3008,7 +3017,12 @@ export function recheckMissions(): Promise<{
     })
   );
   return Promise.resolve({
-    result: { repaired: true, missions: repair.missions, game_values: newGv, levelup: false },
+    result: {
+      repaired: true,
+      missions: repair.missions,
+      game_values: newGv,
+      levelup: rewardLevelup,
+    },
   });
 }
 

--- a/tests/handlers/handlers.test.js
+++ b/tests/handlers/handlers.test.js
@@ -867,6 +867,42 @@ describe('buyPowerup — failure: insufficient cash', () => {
   });
 });
 
+// project001 xp_inc=2; starting at xp_value=9/xp_level=1 a single
+// buyPowerup lands at xp=11, crossing to level 2 (xp_min=11, ap_max=8).
+describe('buyPowerup — level-up refills ap_snapshot and raises ap_max', () => {
+  beforeEach(() => {
+    setOverride(FIXED_NOW);
+    setState(
+      mkProjectState({
+        game_values: Object.assign({}, freshState('test@local').game_values, {
+          xp_value: 9,
+          xp_level: 1,
+          ap_snapshot: 2,
+          ap_max: 6,
+          ap_update: FIXED_NOW,
+          cash_value: 1000,
+        }),
+      })
+    );
+  });
+  afterEach(() => clearOverride());
+
+  it('returns levelup=true and refills ap_snapshot to the new ap_max', async () => {
+    const { result } = await buyPowerup(PROJECT_NODE.full_path, 0, 'ad002');
+    expect(result.levelup).toBe(true);
+    expect(result.game_values.xp_level).toBe(2);
+    expect(result.game_values.ap_snapshot).toBe(8);
+    expect(result.game_values.ap_max).toBe(8);
+  });
+
+  it('keeps the refill across a subsequent materialize() pass', async () => {
+    await buyPowerup(PROJECT_NODE.full_path, 0, 'ad002');
+    const mat = materialize(getState(), FIXED_NOW + 1);
+    expect(mat.state.game_values.ap_snapshot).toBe(8);
+    expect(mat.state.game_values.ap_max).toBe(8);
+  });
+});
+
 // ── sellPowerup ───────────────────────────────────────────────────────────────
 
 // State with ad002 already occupying slot 0.
@@ -936,6 +972,42 @@ describe('sellPowerup — failure: slot empty', () => {
     setState(mkProjectState());
     const { result } = await sellPowerup(PROJECT_NODE.full_path, 99, 'ad002');
     expect(result.error).toBe(1);
+  });
+});
+
+// sellPowerup xp_inc=1; starting at xp_value=9/xp_level=1 lands at xp=10,
+// which meets L1's xp_max threshold and promotes to level 2 (ap_max=8).
+describe('sellPowerup — level-up refills ap_snapshot and raises ap_max', () => {
+  beforeEach(() => {
+    setOverride(FIXED_NOW);
+    var base = mkStateWithPowerup();
+    setState(
+      Object.assign({}, base, {
+        game_values: Object.assign({}, base.game_values, {
+          xp_value: 9,
+          xp_level: 1,
+          ap_snapshot: 2,
+          ap_max: 6,
+          ap_update: FIXED_NOW,
+        }),
+      })
+    );
+  });
+  afterEach(() => clearOverride());
+
+  it('returns levelup=true and refills ap_snapshot to the new ap_max', async () => {
+    const { result } = await sellPowerup(PROJECT_NODE.full_path, 0, 'ad002');
+    expect(result.levelup).toBe(true);
+    expect(result.game_values.xp_level).toBe(2);
+    expect(result.game_values.ap_snapshot).toBe(8);
+    expect(result.game_values.ap_max).toBe(8);
+  });
+
+  it('keeps the refill across a subsequent materialize() pass', async () => {
+    await sellPowerup(PROJECT_NODE.full_path, 0, 'ad002');
+    const mat = materialize(getState(), FIXED_NOW + 1);
+    expect(mat.state.game_values.ap_snapshot).toBe(8);
+    expect(mat.state.game_values.ap_max).toBe(8);
   });
 });
 
@@ -1288,6 +1360,42 @@ describe('buySlots — failure: insufficient cash', () => {
   });
 });
 
+// buySlots xp_inc=1; starting at xp_value=9/xp_level=1 lands at xp=10,
+// which meets L1's xp_max threshold and promotes to level 2 (ap_max=8).
+describe('buySlots — level-up refills ap_snapshot and raises ap_max', () => {
+  beforeEach(() => {
+    setOverride(FIXED_NOW);
+    setState(
+      mkProjectState({
+        game_values: Object.assign({}, freshState('test@local').game_values, {
+          xp_value: 9,
+          xp_level: 1,
+          ap_snapshot: 2,
+          ap_max: 6,
+          ap_update: FIXED_NOW,
+          cash_value: 1000,
+        }),
+      })
+    );
+  });
+  afterEach(() => clearOverride());
+
+  it('returns levelup=true and refills ap_snapshot to the new ap_max', async () => {
+    const { result } = await buySlots(PROJECT_NODE.full_path, 'ad', 1);
+    expect(result.levelup).toBe(true);
+    expect(result.game_values.xp_level).toBe(2);
+    expect(result.game_values.ap_snapshot).toBe(8);
+    expect(result.game_values.ap_max).toBe(8);
+  });
+
+  it('keeps the refill across a subsequent materialize() pass', async () => {
+    await buySlots(PROJECT_NODE.full_path, 'ad', 1);
+    const mat = materialize(getState(), FIXED_NOW + 1);
+    expect(mat.state.game_values.ap_snapshot).toBe(8);
+    expect(mat.state.game_values.ap_max).toBe(8);
+  });
+});
+
 describe('buyPerp — failure: ProxyPerp slot full', () => {
   it('returns error 3 when proxy max_slots is reached', async () => {
     // proxy001 has max_slots=3.  Pre-fill 3 project children.
@@ -1635,6 +1743,79 @@ describe('recheckMissions — recovers stuck goals (current_amount >= amount)', 
     // Second recheck after the first persisted: nothing left to repair.
     await recheckMissions();
     expect(getState().game_values.xp_value).toBe(xpAfterFirst);
+  });
+});
+
+// mission007 reward is +10 XP. Starting at xp_value=1/xp_level=1, repairing
+// the stuck goal brings xp to 11, crossing to level 2 (ap_max=8).
+describe('recheckMissions — level-up from XP reward refills ap_snapshot', () => {
+  beforeEach(() => {
+    setOverride(FIXED_NOW);
+    setState(
+      Object.assign(mkBuyPerpState(), {
+        game_values: {
+          xp_value: 1,
+          xp_level: 1,
+          cash_value: 0,
+          cash_spent: 0,
+          karma_value: 0,
+          profiles_value: 0,
+          profiles_max: 1,
+          ap_snapshot: 2,
+          ap_max: 6,
+          ap_update: FIXED_NOW,
+          ap_inc_value: 1,
+          ap_inc_interval: 120000,
+        },
+        active_missions: ['mission007'],
+        mission_goals: [
+          {
+            mission: 'mission007',
+            workflow: 'buy_perp',
+            target: 'contact001',
+            amount: null,
+            position: 1,
+            current_amount: 1,
+            complete: true,
+          },
+          {
+            mission: 'mission007',
+            workflow: 'collect_profiles',
+            target: 'contact001',
+            amount: 3000,
+            position: 2,
+            current_amount: 3000,
+            complete: true,
+          },
+          {
+            mission: 'mission007',
+            workflow: 'integrate_profiles',
+            target: 'token017',
+            amount: 3000,
+            position: 3,
+            current_amount: 3000,
+            complete: false,
+          },
+        ],
+      })
+    );
+  });
+  afterEach(() => clearOverride());
+
+  it('returns levelup=true and refills ap_snapshot to the new ap_max', async () => {
+    const { result } = await recheckMissions();
+    expect(result.repaired).toBe(true);
+    expect(result.levelup).toBe(true);
+    expect(result.game_values.xp_level).toBe(2);
+    expect(result.game_values.ap_snapshot).toBe(8);
+    expect(result.game_values.ap_max).toBe(8);
+  });
+
+  it('keeps the refill across a subsequent materialize() pass', async () => {
+    await recheckMissions();
+    const mat = materialize(getState(), FIXED_NOW + 1);
+    expect(mat.state.game_values.ap_snapshot).toBe(8);
+    expect(mat.state.game_values.ap_max).toBe(8);
   });
 });
 


### PR DESCRIPTION
## Summary
This PR fixes level-up handling in several game functions to ensure that all level-up effects (such as energy refills) are properly applied, and adds checks for level-ups that occur after mission rewards are applied.

## Key Changes

- **Replaced direct XP level assignment with `_applyLevelUp()` calls**: In `buyPowerup()`, `sellPowerup()`, and `buySlots()`, changed from directly setting `xp_level` to calling `_applyLevelUp()` to ensure all level-up side effects are applied.

- **Added post-reward level-up check in `buyPowerup()`**: After mission rewards are applied, the code now checks if the player has crossed another level threshold and applies level-up effects if needed. This prevents players from missing level-up benefits when rewards push them over a level boundary.

- **Fixed `recheckMissions()` return type and logic**: 
  - Changed return type from hardcoded `levelup: false` to `levelup: boolean` to accurately reflect whether a level-up occurred
  - Added logic to detect and apply level-ups from mission reward XP
  - Now properly calls `_applyLevelUp()` when rewards trigger a level-up

## Implementation Details

The changes ensure that whenever a player gains XP and levels up, the `_applyLevelUp()` function is called to handle all associated effects (e.g., energy refills), rather than just updating the `xp_level` field. Additionally, the code now properly handles the case where mission rewards can push a player into a new level, which was previously not being checked.

https://claude.ai/code/session_016U5hNY54uRhaEwApjm2HQz