### PR TITLE
i18n: translate "tap anywhere to continue" hint in tutorial popups

### DIFF
--- a/i18n/de_AT.json
+++ b/i18n/de_AT.json
@@ -1016,5 +1016,9 @@
   "save import error unavailable": [
     null,
     "Das Importieren von Spielständen wird hier nicht unterstützt."
+  ],
+  "tap anywhere to continue": [
+    null,
+    "Überall antippen um fortzufahren"
   ]
 }

--- a/i18n/de_AT.po
+++ b/i18n/de_AT.po
@@ -1207,6 +1207,10 @@ msgstr ""
 msgid "save import error unavailable"
 msgstr "Das Importieren von Spielständen wird hier nicht unterstützt."
 
+#: scripts/components/popups/LevelUpNotification.tsx scripts/components/popups/TutorialNotification.tsx
+msgid "tap anywhere to continue"
+msgstr "Überall antippen um fortzufahren"
+
 #~ msgid "user is %s%% better than other Data Dealers"
 #~ msgstr "Du hast besser gezockt als %s%% aller anderen Data Dealer!"
 

--- a/i18n/en_US.json
+++ b/i18n/en_US.json
@@ -1016,5 +1016,9 @@
   "save import error unavailable": [
     null,
     "Importing save files is not supported here."
+  ],
+  "tap anywhere to continue": [
+    null,
+    "Tap anywhere to continue"
   ]
 }

--- a/i18n/en_US.po
+++ b/i18n/en_US.po
@@ -1180,6 +1180,10 @@ msgstr ""
 msgid "save import error unavailable"
 msgstr "Importing save files is not supported here."
 
+#: scripts/components/popups/LevelUpNotification.tsx scripts/components/popups/TutorialNotification.tsx
+msgid "tap anywhere to continue"
+msgstr "Tap anywhere to continue"
+
 #~ msgid "user is %s%% better than other Data Dealers"
 #~ msgstr "You outperformed %s%% of all Data Dealers"
 

--- a/i18n/messages.pot
+++ b/i18n/messages.pot
@@ -1038,3 +1038,7 @@ msgstr ""
 #: views/values_details.html:35
 msgid "per deal"
 msgstr ""
+
+#: scripts/components/popups/LevelUpNotification.tsx scripts/components/popups/TutorialNotification.tsx
+msgid "tap anywhere to continue"
+msgstr ""

--- a/scripts/components/popups/LevelUpNotification.tsx
+++ b/scripts/components/popups/LevelUpNotification.tsx
@@ -38,7 +38,7 @@ export function LevelUpNotification({
       <div class="PopupBody TutorialBody">
         <MarcoSpeech says={says} bodyHtml={textHtml} />
       </div>
-      <div class="TutorialTapHint">tap anywhere to continue</div>
+      <div class="TutorialTapHint">{i18n.gettext('tap anywhere to continue')}</div>
     </div>
   );
 }

--- a/scripts/components/popups/TutorialNotification.tsx
+++ b/scripts/components/popups/TutorialNotification.tsx
@@ -32,7 +32,7 @@ export function TutorialNotification({
       <div class="PopupBody TutorialBody">
         <MarcoSpeech says={speaker} bodyHtml={descriptionHtml} />
       </div>
-      <div class="TutorialTapHint">tap anywhere to continue</div>
+      <div class="TutorialTapHint">{i18n.gettext('tap anywhere to continue')}</div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- The "tap anywhere to continue" hint in `LevelUpNotification` and `TutorialNotification` was hardcoded in English and not passed through the i18n system
- Wraps both occurrences with `i18n.gettext('tap anywhere to continue')`
- Adds translation entries to `en_US` and `de_AT` catalogs (both `.json` and `.po`), and adds the `msgid` to `messages.pot`

## Test plan

- [ ] Load the game in `en_US` locale — level-up and tutorial popups show "Tap anywhere to continue"
- [ ] Load the game in `de_AT` locale — popups show "Überall antippen um fortzufahren"
- [ ] Verify no regression in other popup types

https://claude.ai/code/session_01VWkh8MYX86o3RAt4unV5aR

---
_Generated by [Claude Code](https://claude.ai/code/session_01VWkh8MYX86o3RAt4unV5aR)_