### PR TITLE
Deploy a standalone playable build to GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -50,7 +50,7 @@ jobs:
 
       - uses: actions/upload-pages-artifact@v3
         with:
-          path: dist
+          path: dist-pages
 
       - id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,56 @@
+name: Deploy to GitHub Pages
+
+# Standalone playable build (no messenger): dist/ plus the webxdc stub from
+# @webxdc/vite-plugins, so the game runs in a plain browser tab.  Casual
+# variant — palette-quantized sprites, ~60% less to download over the web.
+#
+# Requires Settings → Pages → Source = "GitHub Actions" (one-time).
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Build and deploy
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build static site
+        run: pnpm build:pages
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 # messenger injects this at runtime — never bundle it
 /webxdc.js
 /dist/
+/dist-pages/
 /*.xdc
 /docs/*
 !/docs/*.md

--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ Build the `.xdc` files:
 
 Build the standalone browser version (what GitHub Pages serves):
 
-    $ npm run build:pages   # dist/ — no .xdc, ships a webxdc stub instead
+    $ npm run build:pages   # dist-pages/ — no .xdc, ships a webxdc stub instead
 
-`.github/workflows/pages.yml` deploys that `dist/` to GitHub Pages on every
+`.github/workflows/pages.yml` deploys that `dist-pages/` to GitHub Pages on every
 push to `master` (repo setting: Settings → Pages → Source = "GitHub Actions").
 Since there is no messenger to inject `webxdc.js`, the build ships the
 [`@webxdc/vite-plugins`](https://github.com/webxdc/vite-plugins) stub — the

--- a/README.md
+++ b/README.md
@@ -44,6 +44,17 @@ Build the `.xdc` files:
     $ npm run build:hq        # HQ only — bit-exact lossless pixels
     $ npm run build:casual    # casual only — pre-quantized assets
 
+Build the standalone browser version (what GitHub Pages serves):
+
+    $ npm run build:pages   # dist/ — no .xdc, ships a webxdc stub instead
+
+`.github/workflows/pages.yml` deploys that `dist/` to GitHub Pages on every
+push to `master` (repo setting: Settings → Pages → Source = "GitHub Actions").
+Since there is no messenger to inject `webxdc.js`, the build ships the
+[`@webxdc/vite-plugins`](https://github.com/webxdc/vite-plugins) stub — the
+game is fully playable, "Add Peer" opens a second local player in a new tab,
+and the dev-tools panel has a close button so it can be dismissed.
+
 The casual variant ships pre-quantized PNGs from [`img-casual/`](./img-casual/) and `icon-casual.png` (committed to the repo). If you change anything in [`img/`](./img/) or `icon.png`, run `npm run quantize-assets` (requires `pngquant` and `oxipng`) and commit the resulting diff.
 
 ## Licensing & credits

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build:hq": "BUILD_VARIANT=hq vite build",
     "build:casual": "BUILD_VARIANT=casual vite build",
     "build:all": "pnpm build:hq && pnpm build:casual",
+    "build:pages": "BUILD_TARGET=pages BUILD_VARIANT=casual BUILD_RELEASE=1 vite build",
     "quantize-assets": "node tools/quantize-assets.mjs",
     "preview": "vite preview",
     "test": "vitest run",

--- a/scripts/setup.ts
+++ b/scripts/setup.ts
@@ -31,7 +31,10 @@ const defaults: Setup = {
   debug: false,
   pathSeparator: '.',
   typeSeparator: ':',
-  imagePathPrefix: '/img/',
+  // Document-relative on purpose: inside a messenger the app is served at
+  // the root, but on GitHub Pages it lives under /<repo>/ — a leading `/`
+  // would 404 there.  Resolved against index.html's directory either way.
+  imagePathPrefix: 'img/',
   renderContainer: '#GameContainer',
   viewMapPerspective: false,
   viewMapStopZone: 0,

--- a/vite.config.js
+++ b/vite.config.js
@@ -53,9 +53,13 @@ if (variant !== 'hq' && variant !== 'casual') {
 const isRelease = process.env.BUILD_RELEASE === '1';
 
 // `pnpm build:pages` sets BUILD_TARGET=pages: build a plain static site for
-// GitHub Pages instead of a .xdc — same dist/, plus the webxdc stub the
+// GitHub Pages instead of a .xdc — the same output plus the webxdc stub the
 // messenger would otherwise inject (see pagesWebxdc below).
 const isPages = process.env.BUILD_TARGET === 'pages';
+
+// The pages build gets its own output directory so it never clobbers the
+// dist/ that `pnpm build:all` (and tests/build/build.test.js) work against.
+const outDir = isPages ? 'dist-pages' : 'dist';
 
 // Plugin: for the casual variant, after vite-plugin-static-copy has run,
 // replace the canonical dist/img/ + dist/icon.png with the pre-quantized
@@ -74,8 +78,8 @@ function swapInCasualAssets() {
     closeBundle() {
       if (variant !== 'casual') return;
       const root = fileURLToPath(new URL('.', import.meta.url));
-      const distImg = `${root}dist/img`;
-      const distIcon = `${root}dist/icon.png`;
+      const distImg = `${root}${outDir}/img`;
+      const distIcon = `${root}${outDir}/icon.png`;
       const srcImg = `${root}img-casual`;
       const srcIcon = `${root}icon-casual.png`;
       if (!existsSync(srcImg) || !existsSync(srcIcon)) {
@@ -89,7 +93,7 @@ function swapInCasualAssets() {
       rmSync(distIcon, { force: true });
       cpSync(srcIcon, distIcon);
       console.log(
-        '[swap-in-casual-assets] dist/img/ and dist/icon.png replaced with casual variants'
+        `[swap-in-casual-assets] ${outDir}/img/ and ${outDir}/icon.png replaced with casual variants`
       );
     },
   };
@@ -105,7 +109,7 @@ function swapInCasualAssets() {
 // Order in plugins[] matters: this must run AFTER viteStaticCopy (so
 // the files exist in dist/) and BEFORE buildXDC zips dist/.
 function minifyStaticJson() {
-  const targets = ['dist/data', 'dist/i18n'];
+  const targets = [`${outDir}/data`, `${outDir}/i18n`];
   const root = fileURLToPath(new URL('.', import.meta.url));
 
   function walkJson(dir) {
@@ -235,8 +239,8 @@ function pagesWebxdc() {
     apply: 'build',
     closeBundle() {
       const root = fileURLToPath(new URL('.', import.meta.url));
-      writeFileSync(`${root}dist/webxdc.js`, readWebxdcStub() + DEV_PANEL_CLOSE_BUTTON);
-      console.log('[pages-webxdc] dist/webxdc.js written (stub + dev-panel close button)');
+      writeFileSync(`${root}${outDir}/webxdc.js`, readWebxdcStub() + DEV_PANEL_CLOSE_BUTTON);
+      console.log(`[pages-webxdc] ${outDir}/webxdc.js written (stub + dev-panel close button)`);
     },
   };
 }
@@ -375,7 +379,7 @@ export default defineConfig({
   },
 
   build: {
-    outDir: 'dist',
+    outDir,
     emptyOutDir: true,
     // Tree-shaking and minification (esbuild) come for free from Rollup
     // + Vite defaults — set them explicitly so the .xdc artifact never

--- a/vite.config.js
+++ b/vite.config.js
@@ -52,6 +52,11 @@ if (variant !== 'hq' && variant !== 'casual') {
 // .xdc into Delta Chat can debug against the original sources.
 const isRelease = process.env.BUILD_RELEASE === '1';
 
+// `pnpm build:pages` sets BUILD_TARGET=pages: build a plain static site for
+// GitHub Pages instead of a .xdc — same dist/, plus the webxdc stub the
+// messenger would otherwise inject (see pagesWebxdc below).
+const isPages = process.env.BUILD_TARGET === 'pages';
+
 // Plugin: for the casual variant, after vite-plugin-static-copy has run,
 // replace the canonical dist/img/ + dist/icon.png with the pre-quantized
 // counterparts (img-casual/, icon-casual.png).  This keeps the in-bundle
@@ -161,13 +166,17 @@ async function minifyCssTransform(src) {
   return result.code;
 }
 
-// Serve the @webxdc/vite-plugins simulator with an explicit Content-Type so
-// strict-MIME environments (GitHub Codespaces reverse proxy) don't block it.
-function mockWebxdc() {
-  const src = readFileSync(
+function readWebxdcStub() {
+  return readFileSync(
     fileURLToPath(new URL('./node_modules/@webxdc/vite-plugins/src/webxdc.js', import.meta.url)),
     'utf-8'
   );
+}
+
+// Serve the @webxdc/vite-plugins simulator with an explicit Content-Type so
+// strict-MIME environments (GitHub Codespaces reverse proxy) don't block it.
+function mockWebxdc() {
+  const src = readWebxdcStub();
   return {
     name: 'webxdc-mock',
     configureServer(server) {
@@ -179,6 +188,52 @@ function mockWebxdc() {
           next();
         }
       });
+    },
+  };
+}
+
+// On GitHub Pages there is no messenger to inject webxdc.js, so ship the
+// @webxdc/vite-plugins stub (peer simulation + IndexedDB-persisted updates)
+// as dist/webxdc.js.  Its "webxdc dev tools" panel is useful for poking at
+// multiplayer but in the way of someone who just wants to play the game, so
+// append a close button.  The panel is added by an async `load` handler
+// (it awaits the app icon), hence the MutationObserver rather than a
+// straight querySelector.
+const DEV_PANEL_CLOSE_BUTTON = `
+// --- appended by vite.config.js pagesWebxdc() (GitHub Pages build only) ---
+document.addEventListener('DOMContentLoaded', () => {
+  new MutationObserver((_records, obs) => {
+    const panel = Array.from(document.body.children).find(
+      (el) => el.firstChild && el.firstChild.textContent === 'webxdc dev tools'
+    );
+    if (!panel) return;
+    obs.disconnect();
+    // The stub panel sits at z-index 9999; game popups go up to 100001 and
+    // would bury it (and the close button) mid-tutorial.
+    panel.style.zIndex = '1000000';
+    const close = document.createElement('a');
+    close.href = 'javascript:void(0);';
+    close.textContent = '\\u2715';
+    close.title = 'Hide dev tools';
+    close.setAttribute('aria-label', 'Hide dev tools');
+    close.setAttribute(
+      'style',
+      'color:#fff;text-decoration:none;margin-left:1em;font-size:14px;cursor:pointer'
+    );
+    close.onclick = () => panel.remove();
+    panel.firstChild.append(close);
+  }).observe(document.body, { childList: true });
+});
+`;
+
+function pagesWebxdc() {
+  return {
+    name: 'pages-webxdc',
+    apply: 'build',
+    closeBundle() {
+      const root = fileURLToPath(new URL('.', import.meta.url));
+      writeFileSync(`${root}dist/webxdc.js`, readWebxdcStub() + DEV_PANEL_CLOSE_BUTTON);
+      console.log('[pages-webxdc] dist/webxdc.js written (stub + dev-panel close button)');
     },
   };
 }
@@ -389,6 +444,8 @@ export default defineConfig({
     }),
     swapInCasualAssets(),
     minifyStaticJson(),
-    buildXDC({ inDir: 'dist', outDir: '.', outFileName: `data-dealer-${variant}.xdc` }),
+    isPages
+      ? pagesWebxdc()
+      : buildXDC({ inDir: 'dist', outDir: '.', outFileName: `data-dealer-${variant}.xdc` }),
   ],
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -202,6 +202,9 @@ function mockWebxdc() {
 const DEV_PANEL_CLOSE_BUTTON = `
 // --- appended by vite.config.js pagesWebxdc() (GitHub Pages build only) ---
 document.addEventListener('DOMContentLoaded', () => {
+  // Same condition the stub uses to draw the panel — peer windows get none,
+  // and without this their observer would stay connected forever.
+  if (window.webxdc.selfName !== 'device0') return;
   new MutationObserver((_records, obs) => {
     const panel = Array.from(document.body.children).find(
       (el) => el.firstChild && el.firstChild.textContent === 'webxdc dev tools'


### PR DESCRIPTION
Ships the game as a plain web page so people can try it without installing a messenger, and makes the webxdc dev-tools panel dismissable in that build.

## What changed

**`pnpm build:pages`** (`BUILD_TARGET=pages BUILD_VARIANT=casual BUILD_RELEASE=1 vite build`)
- Builds into `dist-pages/` instead of `dist/`, so it never clobbers the `dist/` that `pnpm build:all` and `tests/build/build.test.js` work against.
- Skips `buildXDC` — no `.xdc` is zipped — and instead writes `dist-pages/webxdc.js`: the `@webxdc/vite-plugins` stub the messenger would normally inject (peer simulation, IndexedDB-persisted updates), plus a small appended snippet.
- Casual variant: palette-quantized sprites, 5.8 MB instead of 14.5 MB over the wire. `BUILD_RELEASE=1` drops the sourcemap.

**The dev-tools panel gets a close button.** The stub draws a fixed "webxdc dev tools" panel (Add Peer / Reset). On Pages that is in the way of someone who just wants to play, so the appended snippet adds a ✕ next to the header that removes the panel. Two details worth knowing:
- The stub appends the panel from an *async* `load` handler (it awaits the app icon), so the snippet uses a `MutationObserver` on `<body>` rather than a `querySelector` at load time. It only observes when `selfName === 'device0'` — the same condition the stub uses — so peer windows don't keep a live observer for a panel that never arrives.
- The panel's own `z-index: 9999` loses against game popups (up to `100001`) and would be buried during the tutorial, so it's raised to `1000000`.

**`setup.imagePathPrefix`: `/img/` → `img/`.** This was the only absolute URL in the app; under a project-Pages subpath (`/data_dealer/`) it 404s. Document-relative resolves correctly both there and at the root a messenger serves from, so the `.xdc` is unaffected. Sprite URLs are built by concatenation onto this prefix and applied as inline styles, which resolve against the document — no CSS-file-relative cases (`css/*.css` already uses `../img/`).

**`.github/workflows/pages.yml`** — builds and deploys `dist-pages/` via `actions/deploy-pages` on push to `master` (plus `workflow_dispatch`).

## Verification

- Served `dist-pages/` under a `/data_dealer/` subpath in Chromium: game boots, sprites load, zero 4xx responses and no page errors; the ✕ is present and removes the panel.
- `biome check`, `tsc --noEmit`, 810 unit tests pass.
- Playwright: 123 pass; 9 `toHaveScreenshot` comparisons fail identically on unmodified `master` in this container (font rendering), so unrelated to this change.

## One-time repo setting

Settings → Pages → Source = **GitHub Actions**. The workflow will fail on the deploy step until that's set.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G5XyCc64jp49sBE7X7bVu4)_