### PR TITLE
Add pnpm-workspace.yaml approving install scripts for pinned deps

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+allowBuilds:
+  '@biomejs/biome': true
+  core-js: true
+  esbuild: true
+  lefthook: true


### PR DESCRIPTION
## Summary

pnpm 11 prompts on `pnpm install` for any dep that runs a postinstall script unless the project explicitly allows it. Without this file, fresh checkouts and CI runs hit an interactive prompt or fail with `[ERR_PNPM_IGNORED_BUILDS]`.

This commits the `allowBuilds` allowlist for the four deps we already build from source:
- `@biomejs/biome`
- `core-js`
- `esbuild`
- `lefthook`

## Test plan

- [x] `pnpm install` no longer raises `[ERR_PNPM_IGNORED_BUILDS]`
- [x] Pre-commit + pre-push hooks (typecheck, vitest, biome) still pass
- [ ] Fresh clone on CI installs cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)