### PR TITLE
Fix XP calculation in status popup description

### DIFF
--- a/scripts/components/popups/XPStatusPopup.tsx
+++ b/scripts/components/popups/XPStatusPopup.tsx
@@ -13,7 +13,7 @@ export function XPStatusPopup({ xpLevel, xpValue, xpMax, onClose }: XPStatusPopu
   const subtitleHtml = sprintf(i18n.gettext('sb_XP subtitle Level %s'), span(toKSNum(xpLevel)));
   const descriptionHtml = sprintf(
     i18n.gettext('sb_XP description %s XP until next level'),
-    span(toKSNum(xpMax - xpValue + 1))
+    span(toKSNum(xpMax - xpValue))
   );
   return (
     <PopupShell


### PR DESCRIPTION
## Summary
Corrected an off-by-one error in the XP status popup's description text that displays how much XP is needed to reach the next level.

## Changes
- Removed the `+ 1` offset from the XP remaining calculation in `XPStatusPopup.tsx`
- Changed `xpMax - xpValue + 1` to `xpMax - xpValue` to accurately reflect the exact amount of XP needed to level up

## Details
The description text shows "X XP until next level" to the user. The previous calculation was inflating this number by 1, causing the displayed value to be inaccurate. This fix ensures the popup displays the correct remaining XP amount needed to reach the next level.

https://claude.ai/code/session_01QBwdmVQQ5iNWMgm3N2kqc5