### PR TITLE
Add pnpm dev:debug for readable Preact devtools

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:debug": "PREACT_DEBUG=1 vite",
     "build": "vite build",
     "build:hq": "BUILD_VARIANT=hq vite build",
     "build:casual": "BUILD_VARIANT=casual vite build",

--- a/scripts/esm-entry-debug.ts
+++ b/scripts/esm-entry-debug.ts
@@ -1,0 +1,10 @@
+// Debug entry — used only when running `pnpm dev:debug` (which sets
+// PREACT_DEBUG=1, picked up by `bundleEsmDev` in vite.config.js).
+//
+// Imports `preact/debug` BEFORE the normal entry so its hooks are
+// installed before any component renders.  Production builds always
+// enter via `esm-entry.ts`; this file is never referenced from the
+// `vite build` input, so `preact/debug` cannot reach the shipped .xdc.
+
+import 'preact/debug';
+import './esm-entry.js';

--- a/vite.config.js
+++ b/vite.config.js
@@ -163,7 +163,16 @@ function mockWebxdc() {
 // file — it is only produced by `vite build`.  Index.html references
 // it as a `<script>` tag, so this plugin runs the same Rollup pipeline
 // the prod build uses, in-memory, and serves the result via middleware.
+//
+// When PREACT_DEBUG=1 (set by `pnpm dev:debug`) the entry is swapped
+// to `esm-entry-debug.js` (which side-effect-imports `preact/debug`)
+// and minification is disabled so the Preact devtools extension shows
+// real component names instead of mangled `ji` / `ki`.  The production
+// `vite build` config below is untouched, so the debug surface cannot
+// reach the shipped .xdc.
 function bundleEsmDev() {
+  const preactDebug = process.env.PREACT_DEBUG === '1';
+  const entry = preactDebug ? 'scripts/esm-entry-debug.js' : 'scripts/esm-entry.js';
   let bundleSrc = null;
   let buildPromise = null;
 
@@ -182,8 +191,9 @@ function bundleEsmDev() {
           build: {
             write: false,
             emptyOutDir: false,
+            minify: !preactDebug,
             rollupOptions: {
-              input: 'scripts/esm-entry.js',
+              input: entry,
               output: {
                 format: 'iife',
                 name: '__DD',


### PR DESCRIPTION
## Summary

Adds `pnpm dev:debug` — a dev-only script that surfaces real Preact component names in the devtools panel.

The dev bundle today is built via an inline `build()` call in `bundleEsmDev`, which defaults to esbuild minification. That renames every component to `ji` / `ki` / etc., making the Preact devtools panel unreadable.

When `PREACT_DEBUG=1` is set, `bundleEsmDev`:
- swaps the entry to a new `scripts/esm-entry-debug.ts` that side-effect-imports `preact/debug` before the regular entry, and
- sets `minify: false` on the inline build so function/class names survive.

The production `vite build` config is untouched and never references the debug entry, so neither `preact/debug` nor the unminified bundle can reach the shipped `.xdc`.

## Test plan

- [x] `pnpm dev` (default) — bundle remains minified, `grep -c preact/debug` on the served `esm-bundle.js` returns 0
- [x] `pnpm dev:debug` — bundle is unminified (multi-line, indented) and contains `preact/debug`
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (722 tests)
- [x] `pnpm build:all` still produces `data-dealer-hq.xdc` / `data-dealer-casual.xdc` unchanged in shape
- [ ] Load the dev:debug page in a browser, open Preact devtools, confirm component names render as `MarcoSpeech`, `Notification`, etc. instead of `ji` / `ki`

🤖 Generated with [Claude Code](https://claude.com/claude-code)