### PR TITLE
feat: auto-detect browser language on first start

### DIFF
--- a/scripts/game/GameRoot.ts
+++ b/scripts/game/GameRoot.ts
@@ -2398,12 +2398,17 @@ export class GameRoot extends GameNode {
       (this.renderNode as { hide?(): void } | undefined)?.hide?.();
     });
 
-    // On first game start with no explicit locale choice, ask the
-    // player before rendering — otherwise the tutorial dialog (which
-    // opens during render via mission after_render → checkTutorial)
-    // would overlap the language chooser with a higher z-index.
+    // On first game start with no explicit locale choice, auto-detect
+    // from the browser locale.  German variants (de, de-DE, de-AT,
+    // de-CH, …) default to DE; everything else defaults to EN.
+    // setLocale persists the choice so this branch is skipped on
+    // every subsequent load.
     if (data.is_new_game && !data.locale_persisted) {
-      _showLangPicker(false);
+      const chosen = /^de\b/i.test(navigator.language ?? '') ? 'de' : 'en';
+      const remote = appModule.getApplication().remote as {
+        setLocale?(locale: string): { done(cb: () => void): unknown };
+      };
+      remote.setLocale?.(chosen).done(() => location.reload());
       return this;
     }
 


### PR DESCRIPTION
## Summary

- On first game start (new game, no prior locale choice), instead of showing the language picker dialog, the browser locale is now read via `navigator.language`
- German variants (`de`, `de-DE`, `de-AT`, `de-CH`, …) automatically default to **DE**; everything else defaults to **EN**
- `setLocale` persists the choice, so detection runs only once — subsequent loads skip this path entirely
- The in-game language switcher (menu toggle) is unaffected; users can still change language any time

## Test plan

- [ ] Open the app in a browser with a German locale (`de`, `de-AT`, `de-CH`) — game should start in German without showing any picker
- [ ] Open with a non-German locale (English, French, etc.) — game should start in English without any picker
- [ ] After first start, reload — no picker, no auto-detection runs again (`locale_persisted` is set)
- [ ] Toggle language via in-game menu — still works as before
- [ ] Existing saves with `locale_persisted` already set — unaffected, normal render path

🤖 Generated with [Claude Code](https://claude.com/claude-code)