### PR TITLE
Rebuild the dev bundle on .tsx edits

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -229,7 +229,10 @@ function bundleEsmDev() {
         server.config.logger.error('[esm-bundle-dev] initial build failed: ' + err.message);
       });
       server.watcher.on('change', (file) => {
-        if (file.includes('/scripts/') && (file.endsWith('.js') || file.endsWith('.ts'))) {
+        // `.tsx` does not end with `.ts`, so a bare `.endsWith('.ts')`
+        // silently skips every Preact component — match the full set of
+        // JS/TS source extensions esbuild compiles into the bundle.
+        if (file.includes('/scripts/') && /\.[jt]sx?$/.test(file)) {
           rebuild().catch((err) => {
             server.config.logger.error('[esm-bundle-dev] rebuild failed: ' + err.message);
           });


### PR DESCRIPTION
## Summary

`bundleEsmDev`'s file watcher gated rebuilds on `file.endsWith('.ts')` — which is **false for `.tsx`**. Editing any of the 24 Preact component files (`scripts/components/**/*.tsx`) during `pnpm dev` left the served `esm-bundle.js` stale until an unrelated `.ts`/`.js` save or a server restart.

The fix matches the full set of JS/TS source extensions esbuild compiles, via a `/\.[jt]sx?$/` test.

## Test plan

- [x] With `pnpm dev` running, edited a `.tsx` component and confirmed the rebuilt `esm-bundle.js` picked up the change (previously it did not)
- [x] `pnpm typecheck` + biome pass
- [x] Production `vite build` is unaffected — this only touches the dev-server watcher (`apply: 'serve'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)