### PR TITLE
feat: game save export/import via webxdc sendToChat + importFiles (#127)

### DIFF
--- a/css/Render.css
+++ b/css/Render.css
@@ -1770,6 +1770,30 @@
 .PopupBody.About .PopupTab {
   padding-bottom: 56px;
 }
+/* Save export/import section (issue #127).  Unlike the base
+ * `.PopupButtons` (absolutely pinned to the dialog's bottom edge), these
+ * buttons live in-flow inside the scrollable `.PopupContent` so they sit
+ * with the surrounding prose and never overlap the pinned Close button. */
+.PopupBody.About .SaveSection {
+  text-align: center;
+}
+.PopupBody.About .SaveButtons {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 12px;
+  margin: 12px 0 4px;
+}
+.PopupBody.About .SaveButtons .Button {
+  position: relative;
+}
+.PopupBody.About .SaveButtons .Button.disabled {
+  opacity: 0.5;
+  pointer-events: none;
+}
+.PopupBody.About .SaveError {
+  color: #cd495d;
+}
 
 .SubpopContainer {
   position: absolute;

--- a/i18n/de_AT.json
+++ b/i18n/de_AT.json
@@ -980,5 +980,41 @@
   "achievement_karma_devil": [
     null,
     "%s hat den vollen Teufelsstatus erreicht"
+  ],
+  "save section headline": [
+    null,
+    "Spielstand"
+  ],
+  "save section text": [
+    null,
+    "Sichere deinen Fortschritt in einem Chat oder lade einen zuvor exportierten Spielstand. Beim Importieren wird dein aktueller Fortschritt ersetzt."
+  ],
+  "Export Save": [
+    null,
+    "Spielstand exportieren"
+  ],
+  "Import Save": [
+    null,
+    "Spielstand importieren"
+  ],
+  "save export chat text": [
+    null,
+    "Mein Data-Dealer-Spielstand"
+  ],
+  "save imported chat info": [
+    null,
+    "%s hat einen importierten Spielstand geladen."
+  ],
+  "save import error malformed": [
+    null,
+    "Diese Datei ist kein gültiger Data-Dealer-Spielstand."
+  ],
+  "save import error version": [
+    null,
+    "Dieser Spielstand wurde mit einer neueren Version des Spiels erstellt und kann nicht importiert werden."
+  ],
+  "save import error unavailable": [
+    null,
+    "Das Importieren von Spielständen wird hier nicht unterstützt."
   ]
 }

--- a/i18n/de_AT.po
+++ b/i18n/de_AT.po
@@ -1167,6 +1167,46 @@ msgstr "Kapazität für %s Projekte"
 msgid "per deal"
 msgstr "Füttern"
 
+#: scripts/components/popups/AboutPopup.tsx
+msgid "save section headline"
+msgstr "Spielstand"
+
+#: scripts/components/popups/AboutPopup.tsx
+msgid "save section text"
+msgstr ""
+"Sichere deinen Fortschritt in einem Chat oder lade einen zuvor exportierten "
+"Spielstand. Beim Importieren wird dein aktueller Fortschritt ersetzt."
+
+#: scripts/components/popups/AboutPopup.tsx
+msgid "Export Save"
+msgstr "Spielstand exportieren"
+
+#: scripts/components/popups/AboutPopup.tsx
+msgid "Import Save"
+msgstr "Spielstand importieren"
+
+#: scripts/LocalEngine.ts
+msgid "save export chat text"
+msgstr "Mein Data-Dealer-Spielstand"
+
+#: scripts/LocalEngine.ts
+msgid "save imported chat info"
+msgstr "%s hat einen importierten Spielstand geladen."
+
+#: scripts/components/popups/AboutPopup.tsx
+msgid "save import error malformed"
+msgstr "Diese Datei ist kein gültiger Data-Dealer-Spielstand."
+
+#: scripts/components/popups/AboutPopup.tsx
+msgid "save import error version"
+msgstr ""
+"Dieser Spielstand wurde mit einer neueren Version des Spiels erstellt und "
+"kann nicht importiert werden."
+
+#: scripts/components/popups/AboutPopup.tsx
+msgid "save import error unavailable"
+msgstr "Das Importieren von Spielständen wird hier nicht unterstützt."
+
 #~ msgid "user is %s%% better than other Data Dealers"
 #~ msgstr "Du hast besser gezockt als %s%% aller anderen Data Dealer!"
 

--- a/i18n/en_US.json
+++ b/i18n/en_US.json
@@ -980,5 +980,41 @@
   "achievement_karma_devil": [
     null,
     "%s has achieved full devil status"
+  ],
+  "save section headline": [
+    null,
+    "Save game"
+  ],
+  "save section text": [
+    null,
+    "Back up your progress to a chat or restore a previously exported save. Importing replaces your current progress."
+  ],
+  "Export Save": [
+    null,
+    "Export Save"
+  ],
+  "Import Save": [
+    null,
+    "Import Save"
+  ],
+  "save export chat text": [
+    null,
+    "My Data Dealer save game"
+  ],
+  "save imported chat info": [
+    null,
+    "%s loaded an imported save."
+  ],
+  "save import error malformed": [
+    null,
+    "That file is not a valid Data Dealer save."
+  ],
+  "save import error version": [
+    null,
+    "This save was created by a newer version of the game and cannot be imported."
+  ],
+  "save import error unavailable": [
+    null,
+    "Importing save files is not supported here."
   ]
 }

--- a/i18n/en_US.po
+++ b/i18n/en_US.po
@@ -1141,6 +1141,45 @@ msgstr "Room for %s ventures"
 msgid "per deal"
 msgstr "per deal"
 
+#: scripts/components/popups/AboutPopup.tsx
+msgid "save section headline"
+msgstr "Save game"
+
+#: scripts/components/popups/AboutPopup.tsx
+msgid "save section text"
+msgstr ""
+"Back up your progress to a chat or restore a previously exported save. "
+"Importing replaces your current progress."
+
+#: scripts/components/popups/AboutPopup.tsx
+msgid "Export Save"
+msgstr "Export Save"
+
+#: scripts/components/popups/AboutPopup.tsx
+msgid "Import Save"
+msgstr "Import Save"
+
+#: scripts/LocalEngine.ts
+msgid "save export chat text"
+msgstr "My Data Dealer save game"
+
+#: scripts/LocalEngine.ts
+msgid "save imported chat info"
+msgstr "%s loaded an imported save."
+
+#: scripts/components/popups/AboutPopup.tsx
+msgid "save import error malformed"
+msgstr "That file is not a valid Data Dealer save."
+
+#: scripts/components/popups/AboutPopup.tsx
+msgid "save import error version"
+msgstr ""
+"This save was created by a newer version of the game and cannot be imported."
+
+#: scripts/components/popups/AboutPopup.tsx
+msgid "save import error unavailable"
+msgstr "Importing save files is not supported here."
+
 #~ msgid "user is %s%% better than other Data Dealers"
 #~ msgstr "You outperformed %s%% of all Data Dealers"
 

--- a/scripts/LocalEngine.ts
+++ b/scripts/LocalEngine.ts
@@ -538,7 +538,9 @@ export function importSave(): Promise<{ result: ImportSaveResult }> {
       if (!file) {
         return Promise.resolve({ result: { cancelled: true } });
       }
-      return file.text().then(function (text): { result: ImportSaveResult } {
+      return file.text().then(function (text):
+        | { result: ImportSaveResult }
+        | Promise<{ result: ImportSaveResult }> {
         var parsed = parseSaveFile(text);
         if (!parsed.ok) {
           return { result: { error: parsed.error } };
@@ -548,9 +550,21 @@ export function importSave(): Promise<{ result: ImportSaveResult }> {
         var name = state.display_name || snapshot.display_name || wx.selfName || state.addr;
 
         // Persist the import as a delta AND surface a one-line chat notice via
-        // the same update's `info` field.  The delta replays own-only (addr
-        // guard); `info`/`summary` are messenger metadata ignored by applyDelta.
-        wx.sendUpdate(
+        // the same update's `info` field — this is the issue #127 anti-cheat
+        // transparency signal, broadcast to every peer.  The delta replays
+        // own-only (addr guard); `info`/`summary` are messenger metadata
+        // ignored by applyDelta.
+        //
+        // CRITICAL: webxdc.sendUpdate does NOT deliver/persist synchronously
+        // — the listener fires on a later turn and (in Delta Chat and the
+        // @webxdc/vite-plugins simulator) the returned thenable resolves only
+        // once the durability write commits.  The caller reloads the page on
+        // {ok:true}, so we MUST wait for that write before reporting success;
+        // otherwise the reload races persistence and the imported save — and
+        // its chat message — are silently dropped.  `Promise.resolve(...)`
+        // tolerates both the spec's `void` return and the simulator's
+        // Promise.
+        var sent = wx.sendUpdate(
           {
             payload: _mkDelta(state.addr, 'importSave', [], {
               state: snapshot,
@@ -561,8 +575,10 @@ export function importSave(): Promise<{ result: ImportSaveResult }> {
             info: _t('save imported chat info', name),
           },
           ''
-        );
-        return { result: { ok: true } };
+        ) as unknown as void | Promise<void>;
+        return Promise.resolve(sent).then(function (): { result: ImportSaveResult } {
+          return { result: { ok: true } };
+        });
       });
     })
     .catch(function (): { result: ImportSaveResult } {

--- a/scripts/LocalEngine.ts
+++ b/scripts/LocalEngine.ts
@@ -18,7 +18,7 @@ import { getState, setState } from './boot.js';
 import { now as clockNow } from './clock.js';
 import type { UpgradeValuesShape } from './game/ProfileSet.js';
 import { materialize } from './materializer.js';
-import { applyDelta } from './state.js';
+import { applyDelta, buildSaveFile, parseSaveFile } from './state.js';
 import type {
   ChargingEntry,
   Delta,
@@ -468,6 +468,106 @@ export function setLocale(localeCode: string): Promise<{ result: string }> {
   });
 
   return Promise.resolve({ result: localeCode });
+}
+
+// ---------------------------------------------------------------------------
+// Save export / import (issue #127)
+// ---------------------------------------------------------------------------
+
+/** Filename used for exported saves; also the suggested name on re-import. */
+export var SAVE_FILE_NAME = 'data_dealer_save.json';
+
+/** Result of an importSave attempt; the popup maps each error to a message. */
+export type ImportSaveResult =
+  | { ok: true }
+  | { cancelled: true }
+  | { error: 'malformed' | 'version' | 'unavailable' };
+
+/**
+ * exportSave() → Promise<{result: {ok: boolean}}>
+ *
+ * Serializes the *current player's* progress (no peer/leaderboard data — see
+ * buildSaveState) and hands it to webxdc.sendToChat so the player can send the
+ * file into any chat as a backup.  sendToChat may close the app before its
+ * promise settles (per the webxdc contract); callers must not depend on the
+ * resolution to do anything destructive.
+ */
+export function exportSave(): Promise<{ result: { ok: boolean } }> {
+  if (typeof webxdc === 'undefined' || !webxdc || typeof webxdc.sendToChat !== 'function') {
+    return Promise.resolve({ result: { ok: false } });
+  }
+  var save = buildSaveFile(getState());
+  var json = JSON.stringify(save, null, 2);
+  return webxdc
+    .sendToChat({
+      file: { name: SAVE_FILE_NAME, plainText: json },
+      text: _t('save export chat text'),
+    })
+    .then(function () {
+      return { result: { ok: true } };
+    })
+    .catch(function () {
+      return { result: { ok: false } };
+    });
+}
+
+/**
+ * importSave() → Promise<{result: ImportSaveResult}>
+ *
+ * Lets the player pick a previously-exported save via webxdc.importFiles,
+ * validates it, then persists an `importSave` delta that replaces the player's
+ * own progress on the next replay.  A visible chat message is attached to the
+ * same sendUpdate (issue #127's anti-cheat transparency requirement) so other
+ * participants can see that a save was loaded.
+ *
+ * Mirrors setLocale's contract: state isn't mutated synchronously — the caller
+ * reloads after a successful ({ok:true}) result so boot() replays the new
+ * importSave delta and rebuilds state from it.
+ */
+export function importSave(): Promise<{ result: ImportSaveResult }> {
+  if (typeof webxdc === 'undefined' || !webxdc || typeof webxdc.importFiles !== 'function') {
+    return Promise.resolve({ result: { error: 'unavailable' } });
+  }
+  // Capture a non-undefined reference so the async closures below keep the
+  // narrowing the early-return guard established.
+  var wx = webxdc;
+  return wx
+    .importFiles({ extensions: ['.json'], mimeTypes: ['application/json'] })
+    .then(function (files): Promise<{ result: ImportSaveResult }> {
+      var file = files && files[0];
+      if (!file) {
+        return Promise.resolve({ result: { cancelled: true } });
+      }
+      return file.text().then(function (text): { result: ImportSaveResult } {
+        var parsed = parseSaveFile(text);
+        if (!parsed.ok) {
+          return { result: { error: parsed.error } };
+        }
+        var state = getState();
+        var snapshot = parsed.save.state;
+        var name = state.display_name || snapshot.display_name || wx.selfName || state.addr;
+
+        // Persist the import as a delta AND surface a one-line chat notice via
+        // the same update's `info` field.  The delta replays own-only (addr
+        // guard); `info`/`summary` are messenger metadata ignored by applyDelta.
+        wx.sendUpdate(
+          {
+            payload: _mkDelta(state.addr, 'importSave', [], {
+              state: snapshot,
+              // Mirror game_values at the top level so the peer aggregator
+              // refreshes this player's leaderboard row from the imported save.
+              game_values: snapshot.game_values,
+            }),
+            info: _t('save imported chat info', name),
+          },
+          ''
+        );
+        return { result: { ok: true } };
+      });
+    })
+    .catch(function (): { result: ImportSaveResult } {
+      return { result: { error: 'malformed' } };
+    });
 }
 
 /**
@@ -3096,6 +3196,8 @@ var LocalEngine = Object.assign(
     ping: ping,
     getSessionLocale: getSessionLocale,
     setLocale: setLocale,
+    exportSave: exportSave,
+    importSave: importSave,
     loadGame: loadGame,
     getRanking: getRanking,
     setDisplayName: setDisplayName,

--- a/scripts/app.ts
+++ b/scripts/app.ts
@@ -74,6 +74,8 @@ interface AppRemote {
   getRanking?(type: string): DoneFailChain<RankingResult>;
   getSessionLocale?(): JQueryLike;
   loadGame?(): JQueryLike;
+  exportSave?(): JQueryLike;
+  importSave?(): JQueryLike;
 }
 
 interface ApplicationApi {

--- a/scripts/components/popups/AboutPopup.tsx
+++ b/scripts/components/popups/AboutPopup.tsx
@@ -6,15 +6,39 @@
 // the dialog is single-purpose and stateless.
 
 import type { JSX } from 'preact';
+import { useState } from 'preact/hooks';
 import i18n from '../../i18n.js';
 import { Link } from '../Link.js';
+
+/** Why an import attempt failed; maps to a localized message in the popup. */
+export type ImportErrorKind = 'malformed' | 'version' | 'unavailable';
+
+/** Normalized outcome of an import attempt, as handed back by `onImport`.
+ *  Keeps the component decoupled from LocalEngine's result shape. */
+export type ImportOutcome =
+  | { status: 'ok' }
+  | { status: 'cancelled' }
+  | { status: 'error'; errorKind: ImportErrorKind };
 
 export interface AboutPopupProps {
   /** `game.setup.locale` — MainMenuLogo sprite locale class. */
   locale: string;
   buttonLabel: string;
   onClose: () => void;
+  /** Export the current player's save via webxdc sendToChat. Fire-and-forget:
+   *  sendToChat may close the app before it resolves. Omitted in environments
+   *  without a messenger (the section is then hidden). */
+  onExport?: () => void;
+  /** Pick + load a save file; resolves with the outcome so the popup can show
+   *  an error or trigger a reload. Omitted → section hidden. */
+  onImport?: () => Promise<ImportOutcome>;
 }
+
+const IMPORT_ERROR_KEY: Record<ImportErrorKind, string> = {
+  malformed: 'save import error malformed',
+  version: 'save import error version',
+  unavailable: 'save import error unavailable',
+};
 
 // Translatable prose carries `%s` markers where external links sit;
 // the link labels are URLs / repo names and stay literal, so we
@@ -30,10 +54,35 @@ function withLinks(template: string, links: JSX.Element[]): (string | JSX.Elemen
   return out;
 }
 
-export function AboutPopup({ locale, buttonLabel, onClose }: AboutPopupProps) {
+export function AboutPopup({ locale, buttonLabel, onClose, onExport, onImport }: AboutPopupProps) {
   const close = (e: JSX.TargetedMouseEvent<HTMLDivElement>): void => {
     e.stopPropagation();
     onClose();
+  };
+
+  const [importing, setImporting] = useState(false);
+  const [importError, setImportError] = useState<string | null>(null);
+
+  const handleImport = (): void => {
+    if (!onImport || importing) return;
+    setImporting(true);
+    setImportError(null);
+    onImport()
+      .then((outcome) => {
+        if (outcome.status === 'ok') {
+          // Replay rebuilds state from the imported delta (mirrors setLocale).
+          window.location.reload();
+          return;
+        }
+        if (outcome.status === 'error') {
+          setImportError(i18n.gettext(IMPORT_ERROR_KEY[outcome.errorKind]));
+        }
+        setImporting(false);
+      })
+      .catch(() => {
+        setImportError(i18n.gettext(IMPORT_ERROR_KEY.malformed));
+        setImporting(false);
+      });
   };
   return (
     <div class="PopupBody About">
@@ -79,6 +128,31 @@ export function AboutPopup({ locale, buttonLabel, onClose }: AboutPopupProps) {
               ])}
             </div>
           </div>
+          {(onExport || onImport) && (
+            <div class="PopupContentText SaveSection">
+              <div class="PopupTitle">{i18n.gettext('save section headline')}</div>
+              <div class="PopupParagraph">{i18n.gettext('save section text')}</div>
+              <div class="SaveButtons">
+                {onExport && (
+                  // biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass
+                  <div class="Button" data-button-id="ExportSave" onClick={() => onExport()}>
+                    {i18n.gettext('Export Save')}
+                  </div>
+                )}
+                {onImport && (
+                  // biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass
+                  <div
+                    class={importing ? 'Button disabled' : 'Button'}
+                    data-button-id="ImportSave"
+                    onClick={handleImport}
+                  >
+                    {i18n.gettext('Import Save')}
+                  </div>
+                )}
+              </div>
+              {importError && <div class="PopupParagraph SaveError">{importError}</div>}
+            </div>
+          )}
           <div class="PopupButtons">
             {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
             <div class="Button" data-button-id="MainButton" onClick={close}>

--- a/scripts/game/GameRoot.ts
+++ b/scripts/game/GameRoot.ts
@@ -21,7 +21,7 @@ import type { ComponentType } from 'preact';
 import { type RenderApi, getRender } from '../Render.js';
 import appModule from '../app.js';
 import { APStatusPopup } from '../components/popups/APStatusPopup.js';
-import { AboutPopup } from '../components/popups/AboutPopup.js';
+import { AboutPopup, type ImportOutcome } from '../components/popups/AboutPopup.js';
 import { CashStatusPopup } from '../components/popups/CashStatusPopup.js';
 import { ProfilesStatusPopup } from '../components/popups/ProfilesStatusPopup.js';
 import { ProvidedPerpPopup } from '../components/popups/ProvidedPerpPopup.js';
@@ -402,6 +402,19 @@ function _stopPropFile(e: unknown): void {
 function _preventDefaultFile(e: unknown): void {
   const fn = (e as { preventDefault?: () => void } | null | undefined)?.preventDefault;
   if (typeof fn === 'function') fn.call(e);
+}
+
+/** Maps LocalEngine.importSave's `{result: ImportSaveResult}` onto the
+ *  AboutPopup's framework-agnostic ImportOutcome.  Unknown shapes degrade to a
+ *  generic 'malformed' error rather than throwing. */
+function _normalizeImport(data: unknown): ImportOutcome {
+  const result = (data as { result?: unknown } | undefined)?.result as
+    | { ok?: boolean; cancelled?: boolean; error?: 'malformed' | 'version' | 'unavailable' }
+    | undefined;
+  if (result?.ok) return { status: 'ok' };
+  if (result?.cancelled) return { status: 'cancelled' };
+  if (result?.error) return { status: 'error', errorKind: result.error };
+  return { status: 'error', errorKind: 'malformed' };
 }
 
 /** First-boot / settings language picker overlay.  jQuery-driven DOM
@@ -2056,6 +2069,13 @@ export class GameRoot extends GameNode {
     // phase – or are we?
     const remoteApi = appModule.getApplication().remote as {
       setPerpCoordinates?(rows: Array<[string, { x: number; y: number }]>): unknown;
+      exportSave?(): unknown;
+      importSave?(): {
+        then(
+          onResolved?: (...a: unknown[]) => unknown,
+          onRejected?: (...a: unknown[]) => unknown
+        ): unknown;
+      };
     };
     this.on('saveCoordsQueue', (_e: unknown, path: unknown, pos: unknown) => {
       remoteApi.setPerpCoordinates?.([[path as string, pos as { x: number; y: number }]]);
@@ -2093,11 +2113,32 @@ export class GameRoot extends GameNode {
 
     this.on('user_data', (e: unknown) => {
       _stopPropFile(e);
+      const onExport = remoteApi.exportSave
+        ? (): void => {
+            remoteApi.exportSave?.();
+          }
+        : undefined;
+      const onImport = remoteApi.importSave
+        ? (): Promise<ImportOutcome> =>
+            new Promise<ImportOutcome>((resolve) => {
+              const chain = remoteApi.importSave?.();
+              if (!chain) {
+                resolve({ status: 'error', errorKind: 'unavailable' });
+                return;
+              }
+              chain.then(
+                (...args: unknown[]) => resolve(_normalizeImport(args[0])),
+                () => resolve({ status: 'error', errorKind: 'malformed' })
+              );
+            })
+        : undefined;
       this.openPreactDialog(
         AboutPopup,
         {
           locale: setup.locale ?? '',
           buttonLabel: i18n.gettext('Close'),
+          ...(onExport && { onExport }),
+          ...(onImport && { onImport }),
         },
         { extendClass: 'About' }
       );

--- a/scripts/state.ts
+++ b/scripts/state.ts
@@ -405,7 +405,10 @@ export function parseSaveFile(text: string): ParsedSave {
   if (!data || typeof data !== 'object' || data.format !== SAVE_FORMAT) {
     return { ok: false, error: 'malformed' };
   }
-  if (typeof data.save_version !== 'number' || data.save_version > SAVE_VERSION) {
+  if (typeof data.save_version !== 'number') {
+    return { ok: false, error: 'malformed' };
+  }
+  if (data.save_version > SAVE_VERSION) {
     return { ok: false, error: 'version' };
   }
   // A valid save must carry an object state body with game_values — the one

--- a/scripts/state.ts
+++ b/scripts/state.ts
@@ -186,9 +186,27 @@ export var SCHEMA_VERSION = 1;
  *  unrelated JSON. */
 export var SAVE_FORMAT = 'data_dealer_save';
 
-/** Save-file format version.  Bumped when the on-disk shape changes so old
- *  exports can be migrated (or rejected) on import. Independent of
- *  SCHEMA_VERSION, which versions the in-memory LocalState. */
+/**
+ * Save-file format version.  Independent of SCHEMA_VERSION (which versions the
+ * in-memory LocalState); this versions the exported-file envelope + snapshot.
+ *
+ * ⚠️ MAINTENANCE CONTRACT — read before changing the save shape ⚠️
+ * The exported snapshot is produced by buildSaveState() and re-applied by the
+ * `importSave` reducer.  If you change WHAT a save contains or HOW it is read,
+ * keep these in lockstep:
+ *   1. Adding a LocalState field that should be exported → add it to
+ *      buildSaveState() (it is allow-listed there, never auto-included) AND
+ *      bump SAVE_VERSION.
+ *   2. Renaming / changing the meaning of an exported field → bump SAVE_VERSION
+ *      and add a migration so old (lower save_version) files still import.
+ *   3. SCHEMA_VERSION changes that alter persisted gameplay shape → consider
+ *      whether old saves need migrating on import too.
+ * Migrations live alongside parseSaveFile() / the importSave reducer: older
+ * save_versions are accepted (parseSaveFile only rejects NEWER ones), and any
+ * field absent from an old snapshot falls back to freshState() defaults in the
+ * reducer — that default-fill is the zero-effort migration for purely-additive
+ * changes.  Anything structural needs an explicit upgrade step.
+ */
 export var SAVE_VERSION = 1;
 
 var _defaultSeed: GameSeed = (defaultGameData as GameSeed) || { game_values: {} };
@@ -350,6 +368,9 @@ export type ParsedSave =
  * Picks the exportable fields off LocalState explicitly (rather than deleting
  * addr/peers from a copy) so adding a future LocalState field never silently
  * leaks into exports — a new field has to be opted in here.
+ *
+ * ⚠️ Adding/removing/renaming a field here changes the save-file shape: bump
+ * SAVE_VERSION and add a migration if needed.  See the SAVE_VERSION doc above.
  */
 export function buildSaveState(state: LocalState): SaveState {
   return {
@@ -390,10 +411,13 @@ export function buildSaveFile(state: LocalState, exportedAt?: number): SaveFile 
  * parseSaveFile(text) → ParsedSave
  *
  * Validates a previously-exported save file's JSON text.  Fails closed:
- *   - 'malformed' — not JSON, wrong format marker, or missing state body
- *   - 'version'   — newer save_version than this build understands
- * Older save_versions are accepted (forward-migration happens in importSave's
- * reducer via freshState defaults filling any absent fields).
+ *   - 'malformed' — not JSON, wrong format marker, non-numeric save_version,
+ *                   or missing/!object state body
+ *   - 'version'   — numeric but NEWER save_version than this build understands
+ * Older save_versions are intentionally accepted: additive changes migrate for
+ * free because the importSave reducer fills any absent field from freshState
+ * defaults.  When you bump SAVE_VERSION for a NON-additive change, branch here
+ * (or in the reducer) on save.save_version to upgrade the older shape.
  */
 export function parseSaveFile(text: string): ParsedSave {
   var data: any;
@@ -826,7 +850,9 @@ reducers.dismissMissionBriefing = function dismissMissionBriefingReducer(state, 
 // from the live local state — never from the snapshot — so importing someone
 // else's save can't hijack your address or wipe the leaderboard.  Missing
 // fields fall back to freshState defaults, which is also how an older
-// save_version forward-migrates.
+// save_version forward-migrates (see the SAVE_VERSION maintenance contract).
+// A NON-additive save_version bump needs an explicit upgrade step here, before
+// the snapshot is merged onto `base`.
 reducers.importSave = function importSaveReducer(state, delta) {
   var snap = delta.result && delta.result.state;
   if (!snap || typeof snap !== 'object') return state;

--- a/scripts/state.ts
+++ b/scripts/state.ts
@@ -178,6 +178,19 @@ export interface GameSeed {
 
 export var SCHEMA_VERSION = 1;
 
+// ---------------------------------------------------------------------------
+// Save-file (export / import) constants (issue #127)
+// ---------------------------------------------------------------------------
+
+/** Magic marker stamped into exported save files; guards against importing
+ *  unrelated JSON. */
+export var SAVE_FORMAT = 'data_dealer_save';
+
+/** Save-file format version.  Bumped when the on-disk shape changes so old
+ *  exports can be migrated (or rejected) on import. Independent of
+ *  SCHEMA_VERSION, which versions the in-memory LocalState. */
+export var SAVE_VERSION = 1;
+
 var _defaultSeed: GameSeed = (defaultGameData as GameSeed) || { game_values: {} };
 
 // Every handler op that can appear as delta.op.  Read-only handlers
@@ -205,6 +218,7 @@ var OP_NAMES = [
   'dismissMissionBriefing',
   'markTokenSeen',
   'recheckMissions',
+  'importSave',
 ];
 
 // ---------------------------------------------------------------------------
@@ -292,6 +306,114 @@ export function freshState(selfAddr?: string, seed?: GameSeed): LocalState {
  */
 export function seedNewGame(state: LocalState): LocalState {
   return state;
+}
+
+// ---------------------------------------------------------------------------
+// Save export / import (issue #127)
+// ---------------------------------------------------------------------------
+
+/**
+ * The current player's own progress, with identity- and peer-scoped fields
+ * stripped.
+ *
+ * `addr` (the webxdc selfAddr) and `peers` (every *other* player's aggregated
+ * leaderboard stats) are deliberately excluded: the export must contain only
+ * the exporting player's state, never other users'. On import the importer's
+ * own addr and peer table are kept, and only these gameplay fields are
+ * replaced.
+ */
+export type SaveState = Omit<LocalState, 'addr' | 'peers'>;
+
+/** Envelope written to / read from an exported save file. */
+export interface SaveFile {
+  /** Always SAVE_FORMAT; rejected on import otherwise. */
+  format: string;
+  /** SAVE_VERSION at export time. */
+  save_version: number;
+  /** SCHEMA_VERSION at export time (informational; LocalState carries its own). */
+  schema_version: number;
+  /** Epoch-ms the file was produced. */
+  exported_at: number;
+  /** The exporting player's own progress (no addr / peers). */
+  state: SaveState;
+}
+
+/** Outcome of parseSaveFile — a discriminated result so callers can map the
+ *  failure to a localized, user-facing message. */
+export type ParsedSave =
+  | { ok: true; save: SaveFile }
+  | { ok: false; error: 'malformed' | 'version' };
+
+/**
+ * buildSaveState(state) → SaveState
+ *
+ * Picks the exportable fields off LocalState explicitly (rather than deleting
+ * addr/peers from a copy) so adding a future LocalState field never silently
+ * leaks into exports — a new field has to be opted in here.
+ */
+export function buildSaveState(state: LocalState): SaveState {
+  return {
+    schema_version: state.schema_version,
+    display_name: state.display_name,
+    game_version: state.game_version,
+    version: state.version,
+    nodes: state.nodes,
+    nodes_charging: state.nodes_charging,
+    nodes_collect: state.nodes_collect,
+    db_queue: state.db_queue,
+    game_values: state.game_values,
+    mission_goals: state.mission_goals,
+    active_missions: state.active_missions,
+    last_seen_ts: state.last_seen_ts,
+    node_counter: state.node_counter,
+    integrated_ids: state.integrated_ids,
+    mission_briefings_seen: state.mission_briefings_seen,
+    tokens_seen: state.tokens_seen,
+    // locale is optional — only include it when set so exactOptionalPropertyTypes
+    // doesn't see an explicit `undefined`.
+    ...(state.locale !== undefined && { locale: state.locale }),
+  };
+}
+
+/** buildSaveFile(state) → SaveFile envelope ready to JSON.stringify. */
+export function buildSaveFile(state: LocalState, exportedAt?: number): SaveFile {
+  return {
+    format: SAVE_FORMAT,
+    save_version: SAVE_VERSION,
+    schema_version: SCHEMA_VERSION,
+    exported_at: typeof exportedAt === 'number' ? exportedAt : clockNow(),
+    state: buildSaveState(state),
+  };
+}
+
+/**
+ * parseSaveFile(text) → ParsedSave
+ *
+ * Validates a previously-exported save file's JSON text.  Fails closed:
+ *   - 'malformed' — not JSON, wrong format marker, or missing state body
+ *   - 'version'   — newer save_version than this build understands
+ * Older save_versions are accepted (forward-migration happens in importSave's
+ * reducer via freshState defaults filling any absent fields).
+ */
+export function parseSaveFile(text: string): ParsedSave {
+  var data: any;
+  try {
+    data = JSON.parse(text);
+  } catch (_) {
+    return { ok: false, error: 'malformed' };
+  }
+  if (!data || typeof data !== 'object' || data.format !== SAVE_FORMAT) {
+    return { ok: false, error: 'malformed' };
+  }
+  if (typeof data.save_version !== 'number' || data.save_version > SAVE_VERSION) {
+    return { ok: false, error: 'version' };
+  }
+  // A valid save must carry an object state body with game_values — the one
+  // field every real game has and the cheapest structural sanity check.
+  if (!data.state || typeof data.state !== 'object' || typeof data.state.game_values !== 'object') {
+    return { ok: false, error: 'malformed' };
+  }
+  return { ok: true, save: data as SaveFile };
 }
 
 function _seedNodesFromTree(src: GameSeed): GameNode[] {
@@ -690,6 +812,35 @@ reducers.dismissMissionBriefing = function dismissMissionBriefingReducer(state, 
   if (seen[gestalt]) return state;
   seen[gestalt] = true;
   return Object.assign({}, state, { mission_briefings_seen: seen });
+};
+
+// 'importSave' (issue #127) replaces the player's own progress with a
+// previously-exported snapshot.  The snapshot rides in delta.result.state and
+// only ever applies to the importing player (applyDelta's addr guard blocks
+// foreign importSave deltas before this reducer runs).
+//
+// Identity (addr) and other players' aggregated stats (peers) are always taken
+// from the live local state — never from the snapshot — so importing someone
+// else's save can't hijack your address or wipe the leaderboard.  Missing
+// fields fall back to freshState defaults, which is also how an older
+// save_version forward-migrates.
+reducers.importSave = function importSaveReducer(state, delta) {
+  var snap = delta.result && delta.result.state;
+  if (!snap || typeof snap !== 'object') return state;
+
+  var base = freshState(state.addr);
+  var merged: LocalState = Object.assign({}, base, snap, {
+    addr: state.addr,
+    peers: state.peers,
+    schema_version: SCHEMA_VERSION,
+    // Respect the monotonic clock guard: never let an imported timestamp
+    // rewind below the value applyDelta already advanced to.
+    last_seen_ts: Math.max(
+      state.last_seen_ts || 0,
+      typeof snap.last_seen_ts === 'number' ? snap.last_seen_ts : 0
+    ),
+  });
+  return merged;
 };
 
 // Stubs — return state unchanged until Wave 4+ fills them in.

--- a/tests/handlers/save-export-import-handlers.test.js
+++ b/tests/handlers/save-export-import-handlers.test.js
@@ -1,0 +1,153 @@
+// @ts-nocheck — strict-TS quarantine; remove when this file is migrated to TS (issue #147)
+//
+// Handler-level tests for exportSave / importSave (issue #127).
+//
+// These assert the webxdc-facing behaviour the pure state tests can't:
+//   - export hands sendToChat a round-trippable, current-user-only file
+//   - import broadcasts an `importSave` status update to peers AND attaches a
+//     visible `info` chat message (the issue's anti-cheat transparency signal)
+//   - import waits for sendUpdate durability before reporting success (the
+//     popup reloads on success, so a lost write would silently drop the import)
+//   - cancel / malformed files emit NO status update
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { exportSave, importSave } from '../../scripts/LocalEngine.js';
+import { __resetBootForTest, boot } from '../../scripts/boot.js';
+import { buildSaveFile, freshState, parseSaveFile } from '../../scripts/state.js';
+
+const ADDR = 'alice@example.com';
+
+let saved;
+let sentUpdates; // full {payload, info, ...} objects passed to sendUpdate
+let chatMessages; // contents passed to sendToChat
+let nextImportFiles; // what importFiles resolves with
+
+function installFakeWebxdc() {
+  sentUpdates = [];
+  chatMessages = [];
+  nextImportFiles = [];
+  const updates = [];
+  let listener = null;
+  saved = globalThis.webxdc;
+  globalThis.webxdc = {
+    selfAddr: ADDR,
+    selfName: 'AliceName',
+    sendUpdate(update) {
+      sentUpdates.push(update);
+      const serial = updates.length + 1;
+      const entry = Object.assign({}, update, { serial, max_serial: serial });
+      updates.push(entry);
+      if (listener) listener(entry);
+      // Mimic the real messenger / simulator: the return value is a thenable
+      // that resolves once the durability write commits, on a later turn.
+      return Promise.resolve();
+    },
+    setUpdateListener(cb, serial) {
+      const after = typeof serial === 'number' ? serial : 0;
+      for (const u of updates) if (u.serial > after) cb(u);
+      listener = cb;
+      return Promise.resolve();
+    },
+    sendToChat(content) {
+      chatMessages.push(content);
+      return Promise.resolve();
+    },
+    importFiles() {
+      return Promise.resolve(nextImportFiles);
+    },
+  };
+}
+
+function fakeFile(text) {
+  return { name: 'data_dealer_save.json', text: () => Promise.resolve(text) };
+}
+
+beforeEach(async () => {
+  installFakeWebxdc();
+  __resetBootForTest();
+  await boot({ selfAddr: ADDR });
+});
+
+afterEach(() => {
+  __resetBootForTest();
+  if (saved === undefined) delete globalThis.webxdc;
+  else globalThis.webxdc = saved;
+});
+
+function makeSaveJson(overrides = {}) {
+  const s = freshState(ADDR);
+  s.display_name = 'Alice';
+  s.game_values = { ...s.game_values, cash_value: 4242 };
+  Object.assign(s, overrides);
+  return JSON.stringify(buildSaveFile(s));
+}
+
+describe('exportSave', () => {
+  it('sends a current-user-only save file to chat', async () => {
+    const res = await exportSave();
+    expect(res.result.ok).toBe(true);
+    expect(chatMessages).toHaveLength(1);
+    const file = chatMessages[0].file;
+    expect(file.name).toBe('data_dealer_save.json');
+    const parsed = parseSaveFile(file.plainText);
+    expect(parsed.ok).toBe(true);
+    // The exported snapshot must not carry identity or other players' stats.
+    expect('addr' in parsed.save.state).toBe(false);
+    expect('peers' in parsed.save.state).toBe(false);
+  });
+
+  it('does not emit a status update (export is local-to-chat only)', async () => {
+    await exportSave();
+    expect(sentUpdates).toHaveLength(0);
+  });
+});
+
+describe('importSave', () => {
+  it('broadcasts an importSave status update with the snapshot', async () => {
+    nextImportFiles = [fakeFile(makeSaveJson())];
+    const res = await importSave();
+    expect(res.result.ok).toBe(true);
+    expect(sentUpdates).toHaveLength(1);
+    const update = sentUpdates[0];
+    expect(update.payload.kind).toBe('delta');
+    expect(update.payload.op).toBe('importSave');
+    expect(update.payload.addr).toBe(ADDR);
+    expect(update.payload.result.state.game_values.cash_value).toBe(4242);
+    // Mirrored game_values so peers' leaderboard view refreshes.
+    expect(update.payload.result.game_values.cash_value).toBe(4242);
+  });
+
+  it('attaches a visible chat info message naming the player (anti-cheat signal)', async () => {
+    nextImportFiles = [fakeFile(makeSaveJson())];
+    await importSave();
+    const info = sentUpdates[0].info;
+    expect(typeof info).toBe('string');
+    expect(info.length).toBeGreaterThan(0);
+    expect(info).toContain('Alice');
+  });
+
+  it('reports cancelled and emits nothing when no file is picked', async () => {
+    nextImportFiles = [];
+    const res = await importSave();
+    expect(res.result.cancelled).toBe(true);
+    expect(sentUpdates).toHaveLength(0);
+  });
+
+  it('reports a malformed error and emits nothing for a bad file', async () => {
+    nextImportFiles = [fakeFile('not a save {')];
+    const res = await importSave();
+    expect(res.result.error).toBe('malformed');
+    expect(sentUpdates).toHaveLength(0);
+  });
+
+  it('rejects a newer save_version without emitting an update', async () => {
+    const future = JSON.stringify({
+      format: 'data_dealer_save',
+      save_version: 999,
+      state: { game_values: {} },
+    });
+    nextImportFiles = [fakeFile(future)];
+    const res = await importSave();
+    expect(res.result.error).toBe('version');
+    expect(sentUpdates).toHaveLength(0);
+  });
+});

--- a/tests/state/save-export-import.test.js
+++ b/tests/state/save-export-import.test.js
@@ -1,0 +1,168 @@
+// @ts-nocheck — strict-TS quarantine; remove when this file is migrated to TS (issue #147)
+//
+// Tests for the game-save export/import primitives (issue #127).
+//
+// Export must contain ONLY the current player's progress — never other
+// players' aggregated leaderboard stats (state.peers) or the player's webxdc
+// address (state.addr).  Import must replace the player's own progress while
+// keeping their identity and peer table, and survive cold-start replay.
+import { describe, expect, it } from 'vitest';
+import {
+  SAVE_FORMAT,
+  SAVE_VERSION,
+  SCHEMA_VERSION,
+  applyDelta,
+  buildSaveFile,
+  buildSaveState,
+  freshState,
+  parseSaveFile,
+} from '../../scripts/state.js';
+
+const ADDR = 'alice@example.com';
+
+function progressedState() {
+  // A fresh state with some divergence from defaults plus a peer entry, so we
+  // can assert the peer never leaks into an export.
+  const s = freshState(ADDR);
+  s.display_name = 'Alice';
+  s.game_values = { ...s.game_values, cash_value: 9999, xp_value: 4242, xp_level: 7 };
+  s.node_counter = 12;
+  s.locale = 'en';
+  s.peers = {
+    'bob@example.com': { cash: 5, xp: 6, display_name: 'Bob' },
+  };
+  return s;
+}
+
+describe('buildSaveState — current user only', () => {
+  it('omits addr and peers', () => {
+    const snap = buildSaveState(progressedState());
+    expect('addr' in snap).toBe(false);
+    expect('peers' in snap).toBe(false);
+  });
+
+  it('carries the player progress fields', () => {
+    const snap = buildSaveState(progressedState());
+    expect(snap.display_name).toBe('Alice');
+    expect(snap.game_values.cash_value).toBe(9999);
+    expect(snap.node_counter).toBe(12);
+    expect(snap.locale).toBe('en');
+  });
+
+  it('omits locale entirely when unset', () => {
+    const s = freshState(ADDR); // no locale
+    const snap = buildSaveState(s);
+    expect('locale' in snap).toBe(false);
+  });
+});
+
+describe('buildSaveFile / parseSaveFile round-trip', () => {
+  it('stamps format + version metadata', () => {
+    const file = buildSaveFile(progressedState(), 1234);
+    expect(file.format).toBe(SAVE_FORMAT);
+    expect(file.save_version).toBe(SAVE_VERSION);
+    expect(file.schema_version).toBe(SCHEMA_VERSION);
+    expect(file.exported_at).toBe(1234);
+  });
+
+  it('parses its own exported JSON', () => {
+    const json = JSON.stringify(buildSaveFile(progressedState()));
+    const parsed = parseSaveFile(json);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.save.state.game_values.cash_value).toBe(9999);
+  });
+
+  it('rejects non-JSON as malformed', () => {
+    expect(parseSaveFile('not json {')).toEqual({ ok: false, error: 'malformed' });
+  });
+
+  it('rejects JSON without the format marker', () => {
+    expect(parseSaveFile(JSON.stringify({ state: { game_values: {} } }))).toEqual({
+      ok: false,
+      error: 'malformed',
+    });
+  });
+
+  it('rejects a save body with no game_values', () => {
+    const bad = JSON.stringify({
+      format: SAVE_FORMAT,
+      save_version: SAVE_VERSION,
+      state: {},
+    });
+    expect(parseSaveFile(bad)).toEqual({ ok: false, error: 'malformed' });
+  });
+
+  it('rejects a newer save_version', () => {
+    const future = JSON.stringify({
+      format: SAVE_FORMAT,
+      save_version: SAVE_VERSION + 1,
+      state: { game_values: {} },
+    });
+    expect(parseSaveFile(future)).toEqual({ ok: false, error: 'version' });
+  });
+});
+
+function importDelta(addr, snapshot, ts) {
+  return {
+    kind: 'delta',
+    addr,
+    op: 'importSave',
+    args: [],
+    result: { state: snapshot, game_values: snapshot.game_values },
+    ts: ts || Date.now(),
+  };
+}
+
+describe('applyDelta — importSave reducer', () => {
+  it('replaces own progress with the imported snapshot', () => {
+    const snapshot = buildSaveState(progressedState());
+    const out = applyDelta(freshState(ADDR), importDelta(ADDR, snapshot));
+    expect(out.display_name).toBe('Alice');
+    expect(out.game_values.cash_value).toBe(9999);
+    expect(out.node_counter).toBe(12);
+  });
+
+  it('keeps the local addr and existing peer rows', () => {
+    const snapshot = buildSaveState(progressedState());
+    let s = freshState(ADDR);
+    // Local player has their own peer table that must survive the import.
+    s = { ...s, peers: { 'carol@example.com': { cash: 1 } } };
+    const out = applyDelta(s, importDelta(ADDR, snapshot));
+    expect(out.addr).toBe(ADDR);
+    // Existing foreign peers are preserved (the snapshot's peers never leak in;
+    // the importer's own row is refreshed by the peer aggregator).
+    expect(out.peers['carol@example.com']).toEqual({ cash: 1 });
+    expect('bob@example.com' in out.peers).toBe(false);
+  });
+
+  it('ignores a foreign player importSave delta (no self-mutation)', () => {
+    const snapshot = buildSaveState(progressedState());
+    const s = freshState(ADDR);
+    const out = applyDelta(s, importDelta('mallory@example.com', snapshot));
+    expect(out.display_name).toBe('');
+    expect(out.game_values.cash_value).toBe(s.game_values.cash_value);
+  });
+
+  it('forces schema_version to current even if the snapshot disagrees', () => {
+    const snapshot = { ...buildSaveState(progressedState()), schema_version: 999 };
+    const out = applyDelta(freshState(ADDR), importDelta(ADDR, snapshot));
+    expect(out.schema_version).toBe(SCHEMA_VERSION);
+  });
+
+  it('survives cold-start replay (delta is the source of truth)', () => {
+    const snapshot = buildSaveState(progressedState());
+    const delta = importDelta(ADDR, snapshot, 1000);
+    const direct = applyDelta(freshState(ADDR), delta);
+    const replayed = [delta].reduce((acc, d) => applyDelta(acc, d), freshState(ADDR));
+    expect(replayed.game_values.cash_value).toBe(direct.game_values.cash_value);
+    expect(replayed.display_name).toBe(direct.display_name);
+    expect(replayed.node_counter).toBe(direct.node_counter);
+  });
+
+  it('refreshes the importing player peer row from the snapshot game_values', () => {
+    const snapshot = buildSaveState(progressedState());
+    const out = applyDelta(freshState(ADDR), importDelta(ADDR, snapshot, 5000));
+    expect(out.peers[ADDR].cash).toBe(9999);
+    expect(out.peers[ADDR].xp).toBe(4242);
+  });
+});

--- a/tests/state/save-export-import.test.js
+++ b/tests/state/save-export-import.test.js
@@ -100,6 +100,51 @@ describe('buildSaveFile / parseSaveFile round-trip', () => {
     });
     expect(parseSaveFile(future)).toEqual({ ok: false, error: 'version' });
   });
+
+  it('accepts an older save_version (forward-migration)', () => {
+    const old = JSON.stringify({
+      format: SAVE_FORMAT,
+      save_version: SAVE_VERSION - 1,
+      state: { game_values: { cash_value: 1 } },
+    });
+    const parsed = parseSaveFile(old);
+    expect(parsed.ok).toBe(true);
+  });
+
+  it('treats a non-numeric save_version as malformed, not version', () => {
+    const bad = JSON.stringify({
+      format: SAVE_FORMAT,
+      save_version: 'one',
+      state: { game_values: {} },
+    });
+    expect(parseSaveFile(bad)).toEqual({ ok: false, error: 'malformed' });
+  });
+
+  it('rejects a null state body', () => {
+    const bad = JSON.stringify({
+      format: SAVE_FORMAT,
+      save_version: SAVE_VERSION,
+      state: null,
+    });
+    expect(parseSaveFile(bad)).toEqual({ ok: false, error: 'malformed' });
+  });
+
+  it('rejects game_values that is not an object', () => {
+    const bad = JSON.stringify({
+      format: SAVE_FORMAT,
+      save_version: SAVE_VERSION,
+      state: { game_values: 42 },
+    });
+    expect(parseSaveFile(bad)).toEqual({ ok: false, error: 'malformed' });
+  });
+
+  it('rejects a JSON array (typeof object but not a save)', () => {
+    expect(parseSaveFile('[1,2,3]')).toEqual({ ok: false, error: 'malformed' });
+  });
+
+  it('rejects the JSON literal null', () => {
+    expect(parseSaveFile('null')).toEqual({ ok: false, error: 'malformed' });
+  });
 });
 
 function importDelta(addr, snapshot, ts) {
@@ -164,5 +209,53 @@ describe('applyDelta — importSave reducer', () => {
     const out = applyDelta(freshState(ADDR), importDelta(ADDR, snapshot, 5000));
     expect(out.peers[ADDR].cash).toBe(9999);
     expect(out.peers[ADDR].xp).toBe(4242);
+  });
+
+  it('leaves progress untouched when the delta carries no state body', () => {
+    const s = freshState(ADDR);
+    const noState = { kind: 'delta', addr: ADDR, op: 'importSave', args: [], result: {}, ts: 1000 };
+    const out = applyDelta(s, noState);
+    expect(out.display_name).toBe('');
+    expect(out.game_values.cash_value).toBe(s.game_values.cash_value);
+    expect(out.node_counter).toBe(s.node_counter);
+  });
+
+  it('leaves progress untouched when state is null', () => {
+    const s = freshState(ADDR);
+    const nullState = {
+      kind: 'delta',
+      addr: ADDR,
+      op: 'importSave',
+      args: [],
+      result: { state: null },
+      ts: 1000,
+    };
+    const out = applyDelta(s, nullState);
+    expect(out.game_values.cash_value).toBe(s.game_values.cash_value);
+  });
+
+  it('fills absent snapshot fields from freshState defaults (partial save)', () => {
+    // A minimal/old save that only carries game_values must still produce a
+    // structurally complete state — seeded nodes, empty collections, etc.
+    const partial = { game_values: { cash_value: 7 } };
+    const out = applyDelta(freshState(ADDR), importDelta(ADDR, partial));
+    expect(out.game_values.cash_value).toBe(7);
+    expect(Array.isArray(out.nodes)).toBe(true);
+    expect(out.nodes.length).toBeGreaterThan(0); // seeded trunk-mission nodes
+    expect(out.nodes_charging).toEqual([]);
+    expect(out.db_queue).toEqual([]);
+    expect(out.integrated_ids).toEqual({});
+  });
+
+  it('does not let a stale imported last_seen_ts rewind the monotonic clock', () => {
+    // Local state is already at a far-future timestamp; importing a save whose
+    // last_seen_ts is in the past must not roll the clock backwards (the guard
+    // that protects progress from clock-skew).
+    const future = Date.now() + 1_000_000_000;
+    let s = freshState(ADDR);
+    s = { ...s, last_seen_ts: future };
+    const snapshot = { ...buildSaveState(progressedState()), last_seen_ts: 1 };
+    const out = applyDelta(s, importDelta(ADDR, snapshot));
+    expect(out.last_seen_ts).toBeGreaterThanOrEqual(future);
   });
 });


### PR DESCRIPTION
Closes #127.

Adds **Export Save** / **Import Save** to the About / settings popup.

## Export
- Serializes **only the current player's own progress** and hands it to `webxdc.sendToChat` as `data_dealer_save.json`.
- Per the request on the issue, the snapshot deliberately **excludes `state.peers`** (every *other* player's aggregated leaderboard stats) **and `state.addr`** — an export contains the current user's state only, never other users'. `buildSaveState` opt-ins each field explicitly so a future `LocalState` field can't silently leak into exports.

## Import
- Picks a file via `webxdc.importFiles({ extensions: ['.json'] })`, validates format + version, then persists an `importSave` delta.
- The reducer replaces the player's own progress while **preserving local identity (`addr`) and the peer table** — importing someone else's save can't hijack your address or wipe the leaderboard. Foreign `importSave` deltas are blocked by `applyDelta`'s existing addr guard.
- Because the delta is the source of truth, the import **survives cold-start replay** (mirrors how `setLocale` persists; the popup reloads on success).
- A visible chat notice — *"&lt;player&gt; loaded an imported save."* — rides on the same `sendUpdate` for the issue's anti-cheat transparency requirement. Top-level `game_values` is mirrored on the delta so the leaderboard row refreshes from the imported save.
- Malformed / newer-version files fail gracefully with a localized message; older `save_version`s forward-migrate via `freshState` defaults.

## Files
- `scripts/state.ts` — `SAVE_FORMAT`/`SAVE_VERSION`, `buildSaveState`/`buildSaveFile`/`parseSaveFile`, `importSave` reducer + op.
- `scripts/LocalEngine.ts` — `exportSave`/`importSave` handlers.
- `scripts/components/popups/AboutPopup.tsx` + `scripts/game/GameRoot.ts` — Export/Import UI wired through `app.remote`.
- `scripts/app.ts` — typed `AppRemote` signatures.
- `i18n/{en_US,de_AT}.{json,po}` — new strings (en + de).
- `css/Render.css` — in-flow save section (doesn't collide with the pinned Close button).
- `tests/state/save-export-import.test.js` — round-trip, validation, reducer (current-user-only, identity/peer preservation, replay safety).

## Verification
- `pnpm typecheck`, `pnpm lint`, `pnpm test` (754 tests, incl. 15 new) all pass.

https://claude.ai/code/session_011BACZuQDuVPdVmy33JLomf

---
_Generated by [Claude Code](https://claude.ai/code/session_011BACZuQDuVPdVmy33JLomf)_