### PR TITLE
fix: karma-incident faithfulness — exclude ClientPerp + correct incident probability

### DIFF
--- a/scripts/LocalEngine.ts
+++ b/scripts/LocalEngine.ts
@@ -2622,13 +2622,22 @@ interface KarmaIncident {
 }
 
 // Returns { gestalt, karma_delta } if a karma incident fires, else null.
-// factor = sqrt((-karma)/100) + 0.05  (dd_app views.py:483 WeightedRandomizer)
+// dd_app views.py:483 _handleKarmaIncident: factor = ((-karma)/100) ** 0.5, then
+// a WeightedRandomizer over { incident: factor, none: (1 - factor) + 0.05 } fires
+// the incident when its draw lands on the incident key.  WeightedRandomizer
+// normalises by the total weight (helpers.py), so the incident probability is
+// factor / (factor + (1 - factor) + 0.05) = factor / 1.05 — the 0.05 padding is
+// on the *no-incident* side, lowering the chance.  (The earlier port used
+// `factor + 0.05` compared directly, which inverted the padding and over-fired,
+// guaranteeing an incident at karma = -100.)
 function _handleKarmaIncident(gv: GameValues, ruleset: Ruleset): KarmaIncident | null {
   var karma = (gv && gv.karma_value) || 0;
   if (karma >= 0) return null;
 
-  var factor = (-karma / 100) ** 0.5 + 0.05;
-  if (_rng() >= factor) return null;
+  var PROBABILITY_PADDING = 0.05;
+  var factor = (-karma / 100) ** 0.5;
+  var incidentProb = factor / (1 + PROBABILITY_PADDING);
+  if (_rng() >= incidentProb) return null;
 
   var level = (gv && gv.xp_level) || 1;
   var eligible = (ruleset.karmalizers || []).filter(function (k) {

--- a/scripts/LocalEngine.ts
+++ b/scripts/LocalEngine.ts
@@ -2809,7 +2809,11 @@ export function collectPerp(
     });
   }
 
-  var incident = _handleKarmaIncident(newGv, ruleset);
+  // dd_app views.py:657 guards ONLY the incident roll with
+  // `game_type != 'ClientPerp'` — the karma decrement above still applies to a
+  // ClientPerp, but collecting cash from one never rolls a Karmalizer (the
+  // original forces `karmalizer = None`).  Mirror that exclusion.
+  var incident = gameType === 'ClientPerp' ? null : _handleKarmaIncident(newGv, ruleset);
   if (incident) {
     newGv = Object.assign({}, newGv, {
       karma_value: Math.max(-100, Math.min(100, (newGv.karma_value || 0) + incident.karma_delta)),

--- a/tests/handlers/collect-integrate.test.js
+++ b/tests/handlers/collect-integrate.test.js
@@ -562,8 +562,8 @@ describe('collectPerp — karma_incident', () => {
   });
 
   it('seeded PRNG fires karma_incident and returns expected karmalizer gestalt', async () => {
-    // karma=-80 → factor≈0.944; seed=42 first RNG value≈0.601 → fires
-    // eligible at level=5: 4 karmalizers; seed=42 second RNG value picks karma014
+    // karma=-80 → incidentProb = sqrt(0.8)/1.05 ≈ 0.852; seed=42 first RNG ≈ 0.601
+    // < 0.852 → fires. eligible at level=5: 4 karmalizers; second RNG picks karma014
     setState(
       mkState({
         nodes: [mkNode('TokenPerp', PATH)],
@@ -626,6 +626,24 @@ describe('collectPerp — karma_incident', () => {
     expect(result.karma_incident).toBeUndefined();
     expect(result.game_values.karma_value).toBe(-80);
   });
+
+  it('incident probability is normalised (factor/1.05), not factor+0.05', async () => {
+    // Faithfulness guard for dd_app views.py:483. At karma=-80 the incident
+    // probability is sqrt(0.8)/1.05 ≈ 0.852. Seed 4's first RNG draw ≈ 0.924
+    // lands in the gap (0.852, 0.944]: under the old buggy `factor+0.05 ≈ 0.944`
+    // compare it would have fired, but under the normalised formula it must not.
+    setState(
+      mkState({
+        nodes: [mkNode('TokenPerp', PATH)],
+        nodes_collect: [{ path: PATH, result: { amount: 50 } }],
+        game_values: mkGv({ karma_value: -80, xp_level: 5 }),
+      })
+    );
+    setPrngSeed(4);
+    const { result } = await collectPerp(PATH);
+    expect(result.karma_incident).toBeUndefined();
+    expect(result.game_values.karma_value).toBe(-80);
+  });
 });
 
 // ── collect_risk karma cost (dd_app views.py:505 parity) ────────────────────
@@ -657,9 +675,9 @@ describe('collectPerp — collect_risk karma cost', () => {
   });
 
   it('collect_risk can push karma negative and trigger a Karmalizer incident', async () => {
-    // 5 − 50 = −45 ⇒ factor = sqrt(0.45)+0.05 ≈ 0.72; seed 42 first RNG ≈ 0.60
-    // < 0.72 ⇒ incident fires.  This is the loop that was unreachable before:
-    // collecting drives karma negative, which makes the incident roll live.
+    // 5 − 50 = −45 ⇒ incidentProb = sqrt(0.45)/1.05 ≈ 0.639; seed 42 first RNG
+    // ≈ 0.601 < 0.639 ⇒ incident fires.  This is the loop that was unreachable
+    // before: collecting drives karma negative, which makes the incident live.
     // Uses TokenPerp, not ClientPerp: ClientPerp is excluded from the incident
     // roll (dd_app views.py:657), and TokenPerp consumes no RNG before the roll
     // so the seeded outcome is unchanged.

--- a/tests/handlers/collect-integrate.test.js
+++ b/tests/handlers/collect-integrate.test.js
@@ -536,8 +536,12 @@ describe('collectPerp — failure paths', () => {
 // ── karma_incident with fixed PRNG seed ─────────────────────────────────────
 
 describe('collectPerp — karma_incident', () => {
-  const PATH = 'Imperium.City.Pusher0.client_karma';
+  const PATH = 'Imperium.City.Pusher0.token_karma';
 
+  // These exercise the incident roll itself, so they use a non-excluded type.
+  // TokenPerp (like ClientPerp) skips _generateId, so it consumes no RNG before
+  // the roll — the seeded-PRNG assertions below are draw-order sensitive — but
+  // unlike ClientPerp it is NOT excluded from incidents (dd_app views.py:657).
   beforeEach(() => setOverride(FIXED_NOW));
   afterEach(() => {
     clearOverride();
@@ -547,7 +551,7 @@ describe('collectPerp — karma_incident', () => {
   it('karma_incident absent when karma_value >= 0', async () => {
     setState(
       mkState({
-        nodes: [mkNode('ClientPerp', PATH)],
+        nodes: [mkNode('TokenPerp', PATH)],
         nodes_collect: [{ path: PATH, result: { amount: 50 } }],
         game_values: mkGv({ karma_value: 50, xp_level: 5 }),
       })
@@ -562,7 +566,7 @@ describe('collectPerp — karma_incident', () => {
     // eligible at level=5: 4 karmalizers; seed=42 second RNG value picks karma014
     setState(
       mkState({
-        nodes: [mkNode('ClientPerp', PATH)],
+        nodes: [mkNode('TokenPerp', PATH)],
         nodes_collect: [{ path: PATH, result: { amount: 50 } }],
         game_values: mkGv({ karma_value: -80, xp_level: 5 }),
       })
@@ -576,7 +580,7 @@ describe('collectPerp — karma_incident', () => {
   it('karma_incident decreases karma_value within [-100, 100]', async () => {
     setState(
       mkState({
-        nodes: [mkNode('ClientPerp', PATH)],
+        nodes: [mkNode('TokenPerp', PATH)],
         nodes_collect: [{ path: PATH, result: { amount: 50 } }],
         game_values: mkGv({ karma_value: -80, xp_level: 5 }),
       })
@@ -592,7 +596,7 @@ describe('collectPerp — karma_incident', () => {
     // All karmalizers have required_level >= 5, so none eligible at level 1.
     setState(
       mkState({
-        nodes: [mkNode('ClientPerp', PATH)],
+        nodes: [mkNode('TokenPerp', PATH)],
         nodes_collect: [{ path: PATH, result: { amount: 50 } }],
         game_values: mkGv({ karma_value: -80, xp_level: 1 }),
       })
@@ -602,6 +606,25 @@ describe('collectPerp — karma_incident', () => {
     const { result } = await collectPerp(PATH);
     // No eligible karmalizers → incident null → karma_incident absent.
     expect(result.karma_incident).toBeUndefined();
+  });
+
+  it('ClientPerp is excluded from the incident roll (dd_app views.py:657)', async () => {
+    // Same negative-karma + seed that fires for TokenPerp above (karma014), but
+    // a ClientPerp must never roll a Karmalizer — collecting cash has no karma
+    // incident. Karma stays put; no incident is reported.
+    const CLIENT_PATH = 'Imperium.City.Pusher0.client_cash';
+    setState(
+      mkState({
+        nodes: [mkNode('ClientPerp', CLIENT_PATH)],
+        nodes_collect: [{ path: CLIENT_PATH, result: { amount: 50 } }],
+        game_values: mkGv({ karma_value: -80, xp_level: 5 }),
+      })
+    );
+    setPrngSeed(42);
+
+    const { result } = await collectPerp(CLIENT_PATH);
+    expect(result.karma_incident).toBeUndefined();
+    expect(result.game_values.karma_value).toBe(-80);
   });
 });
 
@@ -637,9 +660,12 @@ describe('collectPerp — collect_risk karma cost', () => {
     // 5 − 50 = −45 ⇒ factor = sqrt(0.45)+0.05 ≈ 0.72; seed 42 first RNG ≈ 0.60
     // < 0.72 ⇒ incident fires.  This is the loop that was unreachable before:
     // collecting drives karma negative, which makes the incident roll live.
+    // Uses TokenPerp, not ClientPerp: ClientPerp is excluded from the incident
+    // roll (dd_app views.py:657), and TokenPerp consumes no RNG before the roll
+    // so the seeded outcome is unchanged.
     setState(
       mkState({
-        nodes: [mkNode('ClientPerp', PATH, { collect_risk: 50 })],
+        nodes: [mkNode('TokenPerp', PATH, { collect_risk: 50 })],
         nodes_collect: [{ path: PATH, result: { amount: 50 } }],
         game_values: mkGv({ karma_value: 5, xp_level: 5 }),
       })


### PR DESCRIPTION
Two related `_handleKarmaIncident` faithfulness fixes verified against the original backend ([`datadealer/dd_app`](https://github.com/datadealer/dd_app)). Surfaced by the "inert mechanics" audit as follow-ups to #355/#358.

## 1. ClientPerp must not roll an incident (`views.py:657`)

The original guards the `_handleKarmaIncident` call with `game_type != 'ClientPerp'` and forces `karmalizer = None` for a ClientPerp:

```python
if node_data.get('game_type', '') != 'ClientPerp':
    karmalizer = self._handleKarmaIncident(old_karma - decrement, ...)
else:
    karmalizer = None
```

So collecting cash from a ClientPerp never produces a `karma_incident` (the karma *decrement* still applies — only the roll is skipped). The port called `_handleKarmaIncident` for every game type, so after #358 (which lets `collect_risk` drive karma negative) a ClientPerp cash collect could wrongly fire an incident. Fixed by gating the roll on `gameType !== 'ClientPerp'`.

## 2. Incident probability must be `factor/1.05`, not `factor+0.05` (`views.py:483`)

With `factor = sqrt(-karma/100)`, the original feeds a `WeightedRandomizer` over `{ incident: factor, none: (1-factor)+0.05 }`. `WeightedRandomizer` normalises by the total weight (`helpers.py`), so the real incident probability is:

```
factor / (factor + (1-factor) + 0.05) = factor / 1.05
```

The `0.05` padding sits on the **no-incident** side — it *lowers* the chance. The port instead computed `factor + 0.05` and compared `_rng()` directly, inverting the padding and skipping normalisation, which over-fired incidents across the whole range and **guaranteed** one at karma −100 (1.05 capped to 1.0 vs the original's ~0.952):

| karma | original (f/1.05) | old port (f+0.05) |
|------:|------:|------:|
| −1 | 9.5% | 15.0% |
| −25 | 47.6% | 55.0% |
| −50 | 67.3% | 75.7% |
| −100 | 95.2% | 100% |

Fixed to `factor / (1 + PROBABILITY_PADDING)`.

## Tests

- `karma_incident` tests use a non-excluded type (`TokenPerp`, which — like ClientPerp — consumes no RNG before the roll, so seeded outcomes are preserved). Existing "fires" tests still fire (seed 42's first draw ≈ 0.601 is below both old and new thresholds); their comments are updated to the normalised thresholds.
- #358's `collect_risk … trigger a Karmalizer incident` test (which had asserted a ClientPerp fires) switched to `TokenPerp`, same seed/outcome.
- New test: a `ClientPerp` with negative karma + the firing seed does **not** roll an incident.
- New normalisation guard: at karma −80, seed 4's first draw (≈0.924) lands in the gap `(0.852, 0.944]` — it fired under the old `factor+0.05` formula but must not under `factor/1.05`.

Full suite green: **800 passed**. `tsc --noEmit` (both projects) and `biome check` clean.

## Scope note

These cover the **incident** path of the karma system. One latent, non-observable divergence remains and is intentionally **not** changed here: on collect the original folds mission-reward karma (`karma_i`) into the decrement so it cancels in the common branch, whereas the port applies it additively via `_applyRewardsToGv`. Since no ruleset mission grants `karma_value` (see #355), this is never exercised — flagged for the record, not fixed.

Rebased onto `master` after #358 merged (`57399e7`).

Relates to #355 / #358.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V5VuezpeAUf2ZiLgy1i6DK