### PR TITLE
Fix misleading pusher "Requires either…or" copy + new-items card mobile overflow

### DIFF
--- a/css/Render.css
+++ b/css/Render.css
@@ -3914,6 +3914,55 @@ button {
   .Selector.hasPopup {
     display: block;
   }
+
+  /* Tutorial / LevelUp "tap to continue" hint: cap to the viewport so the
+   * centred Bowlby text + its 2 px text-shadow can't bleed past the right
+   * edge on narrow phones (the .TutorialWrap stretches it full-width). */
+  .TutorialTapHint {
+    max-width: 100%;
+    box-sizing: border-box;
+    overflow-wrap: break-word;
+  }
+
+  /* New-items / new-powerups unlock card.  Unlike the buy popups (which
+   * open a dedicated .ProvidedPerpSub dialog on mobile), this .Subpop is
+   * always rendered inline, so its desktop 550 px width + 180 px absolute
+   * logo overflowed the right edge on phones.  Reflow it the same way the
+   * .PopupHeader does: shrink to content width and float the logo, scaling
+   * its 180×180 sprite into an 80×80 cell (transform 0.4444 = 80/180). */
+  .NotificationItem {
+    height: auto;
+  }
+  .NotificationItem .Subpop {
+    position: relative;
+    top: auto;
+    left: auto;
+    width: auto;
+    height: auto;
+    transform: none !important;
+    margin: 6px;
+    padding: 10px 12px 12px;
+    box-sizing: border-box;
+    overflow: hidden;
+  }
+  .NotificationItem .SubpopLogo {
+    position: static;
+    float: left;
+    width: 80px;
+    height: 80px;
+    margin-right: 10px;
+    overflow: hidden;
+  }
+  .NotificationItem .SubpopLogo > * {
+    transform: scale(0.4444);
+    transform-origin: top left;
+  }
+  .NotificationItem .SubpopTitle,
+  .NotificationItem .SubpopSubTitle,
+  .NotificationItem .SubpopText {
+    margin-left: 0;
+    overflow-wrap: break-word;
+  }
 }
 
 /* --- Mission + Topscore tab content: centre via margin auto + max-width --

--- a/i18n/de_AT.json
+++ b/i18n/de_AT.json
@@ -901,6 +901,10 @@
     null,
     "oder<br />"
   ],
+  "and<br/>": [
+    null,
+    "und<br />"
+  ],
   "Buy Upgrade": [
     null,
     "Ausbauen"

--- a/i18n/de_AT.po
+++ b/i18n/de_AT.po
@@ -1098,6 +1098,10 @@ msgstr "Benötigt entweder"
 msgid "or<br/>"
 msgstr "oder<br />"
 
+#: scripts/game/providedView.ts:284
+msgid "and<br/>"
+msgstr "und<br />"
+
 #: views/selector_powerups.html:10
 msgid "Buy Upgrade"
 msgstr "Ausbauen"

--- a/i18n/en_US.json
+++ b/i18n/en_US.json
@@ -901,6 +901,10 @@
     null,
     "or<br/>"
   ],
+  "and<br/>": [
+    null,
+    "and<br/>"
+  ],
   "Buy Upgrade": [
     null,
     "Buy Upgrade"

--- a/i18n/en_US.po
+++ b/i18n/en_US.po
@@ -1073,6 +1073,10 @@ msgstr "Requires either"
 msgid "or<br/>"
 msgstr "or<br/>"
 
+#: scripts/game/providedView.ts:284
+msgid "and<br/>"
+msgstr "and<br/>"
+
 #: views/selector_powerups.html:10
 msgid "Buy Upgrade"
 msgstr "Buy Upgrade"

--- a/i18n/messages.pot
+++ b/i18n/messages.pot
@@ -975,6 +975,10 @@ msgstr ""
 msgid "or<br/>"
 msgstr ""
 
+#: scripts/game/providedView.ts:284
+msgid "and<br/>"
+msgstr ""
+
 #: views/selector_powerups.html:10
 msgid "Buy Upgrade"
 msgstr ""

--- a/scripts/game/providedView.ts
+++ b/scripts/game/providedView.ts
@@ -288,7 +288,13 @@ function buildPusherTile(perp: ProvidedPerpRow, key: number): ProvidedTileVM {
   if (locked) {
     const provs = (data.requiredProviders as string[] | undefined) ?? [];
     const inner = provs
-      .map((v, k) => (k + 1 < provs.length ? `${v},<br />` : `${i18n.gettext('and<br/>')}${v}`))
+      .map((v, k) => {
+        if (k + 1 < provs.length) return `${v},<br />`;
+        // Last provider gets the "and" connector — but only when it
+        // actually follows others; a lone provider must not render a
+        // dangling "Requires and X".
+        return provs.length > 1 ? `${i18n.gettext('and<br/>')}${v}` : v;
+      })
       .join('');
     dataHtml = `<div class="Requires">${i18n.gettext('Requires')}<div class="RequiresProviders">${inner}</div></div>`;
   } else {

--- a/scripts/game/providedView.ts
+++ b/scripts/game/providedView.ts
@@ -272,7 +272,14 @@ function buildAgentTile(perp: ProvidedPerpRow, key: number): ProvidedTileVM {
 }
 
 /** `pusher.html` — CityPerp Pushers-tab tile (PowerupBackground/Label,
- *  box pivot 47, `Requires either … or<br/>` locked branch). */
+ *  box pivot 47, `Requires … and<br/>` locked branch).
+ *
+ *  A pusher unlocks only once **all** of its `required_providers` are
+ *  owned — `_isProvidable` (LocalEngine) ANDs the list, and the
+ *  ruleset-query tests assert "buyable once all required_providers are
+ *  owned".  The locked-tile copy therefore lists them joined with "and",
+ *  not the old "Requires either … or" (which wrongly implied any single
+ *  one would suffice). */
 function buildPusherTile(perp: ProvidedPerpRow, key: number): ProvidedTileVM {
   const data = perp.data;
   const bg = spriteOf(data.perp_background);
@@ -281,9 +288,9 @@ function buildPusherTile(perp: ProvidedPerpRow, key: number): ProvidedTileVM {
   if (locked) {
     const provs = (data.requiredProviders as string[] | undefined) ?? [];
     const inner = provs
-      .map((v, k) => (k + 1 < provs.length ? `${v},<br />` : `${i18n.gettext('or<br/>')}${v}`))
+      .map((v, k) => (k + 1 < provs.length ? `${v},<br />` : `${i18n.gettext('and<br/>')}${v}`))
       .join('');
-    dataHtml = `<div class="Requires">${i18n.gettext('Requires either')}<div class="RequiresProviders">${inner}</div></div>`;
+    dataHtml = `<div class="Requires">${i18n.gettext('Requires')}<div class="RequiresProviders">${inner}</div></div>`;
   } else {
     dataHtml = buildValuesHtml(data);
   }

--- a/tests/game/pusher-requires-text.test.js
+++ b/tests/game/pusher-requires-text.test.js
@@ -38,11 +38,22 @@ describe('pusher locked tile — requirement copy is AND, not OR', () => {
     expect(html).not.toContain('or<br/>');
   });
 
-  it('still renders cleanly for a single required provider', () => {
+  it('renders a lone provider with no dangling "and"', () => {
     const row = lockedPusher(['Warranty Cards']);
     const { tiles } = buildProvided([row], 'pusher', CTX);
     const html = tiles[0].dataHtml;
     expect(html).toContain('Warranty Cards');
     expect(html).not.toContain('Requires either');
+    // A single provider has nothing to join, so no connector must appear.
+    expect(html).not.toContain('and<br/>');
+  });
+
+  it('joins exactly two providers with "and" and no trailing comma-only tail', () => {
+    const row = lockedPusher(['Franz Sauerzapf', 'Warranty Cards']);
+    const { tiles } = buildProvided([row], 'pusher', CTX);
+    const html = tiles[0].dataHtml;
+    expect(html).toContain('and<br/>');
+    expect(html).toContain('Franz Sauerzapf');
+    expect(html).toContain('Warranty Cards');
   });
 });

--- a/tests/game/pusher-requires-text.test.js
+++ b/tests/game/pusher-requires-text.test.js
@@ -1,0 +1,48 @@
+// Pusher locked-tile requirement copy must reflect AND semantics.
+//
+// A pusher (CityPerp "Pushers" tab) only unlocks once **all** of its
+// `required_providers` are owned: `_isProvidable` in scripts/LocalEngine.ts
+// ANDs the list, and tests/handlers/ruleset-queries.test.js asserts a pusher
+// is "buyable once all required_providers are owned".  The locked tile used
+// to render "Requires either A, B, or C", which wrongly implied any single
+// provider would suffice — players reported chasing one provider and finding
+// the pusher still locked.  This guards the corrected "Requires A, B, and C"
+// copy so the OR wording can't silently return.
+import { describe, expect, it } from 'vitest';
+import { buildProvided } from '../../scripts/game/providedView.js';
+
+const CTX = { xpLevel: 1, dbTokens: {}, typeOf: () => '' };
+
+function lockedPusher(requiredProviders) {
+  return {
+    gestalt: 'pusher001',
+    locked: true,
+    data: { requiredProviders, price: 0, label: 'Pusher' },
+  };
+}
+
+describe('pusher locked tile — requirement copy is AND, not OR', () => {
+  it('joins multiple required providers with "and", under a plain "Requires"', () => {
+    const row = lockedPusher(['Anti-piracy crawler', 'Franz Sauerzapf', 'Warranty Cards']);
+    const { tiles } = buildProvided([row], 'pusher', CTX);
+    const html = tiles[0].dataHtml;
+
+    // All three providers are listed (all are required).
+    expect(html).toContain('Anti-piracy crawler');
+    expect(html).toContain('Franz Sauerzapf');
+    expect(html).toContain('Warranty Cards');
+
+    // AND semantics: "Requires … and …", never the misleading "either … or".
+    expect(html).toContain('and<br/>');
+    expect(html).not.toContain('Requires either');
+    expect(html).not.toContain('or<br/>');
+  });
+
+  it('still renders cleanly for a single required provider', () => {
+    const row = lockedPusher(['Warranty Cards']);
+    const { tiles } = buildProvided([row], 'pusher', CTX);
+    const html = tiles[0].dataHtml;
+    expect(html).toContain('Warranty Cards');
+    expect(html).not.toContain('Requires either');
+  });
+});


### PR DESCRIPTION
## Context

Triage + fixes for a batch of player-reported bugs. I validated each report against the code (and reproduced the game-logic ones with the real `LocalEngine` handlers). Two reports turned out to be genuine, low-risk code bugs and are **fixed here**; the rest are documented below with what I found.

## ✅ Fixed in this PR

### 1. Pusher requirement text wrongly says "either … or" (reported as *'Benötigt entweder Sauernapf oder Garantiekarten' stimmt nicht*)

A pusher (a CityPerp "Pushers"-tab buy) unlocks only once **all** of its `required_providers` are owned — `_isProvidable` in `scripts/LocalEngine.ts` ANDs the list, and `tests/handlers/ruleset-queries.test.js` asserts a pusher is *"buyable once all required_providers are owned"*. But the locked tile rendered **"Requires either A, B, or C"**, which reads as *any one* will do.

`pusher001` (New York) requires `project007` (Anti-piracy crawler) **and** `contact004` (**Franz Sauerzapf** → the reporter's "Sauernapf") **and** `project006` (**Warranty Cards** / Garantiekarten). That's exactly why the reporter found that having Sauerzapf + one other wasn't enough and they specifically needed the Warranty Cards — the game was correct, the **text was lying**.

Fix (`scripts/game/providedView.ts` `buildPusherTile`): drop "either", join the providers with **"and"** ("und" in German) under a plain "Requires" header. Adds the `and<br/>` string to both locale JSONs (+ `.po`/`.pot`) and a regression test (`tests/game/pusher-requires-text.test.js`).

### 2. New-items unlock card overflows the right edge on mobile (*Texthinweisfelder schauen zum rechten Rand aus dem Bild am Handy*)

The "New Powerups/Ventures!" notification renders its detail card inline as `.NotificationItem .Subpop`. Unlike the buy popups (which open a dedicated `.ProvidedPerpSub` dialog on mobile), this card kept its **desktop 550 px width + 180 px absolutely-positioned logo** on phones, so it stuck out past the right screen edge. The Marco speech bubble was already made responsive in the earlier mobile pass (hence *"weiterhin"* / still), but this card was missed.

Fix (`css/Render.css`, in the existing `@media (max-width: 768px)` block): reflow the card the same way `.PopupHeader` already does — shrink to content width and float the logo, scaling its 180×180 sprite into an 80×80 cell (`transform: scale(0.4444)`, a pattern already used in this file). Also caps `.TutorialTapHint` to the viewport.

> Note: this reflow reuses a proven in-repo pattern but I could not render it on a device in this environment — worth an on-device glance before/after on a ~360 px screen.

## 🔍 Investigated — not changed (with reasoning)

### 3. "Shell company 2 stops working after the dating company is bought → Body Mass Index / Weight×Height mission unreachable" (the reporter's top priority)

I could **not reproduce this at the engine level**. Using the real handlers I drove the full flow — buy a Bogus Company, buy the Dating Site (`project002`) into it, then buy/charge/collect/integrate:

- the proxy keeps working after the buy: `getProvidedPerps` returns its full buyable list before *and* after, slot counting stays correct, and the same-city sibling proxy is unaffected;
- buying **or** charge→collect→integrating the Dating Site seeds **Weight (`token014`) and Height (`token015`)** into the database (~99 share each), which is exactly what unlocks the Body Mass Index (`token055`) in `Database.compileSuperTokens`.

So the data path that gates this mission is intact. If it's still happening, it's most likely **client-side / UI-state** (e.g. the proxy popup not refreshing, or the Body Mass tile not re-evaluating its lock after integrating) rather than the game rules. To chase it down I'd need a repro detail: when "Scheinfirma 2 geht nicht mehr", does its popup fail to open, open empty/stuck-loading, or open but show no buyable items? And does the Body Mass Index tile not appear in the Database, or appear but stay greyed-out?

### 4. "10 000 € disappears when buying Warranty Cards into a full shell company"

Also **not reproducible**. `buyPerp` returns the slot-full error (`error 3`) *before* any cash deduction, and the client's error branch never touches the balance — a reproduction (full 3-slot `proxy002`, buy `project006`) returns `error 3` with cash unchanged (`50000 → 50000`). I did surface an adjacent latent issue while here (issue #150: the slot check is skipped entirely when the parent node is absent from `state.nodes`), but that path is a *silent success*, not the "error + money gone" symptom reported, so I left it alone.

### 5. Exporting the save closes the whole app

This is **expected webxdc behaviour**, not an in-app bug: export hands the file to the host via `webxdc.sendToChat`, and the platform is allowed to take over / close the mini-app before the promise settles (the code already documents this). The save is fully written first, which matches the reporter's own note that nothing is lost. Not fixable from inside the app without changing the export mechanism.

## Testing
- `npx vitest run` — **802 passing** (incl. the new regression test)
- `npx tsc --noEmit` clean, `biome check` clean
- both `.xdc` bundles still build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014TCrCZcMj5buL4pVPquWTW)_