### PR TITLE
refactor: mobile dialog CSS and sub-popup UX improvements

### DIFF
--- a/css/Render.css
+++ b/css/Render.css
@@ -3663,6 +3663,7 @@ button {
     flex: 1 1 auto;
     overflow-y: auto;
     height: auto;
+    padding-bottom: 72px;
   }
   /* Pin action buttons to the dialog bottom, overlaying its bottom
    * border-area so they read as attached to the card edge without

--- a/css/Render.css
+++ b/css/Render.css
@@ -3664,12 +3664,11 @@ button {
     overflow-y: auto;
     height: auto;
   }
-  /* Flow action buttons at the end of the scrollable content instead of
-   * hanging below the body.  Header buttons keep their grid placement
-   * (unaffected — they are not inside .PopupContent). */
-  .PopupContent .PopupButtons {
-    position: static;
-    margin-top: 10px;
+  /* Pin action buttons to the dialog bottom, overlaying its bottom
+   * border-area so they read as attached to the card edge without
+   * extending below the scrollable content. */
+  .PopupButtons {
+    bottom: 0;
   }
   /* City tab strip: drop the desktop 600-px absolute positioning so it
    * flows as the last header row.  Keep it a single row that scrolls

--- a/css/Render.css
+++ b/css/Render.css
@@ -3663,13 +3663,13 @@ button {
     flex: 1 1 auto;
     overflow-y: auto;
     height: auto;
-    padding-bottom: 72px;
+    padding-bottom: 36px;
   }
-  /* Pin action buttons to the dialog bottom, overlaying its bottom
-   * border-area so they read as attached to the card edge without
-   * extending below the scrollable content. */
+  /* Straddle the action buttons across the dialog bottom edge so half
+   * sits inside the content area and the other half extends outside,
+   * using the padding/border area as usable space. */
   .PopupButtons {
-    bottom: -6px;
+    bottom: -36px;
   }
   /* City tab strip: drop the desktop 600-px absolute positioning so it
    * flows as the last header row.  Keep it a single row that scrolls

--- a/css/Render.css
+++ b/css/Render.css
@@ -3582,7 +3582,8 @@ button {
     box-sizing: border-box;
   }
   .PopupBody.Status .PopupHeader,
-  .PopupBody.TokenPerp:not(.SuperToken) .PopupHeader {
+  .PopupBody.TokenPerp:not(.SuperToken) .PopupHeader,
+  .PopupBody.ProvidedPerpSub .PopupHeader {
     padding-bottom: 76px;
   }
   .PopupBody.CityPerp .PopupHeader,
@@ -3624,6 +3625,37 @@ button {
     align-self: start;
     min-width: 0;
     overflow-wrap: break-word;
+  }
+  /* Desktop rule at line 1466 gives all of SubpopTitle/SubpopSubTitle/
+   * SubpopText/SubpopLabelData a `margin-left:168px` (to sit right of
+   * the 180px logo).  In the mobile dialog PopupHeader grid each element
+   * is already positioned by `grid-area`, so reset the margin here. */
+  .PopupHeader .SubpopTitle,
+  .PopupHeader .SubpopSubTitle,
+  .PopupHeader .SubpopText,
+  .PopupHeader .SubpopLabelData {
+    margin-left: 0;
+    padding-right: 0;
+  }
+  /* Tile-context rule at line 2059 gives PerpLabelData/PowerupLabelData
+   * `position:absolute; top:126px; left:0; width:100px`.  Inside the
+   * dialog PopupHeader grid none of that applies; reset to flow layout.
+   * The SubpopLabelData override (position:static) becomes redundant. */
+  .PopupHeader .PerpLabelData,
+  .PopupHeader .PowerupLabelData {
+    position: static;
+    top: auto;
+    left: auto;
+    width: auto;
+    height: auto;
+    padding-top: 0;
+  }
+  /* ProvidedPerpSub SubpopLabelData: make BonusValues a flex container
+   * so the inline Bonus chips wrap horizontally instead of stacking. */
+  .PopupBody.ProvidedPerpSub .PopupHeader .PowerupLabelData.SubpopLabelData .BonusValues {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
   }
   /* `:not(.APRefillLabel)` so the AP refill caption — which also carries
    * `.PopupText` — keeps its own auto-placed row below instead of being
@@ -3816,24 +3848,6 @@ button {
   /* Keep the buy grid visible while the subpop is open — no hiding. */
   .Selector.hasPopup {
     display: block;
-  }
-  /* ProvidedPerp subpop dialog on mobile: the SubpopLabelData
-   * auto-places into the subtitle grid cell (col 2, row 2 of the
-   * PopupHeader grid).  BonusWrap children default to display:block and
-   * stack vertically; flex on the container + BonusWrap makes the stat
-   * chips flow horizontally, matching the desktop inline layout. */
-  .PopupBody.ProvidedPerp .PopupHeader .PowerupLabelData.SubpopLabelData {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 4px;
-    align-self: start;
-    align-content: flex-start;
-  }
-  .PopupBody.ProvidedPerp .PopupHeader .PowerupLabelData.SubpopLabelData .BonusWrap {
-    margin-bottom: 0;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 4px;
   }
 }
 

--- a/css/Render.css
+++ b/css/Render.css
@@ -3677,6 +3677,10 @@ button {
   .PopupBody.BuySlotsDialogBody .BuySlotsNumWrap {
     float: none;
   }
+  .PopupBody.BuySlotsDialogBody .BuySlotsWrap .ButtonInc,
+  .PopupBody.BuySlotsDialogBody .BuySlotsWrap .ButtonDec {
+    margin-top: 0;
+  }
   /* `:not(.APRefillLabel)` so the AP refill caption — which also carries
    * `.PopupText` — keeps its own auto-placed row below instead of being
    * pulled into the `desc` cell on top of the description. */

--- a/css/Render.css
+++ b/css/Render.css
@@ -3558,6 +3558,7 @@ button {
  * `.TokenPerp .PopupHeader { height:310px }`, …) on mobile. */
 @media (max-width: 768px) {
   .PopupContainer .PopupBody .PopupHeader {
+    flex-shrink: 0;
     height: auto;
     min-height: 0;
     display: grid;
@@ -3644,6 +3645,26 @@ button {
     margin: 8px 0 -34px;
     width: auto;
   }
+  /* Viewport-constrained dialog: flexbox so the dialog never exceeds
+   * the screen.  The header shrinks to its content, the content area
+   * scrolls, and absolutely-positioned children reflow naturally. */
+  .PopupContainer .PopupBody {
+    display: flex;
+    flex-direction: column;
+    max-height: calc(100vh - 24px);
+  }
+  .PopupContainer .PopupContent {
+    flex: 1 1 auto;
+    overflow-y: auto;
+    height: auto;
+  }
+  /* Flow action buttons at the end of the scrollable content instead of
+   * hanging below the body.  Header buttons keep their grid placement
+   * (unaffected — they are not inside .PopupContent). */
+  .PopupContent .PopupButtons {
+    position: static;
+    margin-top: 10px;
+  }
   /* City tab strip: drop the desktop 600-px absolute positioning so it
    * flows as the last header row.  Keep it a single row that scrolls
    * horizontally (touch-draggable; mouse drag + wheel are wired in
@@ -3718,15 +3739,18 @@ button {
   /* Grid viewports (`.PopupSelector` / `.PopupTokens`) keep their fixed
    * height and scroll, but the desktop 540-px width overflows a phone
    * dialog — fit them to the dialog instead.  The `.standalone` perp
-   * selector is absolutely placed, so inset it left/right. */
+   * selector flows in the document (no longer absolutely positioned)
+   * so the blue buy grid sits inside the scrollable content area. */
   .PopupSelector,
   .PopupTokens {
     width: auto;
   }
   .standalone .PopupSelector {
+    position: relative;
+    top: auto;
+    left: auto;
     width: auto;
-    left: 6px;
-    right: 6px;
+    height: auto;
   }
   /* The Client provided→consumed divider arrows are pinned to the desktop
    * 540-px grid (`.ClientDivider { width:540px; left:18px }`), which

--- a/css/Render.css
+++ b/css/Render.css
@@ -3669,7 +3669,7 @@ button {
    * border-area so they read as attached to the card edge without
    * extending below the scrollable content. */
   .PopupButtons {
-    bottom: 0;
+    bottom: -6px;
   }
   /* City tab strip: drop the desktop 600-px absolute positioning so it
    * flows as the last header row.  Keep it a single row that scrolls

--- a/css/Render.css
+++ b/css/Render.css
@@ -3781,21 +3781,35 @@ button {
    * off a phone screen and clip their (narrower-wrapped) content.
    * Inset them to the dialog and let the card grow to its content. */
   .SubpopContainer {
+    position: relative;
+    top: auto;
+    left: auto;
+    right: auto;
+    margin: 6px;
     width: auto;
-    left: 6px;
-    right: 6px;
-    /* Lift the overlay near the top of the popup body so the
-     * grow-to-content card below has room before the screen edge. */
-    top: 40px;
+    height: auto;
+    /* Flow in-content on mobile — no space when closed, visible when
+     * open (the JS toggles `.open` on the container + subpop). */
+  }
+  .SubpopContainer:not(.open) {
+    display: none;
   }
   .Subpop {
+    position: relative;
+    top: auto;
+    left: auto;
+    transform: none !important;
     width: auto;
-    left: 6px;
-    right: 6px;
-    /* Grow to the (narrower-wrapped) content height; `padding-bottom`
-     * reserves room for the absolutely-pinned `.SubpopButtons`. */
     height: auto;
-    padding-bottom: 44px;
+    padding-bottom: 0;
+    opacity: 1;
+  }
+  .Subpop.open {
+    transform: none !important;
+  }
+  /* Keep the buy grid visible while the subpop is open — no hiding. */
+  .Selector.hasPopup {
+    display: block;
   }
 }
 

--- a/css/Render.css
+++ b/css/Render.css
@@ -3612,12 +3612,18 @@ button {
     margin-top: 0;
     padding-right: 0;
     align-self: end;
+    /* Grid items don't shrink below content width by default; allow the
+     * title cell to shrink so long words wrap instead of overflowing. */
+    min-width: 0;
+    overflow-wrap: break-word;
   }
   .PopupHeader .PopupSubTitle {
     grid-area: subtitle;
     margin-left: 0;
     padding-right: 0;
     align-self: start;
+    min-width: 0;
+    overflow-wrap: break-word;
   }
   /* `:not(.APRefillLabel)` so the AP refill caption — which also carries
    * `.PopupText` — keeps its own auto-placed row below instead of being

--- a/css/Render.css
+++ b/css/Render.css
@@ -3657,6 +3657,26 @@ button {
     flex-wrap: wrap;
     gap: 4px;
   }
+  /* BuySlotsDialog: no logo, so switch header from the 2-column grid to
+   * block layout so title/subtitle span full width and can be centred.
+   * BuySlotsWrap uses legacy floats on desktop; override to flex here so
+   * the counter centres inside the full-width block header. */
+  .PopupBody.BuySlotsDialogBody .PopupHeader {
+    display: block;
+    text-align: center;
+  }
+  .PopupBody.BuySlotsDialogBody .PopupHeader .PopupText {
+    text-align: left;
+  }
+  .PopupBody.BuySlotsDialogBody .BuySlotsWrap {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-top: 16px;
+  }
+  .PopupBody.BuySlotsDialogBody .BuySlotsNumWrap {
+    float: none;
+  }
   /* `:not(.APRefillLabel)` so the AP refill caption — which also carries
    * `.PopupText` — keeps its own auto-placed row below instead of being
    * pulled into the `desc` cell on top of the description. */

--- a/css/Render.css
+++ b/css/Render.css
@@ -1910,6 +1910,12 @@
   justify-content: safe center;
   height: 100%;
 }
+/* Buy-grid tiles must not shrink below their specified width so they
+ * stay readable when the horizontal-scroll viewport is narrower than
+ * the tile row.  The viewport scrolls the overflow. */
+.PopupSelector .PopupPage > * {
+  flex-shrink: 0;
+}
 
 .standalone .PopupSelector {
   display: block;

--- a/css/Render.css
+++ b/css/Render.css
@@ -3817,6 +3817,24 @@ button {
   .Selector.hasPopup {
     display: block;
   }
+  /* ProvidedPerp subpop dialog on mobile: the SubpopLabelData
+   * auto-places into the subtitle grid cell (col 2, row 2 of the
+   * PopupHeader grid).  BonusWrap children default to display:block and
+   * stack vertically; flex on the container + BonusWrap makes the stat
+   * chips flow horizontally, matching the desktop inline layout. */
+  .PopupBody.ProvidedPerp .PopupHeader .PowerupLabelData.SubpopLabelData {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    align-self: start;
+    align-content: flex-start;
+  }
+  .PopupBody.ProvidedPerp .PopupHeader .PowerupLabelData.SubpopLabelData .BonusWrap {
+    margin-bottom: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
 }
 
 /* --- Mission + Topscore tab content: centre via margin auto + max-width --

--- a/scripts/components/popups/CityPopup.tsx
+++ b/scripts/components/popups/CityPopup.tsx
@@ -4,12 +4,20 @@
 // provided-perp grids reusing the shared perpShared tiles/subpops.
 // No pagination (popup_city renders a single PerpPage per tab).
 
-import { useState } from 'preact/hooks';
+import { useCallback, useState } from 'preact/hooks';
 import type { CityPopupVM } from '../../game/cityView.js';
 import { PopupHeader } from './PopupHeader.js';
 import { PopupMenu } from './PopupMenu.js';
 import type { PreactDialogHandle } from './dialogManager.js';
-import { NoItems, PerpProvidedSubpop, PerpProvidedTile, fireAction } from './perpShared.js';
+import {
+  NoItems,
+  PerpProvidedSubpop,
+  PerpProvidedSubpopDialog,
+  PerpProvidedTile,
+  fireAction,
+  isMobileWidth,
+  openSubpopDialog,
+} from './perpShared.js';
 
 export interface CityPopupProps {
   vm: CityPopupVM;
@@ -25,6 +33,19 @@ export function CityPopup({ vm, onClose, popup }: CityPopupProps) {
   // tab-switch closes any open subpop, so a single key scoped to the
   // active tab is enough.
   const [openKey, setOpenKey] = useState<number | null>(null);
+
+  const handleOpenKey = useCallback(
+    (key: number) => {
+      if (isMobileWidth()) {
+        const tab = vm.tabs.find((t) => t.pkey === activeTab);
+        const subpop = tab?.subpops.find((s) => s.key === key);
+        if (subpop) openSubpopDialog(PerpProvidedSubpopDialog, { subpop, parentPopup: popup });
+      } else {
+        setOpenKey(key);
+      }
+    },
+    [vm.tabs, activeTab, popup],
+  );
 
   const switchTab = (pkey: string): void => {
     if (pkey === activeTab) return;
@@ -82,7 +103,7 @@ export function CityPopup({ vm, onClose, popup }: CityPopupProps) {
                     ) : (
                       <div class="PopupPage PerpPage">
                         {t.tiles.map((tile) => (
-                          <PerpProvidedTile key={tile.key} tile={tile} onOpen={setOpenKey} />
+                          <PerpProvidedTile key={tile.key} tile={tile} onOpen={handleOpenKey} />
                         ))}
                       </div>
                     )}

--- a/scripts/components/popups/CityPopup.tsx
+++ b/scripts/components/popups/CityPopup.tsx
@@ -44,7 +44,7 @@ export function CityPopup({ vm, onClose, popup }: CityPopupProps) {
         setOpenKey(key);
       }
     },
-    [vm.tabs, activeTab, popup],
+    [vm.tabs, activeTab, popup]
   );
 
   const switchTab = (pkey: string): void => {

--- a/scripts/components/popups/ClientPopup.tsx
+++ b/scripts/components/popups/ClientPopup.tsx
@@ -41,7 +41,7 @@ export function ClientPopup({ vm, onClose, popup }: ClientPopupProps) {
         setOpenToken(gestalt);
       }
     },
-    [vm.providedTokens, vm.consumedTokens],
+    [vm.providedTokens, vm.consumedTokens]
   );
 
   return (

--- a/scripts/components/popups/ClientPopup.tsx
+++ b/scripts/components/popups/ClientPopup.tsx
@@ -5,12 +5,19 @@
 // seam as Contact.  Token tile / subpop / grid / action seam are
 // the shared `perpShared.tsx`.
 
-import { useState } from 'preact/hooks';
+import { useCallback, useState } from 'preact/hooks';
 import type { ClientPopupVM } from '../../game/clientView.js';
 import i18n from '../../i18n.js';
 import { PopupHeader } from './PopupHeader.js';
 import type { PreactDialogHandle } from './dialogManager.js';
-import { TokenGrid, TokenSubpop, fireAction } from './perpShared.js';
+import {
+  TokenGrid,
+  TokenSubpop,
+  TokenSubpopDialog,
+  fireAction,
+  isMobileWidth,
+  openSubpopDialog,
+} from './perpShared.js';
 
 export interface ClientPopupProps {
   vm: ClientPopupVM;
@@ -22,6 +29,20 @@ export interface ClientPopupProps {
 
 export function ClientPopup({ vm, onClose, popup }: ClientPopupProps) {
   const [openToken, setOpenToken] = useState<string | null>(null);
+
+  const handleOpenToken = useCallback(
+    (gestalt: string) => {
+      if (isMobileWidth()) {
+        const token =
+          vm.providedTokens.find((t) => t.gestalt === gestalt) ??
+          vm.consumedTokens.find((t) => t.gestalt === gestalt);
+        if (token) openSubpopDialog(TokenSubpopDialog, { token });
+      } else {
+        setOpenToken(gestalt);
+      }
+    },
+    [vm.providedTokens, vm.consumedTokens],
+  );
 
   return (
     <div class="PopupBody">
@@ -66,7 +87,7 @@ export function ClientPopup({ vm, onClose, popup }: ClientPopupProps) {
             tokens={vm.providedTokens}
             paginationClass="Pagination half small"
             tokensClass="PopupTokens provided"
-            onOpen={setOpenToken}
+            onOpen={handleOpenToken}
           />
           <div class="ClientDivider">
             {Array.from({ length: vm.dividerCount }, (_, i) => (
@@ -78,7 +99,7 @@ export function ClientPopup({ vm, onClose, popup }: ClientPopupProps) {
             tokens={vm.consumedTokens}
             paginationClass="Pagination half"
             tokensClass="PopupTokens consumed"
-            onOpen={setOpenToken}
+            onOpen={handleOpenToken}
           />
         </div>
         {/* `.PopupButtons` is a sibling of `.PopupTab` in

--- a/scripts/components/popups/ClientPopup.tsx
+++ b/scripts/components/popups/ClientPopup.tsx
@@ -1,9 +1,9 @@
 // Client perp popup — Preact port of `views/popup_client.html` +
-// `profileset_client.html` (issue #80 phase 2 tier 5b).  Two paged
-// token grids ("provided" 7/page + "consumed" 6/page) split by a
-// ClientDivider, a single Cash/Penalty income summary, and the same
-// Charge/Collect button seam as Contact.  Token tile / subpop /
-// arrows / action seam are the shared `perpShared.tsx`.
+// `profileset_client.html` (issue #80 phase 2 tier 5b).  Two token
+// grids (provided + consumed) split by a ClientDivider, a single
+// Cash/Penalty income summary, and the same Charge/Collect button
+// seam as Contact.  Token tile / subpop / grid / action seam are
+// the shared `perpShared.tsx`.
 
 import { useState } from 'preact/hooks';
 import type { ClientPopupVM } from '../../game/clientView.js';

--- a/scripts/components/popups/ContactPopup.tsx
+++ b/scripts/components/popups/ContactPopup.tsx
@@ -37,7 +37,7 @@ export function ContactPopup({ vm, onClose, popup }: ContactPopupProps) {
         setOpenToken(gestalt);
       }
     },
-    [vm.tokens],
+    [vm.tokens]
   );
 
   return (

--- a/scripts/components/popups/ContactPopup.tsx
+++ b/scripts/components/popups/ContactPopup.tsx
@@ -3,12 +3,19 @@
 // Issue #80 phase 2 tier 5a.  Token tile / subpop / pagination /
 // action-button seam live in `perpShared.tsx` (shared with Client).
 
-import { useState } from 'preact/hooks';
+import { useCallback, useState } from 'preact/hooks';
 import type { ContactPopupVM } from '../../game/contactView.js';
 import i18n from '../../i18n.js';
 import { PopupHeader } from './PopupHeader.js';
 import type { PreactDialogHandle } from './dialogManager.js';
-import { TokenGrid, TokenSubpop, fireAction } from './perpShared.js';
+import {
+  TokenGrid,
+  TokenSubpop,
+  TokenSubpopDialog,
+  fireAction,
+  isMobileWidth,
+  openSubpopDialog,
+} from './perpShared.js';
 
 export interface ContactPopupProps {
   vm: ContactPopupVM;
@@ -20,6 +27,18 @@ export interface ContactPopupProps {
 
 export function ContactPopup({ vm, onClose, popup }: ContactPopupProps) {
   const [openToken, setOpenToken] = useState<string | null>(null);
+
+  const handleOpenToken = useCallback(
+    (gestalt: string) => {
+      if (isMobileWidth()) {
+        const token = vm.tokens.find((t) => t.gestalt === gestalt);
+        if (token) openSubpopDialog(TokenSubpopDialog, { token });
+      } else {
+        setOpenToken(gestalt);
+      }
+    },
+    [vm.tokens],
+  );
 
   return (
     <div class="PopupBody ContactPerp">
@@ -65,7 +84,7 @@ export function ContactPopup({ vm, onClose, popup }: ContactPopupProps) {
             tokens={vm.tokens}
             paginationClass="Pagination"
             tokensClass="PopupTokens"
-            onOpen={setOpenToken}
+            onOpen={handleOpenToken}
           />
           {vm.collectMode ? (
             <div class="PopupButtons">

--- a/scripts/components/popups/PopupHeader.tsx
+++ b/scripts/components/popups/PopupHeader.tsx
@@ -25,7 +25,9 @@ export interface PopupHeaderProps {
   mainspritesClass?: string | undefined;
   /** Pre-rendered sprite markup for the logo (legacy `<%= sprite %>`). */
   spriteHtml?: string;
-  title: string;
+  title?: string;
+  /** Raw-HTML title (legacy `<%= %>`); wins over `title`. */
+  titleHtml?: string;
   /** Plain-text subtitle. */
   subtitle?: string;
   /** Raw-HTML subtitle (legacy `<% print %>`); wins over `subtitle`. */
@@ -41,6 +43,7 @@ export function PopupHeader({
   mainspritesClass,
   spriteHtml,
   title,
+  titleHtml,
   subtitle,
   subtitleHtml,
   description,
@@ -61,7 +64,12 @@ export function PopupHeader({
         // biome-ignore lint/security/noDangerouslySetInnerHtml: locally produced sprite markup
         <div class="PopupLogo" dangerouslySetInnerHTML={{ __html: spriteHtml ?? '' }} />
       )}
-      <div class="PopupTitle">{title}</div>
+      {titleHtml !== undefined ? (
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: raw ruleset HTML (legacy <%= %>)
+        <div class="PopupTitle" dangerouslySetInnerHTML={{ __html: titleHtml }} />
+      ) : (
+        <div class="PopupTitle">{title ?? ''}</div>
+      )}
       {subtitleHtml !== undefined ? (
         // biome-ignore lint/security/noDangerouslySetInnerHtml: raw ruleset HTML (legacy <% print %>)
         <div class="PopupSubTitle" dangerouslySetInnerHTML={{ __html: subtitleHtml }} />

--- a/scripts/components/popups/ProfileSetPopup.tsx
+++ b/scripts/components/popups/ProfileSetPopup.tsx
@@ -5,11 +5,18 @@
 // summary and one Import MainButton (routed through the same
 // `fireAction` seam, wired to `Database.mergeCued`).
 
-import { useState } from 'preact/hooks';
+import { useCallback, useState } from 'preact/hooks';
 import type { ProfileSetPopupVM } from '../../game/profilesetView.js';
 import { PopupHeader } from './PopupHeader.js';
 import type { PreactDialogHandle } from './dialogManager.js';
-import { TokenGrid, TokenSubpop, fireAction } from './perpShared.js';
+import {
+  TokenGrid,
+  TokenSubpop,
+  TokenSubpopDialog,
+  fireAction,
+  isMobileWidth,
+  openSubpopDialog,
+} from './perpShared.js';
 
 export interface ProfileSetPopupProps {
   vm: ProfileSetPopupVM;
@@ -21,6 +28,18 @@ export interface ProfileSetPopupProps {
 
 export function ProfileSetPopup({ vm, onClose, popup }: ProfileSetPopupProps) {
   const [openToken, setOpenToken] = useState<string | null>(null);
+
+  const handleOpenToken = useCallback(
+    (gestalt: string) => {
+      if (isMobileWidth()) {
+        const token = vm.tokens.find((t) => t.gestalt === gestalt);
+        if (token) openSubpopDialog(TokenSubpopDialog, { token });
+      } else {
+        setOpenToken(gestalt);
+      }
+    },
+    [vm.tokens],
+  );
 
   return (
     <div class="PopupBody">
@@ -59,7 +78,7 @@ export function ProfileSetPopup({ vm, onClose, popup }: ProfileSetPopupProps) {
             tokens={vm.tokens}
             paginationClass="Pagination"
             tokensClass="PopupTokens"
-            onOpen={setOpenToken}
+            onOpen={handleOpenToken}
           />
           <div class="PopupButtons">
             <div class="ButtonDecorator AP">

--- a/scripts/components/popups/ProfileSetPopup.tsx
+++ b/scripts/components/popups/ProfileSetPopup.tsx
@@ -38,7 +38,7 @@ export function ProfileSetPopup({ vm, onClose, popup }: ProfileSetPopupProps) {
         setOpenToken(gestalt);
       }
     },
-    [vm.tokens],
+    [vm.tokens]
   );
 
   return (

--- a/scripts/components/popups/ProjectPopup.tsx
+++ b/scripts/components/popups/ProjectPopup.tsx
@@ -22,7 +22,8 @@ import type {
 } from '../../game/powerupView.js';
 import i18n from '../../i18n.js';
 import { PopupMenu } from './PopupMenu.js';
-import type { PreactDialogHandle } from './dialogManager.js';
+import { PopupHeader } from './PopupHeader.js';
+import { stopAndClose, type PreactDialogHandle } from './dialogManager.js';
 import {
   ProvidedPowerupSubpopDialog,
   TokenSubpop,
@@ -396,6 +397,180 @@ function BuySlotsSubpop({
   );
 }
 
+// ── Mobile subpop-as-dialog wrappers ─────────────────────────────────────────
+
+/** Mobile dialog for the per-slot sell card. */
+function SellSubpopDialog({
+  sub,
+  parentPopup,
+  onClose,
+}: {
+  sub: SellSubpopVM;
+  parentPopup: PreactDialogHandle;
+  onClose: () => void;
+}) {
+  const vd = sub.valuesDetailsHtml;
+  const st = sub.title;
+  const sx = sub.description;
+  return (
+    <div class="PopupBody ProvidedPerp ProvidedPerpSub">
+      <PopupHeader onClose={onClose} spriteHtml={sub.logoHtml} titleHtml={st}>
+        {/* biome-ignore lint/security/noDangerouslySetInnerHtml: locally produced bonus markup */}
+        <div class="PowerupLabelData SubpopLabelData" dangerouslySetInnerHTML={{ __html: vd }} />
+        {/* biome-ignore lint/security/noDangerouslySetInnerHtml: raw ruleset HTML (legacy <%= %>) */}
+        <div class="PopupText" dangerouslySetInnerHTML={{ __html: sx }} />
+        <div class="PopupButtons">
+          <div class="ButtonDecorator Cash">
+            <div class="RenderSprite Tobi" />
+            {sub.sellPriceText}
+          </div>
+          {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
+          <div
+            class="Button sell"
+            data-button-id="PowerupSellButton"
+            data-button-gestalt={sub.gestalt}
+            data-button-data={sub.slot}
+            data-testid={`dd-powerup-sell-${sub.gestalt}`}
+            onClick={(e) => fireAction(parentPopup, e, 'PowerupSellButton', [sub.gestalt, sub.slot])}
+          >
+            {i18n.gettext('Sell')}
+          </div>
+        </div>
+      </PopupHeader>
+    </div>
+  );
+}
+
+/** Mobile dialog for the buy-slots counter card. */
+function BuySlotsSubpopDialog({
+  bs,
+  parentPopup,
+  onClose,
+}: {
+  bs: BuySlotsVM;
+  parentPopup: PreactDialogHandle;
+  onClose: () => void;
+}) {
+  const [num, setNum] = useState(1);
+  const dec = (e: JSX.TargetedMouseEvent<HTMLDivElement>): void => {
+    e.stopPropagation();
+    setNum((n) => (n - 1 < 1 ? 1 : n - 1));
+  };
+  const inc = (e: JSX.TargetedMouseEvent<HTMLDivElement>): void => {
+    e.stopPropagation();
+    setNum((n) => (n + 1 > bs.slotsLeft ? n : n + 1));
+  };
+  const bt = bs.title;
+  const bsub = bs.subtitle;
+  const bd = bs.description;
+  return (
+    <div class="PopupBody ProvidedPerp ProvidedPerpSub">
+      <PopupHeader
+        onClose={onClose}
+        spriteHtml='<div class="BuySlotsLogo"></div>'
+        titleHtml={bt}
+        subtitleHtml={bsub}
+      >
+        <div class="PopupText">
+          {/* biome-ignore lint/security/noDangerouslySetInnerHtml: raw ruleset HTML (legacy <%= %>) */}
+          <span style="display:contents" dangerouslySetInnerHTML={{ __html: bd }} />
+          <div class="BuySlotsWrap">
+            {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
+            <div class="BuySlotsDec ButtonInc" onClick={dec}>-</div>
+            <div class="BuySlotsNumWrap">
+              <div class="BuySlotsNum">{num}</div>/<div class="BuySlotsNumLeft">{bs.slotsLeft}</div>
+            </div>
+            {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
+            <div class="BuySlotsInc ButtonDec" onClick={inc}>+</div>
+          </div>
+        </div>
+        <div class="PopupButtons">
+          <div class="ButtonDecorator Cash">
+            <div class="RenderSprite Tobi" />
+            <span class="SlotCost" data-slot-cost={bs.slotCost}>
+              {numToK(bs.slotCost * num)}
+            </span>
+          </div>
+          {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
+          <div
+            class="Button"
+            data-button-id="PowerupBuySlotsButton"
+            data-button-gestalt={`buyslots:${bs.pkey}`}
+            data-button-data={num}
+            onClick={(e) =>
+              fireAction(parentPopup, e, 'PowerupBuySlotsButton', [`buyslots:${bs.pkey}`, num])
+            }
+          >
+            {bs.buttonText}
+          </div>
+        </div>
+      </PopupHeader>
+    </div>
+  );
+}
+
+/** Mobile dialog for the upgrade-chooser tile grid. */
+function BuySelectorSubpopDialog({
+  cat,
+  slot,
+  parentPopup,
+  onClose,
+}: {
+  cat: PowerupCategoryVM;
+  slot: number;
+  parentPopup: PreactDialogHandle;
+  onClose: () => void;
+}) {
+  const close = stopAndClose(onClose);
+  return (
+    <div class="PopupBody ProjectPerp">
+      <div class="PopupHeader">
+        {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
+        <div class="PopupClose" onClick={close}>X</div>
+        <div class="PopupLogo" />
+        <div class="PopupTitle">{cat.selectorTitle}</div>
+      </div>
+      <div class="PopupContent">
+        <div class="PopupTab Powerups">
+          <div class="Pagination Selector standalone">
+            <div class="PopupSelector">
+              <div class="PopupPageWrap">
+                <div class="PopupPage PowerupPage">
+                  {cat.providedTiles.map((t) => (
+                    <ProvidedTile
+                      key={t.gestalt}
+                      tile={t}
+                      onOpen={
+                        t.locked
+                          ? null
+                          : () => {
+                              const found = cat.providedSubpops.find((s) => s.gestalt === t.gestalt);
+                              if (found)
+                                openSubpopDialog(ProvidedPowerupSubpopDialog, {
+                                  sub: found,
+                                  slot,
+                                  parentPopup,
+                                });
+                            }
+                      }
+                    />
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="SubpopButtons">
+            {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
+            <div class="Button" data-button-id="OKButton" onClick={close}>
+              {i18n.gettext('Close')}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 // Local KS formatter for the live slot-cost*num (mirrors dd-helpers
 // toKSNum's k/M rounding without importing the game helper into a
 // component — the cost values here are already integers).
@@ -668,18 +843,7 @@ export function ProjectPopup({ vm: initialVm, bridge, onClose, popup }: ProjectP
                       cat={cat}
                       isOpen={selOpen}
                       hasPopup={selOpen && inSelectorOpen}
-                      onProvidedOpen={(g) => {
-                        if (isMobileWidth()) {
-                          const found = cat.providedSubpops.find((s) => s.gestalt === g);
-                          if (found)
-                            subpopDialog.current = openSubpopDialog(
-                              ProvidedPowerupSubpopDialog,
-                              { sub: found, slot: buySlot, parentPopup: popup },
-                            );
-                        } else {
-                          setSubId(`Provided${g}`);
-                        }
-                      }}
+                      onProvidedOpen={(g) => setSubId(`Provided${g}`)}
                       onClose={closeTopSubpop}
                     />
                     {cat.providedSubpops.map((s) => (
@@ -707,18 +871,43 @@ export function ProjectPopup({ vm: initialVm, bridge, onClose, popup }: ProjectP
                             const open =
                               slot.kind === 'free'
                                 ? () => {
-                                    setSubId(null);
-                                    setBuySlot(slot.slot);
-                                    setSelPkey(cat.pkey);
+                                    if (isMobileWidth()) {
+                                      subpopDialog.current = openSubpopDialog(
+                                        BuySelectorSubpopDialog,
+                                        { cat, slot: slot.slot, parentPopup: popup },
+                                      );
+                                    } else {
+                                      setSubId(null);
+                                      setBuySlot(slot.slot);
+                                      setSelPkey(cat.pkey);
+                                    }
                                   }
                                 : slot.kind === 'locked'
                                   ? () => {
-                                      setSelPkey(null);
-                                      setSubId('buyslots');
+                                      if (isMobileWidth()) {
+                                        subpopDialog.current = openSubpopDialog(
+                                          BuySlotsSubpopDialog,
+                                          { bs: cat.buySlots, parentPopup: popup },
+                                        );
+                                      } else {
+                                        setSelPkey(null);
+                                        setSubId('buyslots');
+                                      }
                                     }
                                   : () => {
-                                      setSelPkey(null);
-                                      setSubId(slot.subpopId);
+                                      if (isMobileWidth()) {
+                                        const found = cat.sellSubpops.find(
+                                          (s) => s.subpopId === slot.subpopId,
+                                        );
+                                        if (found)
+                                          subpopDialog.current = openSubpopDialog(
+                                            SellSubpopDialog,
+                                            { sub: found, parentPopup: popup },
+                                          );
+                                      } else {
+                                        setSelPkey(null);
+                                        setSubId(slot.subpopId);
+                                      }
                                     };
                             const isUpdating =
                               anim !== null && anim.key === `${cat.pkey}:${slot.slot}`;

--- a/scripts/components/popups/ProjectPopup.tsx
+++ b/scripts/components/popups/ProjectPopup.tsx
@@ -524,15 +524,16 @@ function BuySelectorSubpopDialog({
   const close = stopAndClose(onClose);
   return (
     <div class="PopupBody ProjectPerp">
-      <div class="PopupHeader">
-        {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
-        <div class="PopupClose" onClick={close}>X</div>
-        <div class="PopupLogo" />
-        <div class="PopupTitle">{cat.selectorTitle}</div>
-      </div>
+      {/* PopupBody has position:relative so PopupClose positions at its
+          top-right corner — no PopupHeader wrapper needed. */}
+      {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
+      <div class="PopupClose" onClick={close}>X</div>
       <div class="PopupContent">
         <div class="PopupTab Powerups">
           <div class="Pagination Selector standalone">
+            <div class="SubpopHeader">
+              <div class="SubpopHeaderTitle">{cat.selectorTitle}</div>
+            </div>
             <div class="PopupSelector">
               <div class="PopupPageWrap">
                 <div class="PopupPage PowerupPage">

--- a/scripts/components/popups/ProjectPopup.tsx
+++ b/scripts/components/popups/ProjectPopup.tsx
@@ -21,9 +21,9 @@ import type {
   SellSubpopVM,
 } from '../../game/powerupView.js';
 import i18n from '../../i18n.js';
-import { PopupMenu } from './PopupMenu.js';
 import { PopupHeader } from './PopupHeader.js';
-import { stopAndClose, type PreactDialogHandle } from './dialogManager.js';
+import { PopupMenu } from './PopupMenu.js';
+import { type PreactDialogHandle, stopAndClose } from './dialogManager.js';
 import {
   ProvidedPowerupSubpopDialog,
   TokenSubpop,
@@ -431,7 +431,9 @@ function SellSubpopDialog({
             data-button-gestalt={sub.gestalt}
             data-button-data={sub.slot}
             data-testid={`dd-powerup-sell-${sub.gestalt}`}
-            onClick={(e) => fireAction(parentPopup, e, 'PowerupSellButton', [sub.gestalt, sub.slot])}
+            onClick={(e) =>
+              fireAction(parentPopup, e, 'PowerupSellButton', [sub.gestalt, sub.slot])
+            }
           >
             {i18n.gettext('Sell')}
           </div>
@@ -468,7 +470,9 @@ function BuySlotsSubpopDialog({
     <div class="PopupBody ProvidedPerpSub BuySlotsDialogBody">
       <div class="PopupHeader">
         {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
-        <div class="PopupClose" onClick={close}>X</div>
+        <div class="PopupClose" onClick={close}>
+          X
+        </div>
         {/* biome-ignore lint/security/noDangerouslySetInnerHtml: raw ruleset HTML (legacy <%= %>) */}
         <div class="PopupTitle" dangerouslySetInnerHTML={{ __html: bt }} />
         {/* biome-ignore lint/security/noDangerouslySetInnerHtml: raw ruleset HTML (legacy <%= %>) */}
@@ -477,12 +481,16 @@ function BuySlotsSubpopDialog({
         <div class="PopupText" dangerouslySetInnerHTML={{ __html: bd }} />
         <div class="BuySlotsWrap">
           {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
-          <div class="BuySlotsDec ButtonInc" onClick={dec}>-</div>
+          <div class="BuySlotsDec ButtonInc" onClick={dec}>
+            -
+          </div>
           <div class="BuySlotsNumWrap">
             <div class="BuySlotsNum">{num}</div>/<div class="BuySlotsNumLeft">{bs.slotsLeft}</div>
           </div>
           {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
-          <div class="BuySlotsInc ButtonDec" onClick={inc}>+</div>
+          <div class="BuySlotsInc ButtonDec" onClick={inc}>
+            +
+          </div>
         </div>
         <div class="PopupButtons">
           <div class="ButtonDecorator Cash">
@@ -527,7 +535,9 @@ function BuySelectorSubpopDialog({
       {/* PopupBody has position:relative so PopupClose positions at its
           top-right corner — no PopupHeader wrapper needed. */}
       {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
-      <div class="PopupClose" onClick={close}>X</div>
+      <div class="PopupClose" onClick={close}>
+        X
+      </div>
       <div class="PopupContent">
         <div class="PopupTab Powerups">
           <div class="Pagination Selector standalone">
@@ -545,7 +555,9 @@ function BuySelectorSubpopDialog({
                         t.locked
                           ? null
                           : () => {
-                              const found = cat.providedSubpops.find((s) => s.gestalt === t.gestalt);
+                              const found = cat.providedSubpops.find(
+                                (s) => s.gestalt === t.gestalt
+                              );
                               if (found)
                                 openSubpopDialog(ProvidedPowerupSubpopDialog, {
                                   sub: found,
@@ -595,7 +607,7 @@ export function ProjectPopup({ vm: initialVm, bridge, onClose, popup }: ProjectP
         setOpenToken(gestalt);
       }
     },
-    [vm.tokens],
+    [vm.tokens]
   );
   // Powerup-tab subpop state. `selPkey` = which category's buy Selector
   // is open; `subId` = a card open on top (sell `<pkey><slot>`,
@@ -875,7 +887,7 @@ export function ProjectPopup({ vm: initialVm, bridge, onClose, popup }: ProjectP
                                     if (isMobileWidth()) {
                                       subpopDialog.current = openSubpopDialog(
                                         BuySelectorSubpopDialog,
-                                        { cat, slot: slot.slot, parentPopup: popup },
+                                        { cat, slot: slot.slot, parentPopup: popup }
                                       );
                                     } else {
                                       setSubId(null);
@@ -888,7 +900,7 @@ export function ProjectPopup({ vm: initialVm, bridge, onClose, popup }: ProjectP
                                       if (isMobileWidth()) {
                                         subpopDialog.current = openSubpopDialog(
                                           BuySlotsSubpopDialog,
-                                          { bs: cat.buySlots, parentPopup: popup },
+                                          { bs: cat.buySlots, parentPopup: popup }
                                         );
                                       } else {
                                         setSelPkey(null);
@@ -898,12 +910,12 @@ export function ProjectPopup({ vm: initialVm, bridge, onClose, popup }: ProjectP
                                   : () => {
                                       if (isMobileWidth()) {
                                         const found = cat.sellSubpops.find(
-                                          (s) => s.subpopId === slot.subpopId,
+                                          (s) => s.subpopId === slot.subpopId
                                         );
                                         if (found)
                                           subpopDialog.current = openSubpopDialog(
                                             SellSubpopDialog,
-                                            { sub: found, parentPopup: popup },
+                                            { sub: found, parentPopup: popup }
                                           );
                                       } else {
                                         setSelPkey(null);

--- a/scripts/components/popups/ProjectPopup.tsx
+++ b/scripts/components/popups/ProjectPopup.tsx
@@ -24,6 +24,7 @@ import i18n from '../../i18n.js';
 import { PopupMenu } from './PopupMenu.js';
 import type { PreactDialogHandle } from './dialogManager.js';
 import {
+  ProvidedPowerupSubpopDialog,
   TokenSubpop,
   TokenSubpopDialog,
   TokenTile,
@@ -661,7 +662,19 @@ export function ProjectPopup({ vm: initialVm, bridge, onClose, popup }: ProjectP
                       cat={cat}
                       isOpen={selOpen}
                       hasPopup={selOpen && inSelectorOpen}
-                      onProvidedOpen={(g) => setSubId(`Provided${g}`)}
+                      onProvidedOpen={(g) => {
+                        if (isMobileWidth()) {
+                          const found = cat.providedSubpops.find((s) => s.gestalt === g);
+                          if (found)
+                            openSubpopDialog(ProvidedPowerupSubpopDialog, {
+                              sub: found,
+                              slot: buySlot,
+                              parentPopup: popup,
+                            });
+                        } else {
+                          setSubId(`Provided${g}`);
+                        }
+                      }}
                       onClose={closeTopSubpop}
                     />
                     {cat.providedSubpops.map((s) => (

--- a/scripts/components/popups/ProjectPopup.tsx
+++ b/scripts/components/popups/ProjectPopup.tsx
@@ -8,7 +8,7 @@
 //
 // The Data tab (profileset + Charge/Collect) is structurally identical
 // to popup_contact, so it reuses the shared tokenView VM + the
-// perpShared TokenTile/TokenSubpop/PageArrows/fireAction pieces.
+// perpShared TokenTile/TokenSubpop/fireAction pieces.
 
 import type { JSX } from 'preact';
 import { useEffect, useRef, useState } from 'preact/hooks';

--- a/scripts/components/popups/ProjectPopup.tsx
+++ b/scripts/components/popups/ProjectPopup.tsx
@@ -460,29 +460,29 @@ function BuySlotsSubpopDialog({
     e.stopPropagation();
     setNum((n) => (n + 1 > bs.slotsLeft ? n : n + 1));
   };
+  const close = stopAndClose(onClose);
   const bt = bs.title;
   const bsub = bs.subtitle;
   const bd = bs.description;
   return (
-    <div class="PopupBody ProvidedPerp ProvidedPerpSub">
-      <PopupHeader
-        onClose={onClose}
-        spriteHtml='<div class="BuySlotsLogo"></div>'
-        titleHtml={bt}
-        subtitleHtml={bsub}
-      >
-        <div class="PopupText">
-          {/* biome-ignore lint/security/noDangerouslySetInnerHtml: raw ruleset HTML (legacy <%= %>) */}
-          <span style="display:contents" dangerouslySetInnerHTML={{ __html: bd }} />
-          <div class="BuySlotsWrap">
-            {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
-            <div class="BuySlotsDec ButtonInc" onClick={dec}>-</div>
-            <div class="BuySlotsNumWrap">
-              <div class="BuySlotsNum">{num}</div>/<div class="BuySlotsNumLeft">{bs.slotsLeft}</div>
-            </div>
-            {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
-            <div class="BuySlotsInc ButtonDec" onClick={inc}>+</div>
+    <div class="PopupBody ProvidedPerpSub BuySlotsDialogBody">
+      <div class="PopupHeader">
+        {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
+        <div class="PopupClose" onClick={close}>X</div>
+        {/* biome-ignore lint/security/noDangerouslySetInnerHtml: raw ruleset HTML (legacy <%= %>) */}
+        <div class="PopupTitle" dangerouslySetInnerHTML={{ __html: bt }} />
+        {/* biome-ignore lint/security/noDangerouslySetInnerHtml: raw ruleset HTML (legacy <%= %>) */}
+        <div class="PopupSubTitle" dangerouslySetInnerHTML={{ __html: bsub }} />
+        {/* biome-ignore lint/security/noDangerouslySetInnerHtml: raw ruleset HTML (legacy <%= %>) */}
+        <div class="PopupText" dangerouslySetInnerHTML={{ __html: bd }} />
+        <div class="BuySlotsWrap">
+          {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
+          <div class="BuySlotsDec ButtonInc" onClick={dec}>-</div>
+          <div class="BuySlotsNumWrap">
+            <div class="BuySlotsNum">{num}</div>/<div class="BuySlotsNumLeft">{bs.slotsLeft}</div>
           </div>
+          {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
+          <div class="BuySlotsInc ButtonDec" onClick={inc}>+</div>
         </div>
         <div class="PopupButtons">
           <div class="ButtonDecorator Cash">
@@ -504,7 +504,7 @@ function BuySlotsSubpopDialog({
             {bs.buttonText}
           </div>
         </div>
-      </PopupHeader>
+      </div>
     </div>
   );
 }

--- a/scripts/components/popups/ProjectPopup.tsx
+++ b/scripts/components/popups/ProjectPopup.tsx
@@ -434,6 +434,10 @@ export function ProjectPopup({ vm: initialVm, bridge, onClose, popup }: ProjectP
   const [anim, setAnim] = useState<{ key: string; phase: 'out' | 'in' } | null>(null);
   const [newKey, setNewKey] = useState<string | null>(null);
   const timers = useRef<ReturnType<typeof setTimeout>[]>([]);
+  // Handle for any stacked ProvidedPowerupSubpopDialog open on mobile —
+  // closed explicitly on close_powerup since that event doesn't call
+  // popup.close() and so won't trigger the dialogManager child-close path.
+  const subpopDialog = useRef<PreactDialogHandle | null>(null);
 
   const clearTimers = (): void => {
     for (const t of timers.current) clearTimeout(t);
@@ -465,6 +469,8 @@ export function ProjectPopup({ vm: initialVm, bridge, onClose, popup }: ProjectP
       },
     };
     const onClosePowerup = (_e: unknown, cb?: unknown): void => {
+      subpopDialog.current?.close();
+      subpopDialog.current = null;
       closeSubpops();
       if (typeof cb === 'function') {
         // 400ms matches the legacy `setTimeout(cb, 400)` — lets the
@@ -666,11 +672,10 @@ export function ProjectPopup({ vm: initialVm, bridge, onClose, popup }: ProjectP
                         if (isMobileWidth()) {
                           const found = cat.providedSubpops.find((s) => s.gestalt === g);
                           if (found)
-                            openSubpopDialog(ProvidedPowerupSubpopDialog, {
-                              sub: found,
-                              slot: buySlot,
-                              parentPopup: popup,
-                            });
+                            subpopDialog.current = openSubpopDialog(
+                              ProvidedPowerupSubpopDialog,
+                              { sub: found, slot: buySlot, parentPopup: popup },
+                            );
                         } else {
                           setSubId(`Provided${g}`);
                         }

--- a/scripts/components/popups/ProjectPopup.tsx
+++ b/scripts/components/popups/ProjectPopup.tsx
@@ -11,7 +11,7 @@
 // perpShared TokenTile/TokenSubpop/fireAction pieces.
 
 import type { JSX } from 'preact';
-import { useEffect, useRef, useState } from 'preact/hooks';
+import { useCallback, useEffect, useRef, useState } from 'preact/hooks';
 import type {
   BuySlotsVM,
   PowerupCategoryVM,
@@ -23,7 +23,14 @@ import type {
 import i18n from '../../i18n.js';
 import { PopupMenu } from './PopupMenu.js';
 import type { PreactDialogHandle } from './dialogManager.js';
-import { TokenSubpop, TokenTile, fireAction } from './perpShared.js';
+import {
+  TokenSubpop,
+  TokenSubpopDialog,
+  TokenTile,
+  fireAction,
+  isMobileWidth,
+  openSubpopDialog,
+} from './perpShared.js';
 
 /** Imperative seam used by `ProjectPerp.updatePopupGracefully` to drive
  *  the buy/sell slot plug-out → plug-in animation without re-mounting
@@ -402,6 +409,17 @@ export function ProjectPopup({ vm: initialVm, bridge, onClose, popup }: ProjectP
   const [activeTab, setActiveTab] = useState(initialVm.initialTab);
   // Data-tab profileset token subpop (Contact-shaped).
   const [openToken, setOpenToken] = useState<string | null>(null);
+  const handleOpenToken = useCallback(
+    (gestalt: string) => {
+      if (isMobileWidth()) {
+        const token = vm.tokens.find((t) => t.gestalt === gestalt);
+        if (token) openSubpopDialog(TokenSubpopDialog, { token });
+      } else {
+        setOpenToken(gestalt);
+      }
+    },
+    [vm.tokens],
+  );
   // Powerup-tab subpop state. `selPkey` = which category's buy Selector
   // is open; `subId` = a card open on top (sell `<pkey><slot>`,
   // `buyslots`, or an InSelector `Provided<gestalt>`).
@@ -562,7 +580,7 @@ export function ProjectPopup({ vm: initialVm, bridge, onClose, popup }: ProjectP
               <div class="PopupPageWrap">
                 <div class="PopupPage">
                   {vm.tokens.map((t) => (
-                    <TokenTile key={t.gestalt} token={t} onOpen={setOpenToken} />
+                    <TokenTile key={t.gestalt} token={t} onOpen={handleOpenToken} />
                   ))}
                 </div>
               </div>

--- a/scripts/components/popups/ProvidedPerpPopup.tsx
+++ b/scripts/components/popups/ProvidedPerpPopup.tsx
@@ -5,11 +5,19 @@
 // per-perp views resolve the subtitle / selector title / tile kind /
 // button-disabled / empty-state copy into one `ProvidedPopupVM`.
 
-import { useState } from 'preact/hooks';
+import { useCallback, useState } from 'preact/hooks';
 import type { ProvidedPopupVM } from '../../game/providedView.js';
 import { PopupHeader } from './PopupHeader.js';
 import type { PreactDialogHandle } from './dialogManager.js';
-import { NoItems, PerpProvidedSubpop, PerpProvidedTile, fireAction } from './perpShared.js';
+import {
+  NoItems,
+  PerpProvidedSubpop,
+  PerpProvidedSubpopDialog,
+  PerpProvidedTile,
+  fireAction,
+  isMobileWidth,
+  openSubpopDialog,
+} from './perpShared.js';
 
 export interface ProvidedPerpPopupProps {
   vm: ProvidedPopupVM;
@@ -23,8 +31,19 @@ export function ProvidedPerpPopup({ vm, onClose, popup }: ProvidedPerpPopupProps
   const [openKey, setOpenKey] = useState<number | null>(null);
   // Open/close is just the `.open` toggle: the CSS opacity+scale fade
   // dissolves the whole card cleanly on close (no transparent-bg hack).
-  const openSubpop = (key: number): void => setOpenKey(key);
   const closeSubpop = (): void => setOpenKey(null);
+
+  const handleOpenKey = useCallback(
+    (key: number) => {
+      if (isMobileWidth()) {
+        const subpop = vm.subpops.find((s) => s.key === key);
+        if (subpop) openSubpopDialog(PerpProvidedSubpopDialog, { subpop, parentPopup: popup });
+      } else {
+        setOpenKey(key);
+      }
+    },
+    [vm.subpops, popup],
+  );
 
   return (
     <div class="PopupBody ProvidedPerp">
@@ -78,7 +97,7 @@ export function ProvidedPerpPopup({ vm, onClose, popup }: ProvidedPerpPopupProps
                 ) : (
                   <div class="PopupPage PerpPage">
                     {vm.tiles.map((t) => (
-                      <PerpProvidedTile key={t.key} tile={t} onOpen={openSubpop} />
+                      <PerpProvidedTile key={t.key} tile={t} onOpen={handleOpenKey} />
                     ))}
                   </div>
                 )}

--- a/scripts/components/popups/ProvidedPerpPopup.tsx
+++ b/scripts/components/popups/ProvidedPerpPopup.tsx
@@ -42,7 +42,7 @@ export function ProvidedPerpPopup({ vm, onClose, popup }: ProvidedPerpPopupProps
         setOpenKey(key);
       }
     },
-    [vm.subpops, popup],
+    [vm.subpops, popup]
   );
 
   return (

--- a/scripts/components/popups/TokenPopup.tsx
+++ b/scripts/components/popups/TokenPopup.tsx
@@ -37,7 +37,7 @@ export function TokenPopup({ vm, onClose, popup }: TokenPopupProps) {
         setOpenToken(gestalt);
       }
     },
-    [vm.upgradeSubpops],
+    [vm.upgradeSubpops]
   );
 
   return (

--- a/scripts/components/popups/TokenPopup.tsx
+++ b/scripts/components/popups/TokenPopup.tsx
@@ -5,11 +5,18 @@
 // SuperToken profileset grid + Compute/Update footer.  Reuses the
 // shared TokenTile/TokenGrid/fireAction + the TokenUpgradeSubpop.
 
-import { useState } from 'preact/hooks';
+import { useCallback, useState } from 'preact/hooks';
 import type { TokenPopupVM } from '../../game/tokenPopupView.js';
 import { PopupHeader } from './PopupHeader.js';
 import type { PreactDialogHandle } from './dialogManager.js';
-import { TokenGrid, TokenUpgradeSubpop, fireAction } from './perpShared.js';
+import {
+  TokenGrid,
+  TokenUpgradeSubpop,
+  TokenUpgradeSubpopDialog,
+  fireAction,
+  isMobileWidth,
+  openSubpopDialog,
+} from './perpShared.js';
 
 export interface TokenPopupProps {
   vm: TokenPopupVM;
@@ -21,6 +28,17 @@ export interface TokenPopupProps {
 
 export function TokenPopup({ vm, onClose, popup }: TokenPopupProps) {
   const [openToken, setOpenToken] = useState<string | null>(null);
+  const handleOpenToken = useCallback(
+    (gestalt: string) => {
+      if (isMobileWidth()) {
+        const sub = vm.upgradeSubpops.find((s) => s.subpopId === `token${gestalt}`);
+        if (sub) openSubpopDialog(TokenUpgradeSubpopDialog, { sub });
+      } else {
+        setOpenToken(gestalt);
+      }
+    },
+    [vm.upgradeSubpops],
+  );
 
   return (
     <div class={vm.isSuper ? 'PopupBody TokenPerp SuperToken' : 'PopupBody TokenPerp'}>
@@ -61,7 +79,7 @@ export function TokenPopup({ vm, onClose, popup }: TokenPopupProps) {
               tokens={vm.tokens}
               paginationClass="Pagination half"
               tokensClass="PopupTokens"
-              onOpen={setOpenToken}
+              onOpen={handleOpenToken}
             />
             <div class="PopupSummary half">
               <div class="PopupSummaryItem Profiles">

--- a/scripts/components/popups/TokenPopup.tsx
+++ b/scripts/components/popups/TokenPopup.tsx
@@ -3,7 +3,7 @@
 // `game/tokenPopupView.ts`.  Issue #80 phase 2 tier 11.  Two layouts
 // keyed by `vm.isSuper`: a bare header + Close (normal token), or the
 // SuperToken profileset grid + Compute/Update footer.  Reuses the
-// shared TokenTile/PageArrows/fireAction + the new TokenUpgradeSubpop.
+// shared TokenTile/TokenGrid/fireAction + the TokenUpgradeSubpop.
 
 import { useState } from 'preact/hooks';
 import type { TokenPopupVM } from '../../game/tokenPopupView.js';

--- a/scripts/components/popups/dialogManager.ts
+++ b/scripts/components/popups/dialogManager.ts
@@ -171,6 +171,9 @@ export function openDialog<P>(opts: OpenDialogOptions<P>): PreactDialogHandle {
 
   let isOpen = true;
   const savedActive: ActiveDialog | null = opts.keepParent ? active : null;
+  // Forward ref so `close` can check whether the currently-active dialog
+  // is a stacked child of this one (set after `handle` is constructed).
+  let ownHandle: PreactDialogHandle | null = null;
 
   // Mount into a fresh full-screen overlay appended to the render
   // container (a sibling of `.Stage`), so the backdrop escapes the
@@ -214,6 +217,10 @@ export function openDialog<P>(opts: OpenDialogOptions<P>): PreactDialogHandle {
 
   const close = (): void => {
     if (!isOpen) return;
+    // If a child dialog was stacked on top of this one (keepParent), close
+    // it first so its container is torn down and `active` is restored to
+    // this dialog before our own cleanup runs.
+    if (active && active.handle !== ownHandle) active.handle.close();
     isOpen = false;
     opts.container.removeEventListener('click', handleInteraction);
     opts.container.removeEventListener('touchend', handleInteraction);
@@ -296,6 +303,7 @@ export function openDialog<P>(opts: OpenDialogOptions<P>): PreactDialogHandle {
   );
   render(wrapped, opts.container);
 
+  ownHandle = handle;
   active = { container: opts.container, extendClass: opts.extendClass, handle };
 
   return handle;

--- a/scripts/components/popups/dialogManager.ts
+++ b/scripts/components/popups/dialogManager.ts
@@ -152,6 +152,10 @@ export interface OpenDialogOptions<P> {
   placeBottom?: boolean;
   /** Fires once the dialog has been removed from the DOM. */
   onAfterClose?: () => void;
+  /** When true the current active dialog is kept open underneath (the
+   *  new dialog stacks on top).  Closing the stacked dialog restores
+   *  the previous one as active. */
+  keepParent?: boolean;
 }
 
 interface ActiveDialog {
@@ -163,9 +167,10 @@ interface ActiveDialog {
 let active: ActiveDialog | null = null;
 
 export function openDialog<P>(opts: OpenDialogOptions<P>): PreactDialogHandle {
-  if (active) active.handle.close();
+  if (!opts.keepParent && active) active.handle.close();
 
   let isOpen = true;
+  const savedActive: ActiveDialog | null = opts.keepParent ? active : null;
 
   // Mount into a fresh full-screen overlay appended to the render
   // container (a sibling of `.Stage`), so the backdrop escapes the
@@ -219,9 +224,10 @@ export function openDialog<P>(opts: OpenDialogOptions<P>): PreactDialogHandle {
     for (const b of opts.container.querySelectorAll('.FXBling')) b.remove();
     opts.container.classList.remove('lockOn', 'PopupPreact', 'PopupPreactBottom');
     if (opts.extendClass) opts.container.classList.remove(opts.extendClass);
-    lockMenu?.classList.remove('DialogLock');
+    // Only unlock the menu when the last dialog closes.
+    if (!savedActive) lockMenu?.classList.remove('DialogLock');
     ownContainer?.remove();
-    active = null;
+    active = savedActive;
     opts.onAfterClose?.();
   };
 

--- a/scripts/components/popups/dialogManager.ts
+++ b/scripts/components/popups/dialogManager.ts
@@ -265,7 +265,12 @@ export function openDialog<P>(opts: OpenDialogOptions<P>): PreactDialogHandle {
         return;
       }
       if (FX_EVENTS.has(event)) {
-        applyFxFeedback(event, opts.container, handle.lastButton, handle.lastButtonPoint);
+        // If a child dialog is stacked on top (e.g. buy subpop over parent
+        // perp popup), the FX bling must appear in the child's container —
+        // the parent container is rendered behind the child and invisible.
+        const fxContainer =
+          active && active.handle !== ownHandle ? active.container : opts.container;
+        applyFxFeedback(event, fxContainer, handle.lastButton, handle.lastButtonPoint);
       }
       const set = listeners.get(event);
       if (set) for (const fn of set) fn(evStub, ...(args ?? []));

--- a/scripts/components/popups/perpShared.tsx
+++ b/scripts/components/popups/perpShared.tsx
@@ -1,9 +1,9 @@
 // Shared perp-popup pieces — the token tile, the detail subpop, the
-// pagination arrows, and the action-button click bridge.  popup_contact
-// (tier 5a) and popup_client (tier 5b) render the same `token.html` /
-// `subpop_token.html` partials and route action buttons through the
-// same legacy `popup.trigger('button_click.X')` seam, so these live
-// once here instead of being duplicated per perp component.
+// one-grid-fits-all token grid, and the action-button click bridge.
+// popup_contact (tier 5a) and popup_client (tier 5b) render the same
+// `token.html` / `subpop_token.html` partials and route action buttons
+// through the same legacy `popup.trigger('button_click.X')` seam, so
+// these live once here instead of being duplicated per perp component.
 
 import type { JSX } from 'preact';
 import type { ProvidedSubpopVM, ProvidedTileVM } from '../../game/providedView.js';

--- a/scripts/components/popups/perpShared.tsx
+++ b/scripts/components/popups/perpShared.tsx
@@ -5,12 +5,25 @@
 // through the same legacy `popup.trigger('button_click.X')` seam, so
 // these live once here instead of being duplicated per perp component.
 
-import type { JSX } from 'preact';
+import { type ComponentType, type JSX } from 'preact';
 import type { ProvidedSubpopVM, ProvidedTileVM } from '../../game/providedView.js';
 import type { TokenUpgradeSubpopVM } from '../../game/tokenPopupView.js';
 import type { TokenVM } from '../../game/tokenView.js';
 import i18n from '../../i18n.js';
-import { type PreactDialogHandle, stopAndClose, toFXTarget } from './dialogManager.js';
+import setup from '../../setup.js';
+import { type PreactDialogHandle, openDialog, stopAndClose, toFXTarget } from './dialogManager.js';
+
+function getDialogContainer(): HTMLElement {
+  return document.querySelector<HTMLElement>(setup.renderContainer) ?? document.body;
+}
+
+/** Desktop breakpoint used by the dialog-fit media query. */
+const MOBILE_BP = 768;
+
+export function isMobileWidth(): boolean {
+  return window.innerWidth <= MOBILE_BP;
+}
+
 
 /** Fire the legacy `.Button` seam: park the clicked element +
  *  click point on the handle, then `popup.trigger('button_click.X')`
@@ -273,4 +286,82 @@ export function TokenUpgradeSubpop({
       </div>
     </div>
   );
+}
+
+// ── Mobile subpop-as-dialog wrappers ──────────────────────────────
+
+/** Wrap a token-info subpop in a dialog shell for mobile. */
+export function TokenSubpopDialog({
+  token,
+  onClose,
+}: {
+  token: TokenVM;
+  onClose: () => void;
+}) {
+  return (
+    <div class="PopupBody">
+      <div class="PopupContent">
+        <TokenSubpop token={token} isOpen={true} onClose={onClose} />
+      </div>
+    </div>
+  );
+}
+
+/** Wraps a provided-perp subpop in a dialog shell for mobile.  Uses
+ *  `parentPopup` (the parent perp dialog's handle) for buy actions
+ *  instead of the auto-injected dialog handle. */
+export function PerpProvidedSubpopDialog({
+  subpop,
+  parentPopup,
+  onClose,
+}: {
+  subpop: ProvidedSubpopVM;
+  parentPopup: PreactDialogHandle;
+  onClose: () => void;
+}) {
+  return (
+    <div class="PopupBody">
+      <div class="PopupContent">
+        <PerpProvidedSubpop
+          subpop={subpop}
+          isOpen={true}
+          onClose={onClose}
+          popup={parentPopup}
+        />
+      </div>
+    </div>
+  );
+}
+
+/** Wraps a SuperToken upgrade subpop in a dialog shell for mobile. */
+export function TokenUpgradeSubpopDialog({
+  sub,
+  onClose,
+}: {
+  sub: TokenUpgradeSubpopVM;
+  onClose: () => void;
+}) {
+  return (
+    <div class="PopupBody">
+      <div class="PopupContent">
+        <TokenUpgradeSubpop sub={sub} isOpen={true} onClose={onClose} />
+      </div>
+    </div>
+  );
+}
+
+/** Open a subpop as a dedicated dialog stacked on top of the current
+ *  one (mobile only).  The parent dialog stays open underneath; closing
+ *  the subpop restores the parent.  Returns the dialog handle so callers
+ *  can close it programmatically. */
+export function openSubpopDialog<P>(
+  component: ComponentType<P & { onClose: () => void }>,
+  props: P,
+): PreactDialogHandle {
+  return openDialog({
+    component,
+    props,
+    container: getDialogContainer(),
+    keepParent: true,
+  });
 }

--- a/scripts/components/popups/perpShared.tsx
+++ b/scripts/components/popups/perpShared.tsx
@@ -6,14 +6,14 @@
 // these live once here instead of being duplicated per perp component.
 
 import { type ComponentType, type JSX } from 'preact';
+import type { ProvidedPowerupSubpopVM } from '../../game/powerupView.js';
 import type { ProvidedSubpopVM, ProvidedTileVM } from '../../game/providedView.js';
 import type { TokenUpgradeSubpopVM } from '../../game/tokenPopupView.js';
 import type { TokenVM } from '../../game/tokenView.js';
-import type { ProvidedPowerupSubpopVM } from '../../game/powerupView.js';
 import i18n from '../../i18n.js';
 import setup from '../../setup.js';
-import { type PreactDialogHandle, openDialog, stopAndClose, toFXTarget } from './dialogManager.js';
 import { PopupHeader } from './PopupHeader.js';
+import { type PreactDialogHandle, openDialog, stopAndClose, toFXTarget } from './dialogManager.js';
 
 function getDialogContainer(): HTMLElement {
   return document.querySelector<HTMLElement>(setup.renderContainer) ?? document.body;
@@ -25,7 +25,6 @@ const MOBILE_BP = 768;
 export function isMobileWidth(): boolean {
   return window.innerWidth <= MOBILE_BP;
 }
-
 
 /** Fire the legacy `.Button` seam: park the clicked element +
  *  click point on the handle, then `popup.trigger('button_click.X')`
@@ -439,7 +438,7 @@ export function TokenUpgradeSubpopDialog({
  *  can close it programmatically. */
 export function openSubpopDialog<P>(
   component: ComponentType<P & { onClose: () => void }>,
-  props: P,
+  props: P
 ): PreactDialogHandle {
   return openDialog({
     component,

--- a/scripts/components/popups/perpShared.tsx
+++ b/scripts/components/popups/perpShared.tsx
@@ -12,6 +12,7 @@ import type { TokenVM } from '../../game/tokenView.js';
 import i18n from '../../i18n.js';
 import setup from '../../setup.js';
 import { type PreactDialogHandle, openDialog, stopAndClose, toFXTarget } from './dialogManager.js';
+import { PopupHeader } from './PopupHeader.js';
 
 function getDialogContainer(): HTMLElement {
   return document.querySelector<HTMLElement>(setup.renderContainer) ?? document.body;
@@ -290,7 +291,9 @@ export function TokenUpgradeSubpop({
 
 // ── Mobile subpop-as-dialog wrappers ──────────────────────────────
 
-/** Wrap a token-info subpop in a dialog shell for mobile. */
+/** Wrap a token-info subpop in a dialog shell for mobile.  Uses the
+ *  same `PopupHeader` layout as the token-perp db view so the logo
+ *  shrinks to 80×80 and content reflows to the viewport on phones. */
 export function TokenSubpopDialog({
   token,
   onClose,
@@ -298,18 +301,32 @@ export function TokenSubpopDialog({
   token: TokenVM;
   onClose: () => void;
 }) {
+  const sub = token.subpop;
+  const close = stopAndClose(onClose);
   return (
-    <div class="PopupBody">
-      <div class="PopupContent">
-        <TokenSubpop token={token} isOpen={true} onClose={onClose} />
-      </div>
+    <div class="PopupBody TokenPerp">
+      <PopupHeader
+        onClose={onClose}
+        spriteHtml={sub.logoHtml}
+        title={sub.title}
+        subtitleHtml={sub.subTitleHtml}
+        description={sub.description}
+      >
+        <div class="PopupButtons">
+          {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
+          <div class="Button" data-button-id="OKButton" onClick={close}>
+            {i18n.gettext('Close')}
+          </div>
+        </div>
+      </PopupHeader>
     </div>
   );
 }
 
-/** Wraps a provided-perp subpop in a dialog shell for mobile.  Uses
+/** Wrap a provided-perp subpop in a dialog shell for mobile.  Uses
  *  `parentPopup` (the parent perp dialog's handle) for buy actions
- *  instead of the auto-injected dialog handle. */
+ *  instead of the auto-injected dialog handle.  Renders the same
+ *  header + content layout as the provided-perp db view. */
 export function PerpProvidedSubpopDialog({
   subpop,
   parentPopup,
@@ -319,15 +336,35 @@ export function PerpProvidedSubpopDialog({
   parentPopup: PreactDialogHandle;
   onClose: () => void;
 }) {
+  const vd = subpop.valuesDetailsHtml;
   return (
-    <div class="PopupBody">
+    <div class="PopupBody ProvidedPerp">
+      <PopupHeader
+        onClose={onClose}
+        spriteHtml={subpop.logoHtml}
+        title={subpop.title}
+        description={subpop.description}
+      >
+        {/* biome-ignore lint/security/noDangerouslySetInnerHtml: locally produced bonus markup */}
+        <div class="PowerupLabelData SubpopLabelData" dangerouslySetInnerHTML={{ __html: vd }} />
+      </PopupHeader>
       <div class="PopupContent">
-        <PerpProvidedSubpop
-          subpop={subpop}
-          isOpen={true}
-          onClose={onClose}
-          popup={parentPopup}
-        />
+        <div class="PopupButtons">
+          <div class="ButtonDecorator Cash">
+            <div class="RenderSprite Tobi" />
+            {subpop.priceText}
+          </div>
+          {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
+          <div
+            class="Button"
+            data-button-id="PerpBuyButton"
+            data-button-gestalt={subpop.gestalt}
+            data-testid={`dd-perp-buy-${subpop.gestalt}`}
+            onClick={(e) => fireAction(parentPopup, e, 'PerpBuyButton', [subpop.gestalt])}
+          >
+            {subpop.buyButtonText}
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/scripts/components/popups/perpShared.tsx
+++ b/scripts/components/popups/perpShared.tsx
@@ -323,10 +323,10 @@ export function TokenSubpopDialog({
   );
 }
 
-/** Wrap a provided-perp subpop in a dialog shell for mobile.  Uses
- *  `parentPopup` (the parent perp dialog's handle) for buy actions
- *  instead of the auto-injected dialog handle.  Renders the same
- *  header + content layout as the provided-perp db view. */
+/** Wrap a provided-perp subpop in a dialog shell for mobile.  Single-box
+ *  layout: logo + title + stats + description all in `PopupHeader`, with
+ *  the buy button straddling the header bottom (same pattern as
+ *  `TokenSubpopDialog`).  Uses `parentPopup` for buy actions. */
 export function PerpProvidedSubpopDialog({
   subpop,
   parentPopup,
@@ -338,7 +338,7 @@ export function PerpProvidedSubpopDialog({
 }) {
   const vd = subpop.valuesDetailsHtml;
   return (
-    <div class="PopupBody ProvidedPerp">
+    <div class="PopupBody ProvidedPerp ProvidedPerpSub">
       <PopupHeader
         onClose={onClose}
         spriteHtml={subpop.logoHtml}
@@ -347,8 +347,6 @@ export function PerpProvidedSubpopDialog({
       >
         {/* biome-ignore lint/security/noDangerouslySetInnerHtml: locally produced bonus markup */}
         <div class="PowerupLabelData SubpopLabelData" dangerouslySetInnerHTML={{ __html: vd }} />
-      </PopupHeader>
-      <div class="PopupContent">
         <div class="PopupButtons">
           <div class="ButtonDecorator Cash">
             <div class="RenderSprite Tobi" />
@@ -365,7 +363,7 @@ export function PerpProvidedSubpopDialog({
             {subpop.buyButtonText}
           </div>
         </div>
-      </div>
+      </PopupHeader>
     </div>
   );
 }

--- a/scripts/components/popups/perpShared.tsx
+++ b/scripts/components/popups/perpShared.tsx
@@ -9,6 +9,7 @@ import { type ComponentType, type JSX } from 'preact';
 import type { ProvidedSubpopVM, ProvidedTileVM } from '../../game/providedView.js';
 import type { TokenUpgradeSubpopVM } from '../../game/tokenPopupView.js';
 import type { TokenVM } from '../../game/tokenView.js';
+import type { ProvidedPowerupSubpopVM } from '../../game/powerupView.js';
 import i18n from '../../i18n.js';
 import setup from '../../setup.js';
 import { type PreactDialogHandle, openDialog, stopAndClose, toFXTarget } from './dialogManager.js';
@@ -361,6 +362,53 @@ export function PerpProvidedSubpopDialog({
             onClick={(e) => fireAction(parentPopup, e, 'PerpBuyButton', [subpop.gestalt])}
           >
             {subpop.buyButtonText}
+          </div>
+        </div>
+      </PopupHeader>
+    </div>
+  );
+}
+
+/** Wrap a provided-powerup (upgrade) buy subpop in a dialog shell for
+ *  mobile.  Same single-box layout as `PerpProvidedSubpopDialog`, but
+ *  fires `PowerupBuyButton` with `[gestalt, slot]`. */
+export function ProvidedPowerupSubpopDialog({
+  sub,
+  slot,
+  parentPopup,
+  onClose,
+}: {
+  sub: ProvidedPowerupSubpopVM;
+  slot: number;
+  parentPopup: PreactDialogHandle;
+  onClose: () => void;
+}) {
+  const vd = sub.valuesDetailsHtml;
+  return (
+    <div class="PopupBody ProvidedPerp ProvidedPerpSub">
+      <PopupHeader
+        onClose={onClose}
+        spriteHtml={sub.logoHtml}
+        title={sub.title}
+        description={sub.description}
+      >
+        {/* biome-ignore lint/security/noDangerouslySetInnerHtml: locally produced bonus markup */}
+        <div class="PowerupLabelData SubpopLabelData" dangerouslySetInnerHTML={{ __html: vd }} />
+        <div class="PopupButtons">
+          <div class="ButtonDecorator Cash">
+            <div class="RenderSprite Tobi" />
+            {sub.priceText}
+          </div>
+          {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
+          <div
+            class="Button"
+            data-button-id="PowerupBuyButton"
+            data-button-gestalt={sub.gestalt}
+            data-button-data={slot}
+            data-testid={`dd-powerup-buy-${sub.gestalt}`}
+            onClick={(e) => fireAction(parentPopup, e, 'PowerupBuyButton', [sub.gestalt, slot])}
+          >
+            {sub.buyButtonText}
           </div>
         </div>
       </PopupHeader>

--- a/tests/e2e/dialog-lifecycle.spec.ts
+++ b/tests/e2e/dialog-lifecycle.spec.ts
@@ -1936,16 +1936,11 @@ test.describe('Section P — Pusher/Proxy provided-perp popups', () => {
 
 // ── Section Q — touch subpop reopen ──────────────────────────────────────
 //
-// Regression guard for a touch-only bug: tapping a subpop close control
-// fires a real `touchend` followed by the browser's compatibility
-// `click`.  The dialog manager used to run a legacy jQuery delegated
-// close handler on `touchend` that called `preventDefault()` — which
-// suppressed the compat `click`, so the Preact component's `onClose`
-// never ran.  State desynced (the jQuery handler had stripped `.open`
-// off the DOM behind the vdom's back) and a closed subpop could not be
-// reopened.  Driven with real `.tap()` so the compat-click path is
-// actually exercised; a `.click()` would dispatch mouse events only and
-// miss the bug entirely.
+// Regression guard: on mobile, tapping a free powerup slot opens a stacked
+// dialog (BuySelectorSubpopDialog).  Verifies that closing that dialog by
+// tapping its X and then tapping another slot reopens the dialog — i.e. the
+// stacked-dialog close path correctly restores state so the next tap works.
+// Driven with real `.tap()` so touch-synthesized events are exercised.
 
 test.describe('Section Q — touch subpop reopen', () => {
   test.use({ hasTouch: true, isMobile: true, viewport: { width: 375, height: 667 } });
@@ -1974,34 +1969,30 @@ test.describe('Section Q — touch subpop reopen', () => {
       .first()
       .tap();
 
-    // project001 ships 3 free Ad slots; each opens the buy-selector subpop.
+    // project001 ships 3 free Ad slots; each opens the stacked buy-selector dialog.
     const freeSlots = page.locator(
       '.PopupContainer.lockOn .PopupTab[data-tab="AdPowerup"] .Powerup.free[data-subpop-id="ProvidedAdPowerup"]'
     );
     await expect(freeSlots).toHaveCount(3);
 
-    const container = page.locator(
-      '.PopupContainer.lockOn .PopupTab[data-tab="AdPowerup"] .SubpopContainer'
-    );
-    const selector = page.locator(
-      '.PopupContainer.lockOn .Subpop.Selector[data-subpop-id="ProvidedAdPowerup"]'
-    );
+    // The stacked BuySelectorSubpopDialog places its close button as a direct
+    // child of .PopupBody.ProjectPerp (not inside a .PopupHeader like the
+    // parent popup does) — this CSS child combinator is the distinguishing
+    // handle between the two dialogs.
+    const stackedClose = page.locator('.PopupBody.ProjectPerp > .PopupClose');
 
-    // Tap a free slot — the buy-selector subpop opens.
+    // Tap a free slot — the stacked buy-selector dialog opens.
     await freeSlots.nth(0).tap();
-    await expect(selector).toHaveClass(/open/, { timeout: 2_000 });
-    await expect(container).toHaveClass(/open/);
+    await expect(stackedClose).toBeVisible({ timeout: 2_000 });
 
-    // Tap the SubpopClose X to dismiss it.
-    await selector.locator('.SubpopClose').first().tap();
-    await expect(selector).not.toHaveClass(/open/, { timeout: 2_000 });
-    await expect(container).not.toHaveClass(/open/);
+    // Tap the X to dismiss the stacked dialog.
+    await stackedClose.tap();
+    await expect(stackedClose).not.toBeVisible({ timeout: 2_000 });
 
-    // Tap another free slot — the subpop must reopen (the bug left it
-    // shut: `.SubpopContainer` never regained `.open`).
+    // Tap another free slot — the dialog must reopen (the old bug left the
+    // touch-close path broken so subsequent taps were silently ignored).
     await freeSlots.nth(1).tap();
-    await expect(selector).toHaveClass(/open/, { timeout: 2_000 });
-    await expect(container).toHaveClass(/open/);
+    await expect(stackedClose).toBeVisible({ timeout: 2_000 });
 
     await page.evaluate(() => {
       const groot = (window as any).__dd?._app?.game;


### PR DESCRIPTION
## Summary

- Constrain dialogs to viewport on mobile with flexbox; pin action buttons to the bottom edge straddling the dialog
- Open all buy/sell subpops as dedicated stacked dialogs on mobile instead of inline overlays: token info, provided-perp buy, powerup upgrade buy, powerup sell, buy-slots counter, upgrade-chooser grid
- Fix stat chips (tokens/profiles/cost/risk) stacking vertically in buy dialogs on mobile (root cause: `margin-left: 168px` and `position: absolute` from tile-context CSS leaking into the dialog `PopupHeader`)
- Fix long words (e.g. "TELEFONNUMMER") overflowing popup header title/subtitle on mobile with `overflow-wrap: break-word`
- Fix child dialog not closing when parent closes after a buy action
- Fix `no_cash`/`no_AP` FX bling invisible when a child dialog is stacked (bling was spawned into the hidden parent container)
- Fix buy-slots counter vertical alignment and centering in dialog context (legacy float layout replaced with flexbox)
- Fix upgrade-chooser dialog showing as two separate boxes; collapsed to single `PopupContent`

## Details

**CSS (`Render.css`)** — mobile media query additions:
- Reset `margin-left`, `position`, and size overrides for `SubpopLabelData`, `PerpLabelData`, `PowerupLabelData` inside `.PopupHeader` so stat chips flow horizontally
- `padding-bottom: 76px` on relevant `PopupHeader` classes to leave room for the straddling buy button
- `overflow-wrap: break-word` on `.PopupTitle` / `.PopupSubTitle`
- `BuySlotsDialogBody`: `display: block` on header (no logo grid), flexbox on `BuySlotsWrap` with `margin-top: 0` on buttons for correct vertical centering

**`dialogManager.ts`**:
- Close any stacked child dialog before tearing down the parent
- Spawn FX bling in the active (topmost) container when a child dialog is stacked, so it is visible

**`PopupHeader.tsx`** — add optional `titleHtml` prop for subpops whose titles are raw ruleset HTML

**`perpShared.tsx`** — `TokenSubpopDialog`, `PerpProvidedSubpopDialog`, `ProvidedPowerupSubpopDialog`: single-box `PopupHeader` wrappers used on mobile in place of the inline subpop cards

**`ProjectPopup.tsx`** — all slot-tile taps on mobile open a stacked dialog instead of inline subpop state:
- Free slot → `BuySelectorSubpopDialog` (single `PopupContent` box with title + tile grid)
- Locked slot → `BuySlotsSubpopDialog` (single-box, centered counter)
- Taken slot → `SellSubpopDialog` (single-box, sell button straddling bottom)
- Tile in selector → `ProvidedPowerupSubpopDialog` (stacked on selector); `close_powerup` closes both via cascade
- Desktop inline subpop behaviour unchanged

**`ProvidedPerpPopup.tsx`, `TokenPopup.tsx`** — `isMobileWidth()` guard: open stacked dialog on mobile, set inline state on desktop

## Test plan

- [ ] On mobile (≤ 768 px): tap a free upgrade slot → chooser grid dialog opens; tap a tile → buy detail dialog stacks on top; buy → both dialogs close
- [ ] Tap a locked slot → buy-slots counter dialog with centred -/n/+ widget and buy button
- [ ] Tap a taken slot → sell dialog with stat chips in a horizontal row
- [ ] Tap a raffle/proxy tile → provided-perp buy dialog with horizontal stat chips
- [ ] Buy with insufficient funds → `no_cash` bling appears in the buy dialog (not behind it)
- [ ] Long token names do not overflow the dialog header
- [ ] On desktop, all inline subpop cards still work as before
- [ ] 739/739 tests pass, typecheck clean

🤖 Generated with [Claude Sonnet 4.6](https://claude.ai/claude-code) via [OpenCode Big Pickle](https://github.com/opencodeai/opencode)