### PR TITLE
Auto-scroll active tab into view in PopupMenu

### DIFF
--- a/scripts/components/popups/PopupMenu.tsx
+++ b/scripts/components/popups/PopupMenu.tsx
@@ -118,6 +118,29 @@ export function PopupMenu({
     };
   }, []);
 
+  // When the active tab changes (e.g. tapping a tab on mobile that the
+  // strip had clipped) scroll it fully into view, clear of the 38px
+  // edge-fades.  Inert when the strip isn't overflowing.
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const btn = el.querySelector<HTMLElement>(
+      `.PopupMenuButton[data-tab="${CSS.escape(activeKey)}"]`
+    );
+    if (!btn) return;
+    const FADE = 38; // matches the CSS edge-fade width
+    const cr = el.getBoundingClientRect();
+    const br = btn.getBoundingClientRect();
+    const leftGap = br.left - cr.left;
+    const rightGap = br.right - cr.right;
+    let target = el.scrollLeft;
+    if (leftGap < FADE) target += leftGap - FADE;
+    else if (rightGap > -FADE) target += rightGap + FADE;
+    const max = el.scrollWidth - el.clientWidth;
+    target = Math.max(0, Math.min(target, max));
+    if (Math.abs(target - el.scrollLeft) > 1) el.scrollTo({ left: target, behavior: 'smooth' });
+  }, [activeKey]);
+
   return (
     <div class="PopupMenu" ref={ref}>
       {tabs.map((t) => (


### PR DESCRIPTION
## Summary
Added automatic scrolling functionality to the PopupMenu component to ensure the active tab is fully visible when it changes, accounting for the CSS edge-fade effects.

## Key Changes
- Added a new `useEffect` hook that triggers whenever the `activeKey` (active tab) changes
- Implements smart scrolling logic that:
  - Calculates the position of the active tab button relative to the popup menu container
  - Accounts for the 38px edge-fade width on both sides of the scrollable strip
  - Scrolls the tab into view with smooth animation only when necessary
  - Prevents unnecessary scroll operations when the tab is already fully visible
  - Respects scroll boundaries (doesn't scroll beyond min/max limits)

## Implementation Details
- Uses `CSS.escape()` to safely query the tab button by its data attribute
- Compares bounding rectangles to determine if the tab is clipped by the edge-fades
- Only triggers smooth scroll when the calculated target differs significantly from current scroll position (>1px threshold)
- Particularly useful on mobile where tabs may be clipped and need to be scrolled into view when tapped

https://claude.ai/code/session_01QvFtLyC6MSdbXXURrGA5NT