### PR TITLE
Move MarcoSpeech inside the mission body container in MissionPopup

### DIFF
--- a/scripts/components/popups/MissionPopup.tsx
+++ b/scripts/components/popups/MissionPopup.tsx
@@ -74,8 +74,8 @@ export function MissionPopup({
               </div>
             ))}
           </div>
+          <MarcoSpeech says={says} bodyHtml={bodyHtml} />
         </div>
-        <MarcoSpeech says={says} bodyHtml={bodyHtml} />
         <div class="PopupButtons NotificationButtons">
           {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
           <div class="Button" data-button-id="MainButton" onClick={close}>


### PR DESCRIPTION
## Summary
- Moves the `<MarcoSpeech>` element so it renders as the last child of the mission body container rather than a sibling of it, in `MissionPopup.tsx`.

## Testing
- Pre-push hook: 736 unit tests + type-check passed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)