### PR TITLE
Rename "Highscore" to "Leaderboard" (de: "Bestenliste")

### DIFF
--- a/i18n/de_AT.json
+++ b/i18n/de_AT.json
@@ -159,7 +159,7 @@
   ],
   "Topscores": [
     null,
-    "Highscore"
+    "Bestenliste"
   ],
   "Missions": [
     null,
@@ -243,19 +243,19 @@
   ],
   "topscore cash headline": [
     null,
-    "Data Dealer Highscore<br />Cash"
+    "Data Dealer Bestenliste<br />Cash"
   ],
   "topscore profiles headline": [
     null,
-    "Data Dealer Highscore<br />Gesammelte Profile"
+    "Data Dealer Bestenliste<br />Gesammelte Profile"
   ],
   "topscore xp headline": [
     null,
-    "Data Dealer Highscore<br />Erfahrungspunkte (XP)"
+    "Data Dealer Bestenliste<br />Erfahrungspunkte (XP)"
   ],
   "topscore spent headline": [
     null,
-    "Data Dealer Highscore<br />Investierte Kohle"
+    "Data Dealer Bestenliste<br />Investierte Kohle"
   ],
   "topscore Cash": [
     null,
@@ -883,7 +883,7 @@
   ],
   "userdebug reset game text": [
     null,
-    "Hier kannst du bei Bedarf deinen Spielstand zurücksetzen und komplett von vorne beginnen.<br /><span class=\"warn\">Achtung: Dabei geht dein gesamter Spielfortschritt (erreichte Levels, XP, Profile, Items, Geld, dein Platz in der Highscore-Liste) verloren, für immer!</span>"
+    "Hier kannst du bei Bedarf deinen Spielstand zurücksetzen und komplett von vorne beginnen.<br /><span class=\"warn\">Achtung: Dabei geht dein gesamter Spielfortschritt (erreichte Levels, XP, Profile, Items, Geld, dein Platz in der Bestenliste) verloren, für immer!</span>"
   ],
   "Reset Game": [
     null,

--- a/i18n/en_US.json
+++ b/i18n/en_US.json
@@ -159,7 +159,7 @@
   ],
   "Topscores": [
     null,
-    "Highscore"
+    "Leaderboard"
   ],
   "Missions": [
     null,
@@ -243,19 +243,19 @@
   ],
   "topscore cash headline": [
     null,
-    "Data Dealer Highscore<br />CASH"
+    "Data Dealer Leaderboard<br />CASH"
   ],
   "topscore profiles headline": [
     null,
-    "Data Dealer Highscore<br />Profiles"
+    "Data Dealer Leaderboard<br />Profiles"
   ],
   "topscore xp headline": [
     null,
-    "Data Dealer Highscore<br />Experience Points (XP)"
+    "Data Dealer Leaderboard<br />Experience Points (XP)"
   ],
   "topscore spent headline": [
     null,
-    "Data Dealer Highscore<br />Cash Invested"
+    "Data Dealer Leaderboard<br />Cash Invested"
   ],
   "topscore Cash": [
     null,
@@ -883,7 +883,7 @@
   ],
   "userdebug reset game text": [
     null,
-    "Do you want to delete and reset your game and start again from scratch? <span class=\"warn\">Caution: All your game progress (levels, XP, profiles, items, cash, your ranks in the highscore) will be lost, forever!</span>"
+    "Do you want to delete and reset your game and start again from scratch? <span class=\"warn\">Caution: All your game progress (levels, XP, profiles, items, cash, your ranks in the leaderboard) will be lost, forever!</span>"
   ],
   "Reset Game": [
     null,

--- a/tests/e2e/leaderboard-tab.spec.ts
+++ b/tests/e2e/leaderboard-tab.spec.ts
@@ -48,5 +48,5 @@ test('leaderboard tab: LEADERBOARD button appears in main menu', async ({ page }
   const topscoresView = page.locator('.TopscorePerp').first();
   await expect(topscoresView).toBeVisible({ timeout: 10_000 });
 
-  expect(jsErrors, `JS errors when opening Leaderboard tab: ${jsErrors.join(' | ')}`).toHaveLength(0);
+  expect(jsErrors, `JS errors opening Leaderboard tab: ${jsErrors.join(' | ')}`).toHaveLength(0);
 });

--- a/tests/e2e/leaderboard-tab.spec.ts
+++ b/tests/e2e/leaderboard-tab.spec.ts
@@ -1,7 +1,7 @@
 /**
- * High score tab visibility and rendering test
+ * Leaderboard tab visibility and rendering test
  *
- * Validates that clicking the HIGHSCORE button in the main menu shows
+ * Validates that clicking the LEADERBOARD button in the main menu shows
  * the topscores view without errors.
  */
 
@@ -9,7 +9,7 @@ import { expect, test } from '@playwright/test';
 
 const GAME_CONTAINER = '[data-testid="game-container"]';
 
-test('highscore tab: HIGHSCORE button appears in main menu', async ({ page }) => {
+test('leaderboard tab: LEADERBOARD button appears in main menu', async ({ page }) => {
   const jsErrors: string[] = [];
   page.on('console', (msg) => {
     if (msg.type() === 'error' && !msg.text().includes('favicon')) {
@@ -36,17 +36,17 @@ test('highscore tab: HIGHSCORE button appears in main menu', async ({ page }) =>
     });
   }
 
-  const highscoreButton = page
+  const leaderboardButton = page
     .locator('.mm-tab')
-    .filter({ hasText: /Highscore/ })
+    .filter({ hasText: /Leaderboard/ })
     .first();
 
-  await expect(highscoreButton).toBeVisible();
+  await expect(leaderboardButton).toBeVisible();
 
-  await highscoreButton.click();
+  await leaderboardButton.click();
 
   const topscoresView = page.locator('.TopscorePerp').first();
   await expect(topscoresView).toBeVisible({ timeout: 10_000 });
 
-  expect(jsErrors, `JS errors when opening Highscore tab: ${jsErrors.join(' | ')}`).toHaveLength(0);
+  expect(jsErrors, `JS errors when opening Leaderboard tab: ${jsErrors.join(' | ')}`).toHaveLength(0);
 });


### PR DESCRIPTION
## What

Renames the user-facing high-score list label to **"Leaderboard"** (EN) / **"Bestenliste"** (DE).

| Locale | Before | After |
| --- | --- | --- |
| `en_US` | Highscore | **Leaderboard** |
| `de_AT` | Highscore | **Bestenliste** |

I went with **Bestenliste** for German — it's the natural term for a game high-score list ("list of the best"), and fits the gaming context better than *Rangliste* (which reads more like sport standings). Easy to switch if you'd prefer *Rangliste*.

## Where

All occurrences live in the two runtime locale files (`i18n/en_US.json`, `i18n/de_AT.json`):

- **Main-menu tab label** (`Topscores` key)
- **Per-type ranking headlines** — `Data Dealer Highscore<br />…` → `Data Dealer Leaderboard / Bestenliste<br />…` (cash / profiles / xp / spent)
- **Reset-game warning text** — "your ranks in the highscore" / "dein Platz in der Highscore-Liste"

The e2e spec was updated to match the new label and renamed for clarity: `tests/e2e/highscore-tab.spec.ts` → `leaderboard-tab.spec.ts` (text matcher `/Highscore/` → `/Leaderboard/`).

## Scope notes

- **Internal identifiers left unchanged** — the `Topscore*` GameNode classes, CSS classes (`.TopscorePerp`, `.TopscoreList`, …), view templates (`topscore*.html`), and `data-testid="dd-leaderboard-row-*"` are implementation names, not user-facing, so they're out of scope for a label rename.
- **Legacy gettext catalogs untouched** — `i18n/*.po` / `*.mo` / `*.pot` are not consumed at runtime (`scripts/i18n.ts` statically imports the `.json` files) and are already stale (they still read `"Top50"` from a prior rename). Touching them would be inconsistent with how the project maintains translations.

## Verification

- Both locale JSON files parse cleanly.
- No remaining user-facing `highscore` references (the one match left is a historical comment in `avatars.test.js` referencing a past PR name).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FGUhxfL4UsaTQrjybzYwUa

---
_Generated by [Claude Code](https://claude.ai/code/session_01FGUhxfL4UsaTQrjybzYwUa)_