### PR TITLE
fix(leaderboard): truncate overlong display names with an ellipsis

### DIFF
--- a/css/Render.css
+++ b/css/Render.css
@@ -1167,6 +1167,11 @@
   flex: 1 1 auto;
   color: #009fd9;
   min-width: 0;
+  /* Long display names must truncate with an ellipsis rather than wrap —
+     rows have a fixed 32px height, so wrapping overflows into the row below. */
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .TopscoreValue {
   flex: 0 0 auto;

--- a/tests/e2e/leaderboard-name-ellipsis.spec.ts
+++ b/tests/e2e/leaderboard-name-ellipsis.spec.ts
@@ -1,0 +1,106 @@
+/**
+ * Leaderboard long-name overflow regression test.
+ *
+ * A peer whose display_name is far wider than the row used to wrap onto a
+ * second line, overflowing the fixed 32px row height and overlapping the row
+ * below. The fix constrains `.TopscoreDisplayname` to a single line with an
+ * ellipsis (overflow:hidden + text-overflow:ellipsis + white-space:nowrap).
+ *
+ * This test seeds one peer with a very long name and asserts that:
+ *   1. the name is truncated (rendered width < intrinsic text width), and
+ *   2. the row keeps its single-line height, so it can't overlap neighbours.
+ */
+
+import { expect, test } from '@playwright/test';
+
+type PeerSeed = {
+  display_name: string;
+  cash: number;
+  profiles: number;
+  xp: number;
+  level: number;
+  spent: number;
+  last_seen_ts: number;
+  last_seen_serial: null;
+};
+
+function mkPeer(p: Partial<PeerSeed> & { display_name: string }): PeerSeed {
+  return {
+    cash: 0,
+    profiles: 0,
+    xp: 0,
+    level: 1,
+    spent: 0,
+    last_seen_ts: 0,
+    last_seen_serial: null,
+    ...p,
+  };
+}
+
+const LONG_NAME = 'Maximiliana-Wilhelmina von und zu Habsburg-Lothringen the Third';
+
+test('leaderboard: an overlong display name truncates with an ellipsis instead of wrapping', async ({
+  page,
+}) => {
+  await page.goto('/?devtools=1');
+  await expect(page.locator('[data-testid="game-container"]')).toBeVisible({ timeout: 50_000 });
+
+  const SELF = 'alice@local';
+  await page.evaluate(
+    async ({ peers, selfAddr }) => {
+      const boot = await new Promise<any>((res, rej) =>
+        (window as any).require(['boot'], res, rej)
+      );
+      const app = (window as any).require('app').getApplication();
+      boot.setState(Object.assign({}, boot.getState(), { addr: selfAddr, peers }));
+      await Promise.resolve();
+      await new Promise((r) => setTimeout(r, 50));
+      app.game.Topscores.updateScores();
+      app.game.Topscores.trigger('button_click.ViewTabMenuButton', ['cash']);
+      await Promise.resolve();
+      await new Promise((r) => setTimeout(r, 50));
+    },
+    {
+      peers: {
+        [SELF]: mkPeer({ display_name: LONG_NAME, cash: 9_999_999, last_seen_ts: Date.now() }),
+        'bob@test': mkPeer({ display_name: 'Bob', cash: 250_000, last_seen_ts: Date.now() }),
+      },
+      selfAddr: SELF,
+    }
+  );
+
+  // Open the Leaderboard tab in the UI so the row is actually laid out —
+  // hidden renderNodes report 0 width and can't demonstrate overflow.
+  await page
+    .locator('.mm-tab')
+    .filter({ hasText: /Leaderboard/ })
+    .first()
+    .click();
+
+  const row = page.locator('[data-testid="dd-leaderboard-row-alice@local"]:visible').first();
+  await expect(row).toBeVisible({ timeout: 10_000 });
+  const name = row.locator('.TopscoreDisplayname');
+
+  // The full name text is present in the DOM (only visually clipped).
+  await expect(name).toHaveText(LONG_NAME);
+
+  // CSS contract: single-line ellipsis truncation.
+  await expect(name).toHaveCSS('text-overflow', 'ellipsis');
+  await expect(name).toHaveCSS('white-space', 'nowrap');
+  await expect(name).toHaveCSS('overflow-x', 'hidden');
+
+  // The element is actually overflowing — its content is wider than the box,
+  // which is what makes the ellipsis appear.
+  const overflow = await name.evaluate(
+    (el) => (el as HTMLElement).scrollWidth - (el as HTMLElement).clientWidth
+  );
+  expect(overflow).toBeGreaterThan(0);
+
+  // The name stays on a single line, so the row keeps its design height and
+  // cannot overlap the row below it.
+  const lineHeight = await name.evaluate((el) =>
+    Number.parseFloat(getComputedStyle(el as HTMLElement).lineHeight)
+  );
+  const boxHeight = await name.evaluate((el) => (el as HTMLElement).clientHeight);
+  expect(boxHeight).toBeLessThanOrEqual(lineHeight + 1);
+});


### PR DESCRIPTION
## Problem

On the Leaderboard, very long peer display names wrapped onto a second line. Because rows have a fixed 32px height, the wrapped text overflowed and overlapped the row below, breaking the layout and colliding with the value column.

**Before:** long names wrap and overflow into the next row, overlapping values.
**After:** long names truncate with an ellipsis on a single line; rank, name and value stay aligned.

_(Before/after screenshots were shared in the Claude Code chat.)_

## Fix

Constrain `.TopscoreDisplayname` to a single line with `overflow:hidden`, `text-overflow:ellipsis`, and `white-space:nowrap` (it already had `min-width:0`, required for flex children to shrink/truncate).

## Test

Adds a Playwright regression test (`tests/e2e/leaderboard-name-ellipsis.spec.ts`) that seeds a peer with an overlong name and asserts:
- the full name is still in the DOM (only visually clipped),
- the element truncates (`scrollWidth > clientWidth`) with the expected CSS, and
- the row keeps its single-line height so it cannot overlap neighbours.

Verified the test fails without the CSS change and passes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CkfMnYtcNPSRrC1UUcC8ET