### PR TITLE
fix: show language chooser before tutorial dialog on first start

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -40,6 +40,11 @@ export default defineConfig({
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     video: 'off',
+    // Pre-seed the webxdc-shim localStorage with a setLocale:'en' delta so
+    // locale_persisted is true from the very first navigation.  Without this,
+    // the language chooser appears before render() on every fresh context and
+    // tests that wait directly for [data-testid="game-container"] time out.
+    storageState: 'tests/e2e/playwright-storage-state.json',
   },
 
   projects: [

--- a/scripts/game/GameRoot.ts
+++ b/scripts/game/GameRoot.ts
@@ -2398,12 +2398,16 @@ export class GameRoot extends GameNode {
       (this.renderNode as { hide?(): void } | undefined)?.hide?.();
     });
 
-    this.render();
     // On first game start with no explicit locale choice, ask the
-    // player.
+    // player before rendering — otherwise the tutorial dialog (which
+    // opens during render via mission after_render → checkTutorial)
+    // would overlap the language chooser with a higher z-index.
     if (data.is_new_game && !data.locale_persisted) {
       _showLangPicker(false);
+      return this;
     }
+
+    this.render();
 
     // fitToWindow handles centring; the legacy `is_new_game`
     // `scrollTo` would be immediately overwritten so we no longer

--- a/tests/e2e/_helpers.ts
+++ b/tests/e2e/_helpers.ts
@@ -56,18 +56,18 @@ export async function installSettle(page: Page): Promise<void> {
  */
 export async function bootGame(page: Page): Promise<void> {
   await page.goto('/?devtools=1');
-  await expect(page.locator('[data-testid="game-container"]')).toBeVisible({
-    timeout: 50_000,
-  });
 
-  // Dismiss the first-launch locale picker if it appears.  Picking EN persists
-  // the locale and reloads the page, so we re-wait for the game container.
+  // The language chooser is shown before render() on first start, so the game
+  // container may not appear until after the picker is dismissed.  Race both.
   const picker = page.locator('.LangSelectOverlay');
+  const container = page.locator('[data-testid="game-container"]');
+  await expect(picker.or(container)).toBeVisible({ timeout: 50_000 });
+
+  // Dismiss the first-launch locale picker if it appeared.  Picking EN persists
+  // the locale and reloads the page, so we re-wait for the game container.
   if (await picker.isVisible().catch(() => false)) {
     await picker.locator('.lang-pick[data-locale="en"]').click();
-    await expect(page.locator('[data-testid="game-container"]')).toBeVisible({
-      timeout: 50_000,
-    });
+    await expect(container).toBeVisible({ timeout: 50_000 });
   }
 
   // Wait for the GameRoot to be reachable.  app.ts assigns it to

--- a/tests/e2e/playwright-storage-state.json
+++ b/tests/e2e/playwright-storage-state.json
@@ -1,0 +1,14 @@
+{
+  "cookies": [],
+  "origins": [
+    {
+      "origin": "http://localhost:3000",
+      "localStorage": [
+        {
+          "name": "webxdc-shim-updates",
+          "value": "[{\"serial\":1,\"max_serial\":1,\"payload\":{\"kind\":\"delta\",\"op\":\"setLocale\",\"addr\":\"dev@local\",\"locale\":\"en\",\"ts\":0}}]"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/e2e/playwright-storage-state.json
+++ b/tests/e2e/playwright-storage-state.json
@@ -5,8 +5,8 @@
       "origin": "http://localhost:3000",
       "localStorage": [
         {
-          "name": "webxdc-shim-updates",
-          "value": "[{\"serial\":1,\"max_serial\":1,\"payload\":{\"kind\":\"delta\",\"op\":\"setLocale\",\"addr\":\"dev@local\",\"locale\":\"en\",\"ts\":0}}]"
+          "name": "__xdcUpdatesKey__",
+          "value": "[{\"serial\":1,\"payload\":{\"kind\":\"delta\",\"op\":\"setLocale\",\"addr\":\"device0@local.host\",\"locale\":\"en\",\"ts\":0},\"_sender\":\"device0@local.host\"}]"
         }
       ]
     }


### PR DESCRIPTION
## Problem

On first start, the language chooser appeared **after** `this.render()` in `loadGame()`. But render triggers `after_render` → mission `checkTutorial()` → Marco tutorial dialog (z-index: 100000). When the language chooser then appeared (z-index: 9999), it was **behind** the tutorial dialog, so the user couldn't interact with it.

## Fix

Move the language picker check **before** `this.render()` in `scripts/game/GameRoot.ts:loadGame()`. If it's the first start (`is_new_game \&\& !locale_persisted`):

1. Show the language chooser overlay
2. `return this` immediately — no render happens
3. User picks a language → page reloads
4. On reload, `locale_persisted` is true → picker skipped → render proceeds → tutorial appears correctly

## Verification

- `npm run typecheck` passes cleanly