### PR TITLE
fix: restore LICENSE-ASSETS.txt to original wording

### DIFF
--- a/LICENSE-ASSETS.txt
+++ b/LICENSE-ASSETS.txt
@@ -4,27 +4,41 @@ Asset & data license — Creative Commons Attribution-ShareAlike 3.0 Austria
 This file applies to the non-code material in this repository, including:
 
   - data/                  Game data vendored from datadealer/dd_rules
-                            (see data/UPSTREAM.txt for source details).
+                           (default_game.json, ruleset_3.de.json,
+                           ruleset_3.en.json). See data/UPSTREAM.txt for
+                           the source commit SHA. The vendored ruleset
+                           files are no longer tracked as-is; they have
+                           been transformed into ruleset_base.json +
+                           per-locale string maps under i18n/.
   - img/                   Sprite sheets and other game artwork inherited
-                            from the original Data Dealer project.
-  - font/                  Font files (Bowlby One SC, Source Sans Pro)
-  - i18n/                  UI locale files (en_US.json, de_AT.json) and
-                            the generated ruleset string maps
-                            (ruleset.en.json, ruleset.de.json).
+                           from dd_js.
+  - i18n/                  Translation catalogues inherited from dd_js,
+                           and the generated ruleset locale string maps
+                           (ruleset.en.json, ruleset.de.json).
+  - font/ (game fonts)     The CC-BY-SA portions only. The third-party
+                           webfonts shipped under font/ (Bowlby One SC,
+                           Skranji, Source, Voltaire) remain under the
+                           SIL Open Font License — see font/LICENSE/ for
+                           their original notices.
 
-The assets are under a Creative Commons Attribution-ShareAlike 3.0 Austria
-license (CC BY-SA 3.0 AT).
+These works are licensed under the Creative Commons
+Attribution-ShareAlike 3.0 Austria license (CC BY-SA 3.0 AT).
 
-You are free to:
-  Share — copy and redistribute the material in any medium or format.
-  Adapt — remix, transform, and build upon the material for any purpose,
-          even commercially.
+  License deed:        https://creativecommons.org/licenses/by-sa/3.0/at/
+  Full legal code:     https://creativecommons.org/licenses/by-sa/3.0/at/legalcode
 
-Under the following terms:
-  Attribution — You must give appropriate credit, provide a link to the
-                license, and indicate if changes were made.
-  ShareAlike  — If you remix, transform, or build upon the material, you
-                must distribute your contributions under the same license
-                as the original.
+Original authors (see CREDITS.txt for full credits):
+  Ivan Averintsev, Wolfie Christl, Pascale Osterwalder, Tobi Schäfer,
+  Ralf Traunsteiner.
 
-Full license text: https://creativecommons.org/licenses/by-sa/3.0/at/
+Under CC BY-SA 3.0 AT you are free to share and adapt these works for
+any purpose, including commercially, provided that you:
+
+  - give appropriate credit to the original authors,
+  - indicate if changes were made, and
+  - distribute your contributions under the same license as the
+    original.
+
+Modifications made in this fork (e.g. any reformatting of dd_rules data
+for the webxdc build, or adapted artwork) are also released under
+CC BY-SA 3.0 AT.


### PR DESCRIPTION
## Problem

PR #346 accidentally rewrote `LICENSE-ASSETS.txt` as part of the i18n refactor, which:

- Reclassified OFL-licensed webfonts (Bowlby One SC, Skranji, Source, Voltaire) as CC BY-SA
- Dropped Skranji and Voltaire from the font listing entirely
- Removed the pointer to font/LICENSE/ for original OFL notices
- Stripped the author attribution list (Ivan Averintsev, Wolfie Christl, et al.)

## Fix

Reverts to the original wording from before #346 (commit `5208e22`), with minor additions:
- Notes that the vendored ruleset files have been transformed into base + locale maps
- Adds the generated locale maps (`ruleset.en.json`, `ruleset.de.json`) to the i18n/ listing

Co-authored-by: opencode big-pickle