### PR TITLE
Apply collect_risk karma cost in collectPerp (restores Karmalizer loop)

### DIFF
--- a/scripts/LocalEngine.ts
+++ b/scripts/LocalEngine.ts
@@ -2790,6 +2790,25 @@ export function collectPerp(
     return Promise.resolve({ result: { error: 3 } });
   }
 
+  // Karma cost of the collect, then the incident roll on the *post-decrement*
+  // karma (dd_app views.py:505 collectPerp).  The original lowers karma by the
+  // node's collect_risk (base type_data + active powerup collect_risk_modifiers)
+  // on every collect, clamped at -100, and only then rolls _handleKarmaIncident
+  // against the reduced value.  Recompute the risk from typeData + the node's
+  // powerups rather than reading instance_data.collect_risk: buyPerp seeds nodes
+  // with `instance_data: {}`, so the base risk is only persisted after a powerup
+  // op — recomputing covers the un-upgraded case too.  TokenPerp and any node
+  // whose type carries no collect_risk yield 0 here, i.e. no karma change.
+  var collectRisk = typeData
+    ? _computeModifiers(typeData, (node.instance_data && node.instance_data.powerups) || [])
+        .collect_risk
+    : (node.instance_data && node.instance_data.collect_risk) || 0;
+  if (collectRisk > 0) {
+    newGv = Object.assign({}, newGv, {
+      karma_value: Math.max(-100, (newGv.karma_value || 0) - collectRisk),
+    });
+  }
+
   var incident = _handleKarmaIncident(newGv, ruleset);
   if (incident) {
     newGv = Object.assign({}, newGv, {

--- a/scripts/LocalEngine.ts
+++ b/scripts/LocalEngine.ts
@@ -2980,6 +2980,16 @@ export function integrateCollected(
   var increment = integratedIds[collectId] ? 0 : profilesIncrement;
   var newIntegratedIds = Object.assign({}, integratedIds, { [collectId]: true });
 
+  // Production integrate rewards (xp / cash / karma) come from mission rewards,
+  // applied via _applyRewardsToGv on missionResult.rewards below — this mirrors
+  // dd_app views.py:320, where integrate karma is `rewards.get('karma_value')`
+  // from MissionHandler.compute_rewards (currently no ruleset mission grants
+  // karma, only xp_value/cash_value — original-faithful).  The profile_set's
+  // xp_gain/karma_gain are a separate optional override channel with no
+  // producer: collectPerp/buyPerp build the set as { profiles_value, tokens_map }
+  // only, so these are 0 in production and exercised solely by direct-payload
+  // tests.  They are NOT the karma-on-collect mechanism — that lives in
+  // collectPerp's collect_risk decrement.  See issue #355.
   var xpGain = ps.xp_gain || 0;
   var karmaGain = ps.karma_gain || 0;
   var newGv: GameValues = Object.assign({}, state.game_values, {

--- a/tests/handlers/collect-integrate.test.js
+++ b/tests/handlers/collect-integrate.test.js
@@ -605,6 +605,84 @@ describe('collectPerp — karma_incident', () => {
   });
 });
 
+// ── collect_risk karma cost (dd_app views.py:505 parity) ────────────────────
+
+describe('collectPerp — collect_risk karma cost', () => {
+  const PATH = 'Imperium.City.Pusher0.client_karma';
+
+  beforeEach(() => setOverride(FIXED_NOW));
+  afterEach(() => {
+    clearOverride();
+    setPrngSeed(0xdeadbeef);
+  });
+
+  it('lowers karma_value by the node collect_risk on a collect', async () => {
+    // client_karma is not a real perp gestalt, so collect_risk is sourced from
+    // instance_data (the recompute branch is covered separately below).
+    setState(
+      mkState({
+        nodes: [mkNode('ClientPerp', PATH, { collect_risk: 30 })],
+        nodes_collect: [{ path: PATH, result: { amount: 50 } }],
+        game_values: mkGv({ karma_value: 50, xp_level: 5 }),
+      })
+    );
+    setPrngSeed(42);
+    const { result } = await collectPerp(PATH);
+    // 50 − 30 = 20, still positive ⇒ no incident roll fires.
+    expect(result.game_values.karma_value).toBe(20);
+    expect(result.karma_incident).toBeUndefined();
+  });
+
+  it('collect_risk can push karma negative and trigger a Karmalizer incident', async () => {
+    // 5 − 50 = −45 ⇒ factor = sqrt(0.45)+0.05 ≈ 0.72; seed 42 first RNG ≈ 0.60
+    // < 0.72 ⇒ incident fires.  This is the loop that was unreachable before:
+    // collecting drives karma negative, which makes the incident roll live.
+    setState(
+      mkState({
+        nodes: [mkNode('ClientPerp', PATH, { collect_risk: 50 })],
+        nodes_collect: [{ path: PATH, result: { amount: 50 } }],
+        game_values: mkGv({ karma_value: 5, xp_level: 5 }),
+      })
+    );
+    setPrngSeed(42);
+    const { result } = await collectPerp(PATH);
+    expect(typeof result.karma_incident).toBe('string');
+    expect(result.game_values.karma_value).toBeLessThan(0);
+  });
+
+  it('clamps the karma decrement at -100', async () => {
+    setState(
+      mkState({
+        nodes: [mkNode('ClientPerp', PATH, { collect_risk: 50 })],
+        nodes_collect: [{ path: PATH, result: { amount: 50 } }],
+        game_values: mkGv({ karma_value: -90, xp_level: 5 }),
+      })
+    );
+    setPrngSeed(42);
+    const { result } = await collectPerp(PATH);
+    // −90 − 50 clamps to −100; any incident delta stays clamped at −100.
+    expect(result.game_values.karma_value).toBe(-100);
+  });
+
+  it('recomputes collect_risk from a real perp type_data (base risk applies)', async () => {
+    // contact001 is a real ContactPerp with base collect_risk = 1 and no
+    // powerups, so the recompute branch applies a −1 karma cost.
+    const CONTACT = 'Imperium.City.Agent0.contact001';
+    setState(
+      mkState({
+        nodes: [mkNode('ContactPerp', CONTACT)],
+        nodes_collect: [{ path: CONTACT, result: { amount: 5 } }],
+        game_values: mkGv({ karma_value: 50, xp_level: 5 }),
+      })
+    );
+    setPrngSeed(42);
+    const { result } = await collectPerp(CONTACT);
+    // 50 − 1 = 49, positive ⇒ no incident.
+    expect(result.game_values.karma_value).toBe(49);
+    expect(result.karma_incident).toBeUndefined();
+  });
+});
+
 // ── integrateCollected with token nodes ──────────────────────────────────────
 
 describe('integrateCollected — token node updates', () => {


### PR DESCRIPTION
## Problem

Collecting from a perp never lowers karma. Karma starts at +50 and only ever increases (`buyPerp` `+1`, `buyKarma` `+5..+100`), so it never reaches negative values, `_handleKarmaIncident` always early-returns, and the entire **Karmalizer** incident subsystem is unreachable in normal play. The computed `collect_risk` was also a dead wire — stored on `instance_data` but never read back.

Verified against the original backend ([`datadealer/dd_app`](https://github.com/datadealer/dd_app) `dd_app/views.py:505`): the port ported the incident *roll* into `collectPerp` but dropped the per-collect karma *decrement* that feeds it. The original lowers `karma_value` by the node's `collect_risk` (base `type_data` + active powerup `collect_risk_modifier`s) on every collect, clamped at `-100`, and only then rolls `_handleKarmaIncident` against the reduced value.

Fixes the root cause documented in #355.

## Change

In `collectPerp`, before the existing incident roll, decrement karma by the node's `collect_risk` (clamped at `-100`). Risk is recomputed from `type_data` + the node's powerups via `_computeModifiers` rather than read from `instance_data.collect_risk`, because `buyPerp` seeds nodes with `instance_data: {}` so base risk is only persisted after a powerup op — recomputing also covers the un-upgraded case. Nodes whose type carries no `collect_risk` (e.g. `TokenPerp`) yield `0` and are unaffected.

This makes collecting drive karma down → karma reaches negative → the incident roll goes live → the Karmalizer becomes reachable, and simultaneously gives `collect_risk` (and the risk-raising upgrades) real mechanical meaning.

## Tests

Added to `tests/handlers/collect-integrate.test.js`:
- collect lowers `karma_value` by the node `collect_risk` (no incident while positive);
- `collect_risk` pushing karma negative makes the incident roll fire (the previously-unreachable loop);
- the `-100` clamp on the decrement;
- the recompute branch via a real perp (`contact001`, base risk 1).

Full suite green: **798 passed**. `tsc --noEmit` and `biome check` clean.

## Notes / follow-ups (out of scope)

- `integrateCollected` reads `profile_set.karma_gain`/`xp_gain` that nothing produces. Confirmed against the original this was *not* the karma-on-collect mechanism (original integrate karma came from mission rewards). Tracked as a separate cleanup in #355 — not touched here.
- The karma status bar updates via the handlers' existing `updateGameValues(result.game_values)` call, so non-incident karma changes are reflected without a popup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AMQKJbyC9Q6caB7epPjDtV

---
_Generated by [Claude Code](https://claude.ai/code/session_01AMQKJbyC9Q6caB7epPjDtV)_