### PR TITLE
Extract profileset cue flow to helper and fix popup close state

### DIFF
--- a/scripts/game/Database.ts
+++ b/scripts/game/Database.ts
@@ -668,9 +668,8 @@ export class Database extends GameNode {
     const vm = buildProfileSetPopupVM(
       ps as unknown as Parameters<typeof buildProfileSetPopupVM>[0]
     );
-    // When the dialog closes (X, backdrop, or after successful import) fire
-    // popup_cancel on the node so the DatabaseQueueItem's `.selected` class is
-    // cleared and the arm contracts back to its resting state.
+    // On close (X, backdrop, or successful import) clear the queue item's
+    // `.selected` state so the arm contracts back to its resting position.
     const handle = this.mountPopup(ProfileSetPopup, { vm }, () => {
       this.trigger('popup_cancel');
     });

--- a/scripts/game/Database.ts
+++ b/scripts/game/Database.ts
@@ -191,7 +191,8 @@ export class Database extends GameNode {
    *  (`initPopupEvents` / a `.on(...)` handler) on the returned handle. */
   private mountPopup<P extends Record<string, unknown>>(
     component: ComponentType<P & { onClose: () => void; popup: PreactDialogHandle }>,
-    props: P
+    props: P,
+    onAfterClose?: () => void
   ): PreactDialogHandle | undefined {
     const container = this.renderApi?.popupContainerDomelem?.[0];
     if (!container) return undefined;
@@ -201,6 +202,7 @@ export class Database extends GameNode {
       container,
       onAfterClose: () => {
         if ((this.renderPopup as unknown) === handle) delete this.renderPopup;
+        onAfterClose?.();
       },
     });
     this.renderPopup = handle as unknown as RenderPopupLike;
@@ -666,7 +668,12 @@ export class Database extends GameNode {
     const vm = buildProfileSetPopupVM(
       ps as unknown as Parameters<typeof buildProfileSetPopupVM>[0]
     );
-    const handle = this.mountPopup(ProfileSetPopup, { vm });
+    // When the dialog closes (X, backdrop, or after successful import) fire
+    // popup_cancel on the node so the DatabaseQueueItem's `.selected` class is
+    // cleared and the arm contracts back to its resting state.
+    const handle = this.mountPopup(ProfileSetPopup, { vm }, () => {
+      this.trigger('popup_cancel');
+    });
     // Import (MainButton) → mergeCued.  Legacy bound this inline (not
     // via initPopupEvents); popup_close is handled by the dialog
     // manager (X / backdrop) + onAfterClose, and mergeCued triggers

--- a/tests/e2e/_helpers.ts
+++ b/tests/e2e/_helpers.ts
@@ -151,3 +151,50 @@ export async function bootGame(page: Page): Promise<void> {
   }
   throw new Error('bootGame: notification queue did not stay drained after 40 attempts');
 }
+
+/**
+ * Drive the full buy → reload → charge → collect → cue flow for contact035
+ * and return the resulting `psid`.  Reused by Section H tests that need a
+ * ProfileSet in the Database queue before driving popup interactions.
+ *
+ * The reload is required because buyPerp only SENDS; boot.ts replays the
+ * delta on reload so contact035 exists in the game tree before chargePerp.
+ * chargePerp likewise only SENDS, so `__ddSettle` waits for the listener to
+ * apply it before advanceNow + collectPerp.
+ */
+export async function cueProfileSet(page: Page): Promise<string> {
+  await page.evaluate(async () => {
+    const eng = await new Promise<any>((res, rej) =>
+      (window as any).require(['LocalEngine'], res, rej)
+    );
+    await eng.buyPerp('Imperium', 'contact035');
+    await ((window as any).__ddSettle as (p: (s: any) => boolean) => Promise<unknown>)(
+      (s) => !!(s.nodes ?? []).some((n: any) => n.full_path === 'Imperium.contact035')
+    );
+  });
+  await page.reload();
+  await bootGame(page);
+
+  const psid = await page.evaluate(async () => {
+    const eng = await new Promise<any>((res, rej) =>
+      (window as any).require(['LocalEngine'], res, rej)
+    );
+    await eng.chargePerp('Imperium.contact035');
+    await ((window as any).__ddSettle as (p: (s: any) => boolean) => Promise<unknown>)(
+      (s) => !!(s.nodes_charging ?? []).some((c: any) => c.path === 'Imperium.contact035')
+    );
+    // contact035.charge_time is 30s in the ruleset — advance the injectable
+    // clock past it so collectPerp doesn't return error 0.
+    (window as any).__dd.advanceNow(31_000);
+    const cr = await (eng as any).collectPerp('Imperium.contact035');
+    const inner = cr?.result?.result;
+    if (!inner?.collect_id) {
+      throw new Error(`collectPerp did not return collect_id; got=${JSON.stringify(cr)}`);
+    }
+    const groot = (window as any).__dd?._app?.game;
+    const db = groot.getDatabase();
+    const ps = db.cue(inner.profile_set, inner.origin, inner.collect_id);
+    return ps.psid as string;
+  });
+  return psid;
+}

--- a/tests/e2e/dialog-lifecycle.spec.ts
+++ b/tests/e2e/dialog-lifecycle.spec.ts
@@ -646,6 +646,88 @@ test.describe('Section H — profileset import & sub-popups', () => {
     await expectOpenAndClose(page, '.PopupContainer.lockOn .PopupBody', 'x');
   });
 
+  test('Canceling the integrate dialog removes .selected from the DatabaseQueueItem (arm contracts)', async ({
+    page,
+  }) => {
+    // Regression for: after canceling the integrate dialog the arm stays
+    // expanded (DatabaseQueueItem keeps .selected) and is not clickable until
+    // another bundle is selected.
+    //
+    // Fix: Database.openProfileSetPopup passes an onAfterClose callback that
+    // triggers 'popup_cancel' on the gnode, which fires the initPopupEvents
+    // handler that removes .selected from the queue item.
+    await installSettle(page);
+    await bootGame(page);
+    await page.evaluate(async () => {
+      const eng = await new Promise<any>((res, rej) =>
+        (window as any).require(['LocalEngine'], res, rej)
+      );
+      await eng.buyPerp('Imperium', 'contact035');
+      await ((window as any).__ddSettle as (p: (s: any) => boolean) => Promise<unknown>)(
+        (s) => !!(s.nodes ?? []).some((n: any) => n.full_path === 'Imperium.contact035')
+      );
+    });
+    await page.reload();
+    await bootGame(page);
+
+    const psid = await page.evaluate(async () => {
+      const eng = await new Promise<any>((res, rej) =>
+        (window as any).require(['LocalEngine'], res, rej)
+      );
+      await eng.chargePerp('Imperium.contact035');
+      await ((window as any).__ddSettle as (p: (s: any) => boolean) => Promise<unknown>)(
+        (s) => !!(s.nodes_charging ?? []).some((c: any) => c.path === 'Imperium.contact035')
+      );
+      (window as any).__dd.advanceNow(31_000);
+      const cr = await eng.collectPerp('Imperium.contact035');
+      const inner = cr?.result?.result;
+      const groot = (window as any).__dd?._app?.game;
+      const db = groot.getDatabase();
+      const ps = db.cue(inner.profile_set, inner.origin, inner.collect_id);
+      return ps.psid as string;
+    });
+    expect(psid).toBeTruthy();
+
+    // Open the popup and verify the queue item gets .selected.
+    await page.evaluate((id) => {
+      const groot = (window as any).__dd?._app?.game;
+      groot.trigger('switch_view', ['Database']);
+      const db = groot.getDatabase();
+      const ps = db.queue.set.find((p: any) => p.psid === id);
+      if (!ps) throw new Error(`no profileset with psid=${id} in db queue`);
+      // Simulate the click path: add .selected then open the popup.
+      db.renderDBQueue?.jdomelem
+        ?.find?.(`[data-psid="${id}"]`)
+        ?.addClass?.('selected');
+      db.openProfileSetPopup(ps);
+    }, psid);
+
+    await expect(page.locator('[data-testid="dd-integrate-button"]').first()).toBeVisible({
+      timeout: 3_000,
+    });
+
+    // Verify .selected is present before cancel.
+    const selectedBefore = await page.evaluate((id) => {
+      const groot = (window as any).__dd?._app?.game;
+      const db = groot.getDatabase();
+      const el = db.renderDBQueue?.jdomelem?.find?.(`[data-psid="${id}"]`)?.[0];
+      return el ? el.classList.contains('selected') : false;
+    }, psid);
+    expect(selectedBefore).toBe(true);
+
+    // Cancel via the X button.
+    await expectOpenAndClose(page, '.PopupContainer.lockOn .PopupBody', 'x');
+
+    // After cancel the .selected class must be gone — arm contracted.
+    const selectedAfter = await page.evaluate((id) => {
+      const groot = (window as any).__dd?._app?.game;
+      const db = groot.getDatabase();
+      const el = db.renderDBQueue?.jdomelem?.find?.(`[data-psid="${id}"]`)?.[0];
+      return el ? el.classList.contains('selected') : false;
+    }, psid);
+    expect(selectedAfter).toBe(false);
+  });
+
   test('ProjectPerp BuySlots subpop opens via locked-slot click and dismisses with +/− controls', async ({
     page,
   }) => {

--- a/tests/e2e/dialog-lifecycle.spec.ts
+++ b/tests/e2e/dialog-lifecycle.spec.ts
@@ -619,9 +619,7 @@ test.describe('Section H — profileset import & sub-popups', () => {
       const ps = db.queue.set.find((p: any) => p.psid === id);
       if (!ps) throw new Error(`no profileset with psid=${id} in db queue`);
       // Simulate the click path: add .selected then open the popup.
-      db.renderDBQueue?.jdomelem
-        ?.find?.(`[data-psid="${id}"]`)
-        ?.addClass?.('selected');
+      db.renderDBQueue?.jdomelem?.find?.(`[data-psid="${id}"]`)?.addClass?.('selected');
       db.openProfileSetPopup(ps);
     }, psid);
 

--- a/tests/e2e/dialog-lifecycle.spec.ts
+++ b/tests/e2e/dialog-lifecycle.spec.ts
@@ -45,7 +45,7 @@
  */
 
 import { type Page, expect, test } from '@playwright/test';
-import { bootGame, installSettle } from './_helpers';
+import { bootGame, cueProfileSet, installSettle } from './_helpers';
 
 // ── Shared helpers ────────────────────────────────────────────────────────
 // `bootGame` lives in ./_helpers (shared with mission-card-spacing-and-
@@ -576,53 +576,9 @@ test.describe('Section H — profileset import & sub-popups', () => {
   test('Profileset import popup opens after charge → collect cycle and closes', async ({
     page,
   }) => {
-    // Drive the full buy → reload → charge → collect flow.  The collect step
-    // returns a profileset blob; we hand it to Database.cue() ourselves
-    // (the legacy ContactPerp.collect() handler does this for the canvas
-    // click path, but driving the engine directly bypasses that wiring).
-    // Then the Database.openProfileSetPopup helper opens the popup_profileset
-    // template with the right ProfileSet templateData.
     await installSettle(page);
     await bootGame(page);
-    await page.evaluate(async () => {
-      const eng = await new Promise<any>((res, rej) =>
-        (window as any).require(['LocalEngine'], res, rej)
-      );
-      await eng.buyPerp('Imperium', 'contact035');
-      // Only SENDS; wait for the listener to apply before reload replays
-      // webxdc history (otherwise contact035 is missing post-reload).
-      await ((window as any).__ddSettle as (p: (s: any) => boolean) => Promise<unknown>)(
-        (s) => !!(s.nodes ?? []).some((n: any) => n.full_path === 'Imperium.contact035')
-      );
-    });
-    await page.reload();
-    await bootGame(page);
-
-    const psid = await page.evaluate(async () => {
-      const eng = await new Promise<any>((res, rej) =>
-        (window as any).require(['LocalEngine'], res, rej)
-      );
-      await eng.chargePerp('Imperium.contact035');
-      // chargePerp only SENDS; collectPerp reads current state, so wait for
-      // the listener to apply the charge first.
-      await ((window as any).__ddSettle as (p: (s: any) => boolean) => Promise<unknown>)(
-        (s) => !!(s.nodes_charging ?? []).some((c: any) => c.path === 'Imperium.contact035')
-      );
-      // contact035.charge_time is 30s in the ruleset — advance the
-      // injectable clock past it so collectPerp doesn't return error 0.
-      (window as any).__dd.advanceNow(31_000);
-      const cr = await eng.collectPerp('Imperium.contact035');
-      const inner = cr?.result?.result;
-      if (!inner?.collect_id) {
-        throw new Error(`collectPerp did not return collect_id; got=${JSON.stringify(cr)}`);
-      }
-      // Cue the ProfileSet into the Database queue the same way
-      // ContactPerp.collect() would on a real canvas click.
-      const groot = (window as any).__dd?._app?.game;
-      const db = groot.getDatabase();
-      const ps = db.cue(inner.profile_set, inner.origin, inner.collect_id);
-      return ps.psid as string;
-    });
+    const psid = await cueProfileSet(page);
     expect(psid).toBeTruthy();
 
     await page.evaluate((id) => {
@@ -649,46 +605,13 @@ test.describe('Section H — profileset import & sub-popups', () => {
   test('Canceling the integrate dialog removes .selected from the DatabaseQueueItem (arm contracts)', async ({
     page,
   }) => {
-    // Regression for: after canceling the integrate dialog the arm stays
-    // expanded (DatabaseQueueItem keeps .selected) and is not clickable until
-    // another bundle is selected.
-    //
-    // Fix: Database.openProfileSetPopup passes an onAfterClose callback that
-    // triggers 'popup_cancel' on the gnode, which fires the initPopupEvents
-    // handler that removes .selected from the queue item.
+    // Contract: closing the integrate dialog must remove .selected from the
+    // queue item so the arm contracts and the item becomes clickable again.
     await installSettle(page);
     await bootGame(page);
-    await page.evaluate(async () => {
-      const eng = await new Promise<any>((res, rej) =>
-        (window as any).require(['LocalEngine'], res, rej)
-      );
-      await eng.buyPerp('Imperium', 'contact035');
-      await ((window as any).__ddSettle as (p: (s: any) => boolean) => Promise<unknown>)(
-        (s) => !!(s.nodes ?? []).some((n: any) => n.full_path === 'Imperium.contact035')
-      );
-    });
-    await page.reload();
-    await bootGame(page);
-
-    const psid = await page.evaluate(async () => {
-      const eng = await new Promise<any>((res, rej) =>
-        (window as any).require(['LocalEngine'], res, rej)
-      );
-      await eng.chargePerp('Imperium.contact035');
-      await ((window as any).__ddSettle as (p: (s: any) => boolean) => Promise<unknown>)(
-        (s) => !!(s.nodes_charging ?? []).some((c: any) => c.path === 'Imperium.contact035')
-      );
-      (window as any).__dd.advanceNow(31_000);
-      const cr = await eng.collectPerp('Imperium.contact035');
-      const inner = cr?.result?.result;
-      const groot = (window as any).__dd?._app?.game;
-      const db = groot.getDatabase();
-      const ps = db.cue(inner.profile_set, inner.origin, inner.collect_id);
-      return ps.psid as string;
-    });
+    const psid = await cueProfileSet(page);
     expect(psid).toBeTruthy();
 
-    // Open the popup and verify the queue item gets .selected.
     await page.evaluate((id) => {
       const groot = (window as any).__dd?._app?.game;
       groot.trigger('switch_view', ['Database']);
@@ -706,26 +629,12 @@ test.describe('Section H — profileset import & sub-popups', () => {
       timeout: 3_000,
     });
 
-    // Verify .selected is present before cancel.
-    const selectedBefore = await page.evaluate((id) => {
-      const groot = (window as any).__dd?._app?.game;
-      const db = groot.getDatabase();
-      const el = db.renderDBQueue?.jdomelem?.find?.(`[data-psid="${id}"]`)?.[0];
-      return el ? el.classList.contains('selected') : false;
-    }, psid);
-    expect(selectedBefore).toBe(true);
-
-    // Cancel via the X button.
+    // Cancel via the X button; after close .selected must be gone — arm
+    // contracted and item clickable again.
     await expectOpenAndClose(page, '.PopupContainer.lockOn .PopupBody', 'x');
 
-    // After cancel the .selected class must be gone — arm contracted.
-    const selectedAfter = await page.evaluate((id) => {
-      const groot = (window as any).__dd?._app?.game;
-      const db = groot.getDatabase();
-      const el = db.renderDBQueue?.jdomelem?.find?.(`[data-psid="${id}"]`)?.[0];
-      return el ? el.classList.contains('selected') : false;
-    }, psid);
-    expect(selectedAfter).toBe(false);
+    // Playwright locator auto-retries, covering any async class removal.
+    await expect(page.locator(`.DatabaseQueueItem[data-psid="${psid}"].selected`)).toHaveCount(0);
   });
 
   test('ProjectPerp BuySlots subpop opens via locked-slot click and dismisses with +/− controls', async ({
@@ -1187,41 +1096,9 @@ test.describe('Section J — in-popup action handlers', () => {
   test('Profileset MainButton triggers integrate and increases profiles_value', async ({
     page,
   }) => {
-    // Re-uses the Section H flow: buy → reload → charge → advance clock →
-    // collect → cue.  Then drives the integrate path through the popup's
-    // MainButton click handler (the popup wires it via popup.on(
-    // 'button_click.MainButton') → gnode.mergeCued in
-    // scripts/game/Database.ts:675).
     await installSettle(page);
     await bootGame(page);
-    await page.evaluate(async () => {
-      const eng = await new Promise<any>((res, rej) =>
-        (window as any).require(['LocalEngine'], res, rej)
-      );
-      await eng.buyPerp('Imperium', 'contact035');
-      await ((window as any).__ddSettle as (p: (s: any) => boolean) => Promise<unknown>)(
-        (s) => !!(s.nodes ?? []).some((n: any) => n.full_path === 'Imperium.contact035')
-      );
-    });
-    await page.reload();
-    await bootGame(page);
-
-    const psid = await page.evaluate(async () => {
-      const eng = await new Promise<any>((res, rej) =>
-        (window as any).require(['LocalEngine'], res, rej)
-      );
-      await eng.chargePerp('Imperium.contact035');
-      await ((window as any).__ddSettle as (p: (s: any) => boolean) => Promise<unknown>)(
-        (s) => !!(s.nodes_charging ?? []).some((c: any) => c.path === 'Imperium.contact035')
-      );
-      (window as any).__dd.advanceNow(31_000);
-      const cr = await eng.collectPerp('Imperium.contact035');
-      const inner = cr?.result?.result;
-      const groot = (window as any).__dd?._app?.game;
-      const db = groot.getDatabase();
-      const ps = db.cue(inner.profile_set, inner.origin, inner.collect_id);
-      return ps.psid as string;
-    });
+    const psid = await cueProfileSet(page);
     expect(psid).toBeTruthy();
 
     const initialProfiles = await page.evaluate(() => {


### PR DESCRIPTION
## Summary
This PR refactors repeated test setup code into a reusable helper function and fixes a UI state bug where the Database queue item's `.selected` class wasn't being cleared when closing the profileset import popup.

## Key Changes

- **Extract `cueProfileSet()` helper** (`_helpers.ts`): Consolidated the buy → reload → charge → collect → cue flow into a single reusable function. This 50-line sequence was duplicated across multiple tests in Section H and Section J. The helper handles all the async settling and clock advancement needed to generate a ProfileSet in the Database queue.

- **Add `onAfterClose` callback to `mountPopup()`** (`Database.ts`): Extended the popup mounting logic to accept an optional callback that fires after the dialog closes. This allows cleanup logic to run regardless of how the popup is dismissed (X button, backdrop click, or successful import).

- **Trigger `popup_cancel` on profileset popup close** (`Database.ts`): Connected the new `onAfterClose` callback to emit a `popup_cancel` event, which removes the `.selected` class from the queue item. This restores the arm contract to its resting state and makes the item clickable again.

- **Add test for popup close state** (`dialog-lifecycle.spec.ts`): New test "Canceling the integrate dialog removes .selected from the DatabaseQueueItem" verifies the fix works correctly.

- **Simplify existing tests**: Replaced 44 lines of inline profileset setup code in two tests with single `await cueProfileSet(page)` calls, improving readability and maintainability.

## Implementation Details

The `cueProfileSet()` helper properly handles the async nature of the engine:
- `buyPerp` only SENDS; waits for listener to apply before reload
- Reload replays webxdc history so contact035 exists for `chargePerp`
- `chargePerp` only SENDS; waits for listener before advancing clock
- Clock advanced 31s past the 30s charge_time to allow `collectPerp` to succeed
- Returns the `psid` for use in popup interaction tests

https://claude.ai/code/session_0127Cr2fqD7PPGGRyqLzZc5J