### PR TITLE
Prevent backdrop tap events from propagating to game

### DIFF
--- a/scripts/components/popups/dialogManager.ts
+++ b/scripts/components/popups/dialogManager.ts
@@ -204,6 +204,12 @@ export function openDialog<P>(opts: OpenDialogOptions<P>): PreactDialogHandle {
   // components.
   const handleInteraction = (e: Event): void => {
     if (e.target === opts.container) {
+      // Consume the event so the backdrop tap can't fall through to the
+      // game underneath — on touch, `close()` removes the overlay
+      // before the synthesized click fires, so without preventDefault
+      // that click would land on whatever is now exposed.
+      e.stopPropagation();
+      e.preventDefault();
       close();
       return;
     }


### PR DESCRIPTION
## Summary
Fixed an issue where tapping the dialog backdrop could inadvertently trigger interactions with game elements underneath the dialog overlay.

## Key Changes
- Added `stopPropagation()` and `preventDefault()` calls to the backdrop interaction handler in `dialogManager.ts`
- This ensures that when the backdrop is tapped and the dialog closes, the synthesized click event doesn't propagate to elements that become exposed after the overlay is removed

## Implementation Details
On touch devices, the overlay removal happens before the synthesized click event fires. Without preventing event propagation and default behavior, the click would land on whatever game element is now exposed beneath the closed dialog, causing unintended interactions. The fix consumes the event at the backdrop level to prevent this fallthrough behavior.

https://claude.ai/code/session_01Y1P9qvgJHimWeH4igRWYDb