### PR TITLE
fix: dialog button bars clipped on WebKit + make app text non-selectable

### DIFF
--- a/css/Render.css
+++ b/css/Render.css
@@ -1644,6 +1644,17 @@
   bottom:-50px;
   margin-left: 0px;
 }
+/* Perp / status dialog button bars render as a direct child of `.PopupBody`
+ * (a sibling of `.PopupContent`) rather than nested inside it, so the
+ * straddling overhang is not clipped by `.PopupContent`'s `overflow` +
+ * `border-radius` on WebKit.  Anchor the bar to the dialog box: the base
+ * `margin-left: -12px` assumed the bar sat one `.PopupContent` border (6px)
+ * in, so without this the centred buttons would land 6px to the left. */
+.PopupBody > .PopupButtons {
+  left: 0;
+  right: 0;
+  margin-left: 0;
+}
 
 .PopupSprite {
   position:absolute;

--- a/css/dd.css
+++ b/css/dd.css
@@ -1,7 +1,12 @@
-.Stage *,
-.MainMenu *,
-.button,
-button {
+/* The app text is non-selectable by default — tapping a button, label or
+ * sprite must never start a text selection (on WebKit a long-press would
+ * otherwise highlight a button caption).  `user-select` inherits, so
+ * setting it once on the app root covers the Stage, the main menu AND every
+ * dialog, including the `.PopupContainer`s the dialog manager appends
+ * outside the Stage (the old `.Stage *` / `.MainMenu *` rules missed those,
+ * which is why button text was selectable).  Specific prose opts back in
+ * below. */
+#dd-control {
   user-select: none;
   -o-user-select: none;
   -moz-user-select: none;
@@ -9,15 +14,22 @@ button {
   -khtml-user-select: none;
   -webkit-user-select: none;
 }
+/* Re-enable selection on the bits worth copying: the perp / token
+ * flavour-text descriptions, form fields and the debug overlay.  Must be
+ * `text`, not `auto`: under an inherited `none`, `auto` computes back to
+ * `none`, so it would not re-enable selection. */
+.PopupText,
+.SubpopText,
 #debug *,
 input,
+textarea,
 .allowselect {
-  user-select: auto;
-  -o-user-select: auto;
-  -moz-user-select: auto;
+  user-select: text;
+  -o-user-select: text;
+  -moz-user-select: text;
   /* biome-ignore lint/correctness/noUnknownProperty: legacy vendor prefix for KHTML/Konqueror */
-  -khtml-user-select: auto;
-  -webkit-user-select: auto;
+  -khtml-user-select: text;
+  -webkit-user-select: text;
 }
 @font-face {
   font-family: Bowlby;

--- a/scripts/components/popups/AboutPopup.tsx
+++ b/scripts/components/popups/AboutPopup.tsx
@@ -162,12 +162,17 @@ export function AboutPopup({ locale, buttonLabel, onClose, onExport, onImport }:
               {importError && <div class="PopupParagraph SaveError">{importError}</div>}
             </div>
           )}
-          <div class="PopupButtons">
-            {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
-            <div class="Button" data-button-id="MainButton" onClick={close}>
-              {buttonLabel}
-            </div>
-          </div>
+        </div>
+      </div>
+      {/* The Close bar renders as a direct child of `.PopupBody`, outside the
+          scrolling, rounded `.PopupContent`, so it stays pinned to the
+          dialog's bottom edge without WebKit clipping it to `.PopupContent`'s
+          border-radius (`.PopupTab`'s padding-bottom keeps the last lines
+          clear of it when fully scrolled). */}
+      <div class="PopupButtons">
+        {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
+        <div class="Button" data-button-id="MainButton" onClick={close}>
+          {buttonLabel}
         </div>
       </div>
     </div>

--- a/scripts/components/popups/CityPopup.tsx
+++ b/scripts/components/popups/CityPopup.tsx
@@ -106,19 +106,24 @@ export function CityPopup({ vm, onClose, popup }: CityPopupProps) {
                   )}
                 </div>
               </div>
-              <div class="PopupButtons">
-                {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
-                <div
-                  class="Button"
-                  data-button-id="MainButton"
-                  onClick={(e) => fireAction(popup, e, 'MainButton')}
-                >
-                  {vm.buttonText}
-                </div>
-              </div>
             </div>
           );
         })}
+      </div>
+      {/* One button bar for the whole dialog (the action is identical on
+          every city tab), rendered as a direct child of `.PopupBody`
+          outside the scrolling, rounded `.PopupContent` so it straddles the
+          dialog's bottom edge without WebKit clipping the overhang to
+          `.PopupContent`'s border-radius. */}
+      <div class="PopupButtons">
+        {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
+        <div
+          class="Button"
+          data-button-id="MainButton"
+          onClick={(e) => fireAction(popup, e, 'MainButton')}
+        >
+          {vm.buttonText}
+        </div>
       </div>
     </div>
   );

--- a/scripts/components/popups/ClientPopup.tsx
+++ b/scripts/components/popups/ClientPopup.tsx
@@ -102,45 +102,47 @@ export function ClientPopup({ vm, onClose, popup }: ClientPopupProps) {
             onOpen={handleOpenToken}
           />
         </div>
-        {/* `.PopupButtons` is a sibling of `.PopupTab` in
-            popup_client.html (the tab closes before the button bar),
-            unlike popup_contact.html where it nests inside. */}
-        {vm.collectMode ? (
-          <div class="PopupButtons">
-            <div class="ButtonDecorator AP">
-              <div class="RenderSprite Tobi" />1
-            </div>
-            {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
-            <div
-              class="Button"
-              data-button-id="CollectButton"
-              data-testid="dd-collect-button"
-              onClick={(e) => fireAction(popup, e, 'CollectButton')}
-            >
-              {i18n.gettext('Collect')}
-            </div>
-          </div>
-        ) : (
-          <div class="PopupButtons">
-            <div class="ButtonDecorator AP">
-              <div class="RenderSprite Tobi" />1
-            </div>
-            {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
-            <div
-              class={vm.chargeDisabled ? 'Button disabled' : 'Button'}
-              data-button-id="ChargeButton"
-              data-testid="dd-charge-button"
-              onClick={(e) => fireAction(popup, e, 'ChargeButton')}
-            >
-              {vm.buttonText}
-            </div>
-            <div class="ButtonDecorator Time">
-              <div class="RenderSprite Tobi" />
-              {vm.chargeTimeText}
-            </div>
-          </div>
-        )}
       </div>
+      {/* The button bar renders as a direct child of `.PopupBody`, a sibling
+          of `.PopupContent` (in popup_client.html the tab closes before the
+          bar).  Keeping it outside the scrolling, rounded `.PopupContent`
+          lets it straddle the dialog's bottom edge without WebKit clipping
+          the overhang to `.PopupContent`'s border-radius. */}
+      {vm.collectMode ? (
+        <div class="PopupButtons">
+          <div class="ButtonDecorator AP">
+            <div class="RenderSprite Tobi" />1
+          </div>
+          {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
+          <div
+            class="Button"
+            data-button-id="CollectButton"
+            data-testid="dd-collect-button"
+            onClick={(e) => fireAction(popup, e, 'CollectButton')}
+          >
+            {i18n.gettext('Collect')}
+          </div>
+        </div>
+      ) : (
+        <div class="PopupButtons">
+          <div class="ButtonDecorator AP">
+            <div class="RenderSprite Tobi" />1
+          </div>
+          {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
+          <div
+            class={vm.chargeDisabled ? 'Button disabled' : 'Button'}
+            data-button-id="ChargeButton"
+            data-testid="dd-charge-button"
+            onClick={(e) => fireAction(popup, e, 'ChargeButton')}
+          >
+            {vm.buttonText}
+          </div>
+          <div class="ButtonDecorator Time">
+            <div class="RenderSprite Tobi" />
+            {vm.chargeTimeText}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/scripts/components/popups/ContactPopup.tsx
+++ b/scripts/components/popups/ContactPopup.tsx
@@ -86,44 +86,48 @@ export function ContactPopup({ vm, onClose, popup }: ContactPopupProps) {
             tokensClass="PopupTokens"
             onOpen={handleOpenToken}
           />
-          {vm.collectMode ? (
-            <div class="PopupButtons">
-              <div class="ButtonDecorator AP">
-                <div class="RenderSprite Tobi" />1
-              </div>
-              {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
-              <div
-                class="Button"
-                data-button-id="CollectButton"
-                data-testid="dd-collect-button"
-                onClick={(e) => fireAction(popup, e, 'CollectButton')}
-              >
-                {i18n.gettext('Collect')}
-              </div>
-            </div>
-          ) : (
-            <div class="PopupButtons">
-              <div class="ButtonDecorator Cash">
-                <div class="RenderSprite Tobi" />
-                {vm.chargeCostText}
-              </div>
-              {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
-              <div
-                class={vm.chargeDisabled ? 'Button disabled' : 'Button'}
-                data-button-id="ChargeButton"
-                data-testid="dd-charge-button"
-                onClick={(e) => fireAction(popup, e, 'ChargeButton')}
-              >
-                {vm.buttonText}
-              </div>
-              <div class="ButtonDecorator Time">
-                <div class="RenderSprite Tobi" />
-                {vm.chargeTimeText}
-              </div>
-            </div>
-          )}
         </div>
       </div>
+      {/* The button bar renders as a direct child of `.PopupBody`, outside
+          the scrolling, rounded `.PopupContent`, so it straddles the
+          dialog's bottom edge without WebKit clipping the overhang to
+          `.PopupContent`'s border-radius. */}
+      {vm.collectMode ? (
+        <div class="PopupButtons">
+          <div class="ButtonDecorator AP">
+            <div class="RenderSprite Tobi" />1
+          </div>
+          {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
+          <div
+            class="Button"
+            data-button-id="CollectButton"
+            data-testid="dd-collect-button"
+            onClick={(e) => fireAction(popup, e, 'CollectButton')}
+          >
+            {i18n.gettext('Collect')}
+          </div>
+        </div>
+      ) : (
+        <div class="PopupButtons">
+          <div class="ButtonDecorator Cash">
+            <div class="RenderSprite Tobi" />
+            {vm.chargeCostText}
+          </div>
+          {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
+          <div
+            class={vm.chargeDisabled ? 'Button disabled' : 'Button'}
+            data-button-id="ChargeButton"
+            data-testid="dd-charge-button"
+            onClick={(e) => fireAction(popup, e, 'ChargeButton')}
+          >
+            {vm.buttonText}
+          </div>
+          <div class="ButtonDecorator Time">
+            <div class="RenderSprite Tobi" />
+            {vm.chargeTimeText}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/scripts/components/popups/ProfileSetPopup.tsx
+++ b/scripts/components/popups/ProfileSetPopup.tsx
@@ -80,20 +80,24 @@ export function ProfileSetPopup({ vm, onClose, popup }: ProfileSetPopupProps) {
             tokensClass="PopupTokens"
             onOpen={handleOpenToken}
           />
-          <div class="PopupButtons">
-            <div class="ButtonDecorator AP">
-              <div class="RenderSprite Tobi" />1
-            </div>
-            {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
-            <div
-              class="Button"
-              data-button-id="MainButton"
-              data-testid="dd-integrate-button"
-              onClick={(e) => fireAction(popup, e, 'MainButton')}
-            >
-              {vm.buttonText}
-            </div>
-          </div>
+        </div>
+      </div>
+      {/* The button bar renders as a direct child of `.PopupBody`, outside
+          the scrolling, rounded `.PopupContent`, so it straddles the
+          dialog's bottom edge without WebKit clipping the overhang to
+          `.PopupContent`'s border-radius. */}
+      <div class="PopupButtons">
+        <div class="ButtonDecorator AP">
+          <div class="RenderSprite Tobi" />1
+        </div>
+        {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
+        <div
+          class="Button"
+          data-button-id="MainButton"
+          data-testid="dd-integrate-button"
+          onClick={(e) => fireAction(popup, e, 'MainButton')}
+        >
+          {vm.buttonText}
         </div>
       </div>
     </div>

--- a/scripts/components/popups/ProjectPopup.tsx
+++ b/scripts/components/popups/ProjectPopup.tsx
@@ -767,42 +767,6 @@ export function ProjectPopup({ vm: initialVm, bridge, onClose, popup }: ProjectP
               ))}
             </div>
           </div>
-          {vm.collectMode ? (
-            <div class="PopupButtons">
-              <div class="ButtonDecorator AP">
-                <div class="RenderSprite Tobi" />1
-              </div>
-              {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
-              <div
-                class="Button"
-                data-button-id="CollectButton"
-                data-testid="dd-collect-button"
-                onClick={(e) => fireAction(popup, e, 'CollectButton')}
-              >
-                {i18n.gettext('Collect')}
-              </div>
-            </div>
-          ) : (
-            <div class="PopupButtons">
-              <div class="ButtonDecorator Cash">
-                <div class="RenderSprite Tobi" />
-                {vm.chargeCostText}
-              </div>
-              {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
-              <div
-                class={vm.chargeDisabled ? 'Button disabled' : 'Button'}
-                data-button-id="ChargeButton"
-                data-testid="dd-charge-button"
-                onClick={(e) => fireAction(popup, e, 'ChargeButton')}
-              >
-                {vm.chargeButtonText}
-              </div>
-              <div class="ButtonDecorator Time">
-                <div class="RenderSprite Tobi" />
-                {vm.chargeTimeText}
-              </div>
-            </div>
-          )}
         </div>
 
         {!vm.cached ? (
@@ -928,6 +892,49 @@ export function ProjectPopup({ vm: initialVm, bridge, onClose, popup }: ProjectP
             })
           : null}
       </div>
+      {/* The data-tab Charge / Collect bar renders as a direct child of
+          `.PopupBody`, outside the scrolling, rounded `.PopupContent`, so it
+          straddles the dialog's bottom edge without WebKit clipping the
+          overhang to `.PopupContent`'s border-radius.  Guarded by the active
+          tab so it only shows on the data tab (the powerup tabs have no
+          charge/collect action — they buy/sell through their own subpops). */}
+      {dataActive &&
+        (vm.collectMode ? (
+          <div class="PopupButtons">
+            <div class="ButtonDecorator AP">
+              <div class="RenderSprite Tobi" />1
+            </div>
+            {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
+            <div
+              class="Button"
+              data-button-id="CollectButton"
+              data-testid="dd-collect-button"
+              onClick={(e) => fireAction(popup, e, 'CollectButton')}
+            >
+              {i18n.gettext('Collect')}
+            </div>
+          </div>
+        ) : (
+          <div class="PopupButtons">
+            <div class="ButtonDecorator Cash">
+              <div class="RenderSprite Tobi" />
+              {vm.chargeCostText}
+            </div>
+            {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
+            <div
+              class={vm.chargeDisabled ? 'Button disabled' : 'Button'}
+              data-button-id="ChargeButton"
+              data-testid="dd-charge-button"
+              onClick={(e) => fireAction(popup, e, 'ChargeButton')}
+            >
+              {vm.chargeButtonText}
+            </div>
+            <div class="ButtonDecorator Time">
+              <div class="RenderSprite Tobi" />
+              {vm.chargeTimeText}
+            </div>
+          </div>
+        ))}
     </div>
   );
 }

--- a/scripts/components/popups/ProvidedPerpPopup.tsx
+++ b/scripts/components/popups/ProvidedPerpPopup.tsx
@@ -100,16 +100,20 @@ export function ProvidedPerpPopup({ vm, onClose, popup }: ProvidedPerpPopupProps
               )}
             </div>
           </div>
-          <div class="PopupButtons">
-            {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
-            <div
-              class={vm.buttonDisabled ? 'Button disabled' : 'Button'}
-              data-button-id="MainButton"
-              onClick={(e) => fireAction(popup, e, 'MainButton')}
-            >
-              {vm.buttonText}
-            </div>
-          </div>
+        </div>
+      </div>
+      {/* The button bar renders as a direct child of `.PopupBody`, outside
+          the scrolling, rounded `.PopupContent`, so it straddles the
+          dialog's bottom edge without WebKit clipping the overhang to
+          `.PopupContent`'s border-radius. */}
+      <div class="PopupButtons">
+        {/* biome-ignore lint/a11y/useKeyWithClickEvents: legacy DOM structure, keyboard support is a separate a11y pass */}
+        <div
+          class={vm.buttonDisabled ? 'Button disabled' : 'Button'}
+          data-button-id="MainButton"
+          onClick={(e) => fireAction(popup, e, 'MainButton')}
+        >
+          {vm.buttonText}
         </div>
       </div>
     </div>


### PR DESCRIPTION
Two dialog UI fixes reported on WebKit. They matter on iOS, where messengers run webxdc inside `WKWebView`, so every player there gets the WebKit rendering path.

## 1. Bottom button bars cut off instead of straddling the dialog edge

The `.PopupButtons` bar is `position: absolute` with `.PopupBody` as its containing block, so it's *meant* to overhang the dialog's bottom edge. In Chrome/Firefox the bar correctly escapes the `overflow` clip of the intervening `.PopupContent` (its containing block is an ancestor of that scroll box). But on mobile `.PopupContent` also has `border-radius: 12px`, and **WebKit's border-radius clip catches the escaping absolutely-positioned overhang** — so the bottom half of the bar gets cut off (see the original report's screenshot of the "MAKE A DEAL" button).

**Fix:** render the button bar as a direct child of `.PopupBody` (a sibling of `.PopupContent`) instead of nested inside it, so it's outside the clipping subtree in *every* engine — independent of WebKit's exact clip semantics. Because the bar is abs-positioned against `.PopupBody` either way, its on-screen position is unchanged. A small `.PopupBody > .PopupButtons` rule re-anchors it (`margin-left: 0; left/right: 0`): the base `margin-left: -12px` assumed the bar sat one `.PopupContent` border (6px) in, so without it the centred buttons would drift 6px left.

Covered popups: **About, City, Client, Contact, ProfileSet, ProvidedPerp, Project**. (Notification popups use `position: relative` in-flow buttons; Token/status popups keep their bar in `.PopupHeader`, which doesn't clip — so those were already fine and are untouched.)

Verified pixel-identical at desktop (1280px) and mobile (375px) by measuring the rendered `.Button` centre before/after in headless Chromium.

## 2. App text should not be selectable (except perp/token descriptions)

A long-press could select button captions and other UI text. The old rule scoped `user-select: none` to `.Stage *` / `.MainMenu *`, which never covered the dialogs — the dialog manager appends those outside the Stage, so their buttons/labels stayed selectable.

**Fix:** make the app root `#dd-control` non-selectable (it inherits to the Stage, the menu *and* every dialog), then opt only the bits worth copying back in — the perp/token flavour-text descriptions (`.PopupText`, `.SubpopText`), form fields, and the debug overlay. The opt-ins use `user-select: text` rather than `auto`, because under an inherited `none`, `auto` computes back to `none` and wouldn't re-enable selection.

## Validation
- `pnpm typecheck` ✓ &nbsp; `pnpm lint` ✓
- `pnpm test` — 798 unit tests ✓ (includes the real `.xdc` build)
- `pnpm test:e2e dialog-lifecycle.spec.ts` — 50/50 ✓ (Client/Contact charge+collect, ProfileSet integrate, Pusher/Proxy buy, Project powerup buy/sell, subpop open/close)
- Standalone WebKit-clip diagnosis + Chromium pixel-parity + `user-select` computed-style checks against the real CSS

> Note: the e2e suite only runs Chromium (production webxdc is Chromium-based); WebKit isn't installable in CI here, so the WebKit fix rests on the diagnosis + the structural change (button removed from the clip subtree entirely) rather than an automated WebKit screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7k5SzJLr1UuXrpZwrG5xh

---
_Generated by [Claude Code](https://claude.ai/code/session_01F7k5SzJLr1UuXrpZwrG5xh)_