### PR TITLE
Stop the mission-card progress number clipping under the completion stamp

### DIFF
--- a/css/Render.css
+++ b/css/Render.css
@@ -1040,7 +1040,12 @@
   height:38px;
   display:inline-block;
   padding-left: 40px;
-  padding-right: 32px;
+  /* The completion stamp (`.MissionGoalStatus`, scaled 0.75) reaches
+     ~42px inward from the pill's right border edge.  With 32px the
+     progress number's last digit tucked under the stamp — and on
+     single-unit goals (empty progress) the sprite and stamp collided.
+     46px clears the stamp with an ~8px gap on both. */
+  padding-right: 46px;
   /* Spacing between the inline-block pills must be explicit: the legacy
      `mission_goal_small.html` loop emitted newlines between elements and
      leaned on the inline-block whitespace gap, but the Preact card

--- a/tests/e2e/mission-card-spacing-and-dialog-lock.spec.ts
+++ b/tests/e2e/mission-card-spacing-and-dialog-lock.spec.ts
@@ -54,6 +54,46 @@ test('mission-card small goal pills keep explicit horizontal spacing', async ({ 
   expect(margins.right, 'small pill needs right margin').toBeGreaterThan(0);
 });
 
+test('mission-card small goal pill: progress number and sprite clear the completion stamp', async ({
+  page,
+}) => {
+  // iPhone SE — the viewport the mobile dialog/board pass targets.
+  await page.setViewportSize({ width: 375, height: 667 });
+  await bootGame(page);
+  await page.locator('.mm-tab[data-button-id="Missions"]').dispatchEvent('click');
+  await expect(page.locator('.mm-tab.active[data-button-id="Missions"]')).toBeVisible();
+
+  // The completion stamp (`.MissionGoalStatus`, scaled 0.75) overhangs
+  // ~42px into the pill from the right edge.  With too little
+  // `padding-right` the progress number's last digit tucked under the
+  // stamp, and on single-unit goals the sprite collided with it.
+  const boxes = await page.evaluate(() => {
+    const pills = Array.from(
+      document.querySelectorAll<HTMLElement>('.ViewTab.active .MissionGoal.small')
+    ).filter((p) => p.getBoundingClientRect().width > 1);
+    return pills.map((p) => {
+      const sprite = p.querySelector<HTMLElement>('.MissionGoalSprite')?.getBoundingClientRect();
+      const prog = p.querySelector<HTMLElement>('.MissionGoalProgress')?.getBoundingClientRect();
+      const status = p.querySelector<HTMLElement>('.MissionGoalStatus')?.getBoundingClientRect();
+      return {
+        spriteR: sprite?.right ?? 0,
+        progR: prog?.right ?? 0,
+        statusL: status?.left ?? 0,
+      };
+    });
+  });
+
+  expect(boxes.length, 'at least one visible small goal pill should render').toBeGreaterThan(0);
+  for (const b of boxes) {
+    expect(b.progR, 'progress number must end before the completion stamp').toBeLessThanOrEqual(
+      b.statusL
+    );
+    expect(b.spriteR, 'goal sprite must end before the completion stamp').toBeLessThanOrEqual(
+      b.statusL
+    );
+  }
+});
+
 test('an open dialog dims the header and a tab click dismisses it without switching', async ({
   page,
 }) => {


### PR DESCRIPTION
## Problem
On the Missions tab the goal-pill progress number ran under the completion stamp — the last digit was hidden (`0 / 90̶0̶`), and on single-unit goals the goal sprite collided with the stamp.

## Root cause
`.MissionGoal.small` reserved only `padding-right: 32px`, but the completion stamp (`.MissionGoalStatus`, scaled `0.75`) overhangs ~42px inward from the pill's right border edge.

## Fix
- Bump `padding-right` to `46px` so the number and sprite clear the stamp with an ~8px gap. Base-rule fix — corrects the desktop missions tab too.

| | progress text right | stamp left | gap |
|---|---|---|---|
| before | 219.5 | 213.5 | −6px (overlap) |
| after | 212.5 | 220.5 | +8px |

## Testing
- New e2e guard in `mission-card-spacing-and-dialog-lock.spec.ts` asserts the progress number and sprite never overlap the stamp (iPhone SE viewport).
- Pre-push hook: 739 unit tests + type-check passed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)