### PR TITLE
fix: make About dialog scrollable by tab key and pointer drag

### DIFF
--- a/css/Render.css
+++ b/css/Render.css
@@ -1761,6 +1761,7 @@
   min-height: 0;
   overflow-y: auto;
   overflow-x: hidden;
+  outline: none;
 }
 /* The Close button is absolutely pinned to the dialog's bottom edge
  * (base `.PopupButtons`, containing block `.PopupBody`); it does not

--- a/css/Render.css
+++ b/css/Render.css
@@ -1747,11 +1747,16 @@
    * absorbs `.Popup`'s 12px border (content-box). */
   max-height: calc(100% - 24px);
   min-height: 0;
+  /* Let the absolutely-positioned .PopupClose button overflow above
+   * this flex container without being clipped. */
+  overflow: visible;
 }
 .PopupBody.About {
   display: flex;
   flex-direction: column;
   min-height: 0;
+  /* Same: .PopupClose sits at top:-6px outside this box, must not clip. */
+  overflow: visible;
 }
 /* Single unified scroll area: takes the space of the old header +
  * content. */

--- a/scripts/components/popups/AboutPopup.tsx
+++ b/scripts/components/popups/AboutPopup.tsx
@@ -98,7 +98,7 @@ export function AboutPopup({ locale, buttonLabel, onClose, onExport, onImport }:
       <div class="PopupClose" onClick={close}>
         X
       </div>
-      {/* tabIndex={0} lets keyboard users Tab-focus and arrow-key scroll the content */}
+      {/* biome-ignore lint/a11y/noNoninteractiveTabindex: scroll container — tabIndex lets keyboard users focus and arrow-key scroll the content */}
       <div class="PopupContent" ref={contentRef} tabIndex={0}>
         <div class="PopupTab">
           <div class="SubpopContainer" />

--- a/scripts/components/popups/AboutPopup.tsx
+++ b/scripts/components/popups/AboutPopup.tsx
@@ -6,9 +6,10 @@
 // the dialog is single-purpose and stateless.
 
 import type { JSX } from 'preact';
-import { useState } from 'preact/hooks';
+import { useEffect, useRef, useState } from 'preact/hooks';
 import i18n from '../../i18n.js';
 import { Link } from '../Link.js';
+import { attachDragScroll } from './scrollDrag.js';
 
 /** Why an import attempt failed; maps to a localized message in the popup. */
 export type ImportErrorKind = 'malformed' | 'version' | 'unavailable';
@@ -62,6 +63,13 @@ export function AboutPopup({ locale, buttonLabel, onClose, onExport, onImport }:
 
   const [importing, setImporting] = useState(false);
   const [importError, setImportError] = useState<string | null>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = contentRef.current;
+    if (!el) return;
+    return attachDragScroll(el, 'y');
+  }, []);
 
   const handleImport = (): void => {
     if (!onImport || importing) return;
@@ -90,7 +98,8 @@ export function AboutPopup({ locale, buttonLabel, onClose, onExport, onImport }:
       <div class="PopupClose" onClick={close}>
         X
       </div>
-      <div class="PopupContent">
+      {/* tabIndex={0} lets keyboard users Tab-focus and arrow-key scroll the content */}
+      <div class="PopupContent" ref={contentRef} tabIndex={0}>
         <div class="PopupTab">
           <div class="SubpopContainer" />
           <div class={`RenderSprite MainMenuLogo ${locale}`} />


### PR DESCRIPTION
## Summary

- Add `tabIndex={0}` to the `.PopupContent` scroll container in `AboutPopup.tsx` so keyboard users can Tab-focus it and use arrow keys to scroll through the dialog content
- Attach `attachDragScroll(el, 'y')` (the same pointer-event utility already used by the tab strip in `PopupMenu.tsx`) so the content can be scrolled by clicking and dragging with a mouse or touch gesture
- Add `outline: none` to `.PopupBody.About .PopupContent` in CSS to suppress the browser's default focus ring on a scroll container (which is not an interactive control)

## Test plan

- [ ] Open the About dialog on a viewport where the content overflows (small screen or zoomed in)
- [ ] Press Tab until the content area is focused — arrow keys / Page Up / Page Down should scroll it
- [ ] Click and drag inside the content area — content should scroll in the drag direction
- [ ] Touch drag (mobile / DevTools touch emulation) should also scroll the content
- [ ] Clicking links and buttons inside the dialog should still work normally (drag suppresses click only when the pointer moved ≥ 4 px)

https://claude.ai/code/session_01CsTfcTkd89iL4AvAcBxqHD

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsTfcTkd89iL4AvAcBxqHD)_