### PR TITLE
Fix Requires list to include zero-count required tokens

### DIFF
--- a/scripts/game/providedView.ts
+++ b/scripts/game/providedView.ts
@@ -220,8 +220,14 @@ function buildPerpTile(perp: ProvidedPerpRow, key: number, ctx: ProvidedContext)
       | undefined;
     const reqLevel = (data.required_level as number | undefined) ?? 0;
     if (reqTokens?.length && reqLevel <= ctx.xpLevel) {
+      // Mirror Database.ts's lock condition: a required token leaves the
+      // perp locked when it's either missing OR present with a zero count.
+      // Filtering on key-presence alone dropped the zero-count token from
+      // the list, leaving a bare "Requires" with no names beneath it.
       const filtered = reqTokens.filter(
-        (t) => !Object.prototype.hasOwnProperty.call(ctx.dbTokens, t.gestalt)
+        (t) =>
+          !Object.prototype.hasOwnProperty.call(ctx.dbTokens, t.gestalt) ||
+          ctx.dbTokens[t.gestalt] === 0
       );
       const titles = filtered.map((t) => t.type_data?.title ?? '');
       dataHtml = `<div class="Requires">${i18n.gettext('Requires')}<div class="RequiresProviders">${titles.join(',<br />')}</div></div>`;

--- a/tests/game/provided-requires-zero-token.test.js
+++ b/tests/game/provided-requires-zero-token.test.js
@@ -1,0 +1,52 @@
+// Regression: the "Requires" / "Benötigt" block on a locked supertoken
+// buy tile must list every still-needed required token — including ones
+// that are present in DBTokens but with a zero count.
+//
+// Database.ts locks a buyable supertoken when a required token is missing
+// OR present with count 0. providedView's buildPerpTile used to filter the
+// displayed list on key-presence alone, so a zero-count required token was
+// dropped and the tile rendered just the bare word "Requires" with an
+// empty `.RequiresProviders` list. See issue: health-forecast requirements.
+
+import { describe, expect, it } from 'vitest';
+import { buildProvided } from '../../scripts/game/providedView.ts';
+
+const ctx = (dbTokens) => ({
+  xpLevel: 20,
+  dbTokens,
+  typeOf: () => 'TokenPerp',
+});
+
+const lockedSuperRow = () => ({
+  gestalt: 'supertoken002',
+  locked: true,
+  data: {
+    is_supertoken: true,
+    required_level: 17,
+    title: 'Gesundheits-Prognose',
+    requiredTokens: [
+      { gestalt: 'token017', type_data: { title: 'Krankenakten' } },
+      { gestalt: 'token055', type_data: { title: 'Body Mass Index' } },
+    ],
+  },
+});
+
+describe('buildPerpTile Requires list (zero-count required token)', () => {
+  it('lists a required token that is present but has a zero count', () => {
+    const { tiles } = buildProvided([lockedSuperRow()], 'perp', ctx({ token017: 0, token055: 5 }));
+    const html = tiles[0].dataHtml;
+    expect(html).toContain('Krankenakten');
+    // sanity: the Requires shell is there and not just a bare label
+    expect(html).toContain('RequiresProviders');
+  });
+
+  it('lists a required token that is entirely missing', () => {
+    const { tiles } = buildProvided([lockedSuperRow()], 'perp', ctx({ token055: 5 }));
+    expect(tiles[0].dataHtml).toContain('Krankenakten');
+  });
+
+  it('omits required tokens already owned with a positive count', () => {
+    const { tiles } = buildProvided([lockedSuperRow()], 'perp', ctx({ token017: 0, token055: 5 }));
+    expect(tiles[0].dataHtml).not.toContain('Body Mass Index');
+  });
+});


### PR DESCRIPTION
## Summary
Fixed a regression where required tokens with a zero count were omitted from the "Requires" list on locked supertokens, resulting in a bare "Requires" label with no token names displayed.

## Key Changes
- Updated `buildPerpTile` in `providedView.ts` to mirror the lock condition from `Database.ts`: a required token should be listed when it's either missing entirely OR present with a zero count
- Changed the filter logic from checking only key-presence to also checking for zero-count values
- Added regression test suite to verify the fix handles three scenarios:
  - Required tokens present with zero count are listed
  - Required tokens entirely missing are listed
  - Required tokens with positive counts are omitted from the list

## Implementation Details
The fix aligns the display logic with the actual lock condition: a supertoken remains locked when a required token is missing OR has a count of 0. Previously, the filter only checked `hasOwnProperty`, which would exclude zero-count tokens from the displayed requirements list, creating a confusing UI where the "Requires" section appeared empty despite the tile being locked.

https://claude.ai/code/session_016b6VZAyJLurHt1cgvBoKJN