### PR TITLE
Serve the HQ assets on GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,8 +1,9 @@
 name: Deploy to GitHub Pages
 
-# Standalone playable build (no messenger): dist/ plus the webxdc stub from
-# @webxdc/vite-plugins, so the game runs in a plain browser tab.  Casual
-# variant — palette-quantized sprites, ~60% less to download over the web.
+# Standalone playable build (no messenger): dist-pages/ plus the webxdc stub
+# from @webxdc/vite-plugins, so the game runs in a plain browser tab.  HQ
+# variant — lossless sprites; the web has no bundle-size ceiling to respect
+# and Pages serves the atlases compressed and cached.
 #
 # Requires Settings → Pages → Source = "GitHub Actions" (one-time).
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ Build the standalone browser version (what GitHub Pages serves):
 
     $ npm run build:pages   # dist-pages/ — no .xdc, ships a webxdc stub instead
 
+It builds the HQ assets (lossless sprites): unlike a `.xdc`, which travels
+through a chat, the web version is served once and cached, so there is no
+bundle-size ceiling to trade quality against.
+
 `.github/workflows/pages.yml` deploys that `dist-pages/` to GitHub Pages on every
 push to `master` (repo setting: Settings → Pages → Source = "GitHub Actions").
 Since there is no messenger to inject `webxdc.js`, the build ships the

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:hq": "BUILD_VARIANT=hq vite build",
     "build:casual": "BUILD_VARIANT=casual vite build",
     "build:all": "pnpm build:hq && pnpm build:casual",
-    "build:pages": "BUILD_TARGET=pages BUILD_VARIANT=casual BUILD_RELEASE=1 vite build",
+    "build:pages": "BUILD_TARGET=pages BUILD_RELEASE=1 vite build",
     "quantize-assets": "node tools/quantize-assets.mjs",
     "preview": "vite preview",
     "test": "vitest run",


### PR DESCRIPTION
Follow-up to #368, which shipped the Pages site with the casual (palette-quantized) sprites.

The casual variant exists because a `.xdc` travels through a chat: every megabyte is paid for again on each share, so a 60% smaller bundle is worth a 256-color quantization. A web page has no such constraint — it is served once per visitor, gzipped by Pages and cached by the browser — so there is no reason to hand out the lossy atlases there.

## Change

`build:pages` drops `BUILD_VARIANT=casual` and takes the default (`hq`):

```
"build:pages": "BUILD_TARGET=pages BUILD_RELEASE=1 vite build"
```

`dist-pages/` goes from ~6 MB to ~17 MB. Nothing else moves — same `dist-pages/` output directory, same webxdc stub with its close button, same workflow.

## Verification

Built HQ and served `dist-pages/` under a `/data_dealer/` subpath in Chromium: game boots, sprites load, zero 4xx responses and no page errors; the dev-panel ✕ still appears and removes the panel. `swap-in-casual-assets` correctly no-ops now, so `img/` and `icon.png` come straight from the canonical sources.

The `.xdc` builds are untouched — both variants still build as before.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G5XyCc64jp49sBE7X7bVu4)_